### PR TITLE
More refactoring of prof

### DIFF
--- a/code/act_info.c
+++ b/code/act_info.c
@@ -4562,13 +4562,13 @@ char *get_descr_form(CHAR_DATA *ch, CHAR_DATA *looker, bool get_long)
 /* Replacement for the handler.c get_char_room to handle morph dragon */
 CHAR_DATA *get_char_room(CHAR_DATA *ch, char *argument)
 {
-	// TODO: the following will always be false since arg hasnt been given a value
 	char arg[MAX_INPUT_LENGTH];
+	auto count = 0;
+	auto number = number_argument(argument, arg);
+
 	if (!str_cmp(arg, "self"))
 		return ch;
 
-	auto count = 0;
-	auto number = number_argument(argument, arg);
 	for (auto rch = ch->in_room->people; rch != NULL; rch = rch->next_in_room)
 	{
 		if (argument[0] == '\0')
@@ -4591,13 +4591,13 @@ CHAR_DATA *get_char_room(CHAR_DATA *ch, char *argument)
 
 CHAR_DATA *get_char_from_room(CHAR_DATA *ch, ROOM_INDEX_DATA *room, char *argument)
 {
-	// TODO: the following will always be false since arg hasnt been given a value
 	char arg[MAX_INPUT_LENGTH];
+	auto count = 0;
+	auto number = number_argument(argument, arg);
+
 	if (!str_cmp(arg, "self"))
 		return ch;
 
-	auto count = 0;
-	auto number = number_argument(argument, arg);
 	for (auto rch = room->people; rch != NULL; rch = rch->next_in_room)
 	{
 		if (!can_see(ch, rch))

--- a/code/handler.c
+++ b/code/handler.c
@@ -4782,9 +4782,10 @@ void affect_strip_area(AREA_DATA *area, int sn)
 
 bool is_affected_area(AREA_DATA *area, int sn)
 {
-	AREA_AFFECT_DATA *paf;
+	if (area == nullptr)
+		return false;
 
-	for (paf = area->affected; paf != NULL; paf = paf->next)
+	for (auto paf = area->affected; paf != NULL; paf = paf->next)
 	{
 		if (paf->type == sn)
 			return true;

--- a/code/merc.h
+++ b/code/merc.h
@@ -2675,169 +2675,6 @@ struct aprog_data
 	char *myell_name;
 };
 
-extern CProficiencies prof_none; //empty proficiencies for jackasses who are going to ref ch->Profs() without checking IS_NPC
-
-//
-// One character (PC or NPC).
-//
-class	char_data
-{
-public:
-	CHAR_DATA *next;
-	CHAR_DATA *next_in_room;
-	CHAR_DATA *master;
-	CHAR_DATA *leader;
-	CHAR_DATA *fighting;
-	CHAR_DATA *reply;
-	CHAR_DATA *pet;
-	CHAR_DATA *last_fought;
-	int tracktimer;
-	time_t last_fight_time;
-	char * last_fight_name;
-	CHAR_DATA *hunting;
-	CHAR_DATA *defending;
-	MEM_DATA *memory;
-	GAME_FUN *game_fun;
-	MOB_INDEX_DATA *pIndexData;
-	DESCRIPTOR_DATA *desc;
-	AFFECT_DATA *affected;
-	NOTE_DATA *pnote;
-	OBJ_DATA *carrying;
-	OBJ_DATA *on;
-	ROOM_INDEX_DATA *in_room;
-	ROOM_INDEX_DATA *was_in_room;
-	AREA_DATA *zone;
-	PC_DATA *pcdata;
-	GEN_DATA *gen_data;
-	PATHFIND_DATA *path;	// For smart pathfinding/tracking.  Mob only.
-	PATHFIND_DATA *best;	// Stores best direction thus far.  Mob only.
-	bool valid;
-	char *name;
-	char *true_name;
-	long id;
-	sh_int version;
-	char *short_descr;
-	char *long_descr;
-	char *description;
-	char *prompt;
-	char *prefix;
-	sh_int group;
-	sh_int cabal;
-	sh_int sex;
-
-	CClass *Class()
-	{
-		return !my_class
-			? (pIndexData && pIndexData->Class()
-				? pIndexData->Class()
-				:  CClass::GetClass(CLASS_NONE))
-			: my_class;
-	}
-
-	void		SetClass(int nClassIndex)
-	{
-		my_class = CClass::GetClass(nClassIndex);
-	}
-
-	sh_int race;
-	sh_int level;
-	sh_int trust;
-	int played;
-	int lines;							// for the pager
-	time_t logon;
-	sh_int timer;
-	sh_int wait;
-	sh_int regen_rate;					// For imbue regeneration spell
-	int hit;
-	sh_int max_hit;
-	sh_int mana;
-	sh_int max_mana;
-	sh_int move;
-	sh_int max_move;
-	long gold;
-	long gold_bank;
-	int exp;
-	long act[MAX_BITVECTOR];
-	long comm[MAX_BITVECTOR];			// RT added to pad the vector
-	long wiznet[MAX_BITVECTOR];			// wiz stuff
-	long imm_flags[MAX_BITVECTOR];
-	long res_flags[MAX_BITVECTOR];
-	long vuln_flags[MAX_BITVECTOR];
-	sh_int invis_level;
-	sh_int incog_level;
-	long affected_by[MAX_BITVECTOR];
-	sh_int position;
-	sh_int practice;
-	sh_int train;
-	sh_int carry_weight;
-	sh_int carry_number;
-	sh_int saving_throw;				//svs
-	sh_int alignment;
-	sh_int hitroll;
-	sh_int damroll;
-	sh_int armor[4];
-	sh_int wimpy;
-	char *speechbuf[10];				// Buffer for various mob speech, progs, etc...
-
-	//
-	// stats
-	//
-
-	sh_int perm_stat[MAX_STATS];
-	sh_int mod_stat[MAX_STATS];
-
-	//
-	// parts stuff
-	//
-
-	long form[MAX_BITVECTOR];
-	long parts[MAX_BITVECTOR];
-	sh_int size;
-	char *material;
-
-	//
-	// mobile stuff
-	//
-
-	ROOM_INDEX_DATA *home_room;
-	int mobstyle;
-	long off_flags[MAX_BITVECTOR];
-	sh_int damage[3];
-	sh_int dam_type;
-	sh_int start_pos;
-	sh_int pause;
-	sh_int ghost;
-	int status;
-	long progtypes[MAX_BITVECTOR];
-	int hometown;
-	float dam_mod;
-	sh_int defense_mod;
-	bool moved;
-
-	//
-	// skill/spell-specific stuff
-	//
-
-	sh_int arms;
-	sh_int legs;
-	sh_int balance;
-	sh_int batter;
-	CHAR_DATA *analyzePC;
-	int analyze;
-	sh_int pulseTimer;					// counter for racial combat pulse
-	char *backup_true_name;				// Dev's SUPAR CLEVAR CORRUPTION FIX!!!
-	float talismanic;
-	bool disrupted;						// Has queue-using spell been disrupted?
-	int bounty_timer;
-	bool law_pass;
-	bool stolen_from;
-	CProficiencies *Profs();
-private:
-	CClass *	my_class;
-};
-
-
-
 //
 // Data which only PC's have.
 //
@@ -3279,6 +3116,170 @@ struct pathfind_data
 	int steps;							// Number of steps from parent node
 	PATHFIND_DATA *prev;				// Room we came from
 	PATHFIND_DATA *dir_to[6];			// Points to up to 6 rooms, NEWSUD.
+};
+
+
+//
+// One character (PC or NPC).
+//
+
+
+extern CProficiencies prof_none; //empty proficiencies for jackasses who are going to ref ch->Profs() without checking IS_NPC
+
+class	char_data
+{
+public:
+	CHAR_DATA *next;
+	CHAR_DATA *next_in_room;
+	CHAR_DATA *master;
+	CHAR_DATA *leader;
+	CHAR_DATA *fighting;
+	CHAR_DATA *reply;
+	CHAR_DATA *pet;
+	CHAR_DATA *last_fought;
+	int tracktimer;
+	time_t last_fight_time;
+	char * last_fight_name;
+	CHAR_DATA *hunting;
+	CHAR_DATA *defending;
+	MEM_DATA *memory;
+	GAME_FUN *game_fun;
+	MOB_INDEX_DATA *pIndexData;
+	DESCRIPTOR_DATA *desc;
+	AFFECT_DATA *affected;
+	NOTE_DATA *pnote;
+	OBJ_DATA *carrying;
+	OBJ_DATA *on;
+	ROOM_INDEX_DATA *in_room;
+	ROOM_INDEX_DATA *was_in_room;
+	AREA_DATA *zone;
+	PC_DATA *pcdata;
+	GEN_DATA *gen_data;
+	PATHFIND_DATA *path;	// For smart pathfinding/tracking.  Mob only.
+	PATHFIND_DATA *best;	// Stores best direction thus far.  Mob only.
+	bool valid;
+	char *name;
+	char *true_name;
+	long id;
+	sh_int version;
+	char *short_descr;
+	char *long_descr;
+	char *description;
+	char *prompt;
+	char *prefix;
+	sh_int group;
+	sh_int cabal;
+	sh_int sex;
+
+	CClass *Class()
+	{
+		return !my_class
+			? (pIndexData && pIndexData->Class()
+				? pIndexData->Class()
+				:  CClass::GetClass(CLASS_NONE))
+			: my_class;
+	}
+
+	void		SetClass(int nClassIndex)
+	{
+		my_class = CClass::GetClass(nClassIndex);
+	}
+
+	sh_int race;
+	sh_int level;
+	sh_int trust;
+	int played;
+	int lines;							// for the pager
+	time_t logon;
+	sh_int timer;
+	sh_int wait;
+	sh_int regen_rate;					// For imbue regeneration spell
+	int hit;
+	sh_int max_hit;
+	sh_int mana;
+	sh_int max_mana;
+	sh_int move;
+	sh_int max_move;
+	long gold;
+	long gold_bank;
+	int exp;
+	long act[MAX_BITVECTOR];
+	long comm[MAX_BITVECTOR];			// RT added to pad the vector
+	long wiznet[MAX_BITVECTOR];			// wiz stuff
+	long imm_flags[MAX_BITVECTOR];
+	long res_flags[MAX_BITVECTOR];
+	long vuln_flags[MAX_BITVECTOR];
+	sh_int invis_level;
+	sh_int incog_level;
+	long affected_by[MAX_BITVECTOR];
+	sh_int position;
+	sh_int practice;
+	sh_int train;
+	sh_int carry_weight;
+	sh_int carry_number;
+	sh_int saving_throw;				//svs
+	sh_int alignment;
+	sh_int hitroll;
+	sh_int damroll;
+	sh_int armor[4];
+	sh_int wimpy;
+	char *speechbuf[10];				// Buffer for various mob speech, progs, etc...
+
+	//
+	// stats
+	//
+
+	sh_int perm_stat[MAX_STATS];
+	sh_int mod_stat[MAX_STATS];
+
+	//
+	// parts stuff
+	//
+
+	long form[MAX_BITVECTOR];
+	long parts[MAX_BITVECTOR];
+	sh_int size;
+	char *material;
+
+	//
+	// mobile stuff
+	//
+
+	ROOM_INDEX_DATA *home_room;
+	int mobstyle;
+	long off_flags[MAX_BITVECTOR];
+	sh_int damage[3];
+	sh_int dam_type;
+	sh_int start_pos;
+	sh_int pause;
+	sh_int ghost;
+	int status;
+	long progtypes[MAX_BITVECTOR];
+	int hometown;
+	float dam_mod;
+	sh_int defense_mod;
+	bool moved;
+
+	//
+	// skill/spell-specific stuff
+	//
+
+	sh_int arms;
+	sh_int legs;
+	sh_int balance;
+	sh_int batter;
+	CHAR_DATA *analyzePC;
+	int analyze;
+	sh_int pulseTimer;					// counter for racial combat pulse
+	char *backup_true_name;				// Dev's SUPAR CLEVAR CORRUPTION FIX!!!
+	float talismanic;
+	bool disrupted;						// Has queue-using spell been disrupted?
+	int bounty_timer;
+	bool law_pass;
+	bool stolen_from;
+	CProficiencies *Profs() { return pcdata ? &pcdata->profs : &prof_none; }
+private:
+	CClass *	my_class;
 };
 
 //

--- a/code/prof.c
+++ b/code/prof.c
@@ -65,10 +65,10 @@ const std::vector<prof_cmd_type> CProficiencies::prof_cmd_table =
 	// name,		cmd,			requires
 	{ "butcher",	prof_butcher,	"butchery"		},
 	{ "bandage",	prof_bandage,	"bandaging"		},
-	{ "appraise",	prof_appraise,	"appraise"		},
-	{ "cook",		prof_cook,		"cook"			},
+	{ "appraise",	prof_appraise,	"appraising"	},
+	{ "cook",		prof_cook,		"cooking"		},
 	{ "firestart",	prof_firestart, "firestarting"	},
-	{ "track",		prof_tracking,	"track"			}
+	{ "track",		prof_tracking,	"tracking"		}
 };
 
 //last entry in each one should be null
@@ -890,9 +890,15 @@ void do_proficiencies(CHAR_DATA *ch, char *argument)
 /// @param argument: The target of the tracking.
 void prof_tracking(CHAR_DATA *ch, char *argument)
 {
-	if (is_affected_prof(ch, "tracking"))
+	if (ch == nullptr)
 	{
-		send_to_char("You cannot attempt to track them again yet.\n\r",ch);
+		bug("prof_bandage: ch is nullptr");
+		return;
+	}
+
+	if (argument == nullptr)
+	{
+		send_to_char("Track who?\n\r",ch);
 		return;
 	}
 
@@ -902,7 +908,13 @@ void prof_tracking(CHAR_DATA *ch, char *argument)
 		send_to_char("Track who?\n\r",ch);
 		return;
 	}
-	
+
+	if (is_affected_prof(ch, "tracking"))
+	{
+		send_to_char("You cannot attempt to track them again yet.\n\r",ch);
+		return;
+	}
+
 	auto sect = ch->in_room->sector_type;
 	if (!IS_GROUND(ch->in_room) || sect == SECT_CITY || sect == SECT_INSIDE || sect == SECT_BURNING || sect == SECT_ROAD)
 	{
@@ -937,7 +949,7 @@ void prof_tracking(CHAR_DATA *ch, char *argument)
 			? ch->in_room->tracks[i]->direction
 			: number_range(0, MAX_DIR - 1);
 
-		direction = flag_name_lookup(diruse,direction_table);
+		direction = flag_name_lookup(diruse, direction_table);
 
 		buffer = std::string("From the pattern of tracks here, you suspect $N left $t.");
 	}

--- a/code/prof.c
+++ b/code/prof.c
@@ -204,11 +204,6 @@ sh_int psn_none;
 sh_int psn_swimming;
 sh_int psn_mountaineering;
 
-CProficiencies * char_data::Profs()
-{
-	return pcdata ? &pcdata->profs : &prof_none;
-}
-
 CProficiencies::CProficiencies()
 {
 	ch = 0;

--- a/code/prof.c
+++ b/code/prof.c
@@ -60,7 +60,6 @@ const std::vector<proficiency_type> CProficiencies::prof_table =
 	{ &psn_none,			"tracking",					30,		30,			NULL,		PFLAGS_NONE		}
 };
 
-//TODO: bring prof_cmd_type from tables.h over to prof.h
 const std::vector<prof_cmd_type> prof_cmd_table =
 {
 	// name,		cmd,			requires

--- a/code/prof.c
+++ b/code/prof.c
@@ -60,7 +60,7 @@ const std::vector<proficiency_type> CProficiencies::prof_table =
 	{ &psn_none,			"tracking",					30,		30,			NULL,		PFLAGS_NONE		}
 };
 
-const std::vector<prof_cmd_type> prof_cmd_table =
+const std::vector<prof_cmd_type> CProficiencies::prof_cmd_table =
 {
 	// name,		cmd,			requires
 	{ "butcher",	prof_butcher,	"butchery"		},
@@ -72,7 +72,7 @@ const std::vector<prof_cmd_type> prof_cmd_table =
 };
 
 //last entry in each one should be null
-const struct proficiency_msg prof_msg_table [] =
+const struct proficiency_msg CProficiencies::prof_msg_table [] =
 {
 	// swimming
 	{

--- a/code/prof.c
+++ b/code/prof.c
@@ -30,17 +30,6 @@
 #define OBJ_VNUM_MEAT_CHUNKS	75
 #define OBJ_VNUM_CAMPFIRE		76
 
-void add_prof_affect(CHAR_DATA *ch, char *name, int duration, bool fInvis);
-bool is_affected_prof(CHAR_DATA *ch, char *prof);
-void do_proficiencies(CHAR_DATA *ch, char *argument);
-void prof_tracking(CHAR_DATA *ch, char *argument);
-void build_fire(CHAR_DATA *ch, int dur);
-void prof_firestart(CHAR_DATA *ch, char *argument);
-void prof_cook(CHAR_DATA *ch, char *argument);
-void prof_appraise(CHAR_DATA *ch, char *argument);
-void prof_butcher(CHAR_DATA *ch, char *argument);
-void prof_bandage(CHAR_DATA *ch, char *argument);
-
 const std::vector<prof_level_type> CProficiencies::prof_level_table =
 {
 	// name,				level

--- a/code/prof.c
+++ b/code/prof.c
@@ -1110,6 +1110,18 @@ void prof_butcher(CHAR_DATA *ch, char *argument)
 /// @param argument: The character to bandage.
 void prof_bandage(CHAR_DATA *ch, char *argument)
 {
+	if (argument == nullptr)
+	{
+		if (ch != nullptr)
+		{
+			send_to_char("They aren't here.\n\r", ch);
+			return;
+		}
+
+		bug("prof_bandage: argument is nullptr");
+		return;
+	}
+
 	auto victim = argument[0] != '\0'
 		? get_char_room(ch, argument)
 		: ch;

--- a/code/prof.c
+++ b/code/prof.c
@@ -1110,21 +1110,15 @@ void prof_butcher(CHAR_DATA *ch, char *argument)
 /// @param argument: The character to bandage.
 void prof_bandage(CHAR_DATA *ch, char *argument)
 {
-	if (argument == nullptr)
+	if (ch == nullptr)
 	{
-		if (ch != nullptr)
-		{
-			send_to_char("They aren't here.\n\r", ch);
-			return;
-		}
-
-		bug("prof_bandage: argument is nullptr");
+		bug("prof_bandage: ch is nullptr");
 		return;
 	}
 
-	auto victim = argument[0] != '\0'
-		? get_char_room(ch, argument)
-		: ch;
+	auto victim = argument == nullptr || argument[0] == '\0'
+		? get_char_room(ch, "self")
+		: get_char_room(ch, argument);
 
 	if (!victim)
 	{

--- a/code/prof.h
+++ b/code/prof.h
@@ -112,6 +112,8 @@ private:
 	int profs[MAX_PROFS];
 	static const std::vector<prof_level_type> prof_level_table;
 	static const std::vector<proficiency_type> prof_table;
+	static const std::vector<prof_cmd_type> prof_cmd_table;
+	static const struct proficiency_msg prof_msg_table [MAX_PROFS];
 };
 
 #endif /* PROF_H */

--- a/code/prof.h
+++ b/code/prof.h
@@ -7,10 +7,9 @@
 
 // TODO: these are defined in utility.h as regular functions but for some reason the compiler freaks out
 // TODO: so leaving them as macros for the time being
-//#define IS_SET(flag, bit)			((flag[(int)(bit/32)]) & ((long)pow(2,(bit % 32))))
 #define IS_NPC(ch)					(IS_SET(ch->act, ACT_IS_NPC))
 #define IS_GROUND(room)				(room->sector_type != SECT_AIR && room->sector_type != SECT_WATER && room->sector_type != SECT_UNDERWATER && room->sector_type != SECT_VERTICAL)
-//
+
 
 #define PFLAGS_NONE 0
 #define PFLAGS_BASIC 1
@@ -18,7 +17,10 @@
 #define MAX_PROFS 25
 
 
-typedef short int sh_int;
+struct char_data;										
+typedef struct char_data CHAR_DATA;						// mirrored definition from merc.h
+typedef void DO_FUN (CHAR_DATA *ch, char *argument);	// mirrored definition from merc.h
+typedef short int sh_int;								// mirrored definition from merc.h
 
 struct proficiency_type
 {
@@ -41,8 +43,13 @@ struct proficiency_msg
 	char *learning_msgs[5];
 };
 
-struct char_data;
-typedef struct char_data CHAR_DATA;
+struct prof_cmd_type
+{
+	char *name;
+	DO_FUN *cmd;
+	char *requires;
+};
+
 
 extern char *format_string (char *oldstring);
 extern sh_int psn_none;

--- a/code/prof.h
+++ b/code/prof.h
@@ -42,11 +42,24 @@ struct proficiency_msg
 };
 
 struct char_data;
+typedef struct char_data CHAR_DATA;
 
 extern char *format_string (char *oldstring);
 extern sh_int psn_none;
 extern sh_int psn_swimming;
 extern sh_int psn_mountaineering;
+
+void add_prof_affect(CHAR_DATA *ch, char *name, int duration, bool fInvis);
+bool is_affected_prof(CHAR_DATA *ch, char *prof);
+void do_proficiencies(CHAR_DATA *ch, char *argument);
+void prof_tracking(CHAR_DATA *ch, char *argument);
+void build_fire(CHAR_DATA *ch, int dur);
+void prof_firestart(CHAR_DATA *ch, char *argument);
+void prof_cook(CHAR_DATA *ch, char *argument);
+void prof_appraise(CHAR_DATA *ch, char *argument);
+void prof_butcher(CHAR_DATA *ch, char *argument);
+void prof_bandage(CHAR_DATA *ch, char *argument);
+
 
 class CProficiencies
 {

--- a/code/tables.h
+++ b/code/tables.h
@@ -227,13 +227,6 @@ struct order_list
 	char * command;
 };
 
-struct prof_cmd_type
-{
-	char *name;
-	DO_FUN *cmd;
-	char *requires;
-};
-
 extern const struct flag_type aftype_table[];
 extern const struct display_type apply_locations[];
 extern const struct mod_name_type mod_names[];

--- a/tests/prof_tests.c
+++ b/tests/prof_tests.c
@@ -1468,25 +1468,6 @@ SCENARIO("Attempt to bandage a character", "[prof_bandage]")
 
 	GIVEN("a player has the bandaging proficiency")
 	{
-		WHEN("the player tries issuing a bandage command with no target")
-		{
-			auto player = new char_data();
-			TestHelperSetupPlayerBuffer(player);
-
-			player->Profs()->SetChar(player);
-			player->Profs()->SetProf(3, 1);
-
-			THEN("it should display a message notifying the player")
-			{
-				player->Profs()->InterpCommand("bandage", nullptr);
-				auto result = !str_cmp(player->desc->outbuf,"\n\rThey aren't here.\n\r");
-
-				REQUIRE(result == true);
-			}
-
-			TestHelperCleanupPlayerObject(player);
-		}
-
 		WHEN("the player tries bandaging themselve while not bleeding")
 		{
 			auto player = new char_data();

--- a/tests/prof_tests.c
+++ b/tests/prof_tests.c
@@ -1313,8 +1313,50 @@ SCENARIO("testing interpreting proficiency commands", "[InterpCommand]")
 	}
 }
 
-// TODO: write tests
-// bool is_affected_prof(CHAR_DATA *ch, char *prof)
+SCENARIO("Determine if a player is affected by a proficiency affect", "[is_affected_prof]")
+{
+	GIVEN("a player not under the effects of an affect")
+	{
+		WHEN("the function is called")
+		{
+			auto player = new char_data();
+			TestHelperSetupPlayerBuffer(player);
+
+			player->Profs()->SetChar(player);
+			//add_prof_affect(player, "bandage", 2, false);
+
+			THEN("it should return false")
+			{
+				auto result = is_affected_prof(player, "bandage");
+
+				REQUIRE(result == false);
+			}
+
+			TestHelperCleanupPlayerObject(player);
+		}
+	}
+
+	GIVEN("a player under the effects of an affect")
+	{
+		WHEN("the function is called")
+		{
+			auto player = new char_data();
+			TestHelperSetupPlayerBuffer(player);
+
+			player->Profs()->SetChar(player);
+			add_prof_affect(player, "bandage", 2, false);
+
+			THEN("it should return true")
+			{
+				auto result = is_affected_prof(player, "bandage");
+
+				REQUIRE(result == true);
+			}
+
+			TestHelperCleanupPlayerObject(player);
+		}
+	}
+}
 
 // TODO: write tests
 // void do_proficiencies(CHAR_DATA *ch, char *argument)

--- a/tests/test_helpers.c
+++ b/tests/test_helpers.c
@@ -1,7 +1,7 @@
 #include "../code/merc.h"
 #include "../code/prof.h"
 
-void TestHelperSetupPlayerBuffer(CHAR_DATA *player, char *name = "player1")
+void TestHelperSetupPlayerBuffer(CHAR_DATA *player, char *name = "player1", char *room_name = "room1")
 {
 	player->name = name;
 	player->pcdata = new pc_data();
@@ -10,6 +10,8 @@ void TestHelperSetupPlayerBuffer(CHAR_DATA *player, char *name = "player1")
 	player->desc->outtop = 0;
 	player->desc->fcommand = false;
 	player->desc->outsize = 2;
+	player->in_room = new room_index_data();
+	player->in_room->name = room_name;
 }
 
 void TestHelperSetupTrainer(CHAR_DATA *trainer, char *name = "trainer1")


### PR DESCRIPTION
This PR cleans up a number of issues with prof and adds more tests.

- Moved structs and functions related to prof in other files back in the prof files.
- Fixed a linking issue between prof_table and prof_cmd_table
- Moved a related vectors/arrays into the `CProficiencies` class. These were already in the prof files; just needed to add them to the class proper.
- Moved function declarations into the header file.
- Added tests. (Still missing a few prof_ function tests).