### PR TITLE
Added support for debugging tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 
 # VSCode entries
 .vs/
-.vscode/launch.json
+!.vscode/launch.json
 .vscode/tasks.json
 !.vscode/settings.json
 .vscode/c_cpp_properties.json

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,222 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "C++ Launch",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceRoot}/code/rift",
+            "args": [],
+            "stopAtEntry": false,
+            "cwd": "${workspaceRoot}/code/",
+            "environment": [],
+            "externalConsole": true,
+            // "miDebuggerPath": "/bin",
+            "linux": {
+                "MIMode": "gdb"
+            },
+            "osx": {
+                "MIMode": "lldb"
+            },
+            "windows": {
+                "MIMode": "gdb"
+            }
+        },
+        {
+            "name": "C++ Attach",
+            "type": "cppdbg",
+            "request": "attach",
+            "program": "${workspaceRoot}/code/rift",
+            "processId": "${command:pickProcess}",
+            "linux": {
+                "MIMode": "gdb"
+            },
+            "osx": {
+                "MIMode": "lldb"
+            },
+            "windows": {
+                "MIMode": "gdb"
+            }
+        },
+        {
+            "name": "ActObj Tests Launch",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceRoot}/tests/act_obj_tests",
+            "args": [],
+            "stopAtEntry": false,
+            "cwd": "${workspaceRoot}/tests/",
+            "environment": [],
+            "linux": {
+                "MIMode": "gdb",
+                "miDebuggerPath": "/usr/bin/gdb"
+            },
+            "osx": {
+                "MIMode": "lldb"
+            },
+            "windows": {
+                "MIMode": "gdb"
+            }
+        },
+        {
+            "name": "Cabal Tests Launch",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceRoot}/tests/cabal_tests",
+            "args": [],
+            "stopAtEntry": false,
+            "cwd": "${workspaceRoot}/tests/",
+            "environment": [],
+            "linux": {
+                "MIMode": "gdb",
+                "miDebuggerPath": "/usr/bin/gdb"
+            },
+            "osx": {
+                "MIMode": "lldb"
+            },
+            "windows": {
+                "MIMode": "gdb"
+            }
+        },
+        {
+            "name": "Db Tests Launch",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceRoot}/tests/db_tests",
+            "args": [],
+            "stopAtEntry": false,
+            "cwd": "${workspaceRoot}/tests/",
+            "environment": [],
+            "linux": {
+                "MIMode": "gdb",
+                "miDebuggerPath": "/usr/bin/gdb"
+            },
+            "osx": {
+                "MIMode": "lldb"
+            },
+            "windows": {
+                "MIMode": "gdb"
+            }
+        },
+        {
+            "name": "Fight Tests Launch",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceRoot}/tests/fight_tests",
+            "args": [],
+            "stopAtEntry": false,
+            "cwd": "${workspaceRoot}/tests/",
+            "environment": [],
+            "linux": {
+                "MIMode": "gdb",
+                "miDebuggerPath": "/usr/bin/gdb"
+            },
+            "osx": {
+                "MIMode": "lldb"
+            },
+            "windows": {
+                "MIMode": "gdb"
+            }
+        },
+        {
+            "name": "Handler Tests Launch",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceRoot}/tests/handler_tests",
+            "args": [],
+            "stopAtEntry": false,
+            "cwd": "${workspaceRoot}/tests/",
+            "environment": [],
+            "linux": {
+                "MIMode": "gdb",
+                "miDebuggerPath": "/usr/bin/gdb"
+            },
+            "osx": {
+                "MIMode": "lldb"
+            },
+            "windows": {
+                "MIMode": "gdb"
+            }
+        },
+        {
+            "name": "Magic Tests Launch",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceRoot}/tests/magic_tests",
+            "args": [],
+            "stopAtEntry": false,
+            "cwd": "${workspaceRoot}/tests/",
+            "environment": [],
+            "linux": {
+                "MIMode": "gdb",
+                "miDebuggerPath": "/usr/bin/gdb"
+            },
+            "osx": {
+                "MIMode": "lldb"
+            },
+            "windows": {
+                "MIMode": "gdb"
+            }
+        },
+        {
+            "name": "Prof Tests Launch",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceRoot}/tests/prof_tests",
+            "args": [],
+            "stopAtEntry": false,
+            "cwd": "${workspaceRoot}/tests/",
+            "environment": [],
+            "linux": {
+                "MIMode": "gdb",
+                "miDebuggerPath": "/usr/bin/gdb"
+            },
+            "osx": {
+                "MIMode": "lldb"
+            },
+            "windows": {
+                "MIMode": "gdb"
+            }
+        },
+        {
+            "name": "Queue Tests Launch",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceRoot}/tests/queue_tests",
+            "args": [],
+            "stopAtEntry": false,
+            "cwd": "${workspaceRoot}/tests/",
+            "environment": [],
+            "linux": {
+                "MIMode": "gdb",
+                "miDebuggerPath": "/usr/bin/gdb"
+            },
+            "osx": {
+                "MIMode": "lldb"
+            },
+            "windows": {
+                "MIMode": "gdb"
+            }
+        },
+        {
+            "name": "Utility Tests Launch",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceRoot}/tests/utility_tests",
+            "args": [],
+            "stopAtEntry": false,
+            "cwd": "${workspaceRoot}/tests/",
+            "environment": [],
+            "linux": {
+                "MIMode": "gdb",
+                "miDebuggerPath": "/usr/bin/gdb"
+            },
+            "osx": {
+                "MIMode": "lldb"
+            },
+            "windows": {
+                "MIMode": "gdb"
+            }
+        }
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -68,6 +68,25 @@
 		"cinttypes": "cpp"
 	},
 	"testMate.cpp.test.executables": "tests/*{_tests}*",
