### PR TITLE
Fixed various compiler warnings

### DIFF
--- a/code/bootup.c
+++ b/code/bootup.c
@@ -18,73 +18,79 @@ void CMud::LoadObjLimits()
 	long min_bounty = 0;
 	float tempfloat;
 
-    RS.Log("Loading object counts off players now...");
-        sprintf(pbuf,"ls %s/%s > %s", RIFT_PLAYER_DIR,"*.plr", PLAYER_LIST);
-        system(pbuf);
+	RS.Log("Loading object counts off players now...");
+	sprintf(pbuf,"ls %s/%s > %s", RIFT_PLAYER_DIR,"*.plr", PLAYER_LIST);
 
-        if ((fpChar_list = fopen( PLAYER_LIST, "r")) == NULL)
-        {
-                perror(PLAYER_LIST);
-                exit(1);
-        }
+	auto returnCode = system(pbuf);
+	if(returnCode != 0) // ls returns 0 on SUCCESS, > 0 on ERROR. system returns -1 on ERROR
+		bug("Command [%s] failed with exit code [%d]", pbuf, returnCode);
 
-        //for(i=0;i<=MAX_TOP_BOUNTY;i++)
-        //      top_bounty_value[i]=0;
-        sprintf(chkbuf,"%s/%s", RIFT_PLAYER_DIR,"Zzz.plr");
-        for (; ;)
-        {
-                strcpy(strPlr, fread_word(fpChar_list) );
-                if(bDebug)
-                        log_string(strPlr);
+	if ((fpChar_list = fopen( PLAYER_LIST, "r")) == NULL)
+	{
+		perror(PLAYER_LIST);
+		exit(1);
+	}
 
-                if (!str_cmp(strPlr,chkbuf))
-                        break;
+	//for(i=0;i<=MAX_TOP_BOUNTY;i++)
+	//      top_bounty_value[i]=0;
+	sprintf(chkbuf,"%s/%s", RIFT_PLAYER_DIR,"Zzz.plr");
+	for (; ;)
+	{
+		strcpy(strPlr, fread_word(fpChar_list) );
+		if(bDebug)
+			log_string(strPlr);
 
-                if ( (  fpChar = fopen(strPlr, "r") ) == NULL)
-                {
-                        perror(strPlr);
-                        exit(1);
-                }
+		if (!str_cmp(strPlr,chkbuf))
+			break;
 
-                num_pfiles++;
-                temp_bounty=0;
+		if ( (  fpChar = fopen(strPlr, "r") ) == NULL)
+		{
+			perror(strPlr);
+			exit(1);
+		}
 
-                for (; ;)
-                {
-                        int vnum, lastlogin = 0, plevel = 0;
+		num_pfiles++;
+		temp_bounty=0;
+
+		for (; ;)
+		{
+			int vnum, lastlogin = 0, plevel = 0;
 			bool breakout;
-                        char letter;
-                        char *word;
-                        OBJ_INDEX_DATA *pObjIndex;
+			char letter;
+			char *word;
+			OBJ_INDEX_DATA *pObjIndex;
+
 			temp_player_name[0] = '\0';
-                        letter = fread_letter(fpChar);
+			letter = fread_letter(fpChar);
 
-                        if (letter != '#')
-                                continue;
+			if (letter != '#')
+				continue;
 
-                        word = fread_word(fpChar);
+			word = fread_word(fpChar);
 
-                        if (!str_cmp(word,"End"))
-                                break;
-                        if ( !str_cmp( word, "PLAYER"))
-                        {
-                                for ( ; ; )
-                                {
-                                        word   = fread_word( fpChar );
+			if (!str_cmp(word,"End"))
+				break;
+
+			if ( !str_cmp( word, "PLAYER"))
+			{
+				for ( ; ; )
+				{
+					word   = fread_word( fpChar );
 					//NOTE: Be careful that occurances of this word INSIDE role/desc don't fuck it up!
 					//read before/after role/desc and test accordingly
-                                        if(!str_cmp(word,"Name") && temp_player_name[0] == '\0')
-                                                sprintf(temp_player_name,"%s",fread_string( fpChar ));
-                                        if(!str_cmp(word,"Cabal"))
-                                                cabal_members[cabal_lookup(fread_string(fpChar))]++;
+					if(!str_cmp(word,"Name") && temp_player_name[0] == '\0')
+						sprintf(temp_player_name,"%s",fread_string( fpChar ));
+					if(!str_cmp(word,"Cabal"))
+						cabal_members[cabal_lookup(fread_string(fpChar))]++;
 					if(!str_cmp(word,"LogO") && lastlogin == 0)
 						lastlogin = fread_number(fpChar);
 					if(!str_cmp(word,"Levl"))
 						plevel = fread_number(fpChar);
 					if(!str_cmp(word,"End"))
 						break;
-                                }
-                        }
+				}
+			}
+
 			if(lastlogin && plevel && plevel < 52 && lastlogin + 3456000 < current_time)
 			{
 				auto buffer = fmt::format("Autodeleting {}.", temp_player_name);
@@ -93,34 +99,38 @@ void CMud::LoadObjLimits()
 				delete_char(temp_player_name, true);
 				break;
 			}
-                        if ( !str_cmp( word, "O") || !str_cmp( word, "OBJECT"))
-                        {
-                                word = fread_word(fpChar);
 
-                                if (!str_cmp(word, "Vnum"))
-                                {
-                                        vnum = fread_number(fpChar);
-                                        if ( (get_obj_index(vnum)) != NULL)
-                                        {
-                                                pObjIndex = get_obj_index(vnum);
-                                                pObjIndex->limcount++;
-                                        }
-                                }
-                        }
-                }
-                fclose(fpChar);
-                fpChar = NULL;
-        }
-        fclose( fpChar_list);
-        RS.Log("Object Limits loaded");
+			if ( !str_cmp( word, "O") || !str_cmp( word, "OBJECT"))
+			{
+				word = fread_word(fpChar);
 
-        /* CABAL LIMITS */
-        for(i=1;i<MAX_CABAL;i++)
-        {
-                tempfloat = num_pfiles / cabal_table[i].max_members;
-                cabal_max[i] = (short)tempfloat<=15 ? 15 : (short)tempfloat;
-        }
-        RS.Log("Cabal Limits loaded");
+				if (!str_cmp(word, "Vnum"))
+				{
+					vnum = fread_number(fpChar);
+					if ( (get_obj_index(vnum)) != NULL)
+					{
+						pObjIndex = get_obj_index(vnum);
+						pObjIndex->limcount++;
+					}
+				}
+			}
+		}
+
+		fclose(fpChar);
+		fpChar = NULL;
+	}
+
+	fclose( fpChar_list);
+	RS.Log("Object Limits loaded");
+
+	/* CABAL LIMITS */
+	for(i=1;i<MAX_CABAL;i++)
+	{
+		tempfloat = num_pfiles / cabal_table[i].max_members;
+		cabal_max[i] = (short)tempfloat<=15 ? 15 : (short)tempfloat;
+	}
+
+	RS.Log("Cabal Limits loaded");
 }
 
 

