### PR TITLE
Standardized definitions

### DIFF
--- a/code/bit.c
+++ b/code/bit.c
@@ -19,11 +19,12 @@
 
 
 
-#if defined(macintosh)
+#ifdef macintosh
 #include <types.h>
 #else
 #include <sys/types.h>
 #endif
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/code/comm.c
+++ b/code/comm.c
@@ -75,7 +75,7 @@ void announce_logout args( ( CHAR_DATA *ch));
  * Malloc debugging stuff.
  */
 
-#if defined(MALLOC_DEBUG)
+#ifdef MALLOC_DEBUG
 extern	int	malloc_debug	args( ( int  ) );
 extern	int	malloc_verify	args( ( void ) );
 #endif
@@ -104,7 +104,7 @@ const	char 	go_ahead_str	[] = { IAC, GA, '\0' };
  * OS-dependent declarations.
  */
 
-#if	defined(linux)
+#ifdef __linux__
 /*
     Linux shouldn't need these. If you have a problem compiling, try
     uncommenting accept and bind.
@@ -184,7 +184,7 @@ int main( int argc, char **argv )
 	/*
      * Memory debugging if needed.
      */
-#if defined(MALLOC_DEBUG)
+#ifdef MALLOC_DEBUG
     malloc_debug( 2 );
 #endif
 
@@ -273,7 +273,7 @@ BIND_AGAIN:
 	exit( 0 );
     }
 /*
-#if defined(SO_DONTLINGER)
+#ifdef SO_DONTLINGER
     {
 	struct	linger	ld;
 
@@ -340,7 +340,7 @@ void game_loop_unix( int control )
 	DESCRIPTOR_DATA *d;
 	int maxdesc;
 
-#if defined(MALLOC_DEBUG)
+#ifdef MALLOC_DEBUG
 	if ( malloc_verify( ) != 1 )
 	    abort( );
 #endif
@@ -583,7 +583,7 @@ void init_descriptor( int control )
 	return;
     }
 
-#if !defined(FNDELAY)
+#ifndef FNDELAY
 #define FNDELAY O_NDELAY
 #endif
 

--- a/code/db.c
+++ b/code/db.c
@@ -50,7 +50,7 @@
 #include "olc.h"
 #include "spec.h"
 
-#if !defined(OLD_RAND)
+#ifndef OLD_RAND
 //long random();
 void srandom(unsigned int);
 int getpid();

--- a/code/devextra.c
+++ b/code/devextra.c
@@ -1081,12 +1081,12 @@ void do_listvotes(CHAR_DATA *ch, char *argument)
 
 #ifndef KEY
 #define KEY( literal, field, value )                    \
-				if ( !str_cmp( word, literal ) )        \
-				{                                       \
-					field  = value;                     \
-					fMatch = TRUE;                      \
-					break;                              \
-				}
+                if ( !str_cmp( word, literal ) )        \
+                {                                       \
+                    field  = value;                     \
+                    fMatch = TRUE;                      \
+                    break;                              \
+                }
 #endif
 
 /* provided to free strings */