+	"testMate.cpp.debug.configTemplate": { 
+		"type": "cppvsdbg", 
+		"program": "${exec}", 
+		"args": "${argsArray}", 
+		"env": "${envObj}", 
+		"environment": "${envObjArray}", 
+		"cwd": "${workspaceFolder}",
+		"linux": { 
+			"type": "cppdbg", 
+			"MIMode": "gdb"
+		}, 
+		"osx": { 
+			"type": "cppdbg", 
+			"MIMode": "lldb" 
+		}, 
+		"windows": { 
+			"type": "cppvsdbg" 
+		}, 
+	},
 	"C_Cpp.intelliSenseEngine": "Tag Parser",
 	"php.suggest.basic": false,
 	"php.validate.enable": false,
@@ -81,14 +100,14 @@
 	"php-cs-fixer.config": "./admin/.phpcs.xml",
 	"runOnSave.commands": [],
 	"triggerTaskOnSave.tasks": {
-        "compile source": [
-            "${workspaceRoot}/code/*.h",
+		"compile source": [
+			"${workspaceRoot}/code/*.h",
 			"${workspaceRoot}/code/*.c",
-            "${workspaceRoot}/code/*.cpp",
+			"${workspaceRoot}/code/*.cpp",
 			"${workspaceRoot}/tests/*.c",
 			"${workspaceRoot}/tests/*.cpp",
-        ],
-    },
+		],
+	},
 	"editor.tokenColorCustomizations": {
 		"textMateRules": [
 			{

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -105,8 +105,8 @@
 			"${workspaceRoot}/code/*.c",
 			"${workspaceRoot}/code/*.cpp",
 			"${workspaceRoot}/tests/*.c",
-			"${workspaceRoot}/tests/*.cpp",
-		],
+			"${workspaceRoot}/tests/*.cpp"
+		]
 	},
 	"editor.tokenColorCustomizations": {
 		"textMateRules": [


### PR DESCRIPTION
This PR adds support for debugging tests. However, there are some caveats to this.

Before debugging starts, the test being debugged needs to have that file opened and be the active tab in the editor. (e.g. utility_tests.c being the active tab for a test being debugged in utility_tests)

![rs-debug-tests](https://user-images.githubusercontent.com/427184/134785330-7546a315-56db-4cf6-a62a-2184fb6be31e.png)

Also before debugging starts, in the Run and Debug sidebar, the test file being debugged needs to be selected in the drop down. (e.g. a test being debugged in utility_tests.c needs the Utility Tests Launch needs to be the active selection)

![rs-debug-tests-selection](https://user-images.githubusercontent.com/427184/134785335-1256450b-1a18-491b-be3c-9a1148262cf5.png)
