### PR TITLE
relocate weather defines to enums

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -129,5 +129,6 @@
 				}
 			}
 		]
-	}
+	},
+	"cmake.configureOnOpen": false
 }

--- a/code/act_info.c
+++ b/code/act_info.c
@@ -32,6 +32,7 @@
  ***************************************************************************/
 
 #include "act_info.h"
+#include "weather_enums.h"
 
 char *const where_name[] = {
 	"<used as light>     ",
@@ -70,7 +71,7 @@ static char *const moon_look[MAX_MOON] =
 	"crescent waning"
 };
 
-static char *const sky_look[MAX_SKY] = 
+static char *const sky_look[WeatherCondition::MaxWeatherCondition] = 
 {
 	"The sky is cloudless",
 	"The sky is partly cloudy",
@@ -83,7 +84,7 @@ static char *const sky_look[MAX_SKY] =
 	"Pebble-sized hailstones fall from the sky"
 };
 
-static char *const temp_look[MAX_TEMP] = 
+static char *const temp_look[Temperature::MaxTemperature] = 
 {
 	"hot",
 	"warm",
@@ -91,7 +92,7 @@ static char *const temp_look[MAX_TEMP] =
 	"cold"
 };
 
-static char *const wind_look[MAX_WIND] = 
+static char *const wind_look[Windspeed::MaxWindspeed] = 
 {
 	"is perfectly still.", 
 	"wafts on a gentle breeze.", 
@@ -1992,7 +1993,7 @@ void do_look(CHAR_DATA *ch, char *argument)
 			return;
 		}
 
