### PR TITLE
updating cmake test project

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ script:
 - ninja --version
 - gcc --version
 - g++ --version
-- ninja
-- ninja test 
+- time ninja
+- time ninja test 
 #- make
 #- make test

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5,38 +5,23 @@ target_include_directories(catch INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
 
 set(TEST_LIB_FLAGS RiftCore catch ${CRYPTOLIB} ${MARIADBLIB} m)
 
-##
-## ACT_OBJ TESTS
-##
-set(ACT_OBJ_TESTS act_obj_tests.c main.c)
-set_source_files_properties(${ACT_OBJ_TESTS} PROPERTIES LANGUAGE CXX)
-add_executable(act_obj_tests ${ACT_OBJ_TESTS})
-target_link_libraries(act_obj_tests PRIVATE ${TEST_LIB_FLAGS})
-add_test(NAME ACT_OBJ_TESTS COMMAND act_obj_tests)
+set_source_files_properties(main.c PROPERTIES LANGUAGE CXX)
+add_library(TestMain main.c)
+set_target_properties(TestMain PROPERTIES LINKER_LANGUAGE CXX)
+
+set(TEST_SRC_FILES act_obj_tests.c
+	db_tests.c
+	fight_tests.c
+	queue_tests.c
+)
 
 ##
-## DB TESTS
+## CREATE TEST TARGETS
 ##
-set(DB_TESTS db_tests.c main.c)
-set_source_files_properties(${DB_TESTS} PROPERTIES LANGUAGE CXX)
-add_executable(db_tests ${DB_TESTS})
-target_link_libraries(db_tests PRIVATE ${TEST_LIB_FLAGS})
-add_test(NAME DB_TESTS COMMAND db_tests)
-
-##
-## FIGHT TESTS
-##
-set(FIGHT_TESTS fight_tests.c main.c)
-set_source_files_properties(${FIGHT_TESTS} PROPERTIES LANGUAGE CXX)
-add_executable(fight_tests ${FIGHT_TESTS})
-target_link_libraries(fight_tests PRIVATE ${TEST_LIB_FLAGS})
-add_test(NAME FIGHT_TESTS COMMAND fight_tests)
-
-##
-## QUEUE TESTS
-##
-set(QUEUE_TESTS queue_tests.c main.c)
-set_source_files_properties(${QUEUE_TESTS} PROPERTIES LANGUAGE CXX)
-add_executable(queue_tests ${QUEUE_TESTS})
-target_link_libraries(queue_tests PRIVATE ${TEST_LIB_FLAGS})
-add_test(NAME QUEUE_TESTS COMMAND queue_tests)
+foreach(testsource ${TEST_SRC_FILES})
+	get_filename_component(filename ${testsource} NAME_WE)
+	set_source_files_properties(${filename}.c PROPERTIES LANGUAGE CXX)
+	add_executable(${filename} ${filename}.c)
+	target_link_libraries(${filename} PRIVATE ${TEST_LIB_FLAGS} TestMain)
+	add_test(NAME ${filename} COMMAND ${filename})
+endforeach()


### PR DESCRIPTION
This PR builds the main.c file in tests only once and links it to the various tests. Should reduce build times.