--- a/code/db.c
+++ b/code/db.c
@@ -2440,7 +2440,7 @@ void clear_char(CHAR_DATA *ch)
 	ch->move = 100;
 	ch->max_move = 100;
 	ch->last_fought = NULL;
-	ch->last_fight_time = NULL;
+	ch->last_fight_time = 0;
 	ch->last_fight_name = NULL;
 	ch->on = NULL;
 	ch->hometown = 0;
@@ -3929,7 +3929,9 @@ void do_llimit(CHAR_DATA *ch, char *argument)
 	send_to_char("Loading all pfile object counts now.\n\r", ch);
 
 	auto buffer = fmt::format("ls {}/{} > {}", RIFT_PLAYER_DIR, "*.plr", PLAYER_LIST); //TODO: change the rest of the sprintf calls to format
-	system(buffer.c_str());
+	auto returnCode = system(buffer.c_str());
+	if(returnCode != 0) // ls returns 0 on SUCCESS, > 0 on ERROR. system returns -1 on ERROR
+		bug("Command [%s] failed with exit code [%d]", buffer.data(), returnCode);
 
 	fpChar_list = fopen(PLAYER_LIST, "r");
 

--- a/code/devextra.c
+++ b/code/devextra.c
@@ -61,7 +61,10 @@ void do_pswitch(CHAR_DATA *ch, char *argument)
 	}
 
 	sprintf(buf, "cp %s/%s%s %s/pload.txt", RIFT_PLAYER_DIR, name, ".plr", RIFT_PLAYER_DIR);
