### PR TITLE
Fixed format-security compiler warnings.

### DIFF
--- a/code/act_comm.c
+++ b/code/act_comm.c
@@ -2197,7 +2197,7 @@ void do_group(CHAR_DATA *ch, char *argument)
 				}
 				else
 				{
-					sprintf(buf2, pers(gch, ch));
+					sprintf(buf2, "%s", pers(gch, ch));
 					if (buf2[0] != '\0')
 						buf2[0] = UPPER(buf2[0]);
 

--- a/code/act_info.c
+++ b/code/act_info.c
@@ -1712,7 +1712,7 @@ void do_look(CHAR_DATA *ch, char *argument)
 
 		if (get_bv_stage(ch) < 2)
 		{
-			sprintf(buf, get_room_name(ch->in_room));
+			sprintf(buf, "%s", get_room_name(ch->in_room));
 			buf[0] = UPPER(buf[0]);
 			send_to_char(buf, ch);
 
@@ -5424,7 +5424,7 @@ void add_role(CHAR_DATA *ch, char *string)
 	chomp(strtime);
 
 	if (ch->pcdata->role)
-		sprintf(buf, ch->pcdata->role);
+		sprintf(buf, "%s", ch->pcdata->role);
 	else
 		strcpy(buf, "");
 

--- a/code/act_wiz.c
+++ b/code/act_wiz.c
@@ -6947,7 +6947,7 @@ void add_history(CHAR_DATA *ch, CHAR_DATA *victim, char *string)
 	chomp(strtime);
 
 	if (victim->pcdata->history_buffer)
-		sprintf(buf, victim->pcdata->history_buffer);
+		sprintf(buf, "%s", victim->pcdata->history_buffer);
 	else
 		strcpy(buf, "");
 

--- a/code/fight.c
+++ b/code/fight.c
@@ -277,7 +277,7 @@ void check_assist(CHAR_DATA *ch, CHAR_DATA *victim)
 
 					if (target != NULL)
 					{
-						sprintf(buf, rch->short_descr);
+						sprintf(buf, "%s", rch->short_descr);
 						pbuf = &buf[0];
 
 						if (!str_prefix("a ", rch->short_descr))

--- a/code/handler.c
+++ b/code/handler.c
@@ -2409,9 +2409,9 @@ CHAR_DATA *get_char_world(CHAR_DATA *ch, char *argument)
 	for (wch = char_list; wch != NULL; wch = wch->next)
 	{
 		if (is_immortal(ch) && !is_npc(wch))
-			sprintf(name, wch->true_name);
+			sprintf(name, "%s", wch->true_name);
 		else
-			sprintf(name, wch->name);
+			sprintf(name, "%s", wch->name);
 
 		if (wch->in_room == NULL || !can_see(ch, wch) || !is_name(arg, name))
 			continue;

--- a/code/misc.c
+++ b/code/misc.c
@@ -390,7 +390,7 @@ void fprint_vector(FILE *fp, char *string, long vector[], bool eol)
 {
 	char buf[MSL], buf2[MSL];
 
-	sprintf(buf, string);
+	sprintf(buf, "%s", string);
 	for (int i = 0; i < MAX_BITVECTOR; i++)
 	{
 		sprintf(buf2, " %ld", vector[i]);
@@ -400,7 +400,7 @@ void fprint_vector(FILE *fp, char *string, long vector[], bool eol)
 	if (eol)
 		strcat(buf, "\n");
 
-	fprintf(fp, buf);
+	fprintf(fp, "%s", buf);
 }
 
 char *int_to_cap_string(int number)

--- a/code/olc_save.c
+++ b/code/olc_save.c
@@ -548,8 +548,8 @@ void save_rooms(FILE *fp, AREA_DATA *pArea)
 			if (pRoom->area != pArea)
 				continue;
 
-			sprintf(buf1, munch(pRoom->name));
-			sprintf(buf2, munch(pRoom->description));
+			sprintf(buf1, "%s", munch(pRoom->name));
+			sprintf(buf2, "%s", munch(pRoom->description));
 
 			fprintf(fp, "#%d\n", pRoom->vnum);
 			fprintf(fp, "%s~\n%s~\n", buf1, buf2);
@@ -570,8 +570,8 @@ void save_rooms(FILE *fp, AREA_DATA *pArea)
 			{
 				if ((pexit = pRoom->exit[i]))
 				{
-					sprintf(buf1, pexit->keyword ? munch(pexit->keyword) : "door");
-					sprintf(buf2, munch(pexit->description));
+					sprintf(buf1, "%s", pexit->keyword ? munch(pexit->keyword) : "door");
+					sprintf(buf2, "%s", munch(pexit->description));
 					fprintf(fp, "D %s %d %s %d\n%s~\n%s~\n",
 						upstring(direction_table[std::max((long)0, i)].name),
 						pexit->u1.to_room ? pexit->u1.to_room->vnum : 0,

--- a/code/update.c
+++ b/code/update.c
@@ -726,19 +726,19 @@ void time_update(void)
 				{
 					case 7:
 						sun = SUN_RISE;
-						sprintf(buf, bw1);
+						sprintf(buf, "%s", bw1);
 						break;
 					case 8:
 						sun = SUN_LIGHT;
-						sprintf(buf, bw2);
+						sprintf(buf, "%s", bw2);
 						break;
 					case 16:
 						sun = SUN_SET;
-						sprintf(buf, bw3);
+						sprintf(buf, "%s", bw3);
 						break;
 					case 17:
 						sun = SUN_DARK;
-						sprintf(buf, bw4);
+						sprintf(buf, "%s", bw4);
 						break;
 					case 24:
 						time_info.hour = 0;
@@ -752,19 +752,19 @@ void time_update(void)
 				{
 					case 6:
 						sun = SUN_RISE;
-						sprintf(buf, bw1);
+						sprintf(buf, "%s", bw1);
 						break;
 					case 7:
 						sun = SUN_LIGHT;
-						sprintf(buf, bw2);
+						sprintf(buf, "%s", bw2);
 						break;
 					case 18:
 						sun = SUN_SET;
-						sprintf(buf, bw3);
+						sprintf(buf, "%s", bw3);
 						break;
 					case 19:
 						sun = SUN_DARK;
-						sprintf(buf, bw4);
+						sprintf(buf, "%s", bw4);
 						break;
 					case 24:
 						time_info.hour = 0;
@@ -778,19 +778,19 @@ void time_update(void)
 				{
 					case 5:
 						sun = SUN_RISE;
-						sprintf(buf, bw1);
+						sprintf(buf, "%s", bw1);
 						break;
 					case 6:
 						sun = SUN_LIGHT;
-						sprintf(buf, bw2);
+						sprintf(buf, "%s", bw2);
 						break;
 					case 20:
 						sun = SUN_SET;
-						sprintf(buf, bw3);
+						sprintf(buf, "%s", bw3);
 						break;
 					case 21:
 						sun = SUN_DARK;
-						sprintf(buf, bw4);
+						sprintf(buf, "%s", bw4);
 						break;
 					case 24:
 						time_info.hour = 0;
@@ -804,19 +804,19 @@ void time_update(void)
 				{
 					case 6:
 						sun = SUN_RISE;
-						sprintf(buf, bw1);
+						sprintf(buf, "%s", bw1);
 						break;
 					case 7:
 						sun = SUN_LIGHT;
-						sprintf(buf, bw2);
+						sprintf(buf, "%s", bw2);
 						break;
 					case 18:
 						sun = SUN_SET;
-						sprintf(buf, bw3);
+						sprintf(buf, "%s", bw3);
 						break;
 					case 19:
 						sun = SUN_DARK;
-						sprintf(buf, bw4);
+						sprintf(buf, "%s", bw4);
 						break;
 					case 24:
 						time_info.hour = 0;


### PR DESCRIPTION
This PR fixes the format-security compiler warnings.

The various `printf` methods don't necessarily need a formatting string in order to function if the only parameter is a string itself. However, this is incorrect usage of said methods. The correct usage is to supply a formatting string and the regular string.

So instead of this

```cpp
//INCORRECT
sprintf(buf, some_string); // <-- some_string is assumed to be both the format and regular string
```

we do this

```cpp
//CORRECT
sprintf(buf, "%s", some_string);
```