-		if (ch->in_room->area->sky == SKY_OVERCAST || ch->in_room->area->sky >= SKY_DOWNPOUR)
+		if (ch->in_room->area->sky == WeatherCondition::Overcast || ch->in_room->area->sky >= WeatherCondition::Downpour)
 		{
 			send_to_char("You cannot make out the moons through the cloud cover.\n\r", ch);
 			return;
@@ -2811,7 +2812,7 @@ void do_weather(CHAR_DATA *ch, char *argument)
 
 	if (sun != SUN_LIGHT)
 	{
-		if (ch->in_room->area->sky == SKY_OVERCAST || ch->in_room->area->sky >= SKY_DOWNPOUR)
+		if (ch->in_room->area->sky == WeatherCondition::Overcast || ch->in_room->area->sky >= WeatherCondition::Downpour)
 		{
 			send_to_char("You cannot make out the twin moons through the thick cloud cover.\n\r", ch);
 			return;

--- a/code/act_wiz.c
+++ b/code/act_wiz.c
@@ -33,6 +33,8 @@
 
 #include "act_wiz.h"
 #include "prof.h"
+#include "weather_enums.h"
+
 
 AREA_DATA *area_first;
 unsigned int *gDebug;
@@ -2327,16 +2329,16 @@ void do_astat(CHAR_DATA *ch, char *argument)
 
 	switch (area->temp)
 	{
-		case TEMP_HOT:
+		case Temperature::Hot:
 			sprintf(buf, "Hot\n\r");
 			break;
-		case TEMP_WARM:
+		case Temperature::Warm:
 			sprintf(buf, "Warm\n\r");
 			break;
-		case TEMP_COOL:
+		case Temperature::Cool:
 			sprintf(buf, "Cool\n\r");
 			break;
-		case TEMP_COLD:
+		case Temperature::Cold:
 			sprintf(buf, "Cold\n\r");
 			break;
 		default:
@@ -2350,16 +2352,16 @@ void do_astat(CHAR_DATA *ch, char *argument)
 
 	switch (area->wind)
 	{
-		case WIND_CALM:
+		case Windspeed::Calm:
 			sprintf(buf, "Calm\n\r");
 			break;
-		case WIND_BREEZE:
+		case Windspeed::Breeze:
 			sprintf(buf, "Breeze\n\r");
 			break;
-		case WIND_WINDY:
+		case Windspeed::Windy:
 			sprintf(buf, "Windy\n\r");
 			break;
-		case WIND_GALE:
+		case Windspeed::Gale:
 			sprintf(buf, "Gale\n\r");
 			break;
 		default:
@@ -2373,31 +2375,31 @@ void do_astat(CHAR_DATA *ch, char *argument)
 
 	switch (area->sky)
 	{
-		case SKY_CLEAR:
+		case WeatherCondition::Clear:
 			sprintf(buf, "Clear\n\r");
 			break;
-		case SKY_PCLOUDY:
+		case WeatherCondition::PartlyCloudy:
 			sprintf(buf, "Partly cloudy\n\r");
 			break;
-		case SKY_OVERCAST:
+		case WeatherCondition::Overcast:
 			sprintf(buf, "Overcast\n\r");
 			break;
-		case SKY_DRIZZLE:
+		case WeatherCondition::Drizzle:
 			sprintf(buf, "Drizzling\n\r");
 			break;
-		case SKY_DOWNPOUR:
+		case WeatherCondition::Downpour:
 			sprintf(buf, "Pouring rain\n\r");
 			break;
-		case SKY_TSTORM:
+		case WeatherCondition::ThunderStorm:
 			sprintf(buf, "Thunderstorm\n\r");
 			break;
-		case SKY_FLURRY:
+		case WeatherCondition::SnowFlurry:
 			sprintf(buf, "Snow flurries\n\r");
 			break;
-		case SKY_BLIZZARD:
+		case WeatherCondition::Blizzard:
 			sprintf(buf, "Blizzard\n\r");
 			break;
-		case SKY_HAIL:
+		case WeatherCondition::Hail:
 			sprintf(buf, "Hail\n\r");
 			break;
 		default:
@@ -7701,11 +7703,11 @@ void do_interpdump(CHAR_DATA *ch, char *argument)
 
 	fp = fopen(RIFT_CODE_DIR "/climate-dump.txt", "w");
 
-	for (i = 0; climate_table[i].number != CLIMATE_ENGLISH; i++)
+	for (i = 0; climate_table[i].number != Climate::English; i++)
 	{
 		fprintf(fp, "%s;%d;", climate_table[i].name, climate_table[i].number);
 
-		for (j = 0; j < MAX_SKY; j++)
+		for (j = 0; j < WeatherCondition::MaxWeatherCondition; j++)
 		{
 			if (j != 0)
 				fprintf(fp, ",");
@@ -7721,7 +7723,7 @@ void do_interpdump(CHAR_DATA *ch, char *argument)
 
 		fprintf(fp, ";");
 
-		for (j = 0; j < MAX_TEMP; j++)
+		for (j = 0; j < Temperature::MaxTemperature; j++)
 		{
 			if (j != 0)
 				fprintf(fp, ",");

--- a/code/aprog.c
+++ b/code/aprog.c
@@ -1,6 +1,7 @@
 /* IMPROGS Expansion: AREA PROGS (Eladrian) */
 
 #include "aprog.h"
+#include "weather_enums.h"
 
 const struct improg_type aprog_table[] = 
 {
@@ -220,7 +221,7 @@ void tick_prog_ilopheth(AREA_DATA *area)
 	if ((time_info.hour != 15 && time_info.hour != 17) || time_info.half)
 		return;
 
-	if (area->sky >= SKY_OVERCAST)
+	if (area->sky >= WeatherCondition::Overcast)
 		return;
 
 	for (obj = pedroom->contents; obj; obj = obj->next_content)

--- a/code/area.h
+++ b/code/area.h
@@ -14,7 +14,6 @@ public:
 	CArea *			next;
 	static CArea *	first;
 	
-	static void		LoadAreaData();
 	static void		LoadAreaTable(const char *query); /*this is reserved for bootstrap use*/
 	
 	int				GetPlayerCount(void);

--- a/code/autogen/stddefs.h
+++ b/code/autogen/stddefs.h
@@ -259,14 +259,6 @@
 #define ARE_CITY			4
 #define ARE_UNOPENED			5
 #define ARE_SHRINE			6
-#define CLIMATE_NONE			0
-#define CLIMATE_TEMPERATE			1
-#define CLIMATE_DESERT			2
-#define CLIMATE_TROPICAL			3
-#define CLIMATE_ALPINE			4
-#define CLIMATE_TUNDRA			5
-#define CLIMATE_SUBTROPICAL			6
-#define CLIMATE_ARID			7
 #define DIR_NORTH			0
 #define DIR_EAST			1
 #define DIR_SOUTH			2

--- a/code/bootup.c
+++ b/code/bootup.c
@@ -175,11 +175,15 @@ void CMud::LoadTime()
 	calabren_pos = ((current_time-RS_EPOCH)%(CALABREN_SPD*360))/CALABREN_SPD;
 }
 
+///
+/// 
+/// Loads all areas from the area index file declared as  @see AREA_LIST
+/// 
+/// @param someparam description
+///
 void CMud::LoadAreas()
 {
 	FILE *fpList;
-	//	CArea::LoadAreaData();	//loads the data about each area - name, uid, etc
-
 
 	log_string("Loading area files now...");
 
@@ -249,18 +253,6 @@ void CMud::LoadAreas()
 
 	fBootDb = false;
 	
-}
-
-
-void CArea::LoadAreaData()
-{
-	/* NOTE: class macro weapon is disabled 'cause it's a double for some
-	* reason: fix0r */
-	RS.Log("Loading area data...");
-//	CArea::LoadAreaTable("* FROM world_areas ORDER BY min_vnum ASC");
-//	begin_benchmark
-//	CRoom::LoadRoomTable("* FROM world_rooms ORDER BY vnum ASC");
-//	end_benchmark("Loading rooms");
 }
 
 void CMud::LoadOptions()

--- a/code/db2.c
+++ b/code/db2.c
@@ -968,7 +968,10 @@ void bug_exit(char *file, int nLine)
 }
 
 /*
- * Snarf an obj section. dev style
+ * @brief processes object sections for a provided file
+ * 
+ * @old Snarf an obj section. dev style
+ * 
  */
 void load_objs(FILE *fp)
 {
@@ -994,6 +997,8 @@ void load_objs(FILE *fp)
 			exit(1);
 		}
 
+		// object areas end with an empty #0 line to denote the end
+		// of the object definitions
 		vnum = fread_number(fp);
 		if (vnum == 0)
 			break;

--- a/code/handler.c
+++ b/code/handler.c
@@ -2847,7 +2847,7 @@ bool can_see(CHAR_DATA *ch, CHAR_DATA *victim)
 		&& (!(is_affected(ch, gsn_hydroperception)
 			&& (ch->in_room->sector_type == SECT_WATER
 				|| ch->in_room->sector_type == SECT_UNDERWATER
-				|| (ch->in_room->sector_type != SECT_INSIDE && victim->in_room->area->sky >= SKY_DRIZZLE))
+				|| (ch->in_room->sector_type != SECT_INSIDE && victim->in_room->area->sky >= WeatherCondition::Drizzle))
 			&& ch->in_room == victim->in_room))
 		&& !(is_affected(ch, gsn_sense_disturbance)
 			&& ch->in_room->sector_type != SECT_UNDERWATER
@@ -2873,7 +2873,7 @@ bool can_see(CHAR_DATA *ch, CHAR_DATA *victim)
 		&& !(is_affected(ch, gsn_hydroperception)
 			&& (ch->in_room->sector_type == SECT_WATER
 				|| ch->in_room->sector_type == SECT_UNDERWATER
-				|| (ch->in_room->sector_type != SECT_INSIDE && victim->in_room->area->sky >= SKY_DRIZZLE))
+				|| (ch->in_room->sector_type != SECT_INSIDE && victim->in_room->area->sky >= WeatherCondition::Drizzle))
 			&& ch->in_room == victim->in_room)
 		&& !(is_affected(ch, gsn_sensevibrations)
 			&& victim->in_room->sector_type != SECT_UNDERWATER
@@ -4633,22 +4633,22 @@ void affect_modify_area(AREA_DATA *area, AREA_AFFECT_DATA *paf, bool fAdd)
 		case APPLY_AREA_TEMP:
 			area->temp += paf->modifier;
 
-			if (area->temp >= MAX_TEMP)
-				area->temp = MAX_TEMP - 1;
+			if (area->temp >= Temperature::MaxTemperature)
+				area->temp = Temperature::MaxTemperature - 1;
 
 			break;
 		case APPLY_AREA_WIND:
 			area->wind += paf->modifier;
 
-			if (area->wind >= MAX_WIND)
-				area->wind = MAX_WIND - 1;
+			if (area->wind >= Windspeed::MaxWindspeed)
+				area->wind = Windspeed::MaxWindspeed - 1;
 
 			break;
 		case APPLY_AREA_SKY:
 			area->sky += paf->modifier;
 
-			if (area->sky >= MAX_SKY)
-				area->sky = MAX_SKY - 1;
+			if (area->sky >= WeatherCondition::MaxWeatherCondition)
+				area->sky = WeatherCondition::MaxWeatherCondition - 1;
 
 			break;
 		default:

--- a/code/magic.c
+++ b/code/magic.c
@@ -1931,7 +1931,7 @@ void spell_create_water(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 		return;
 	}
 
-	water = std::min(level * (ch->in_room->area->sky >= SKY_DRIZZLE ? 4 : 2), obj->value[0] - obj->value[1]);
+	water = std::min(level * (ch->in_room->area->sky >= WeatherCondition::Drizzle ? 4 : 2), obj->value[0] - obj->value[1]);
 
 	if (water > 0)
 	{

--- a/code/merc.h
+++ b/code/merc.h
@@ -2192,43 +2192,6 @@ struct kill_data
 #define WEAR_COSMETIC				21
 #define MAX_WEAR					22
 
-//
-// Climate types
-//
-
-#define CLIMATE_NONE				0
-#define CLIMATE_TEMPERATE			1
-#define CLIMATE_DESERT				2
-#define CLIMATE_TROPICAL			3
-#define CLIMATE_ALPINE				4
-#define CLIMATE_TUNDRA				5
-#define CLIMATE_SUBTROPICAL			6
-#define CLIMATE_ARID				7
-#define CLIMATE_ENGLISH				8
-#define MAX_CLIMATE					9
-
-#define SKY_CLEAR					0
-#define SKY_PCLOUDY					1
-#define SKY_OVERCAST				2
-#define SKY_DRIZZLE					3
-#define SKY_DOWNPOUR				4
-#define SKY_TSTORM					5
-#define SKY_FLURRY					6
-#define SKY_BLIZZARD				7
-#define SKY_HAIL					8
-#define MAX_SKY						9
-
-#define TEMP_HOT					0
-#define TEMP_WARM					1
-#define TEMP_COOL					2
-#define TEMP_COLD					3
-#define MAX_TEMP					4
-
-#define WIND_CALM					0
-#define WIND_BREEZE					1
-#define WIND_WINDY					2
-#define WIND_GALE					3
-#define MAX_WIND					4
 
 #define BLOCK_YES					1
 #define BLOCK_NO					0

--- a/code/moremagic.c
+++ b/code/moremagic.c
@@ -32,6 +32,7 @@
  ***************************************************************************/
 
 #include "moremagic.h"
+#include "weather_enums.h"
 
 void spell_enlarge(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 {
@@ -111,16 +112,16 @@ void spell_sunray(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 	if (sun == SUN_SET)
 		dam = 100;
 
-	if (ch->in_room->area->sky == SKY_CLEAR)
+	if (ch->in_room->area->sky == WeatherCondition::Clear)
 		dam = (int)((float)dam * 1.7);
 
-	if (ch->in_room->area->sky == SKY_PCLOUDY)
+	if (ch->in_room->area->sky == WeatherCondition::PartlyCloudy)
 		dam *= 1;
 
-	if (ch->in_room->area->sky == SKY_DRIZZLE)
+	if (ch->in_room->area->sky == WeatherCondition::Drizzle)
 		dam = (int)((float)dam * .8);
 
-	if (ch->in_room->area->sky == SKY_TSTORM)
+	if (ch->in_room->area->sky == WeatherCondition::ThunderStorm)
 		dam *= 1;
 
 	// Fuzz it up.

--- a/code/olc_act.c
+++ b/code/olc_act.c
@@ -2064,7 +2064,7 @@ int aclimate_lookup(const char *name)
 {
 	int sn;
 
-	for (sn = 0; sn < MAX_CLIMATE; sn++)
+	for (sn = 0; sn < Climate::MaxClimate; sn++)
 	{
 		if (climate_table[sn].name == NULL)
 			break;
@@ -2096,7 +2096,7 @@ bool aedit_climate(CHAR_DATA *ch, char *argument)
 		send_to_char(buffer.c_str(), ch);
 		send_to_char("The following climates are available:\n\r", ch);
 
-		for (climate = 0; climate < MAX_CLIMATE; climate++)
+		for (climate = 0; climate < Climate::MaxClimate; climate++)
 		{
 			if (climate_table[climate].name == NULL)
 				break;

--- a/code/scan.c
+++ b/code/scan.c
@@ -91,16 +91,16 @@ void do_scan(CHAR_DATA *ch, char *argument)
 	if (sun == SUN_DARK)
 		depth--;
 
-	if (ch->in_room->area->sky == SKY_DRIZZLE
-		|| ch->in_room->area->sky == SKY_FLURRY
-		|| ch->in_room->area->sky == SKY_HAIL)
+	if (ch->in_room->area->sky == WeatherCondition::Drizzle
+		|| ch->in_room->area->sky == WeatherCondition::SnowFlurry
+		|| ch->in_room->area->sky == WeatherCondition::Hail)
 	{
 		depth--;
 	}
 
-	if (ch->in_room->area->sky == SKY_DOWNPOUR
-		|| ch->in_room->area->sky == SKY_TSTORM
-		|| ch->in_room->area->sky == SKY_BLIZZARD)
+	if (ch->in_room->area->sky == WeatherCondition::Downpour
+		|| ch->in_room->area->sky == WeatherCondition::ThunderStorm
+		|| ch->in_room->area->sky == WeatherCondition::Blizzard)
 	{
 		depth -= 2;
 	}

--- a/code/sorcerer.c
+++ b/code/sorcerer.c
@@ -2,6 +2,7 @@
  *                        Welcome to Sorcerer land.                         *
  ****************************************************************************/
 #include "sorcerer.h"
+#include "weather_enums.h"
 
 int para_compute(int ele1, int ele2)
 {
@@ -2111,7 +2112,7 @@ void spell_hydration(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 			break;
 	}
 
-	if (ch->in_room->area->sky == SKY_DRIZZLE
+	if (ch->in_room->area->sky == WeatherCondition::Drizzle
 		&& ch->in_room->sector_type != SECT_WATER
 		&& ch->in_room->sector_type != SECT_INSIDE
 		&& ch->in_room->sector_type != SECT_UNDERWATER)
@@ -4220,7 +4221,7 @@ void spell_attract(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 
 void attract_tick(CHAR_DATA *ch, AFFECT_DATA *af)
 {
-	if (ch->in_room->area->sky < SKY_OVERCAST || IS_SET(ch->in_room->room_flags, ROOM_INDOORS))
+	if (ch->in_room->area->sky < WeatherCondition::Overcast || IS_SET(ch->in_room->room_flags, ROOM_INDOORS))
 		return;
 
 	act("Your skin tingles briefly, and a bolt arcs down from the dark skies above!", ch, NULL, ch, TO_CHAR);
@@ -4286,7 +4287,7 @@ void spell_call_lightning(int sn, int level, CHAR_DATA *ch, void *vo, int target
 		return;
 	}
 
-	if (ch->in_room->area->sky < SKY_DRIZZLE)
+	if (ch->in_room->area->sky < WeatherCondition::Drizzle)
 	{
 		send_to_char("The weather is not suitable for calling lightning.\n\r", ch);
 		return;
@@ -4881,7 +4882,7 @@ void spell_blanket(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 		return;
 	}
 
-	if (ch->in_room->area->temp == TEMP_HOT)
+	if (ch->in_room->area->temp == Temperature::Hot)
 	{
 		send_to_char("It is too hot to create even magical snow right now.\n\r", ch);
 		return;
@@ -4940,16 +4941,16 @@ void spell_boreal_wind(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 
 	switch (ch->in_room->area->temp)
 	{
-		case TEMP_HOT:
+		case Temperature::Hot:
 			dam = (int)((float)dam * 0.25);
 			break;
-		case TEMP_WARM:
+		case Temperature::Warm:
 			dam = (int)((float)dam * 0.75);
 			break;
-		case TEMP_COOL:
+		case Temperature::Cool:
 			dam = (int)((float)dam * 1.25);
 			break;
-		case TEMP_COLD:
+		case Temperature::Cold:
 			dam = (int)((float)dam * 1.75);
 			break;
 		default:
@@ -5144,16 +5145,16 @@ void spell_frost_glaze(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 
 	switch (ch->in_room->area->temp)
 	{
-		case TEMP_HOT:
+		case Temperature::Hot:
 			acmod /= (int)2;
 			break;
-		case TEMP_WARM:
+		case Temperature::Warm:
 			acmod = (int)((float)acmod * 0.8);
 			break;
-		case TEMP_COOL:
+		case Temperature::Cool:
 			acmod = (int)((float)acmod * 1.25);
 			break;
-		case TEMP_COLD:
+		case Temperature::Cold:
 			acmod = (int)((float)acmod * 1.5);
 			break;
 	}
@@ -5305,7 +5306,7 @@ void spell_whiteout(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 		return;
 	}
 
-	if (area->temp == TEMP_HOT || area->sky == SKY_CLEAR)
+	if (area->temp == Temperature::Hot || area->sky == WeatherCondition::Clear)
 	{
 		send_to_char("It is beyond your magic to change the weather so drastically.\n\r", ch);
 		return;
@@ -5320,7 +5321,7 @@ void spell_whiteout(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 	aaf.level = level;
 	aaf.duration = 2;
 	aaf.location = APPLY_AREA_TEMP;
-	aaf.modifier = TEMP_COLD - area->temp;
+	aaf.modifier = Temperature::Cold - area->temp;
 	aaf.owner = ch;
 	aaf.end_fun = whiteout_end;
 	aaf.tick_fun = NULL;
@@ -5328,11 +5329,11 @@ void spell_whiteout(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 
 	aaf.end_fun = NULL;
 	aaf.location = APPLY_AREA_WIND;
-	aaf.modifier = WIND_GALE - area->wind;
+	aaf.modifier = Windspeed::Gale - area->wind;
 	affect_to_area(area, &aaf);
 
 	aaf.location = APPLY_AREA_SKY;
-	aaf.modifier = SKY_BLIZZARD - area->sky;
+	aaf.modifier = WeatherCondition::Blizzard - area->sky;
 	affect_to_area(area, &aaf);
 
 	init_affect(&af);
@@ -5382,19 +5383,19 @@ void spell_frigid_breeze(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 
 		switch (ch->in_room->area->temp)
 		{
-			case TEMP_HOT:
+			case Temperature::Hot:
 				if (chance <= 80)
 					continue;
 				break;
-			case TEMP_WARM:
+			case Temperature::Warm:
 				if (chance <= 60)
 					continue;
 				break;
-			case TEMP_COOL:
+			case Temperature::Cool:
 				if (chance <= 40)
 					continue;
 				break;
-			case TEMP_COLD:
+			case Temperature::Cold:
 				if (chance <= 20)
 					continue;
 				break;
@@ -5419,7 +5420,7 @@ void spell_pure_air(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 		return;
 	}
 
-	if (ch->in_room->area->temp <= TEMP_WARM)
+	if (ch->in_room->area->temp <= Temperature::Warm)
 	{
 		send_to_char("The air here is too warm for a purifying breeze.\n\r", ch);
 		return;
@@ -5644,7 +5645,7 @@ void spell_glaciate(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 		return;
 	}
 
-	if (room->area->temp == TEMP_HOT)
+	if (room->area->temp == Temperature::Hot)
 	{
 		send_to_char("The ambient temperature is too high to freeze the water.\n\r", ch);
 		return;
@@ -5897,7 +5898,7 @@ void spell_sheath_of_ice(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 		return;
 	}
 
-	if (ch->in_room->area->temp == TEMP_HOT)
+	if (ch->in_room->area->temp == Temperature::Hot)
 	{
 		send_to_char("It is too hot to create ice in such quantity.\n\r", ch);
 		return;
@@ -6448,7 +6449,7 @@ void spell_vigorize(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 
 	refresh = level;
 
-	if (ch->in_room->area->temp == TEMP_HOT || ch->in_room->area->temp == TEMP_COLD)
+	if (ch->in_room->area->temp == Temperature::Hot || ch->in_room->area->temp == Temperature::Cold)
 		refresh /= 2;
 
 	act("You blanket the area with a soothing mist.", ch, 0, 0, TO_CHAR);

--- a/code/tables.c
+++ b/code/tables.c
@@ -32,7 +32,7 @@
  ***************************************************************************/
 
 #include "tables.h"
-
+#include "weather_enums.h"
 
 //Steal the flag table, we're not storing bitvectors, but shhh, we like their functions!
 const struct flag_type aftype_table[] =
@@ -758,36 +758,36 @@ const struct flag_type area_type_table[] =
 	{	NULL,			0,				true	}
 };
 
-const struct flag_type sky_table[MAX_SKY] =
+const struct flag_type sky_table[WeatherCondition::MaxWeatherCondition] =
 {
 	//	name			bit				settable
-	{	"clear",		SKY_CLEAR,		true	},
-	{	"partlycloudy",	SKY_PCLOUDY,	true	},
-	{	"overcast",		SKY_OVERCAST,	true	},
-	{	"drizzle",		SKY_DRIZZLE,	true	},
-	{	"downpour",		SKY_DOWNPOUR,	true	},
-	{	"thunderstorm",	SKY_TSTORM,		true	},
-	{	"flurry",		SKY_FLURRY,		true	},
-	{	"blizzard",		SKY_BLIZZARD,	true	},
-	{	"hail",			SKY_HAIL,		true	}
+	{	"clear",		WeatherCondition::Clear,		true	},
+	{	"partlycloudy",	WeatherCondition::PartlyCloudy,	true	},
+	{	"overcast",		WeatherCondition::Overcast,	true	},
+	{	"drizzle",		WeatherCondition::Drizzle,	true	},
+	{	"downpour",		WeatherCondition::Downpour,	true	},
+	{	"thunderstorm",	WeatherCondition::ThunderStorm,		true	},
+	{	"flurry",		WeatherCondition::SnowFlurry,		true	},
+	{	"blizzard",		WeatherCondition::Blizzard,	true	},
+	{	"hail",			WeatherCondition::Hail,		true	}
 };
 
-const struct flag_type temp_table[MAX_TEMP] =
+const struct flag_type temp_table[Temperature::MaxTemperature] =
 {
 	//	name		bit				settable
-	{	"hot",		TEMP_HOT,		true	},
-	{	"warm",		TEMP_WARM,		true	},
-	{	"cool",		TEMP_COOL,		true	},
-	{	"cold",		TEMP_COLD,		true	}
+	{	"hot",		Temperature::Hot,		true	},
+	{	"warm",		Temperature::Warm,		true	},
+	{	"cool",		Temperature::Cool,		true	},
+	{	"cold",		Temperature::Cold,		true	}
 };
 
-const struct flag_type wind_table[MAX_WIND] =
+const struct flag_type wind_table[Windspeed::MaxWindspeed] =
 {
 	//	name		bit				settable
-	{	"calm",		WIND_CALM,		true	},
-	{	"breeze",	WIND_BREEZE,	true	},
-	{	"windy",	WIND_WINDY,		true	},
-	{	"gale",		WIND_GALE,		true	}
+	{	"calm",		Windspeed::Calm,		true	},
+	{	"breeze",	Windspeed::Breeze,	true	},
+	{	"windy",	Windspeed::Windy,		true	},
+	{	"gale",		Windspeed::Gale,		true	}
 };
 
 const struct restrict_type restrict_table[] =
@@ -1076,11 +1076,11 @@ const struct demon_type demon_table[] =
  *                                                    --Eladrian
  */
 
-const struct climate_type climate_table[MAX_CLIMATE] =
+const struct climate_type climate_table[Climate::MaxClimate] =
 {	
 	{	
 		"none",											// Climate name
-		CLIMATE_NONE,									// Climate number
+		Climate::None,									// Climate number
 		{												// Sky frequencies by season
 			{	0,	0,	0,	0,	0,	0,	0,	0,	0	},	//		Winter
 			{	0,	0,	0,	0,	0,	0,	0,	0,	0	},	//		Spring
@@ -1096,7 +1096,7 @@ const struct climate_type climate_table[MAX_CLIMATE] =
 	},
 	{
 		"temperate",
-		CLIMATE_TEMPERATE,
+		Climate::Temperate,
 		{
 			{	20,		40,		60,		60,		60,		 65,	 90,	 95,	100		},
 			{	20,		40,		60,		70,		80,		 90,	 97,	 98,	100		},
@@ -1112,7 +1112,7 @@ const struct climate_type climate_table[MAX_CLIMATE] =
 	},
 	{
 		"desert",
-		CLIMATE_DESERT,
+		Climate::Desert,
 		{
 			{	70,		 80,	 80,	 80,	 95,	100,	100,	100,	100		},
 			{	80,		 90,	 90,	 90,	 98,	100,	100,	100,	100		},
@@ -1128,7 +1128,7 @@ const struct climate_type climate_table[MAX_CLIMATE] =
 	},
 	{
 		"tropical",
-		CLIMATE_TROPICAL,
+		Climate::Tropical,
 		{
 			{	5,		10,		30,		50,		80,		100,	100,	100,	100		},
 			{	5,		10,		30,		50,		80,		100,	100,	100,	100		},
@@ -1144,7 +1144,7 @@ const struct climate_type climate_table[MAX_CLIMATE] =
 	},
 	{
 		"alpine",
-		CLIMATE_ALPINE,
+		Climate::Alpine,
 		{
 			{	20,		40,		60,		60,		60,		60,		70,		95,		100		},
 			{	20,		40,		60,		60,		60,		60,		80,		90,		100		},
@@ -1160,7 +1160,7 @@ const struct climate_type climate_table[MAX_CLIMATE] =
 	},
 	{
 		"tundra",
-		CLIMATE_TUNDRA,
+		Climate::Tundra,
 		{
 			{	30,		40,		50,		50,		50,		50,		70,		95,		100		},
 			{	30,		40,		50,		50,		50,		50,		80,		90,		100		},
@@ -1176,7 +1176,7 @@ const struct climate_type climate_table[MAX_CLIMATE] =
 	},
 	{
 		"subtropical",
-		CLIMATE_SUBTROPICAL,
+		Climate::Subtropical,
 		{
 			{	0,	0,	0,	0,	0,	0,	0,	0,	0	},
 			{	0,	0,	0,	0,	0,	0,	0,	0,	0	},
@@ -1192,7 +1192,7 @@ const struct climate_type climate_table[MAX_CLIMATE] =
 	},
 	{
 		"arid",
-		CLIMATE_ARID,
+		Climate::Arid,
 		{
 			{	30,		40,		 50,	 60,	 80,	 96,	 98,	 98,	100		},
 			{	50,		75,		 85,	 90,	 95,	100,	100,	100,	100		},
@@ -1208,7 +1208,7 @@ const struct climate_type climate_table[MAX_CLIMATE] =
 	},
 	{
 		"english",
-		CLIMATE_ENGLISH,
+		Climate::English,
 		{
 			{	0,	0,	0,	0,	0,	0,	0,	0,	0	},
 			{	0,	0,	0,	0,	0,	0,	0,	0,	0	},

--- a/code/tables.h
+++ b/code/tables.h
@@ -39,7 +39,7 @@
 #include <time.h>
 #include "merc.h"
 #include "material.h"
-
+#include "weather_enums.h"
 
 struct flag_type
 {
@@ -209,8 +209,8 @@ struct climate_type
 {
 	char *name;
 	sh_int number;
-	sh_int skyfreqs[NUM_SEASONS][MAX_SKY];
-	sh_int tempfreqs[NUM_SEASONS][MAX_TEMP];
+	sh_int skyfreqs[NUM_SEASONS][WeatherCondition::MaxWeatherCondition];
+	sh_int tempfreqs[NUM_SEASONS][Temperature::MaxTemperature];
 };
 
 struct demon_type
@@ -269,9 +269,9 @@ extern const struct flag_type room_flags[];
 extern const struct flag_type direction_table[];
 extern const struct flag_type exit_flags[];
 extern const struct flag_type area_type_table[];
-extern const struct flag_type sky_table[MAX_SKY];
-extern const struct flag_type temp_table[MAX_TEMP];
-extern const struct flag_type wind_table[MAX_WIND];
+extern const struct flag_type sky_table[WeatherCondition::MaxWeatherCondition];
+extern const struct flag_type temp_table[Temperature::MaxTemperature];
+extern const struct flag_type wind_table[Windspeed::MaxWindspeed];
 extern const struct restrict_type restrict_table[];
 extern const struct tribe_type tribe_table[];
 extern const char* day_name[];
@@ -284,7 +284,7 @@ extern const struct style_list style_percent[];
 extern const std::vector<cabal_list> cabal_skills;
 extern const struct flag_type wealth_table[];
 extern const struct demon_type demon_table[];
-extern const struct climate_type climate_table[MAX_CLIMATE];
+extern const struct climate_type climate_table[Climate::MaxClimate];
 extern const struct beauty_type beauty_table[];
 extern const struct order_list order_table[];
 extern const struct flag_type area_flags[];

--- a/code/update.c
+++ b/code/update.c
@@ -32,6 +32,7 @@
  ***************************************************************************/
 
 #include "update.h"
+#include "weather_enums.h"
 
 int save_number = 0;
 
@@ -927,7 +928,7 @@ void weather_update(void)
 	{
 		random = number_percent();
 
-		for (i = 0; i < MAX_SKY; i++)
+		for (i = 0; i < WeatherCondition::MaxWeatherCondition; i++)
 		{
 			if (random <= climate_table[area->climate].skyfreqs[season][i])
 			{
@@ -938,7 +939,7 @@ void weather_update(void)
 
 		random = number_percent();
 
-		for (i = 0; i < MAX_TEMP; i++)
+		for (i = 0; i < Temperature::MaxTemperature; i++)
 		{
 			if (random <= climate_table[area->climate].tempfreqs[season][i])
 			{
@@ -981,17 +982,19 @@ void weather_update(void)
 				area->temp = (area->sky + average) / 2;
 		}
 
-		if (area->sky >= SKY_FLURRY && area->temp < TEMP_COOL)
-			area->temp = TEMP_COOL;
+		if (area->sky >= WeatherCondition::SnowFlurry && area->temp < Temperature::Cool)
+			area->temp = Temperature::Cool;
 
-		if (area->sky == SKY_DOWNPOUR || area->sky == SKY_TSTORM || area->sky == SKY_BLIZZARD)
+		if (area->sky == WeatherCondition::Downpour
+				 || area->sky == WeatherCondition::ThunderStorm
+				 || area->sky == WeatherCondition::Blizzard)
 			area->wind++;
 
-		if (area->climate == CLIMATE_NONE)
+		if (area->climate == Climate::None)
 		{
-			area->sky = SKY_PCLOUDY;
-			area->temp = TEMP_WARM;
-			area->wind = WIND_CALM;
+			area->sky = WeatherCondition::PartlyCloudy;
+			area->temp = Temperature::Warm;
+			area->wind = Windspeed::Calm;
 		}
 	}
 
@@ -1000,31 +1003,31 @@ void weather_update(void)
 	{
 		switch (area->sky)
 		{
-			case SKY_CLEAR:
+			case WeatherCondition::Clear:
 				sprintf(buf, "There is not a cloud to be seen in the sky above.");
 				break;
-			case SKY_PCLOUDY:
+			case WeatherCondition::PartlyCloudy:
 				sprintf(buf, "A few clouds dot the skies above.");
 				break;
-			case SKY_OVERCAST:
+			case WeatherCondition::Overcast:
 				sprintf(buf, "A thick grey mass of clouds obscures the sky.");
 				break;
-			case SKY_DRIZZLE:
+			case WeatherCondition::Drizzle:
 				sprintf(buf, "A light drizzle falls from the sky.");
 				break;
-			case SKY_DOWNPOUR:
+			case WeatherCondition::Downpour:
 				sprintf(buf, "Sheets of rain pour down from the skies above.");
 				break;
-			case SKY_TSTORM:
+			case WeatherCondition::ThunderStorm:
 				sprintf(buf, "Lightning flashes in the distance as a booming peal of thunder approaches.");
 				break;
-			case SKY_FLURRY:
+			case WeatherCondition::SnowFlurry:
 				sprintf(buf, "Scattered snowflakes drift down from the skies above.");
 				break;
-			case SKY_BLIZZARD:
+			case WeatherCondition::Blizzard:
 				sprintf(buf, "Driving snow sweeps down from the skies as a chill fills the air.");
 				break;
-			case SKY_HAIL:
+			case WeatherCondition::Hail:
 				sprintf(buf, "Pebble-sized hailstones begin to fall from the skies.");
 				break;
 			default:

--- a/code/weather_enums.h
+++ b/code/weather_enums.h
@@ -1,0 +1,84 @@
+#ifndef WEATHER_ENUMS_H
+#define WEATHER_ENUMS_H
+
+// TEMP_HOT					0
+// TEMP_WARM					1
+// TEMP_COOL					2
+// TEMP_COLD					3
+// MAX_TEMP					4
+
+enum Temperature 
+{
+	Hot, 
+	Warm,
+	Cool,
+	Cold,
+	MaxTemperature // used for setting the max size of const tables, should always be last
+};
+
+// WIND_CALM					0
+// WIND_BREEZE					1
+// WIND_WINDY					2
+// WIND_GALE					3
+// MAX_WIND					4
+
+enum Windspeed 
+{
+	Calm,
+	Breeze,
+	Windy,
+	Gale,
+	MaxWindspeed // used for setting the max size of const tables, should always be last
+};
+
+// #define CLIMATE_NONE				0
+// #define CLIMATE_TEMPERATE			1
+// #define CLIMATE_DESERT				2
+// #define CLIMATE_TROPICAL			3
+// #define CLIMATE_ALPINE				4
+// #define CLIMATE_TUNDRA				5
+// #define CLIMATE_SUBTROPICAL			6
+// #define CLIMATE_ARID				7
+// #define CLIMATE_ENGLISH				8
+// #define MAX_CLIMATE					9
+
+enum Climate
+{
+	None,
+	Temperate,
+	Desert,
+	Tropical,
+	Alpine,
+	Tundra,
+	Subtropical,
+	Arid,
+	English,
+	MaxClimate // used for setting the max size of const tables, should always be last
+};
+
+// #define SKY_CLEAR					0
+// #define SKY_PCLOUDY					1
+// #define SKY_OVERCAST				2
+// #define SKY_DRIZZLE					3
+// #define SKY_DOWNPOUR				4
+// #define SKY_TSTORM					5
+// #define SKY_FLURRY					6
+// #define SKY_BLIZZARD				7
+// #define SKY_HAIL					8
+// #define MAX_SKY						9
+
+enum WeatherCondition
+{
+	Clear,
+	PartlyCloudy,
+	Overcast,
+	Drizzle,
+	Downpour,
+	ThunderStorm,
+	SnowFlurry,
+	Blizzard,
+	Hail,
+	MaxWeatherCondition // used for setting the max size of const tables, should always be last
+};
+
+#endif


### PR DESCRIPTION
Relocates all weather-related enums to `weather_enums.h` header and adjusts all references to rely on those enums now.