-	system(buf);
+
+	auto returnCode = system(buf);
+	if(returnCode != 0) // cp returns 0 on SUCCESS, 1 on ERROR. system returns -1 on ERROR
+		bug("Command [%s] failed with exit code [%d]", buf, returnCode);
 
 	d->character->desc = NULL;
 	d->character->next = char_list;
@@ -726,7 +729,9 @@ void delete_char(char *name, bool save_pfile)
 	else
 		sprintf(buf2, "rm %s/%s.plr", RIFT_PLAYER_DIR, name);
 
-	system(buf2);
+	auto returnCode = system(buf2);
+	if(returnCode != 0) // both mv and rm return 0 on SUCCESS, > 0 on ERROR. system returns -1 on ERROR
+		bug("Command [%s] failed with exit code [%d]", buf2, returnCode);
 
 	cres = RS.SQL.Delete("players WHERE name='%s'", name);
 

--- a/code/dioextra.c
+++ b/code/dioextra.c
@@ -1427,7 +1427,10 @@ void do_ctrack(CHAR_DATA *ch, char *argument)
 
 	sprintf(arg, "%s", lowstring(arg));
 	sprintf(buf, "grep 'Cabal %s~' %s/%s > %s", arg, RIFT_PLAYER_DIR, "*.plr", TEMP_GREP_RESULTS);
-	system(buf);
+
+	auto returnCode = system(buf);
+	if(returnCode != 0) // grep returns 0 on SUCCESS, > 0 on ERROR. system returns -1 on ERROR
+		bug("Command [%s] failed with exit code [%d]", buf, returnCode);
 
 	fpChar = fopen(TEMP_GREP_RESULTS, "r");
 	if (fpChar == NULL)
@@ -1634,7 +1637,10 @@ void do_pload(CHAR_DATA *ch, char *argument)
 	}
 
 	auto buffer = fmt::format("cp {}{}{} {}pload.txt", RIFT_PLAYER_DIR, name, ".plr", RIFT_PLAYER_DIR);
-	system(buffer.c_str());
+
+	auto returnCode = system(buffer.c_str());
+	if(returnCode != 0) // cp returns 0 on SUCCESS, 1 on ERROR. system returns -1 on ERROR
+		bug("Command [%s] failed with exit code [%d]", buffer.data(), returnCode);
 
 	d->character->desc = NULL;
 	d->character->next = char_list;

--- a/code/interp.c
+++ b/code/interp.c
@@ -1006,7 +1006,7 @@ void interpret(CHAR_DATA *ch, char *argument)
 					return;
 				}
 
-				vo = (void *)where;
+				vo = (void *)(long)where;
 				break;
 			case TAR_IGNORE:
 			default:

--- a/code/merc.h
+++ b/code/merc.h
@@ -238,7 +238,14 @@ typedef void APROG_FUN_MYELL (AREA_DATA *area, CHAR_DATA *ch, CHAR_DATA *victim)
 //
 
 #define MAX_KEY_HASH				1024
+
+#ifdef MAX_STRING_LENGTH
+#undef MAX_STRING_LENGTH
 #define MAX_STRING_LENGTH			4608
+#else
+#define MAX_STRING_LENGTH			4608
+#endif
+
 #define MAX_INPUT_LENGTH			4608
 #define PAGELEN						20
 #define MSL							MAX_STRING_LENGTH
