### PR TITLE
add support for stone items in create_object

### DIFF
--- a/code/db.c
+++ b/code/db.c
@@ -2272,6 +2272,7 @@ OBJ_DATA *create_object(OBJ_INDEX_DATA *pObjIndex, int level)
 		case ITEM_BOOK:
 		case ITEM_PEN:
 		case ITEM_ALTAR:
+		case ITEM_STONE:
 		case ITEM_CAMPFIRE:
 			break;
 		case ITEM_SCROLL:


### PR DESCRIPTION
Resolves vnum errors associated with ITEM_STONE value as reported in issue #129. 