--- a/code/dioextra.c
+++ b/code/dioextra.c
@@ -917,11 +917,11 @@ int get_spell_aftype(CHAR_DATA *ch) {
 #ifndef KEYV
 #define KEYV( literal, field )                      \
                 if ( !str_cmp( word, literal ) )    \
-				{                                   \
-					fread_flag_new(field, fp);      \
-					fMatch = TRUE;                  \
-					break;                          \
-				}
+                {                                   \
+                    fread_flag_new(field, fp);      \
+                    fMatch = TRUE;                  \
+                    break;                          \
+                }
 #endif
 
 

--- a/code/mem.c
+++ b/code/mem.c
@@ -13,7 +13,7 @@
 
 
 
-#if defined(macintosh)
+#ifdef macintosh
 #include <types.h>
 #else
 #include <sys/types.h>

--- a/code/merc.h
+++ b/code/merc.h
@@ -104,16 +104,16 @@ int remove();
  * Short scalar types.
  * Diavolo reports AIX compiler has bugs with short types.
  */
-#if	!defined(FALSE)
+#ifndef FALSE
 #define FALSE	 0
 #endif
 
-#if	!defined(TRUE)
+#ifndef TRUE
 #define TRUE	 1
 #endif
 
-#if	defined(_AIX)
-#if	!defined(const)
+#ifdef _AIX
+#ifndef const
 #define const
 #endif
 typedef int				sh_int;
@@ -4054,7 +4054,7 @@ void *  calloc          args( ( unsigned nelem, size_t size ) );
  * Then we close it whenever we need to open a file (e.g. a save file).
  */
 
-#if defined(unix)
+#ifdef __unix__
 // #define PLAYER_DIR      "../player/"        	/* Player files */
 #define PLAYER_LIST	RIFT_PLAYER_DIR "/Player.lst"  /* Player list for limits */
 #define TEMP_GREP_RESULTS RIFT_TEMP_DIR "/tempgrepresults.tmp" /* Temporary grep results */

--- a/code/olc.c
+++ b/code/olc.c
@@ -13,11 +13,12 @@
 
 
 
-#if defined(macintosh)
+#ifdef macintosh
 #include <types.h>
 #else
 #include <sys/types.h>
 #endif
+
 #include <ctype.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/code/olc_act.c
+++ b/code/olc_act.c
@@ -13,11 +13,12 @@
 
 
 
-#if defined(macintosh)
+#ifdef macintosh
 #include <types.h>
 #else
 #include <sys/types.h>
 #endif
+
 #include <ctype.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/code/olc_save.c
+++ b/code/olc_save.c
@@ -19,11 +19,12 @@
  *  mob etc is part of that area.
  */
 
-#if defined(macintosh)
+#ifdef macintosh
 #include <types.h>
 #else
 #include <sys/types.h>
 #endif
+
 #include <ctype.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/code/recycle.c
+++ b/code/recycle.c
@@ -31,13 +31,14 @@
 *       found in the file /Tartarus/doc/tartarus.doc                       *
 ***************************************************************************/
 
-#if defined(macintosh)
+#ifdef macintosh
 #include <types.h>
 #include <time.h>
 #else
 #include <sys/types.h>
 #include <sys/time.h>
 #endif
+
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>

--- a/code/save.c
+++ b/code/save.c
@@ -977,35 +977,35 @@ bool load_char_obj( DESCRIPTOR_DATA *d, char *name )
  */
 
 #ifndef KEY
-#define KEY( literal, field, value )				\
-				if ( !str_cmp( word, literal ) )	\
-				{					                \
-				    field  = value;			        \
-				    fMatch = TRUE;			        \
-				    break;				            \
-				}
+#define KEY( literal, field, value )                \
+                if ( !str_cmp( word, literal ) )    \
+                {                                   \
+                    field  = value;                 \
+                    fMatch = TRUE;                  \
+                    break;                          \
+                }
 #endif
 
 /* provided to free strings */
 #ifndef KEYS
-#define KEYS( literal, field, value )				\
-				if ( !str_cmp( word, literal ) )	\
-				{					                \
-				    free_pstring(field);			\
-				    field  = value;			        \
-				    fMatch = TRUE;			        \
-				    break;				            \
-				}
+#define KEYS( literal, field, value )               \
+                if ( !str_cmp( word, literal ) )    \
+                {                                   \
+                    free_pstring(field);            \
+                    field  = value;                 \
+                    fMatch = TRUE;                  \
+                    break;                          \
+                }
 #endif
 
 #ifndef KEYV
-#define KEYV( literal, field )						\
-				if ( !str_cmp( word, literal ) )	\
-				{									\
-					fread_flag_new(field, fp);		\
-					fMatch = TRUE;					\
-					break;							\
-				}
+#define KEYV( literal, field )                      \
+                if ( !str_cmp( word, literal ) )    \
+                {                                   \
+                    fread_flag_new(field, fp);      \
+                    fMatch = TRUE;                  \
+                    break;                          \
+                }
 #endif
 
 void fread_char( CHAR_DATA *ch, FILE *fp )

--- a/code/string.c
+++ b/code/string.c
@@ -12,11 +12,12 @@
  ***************************************************************************/
 
 
-#if defined(macintosh)
+#ifdef macintosh
 #include <types.h>
 #else
 #include <sys/types.h>
 #endif
+
 #include <ctype.h>
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
This PR standardizes on using `#ifdef ...` instead of `#if defined(...)`. Also used the standard OS macros from https://sourceforge.net/p/predef/wiki/OperatingSystems.

There was a mix of the two styles and since only one condition is being evaluated, `#ifdef ...` it is.

If multiple conditions were being evaluated then `#if defined(...)` would be the obvious choice.