@@ -2399,7 +2406,14 @@ struct kill_data
 #define WIZ_TICKS					(ASCII_B)
 #define WIZ_LOGINS					(ASCII_C)
 #define WIZ_SITES					(ASCII_D)
+
+#ifdef WIZ_LINKS
+#undef WIZ_LINKS
 #define WIZ_LINKS					(ASCII_E)
+#else
+#define WIZ_LINKS					(ASCII_E)
+#endif
+
 #define WIZ_DEATHS					(ASCII_F)
 #define WIZ_RESETS					(ASCII_G)
 #define WIZ_MOBDEATHS				(ASCII_H)

--- a/code/olc_save.c
+++ b/code/olc_save.c
@@ -900,15 +900,22 @@ void save_shops(FILE *fp, AREA_DATA *pArea)
 
 void save_area(AREA_DATA *pArea)
 {
+	std::string buffer;
 	long long temp_bit;
 	char buf[MSL];
 	FILE *fp = NULL;
 	fclose(fpReserve);
 
 	sprintf(buf, "mv -f %s " RIFT_AREA_DIR "/backup/%s.bak", pArea->file_name, pArea->file_name);
-	system(buf);
 
-	system("touch " RIFT_CODE_DIR "/area-dump.txt");
+	auto returnCode = system(buf);
+	if(returnCode != 0) // mv returns 0 on SUCCESS, > 0 on ERROR. system returns -1 on ERROR
+		bug("Command [%s] failed with exit code [%d]", buf, returnCode);
+
+	buffer = std::string("touch " RIFT_CODE_DIR "/area-dump.txt");
+	returnCode = system(buffer.c_str());
+	if(returnCode != 0) // couldn't find exit code for touch, assuming touch returns 0 on SUCCESS, > 0 on ERROR. system returns -1 on ERROR
+		bug("Command [%s] failed with exit code [%d]", buffer.data(), returnCode);
 
 	if (!(fp = fopen(pArea->file_name, "w")))
 	{

--- a/code/save.c
+++ b/code/save.c
@@ -1005,7 +1005,10 @@ bool load_char_obj(DESCRIPTOR_DATA *d, char *name)
 		fclose(fp);
 
 		auto buffer = fmt::format("gzip -dfq {}", strsave);
-		system(buffer.c_str());
+
+		auto returnCode = system(buffer.c_str());
+		if(returnCode != 0) // gzip returns 0 on SUCCESS, 1 on ERROR. system returns -1 on ERROR
+			bug("Command [%s] failed with exit code [%d]", buffer.data(), returnCode);
 	}
 
 	sprintf(strsave, "%s/%s.plr", RIFT_PLAYER_DIR, capitalize(name));

--- a/code/socket.h
+++ b/code/socket.h
@@ -5,6 +5,8 @@
 #include <arpa/inet.h>
 #include <cstddef>
 
+//TODO: WIZ_LINKS also defined in merc.h. Nothing appears to reference this define. 
+// Leaving it here for now. If it's used in the future, we can fix it then.
 #define WIZ_LINKS 1
 
 #define PLAYER_OUTPUT_SIZE	8192	//flah.

--- a/code/stdlibs/file.h
+++ b/code/stdlibs/file.h
@@ -13,7 +13,9 @@
 #endif
 
 #define MAX_WORD_LENGTH 2048
-#define MAX_STRING_LENGTH 4096
+//TODO: MAX_STRING_LENGTH also defined in merc.h. Only referenced in the ReadString method in file.c. 
+// Leaving it here for now. If it's used in the future, we can fix it then.
+#define MAX_STRING_LENGTH 4096 
 
 #define MODE_READ 	0
 #define MODE_WRITE 	1


### PR DESCRIPTION
This PR fixes several compiler warnings. After merging this PR, we should be able to get a clean build (0 warnings / 0 errors) with our current compiler flags.

Fixes include:
- Checking return values of system calls.
- Proper way to redefine macros.
- Casting int to long before casting to a void pointer.
 
Unrelated to the warnings, I fixed the formatting of the `LoadObjLimits` method in `bootup.c`. 
