### PR TITLE
group ban functions and structures

### DIFF
--- a/code/ban.c
+++ b/code/ban.c
@@ -45,21 +45,27 @@
 #include "db.h"
 #include "./include/fmt/format.h"
 
+#define BAN_FILE RIFT_AREA_DIR "/ban.txt"
+
+
+/// Determines if a player has been banned.
+/// @param usite: The IP address or DNS name of the computer that the player uses to connect.
+/// @param type: The type of ban in place. Valid input is either NBAN_ALL or NBAN_NEWBIE.
+/// @param host: The type of host defined in usite. Valid input is either NBAN_IP or NBAN_HOST.
+/// @returns true if the player has been ban; false otherwise.
 bool check_ban(char *usite, int type, int host)
 {
-	BAN_DATA *pban;
 	char site[MSL];
-	CRow row;
 
 	strcpy(site, capitalize(usite));
 	site[0] = LOWER(site[0]);
 
-	int res = RS.SQL.Select("site,duration FROM bans WHERE ban_type=%d AND host_type=%d", type, host);
+	auto res = RS.SQL.Select("site,duration FROM bans WHERE ban_type=%d AND host_type=%d", type, host);
 	if (res)
 	{
 		while (!RS.SQL.End())
 		{
-			row = RS.SQL.GetRow();
+			auto row = RS.SQL.GetRow();
 			if (strstr(site, row[0]) != NULL)
 			{
 				auto buffer = fmt::format("BANNED - {} just tried to connect.", site); //TODO: change the rest of the sprintf calls to format
@@ -72,13 +78,19 @@ bool check_ban(char *usite, int type, int host)
 	return false;
 }
 
+/// Bans a player from the game.
+///
+/// NOTE: If the argument equals "show" then it prints out the current list of bans.
+/// @param ch: The character that is banning the player.
+/// @param argument: A list of arguments related to the player being banned including ip/host name, ban type, duration and reason.
 void do_ban(CHAR_DATA *ch, char *argument)
 {
+	//TODO: This is function really needs to be two functions. One to perform bans and the other to list bans.
+
 	char buf[MSL];
 	char arg1[MSL], arg2[MSL], arg3[MSL], arg4[MSL], date[MSL];
 	BUFFER *buffer;
 	int ban_type = 0, host_type = 0, res, duration = 0;
-	CRow row;
 
 	argument = one_argument(argument, arg1);
 	argument = one_argument(argument, arg2);
@@ -98,7 +110,7 @@ void do_ban(CHAR_DATA *ch, char *argument)
 
 			while (!RS.SQL.End())
 			{
-				row = RS.SQL.GetRow();
+				auto row = RS.SQL.GetRow();
 
 				sprintf(buf, "%-25s\t%-10s\t%-10s\t%-10s\t%-10s\t%-10s\n\r",
 					row[0],
@@ -174,19 +186,18 @@ void do_ban(CHAR_DATA *ch, char *argument)
 	}
 }
 
+/// Unbans a player from the game.
+/// @param ch: The character that is unbanning the player.
+/// @param argument: The IP address or DNS name of the computer that the player uses to connect.
 void do_unban(CHAR_DATA *ch, char *argument)
 {
-	char arg[MAX_INPUT_LENGTH];
-	char buf[MAX_STRING_LENGTH];
-	int res = 0;
-
 	if (argument[0] == '\0')
 	{
 		send_to_char("Remove which site from the ban list?\n\r", ch);
 		return;
 	}
 
-	res = RS.SQL.Delete("bans WHERE site LIKE \'%%%s%%\'", argument);
+	auto res = RS.SQL.Delete("bans WHERE site LIKE \'%%%s%%\'", argument);
 	if (res)
 		send_to_char("Site unbanned.\n\r", ch);
 	else

--- a/code/ban.h
+++ b/code/ban.h
@@ -2,6 +2,38 @@
 #define BAN_H
 
 #include "merc.h"
+#include "newmem.h"
+
+//
+// Site ban structure.
+//
+
+#define BAN_SUFFIX					A
+#define BAN_PREFIX					B
+#define BAN_NEWBIES					C
+#define BAN_ALL						D
+#define BAN_PERMIT					E
+#define BAN_PERMANENT				F
+
+//
+// New ban defines
+//
+
+#define NBAN_ALL					0
+#define NBAN_NEWBIE					1
+
+#define NBAN_IP						1
+#define NBAN_HOST					0
+
+typedef struct ban_data BAN_DATA;
+struct ban_data
+{
+	BAN_DATA *next;
+	bool valid;
+	long ban_flags[MAX_BITVECTOR];
+	sh_int level;
+	char *name;
+};
 
 //
 // LOCAL FUNCTIONS

--- a/code/merc.h
+++ b/code/merc.h
@@ -128,7 +128,6 @@ int remove();
 
 typedef struct affect_data		AFFECT_DATA;
 typedef struct area_data		AREA_DATA;
-typedef struct ban_data			BAN_DATA;
 typedef struct buf_type			BUFFER;
 typedef struct char_data		CHAR_DATA;
 typedef struct descriptor_data	DESCRIPTOR_DATA;
@@ -423,36 +422,6 @@ typedef void APROG_FUN_MYELL (AREA_DATA *area, CHAR_DATA *ch, CHAR_DATA *victim)
 
 #define NOTE_UNSTARTED				0
 #define NOTE_IN_PROGRESS			1
-
-//
-// Site ban structure.
-//
-
-#define BAN_SUFFIX					A
-#define BAN_PREFIX					B
-#define BAN_NEWBIES					C
-#define BAN_ALL						D
-#define BAN_PERMIT					E
-#define BAN_PERMANENT				F
-
-//
-// New ban defines
-//
-
-#define NBAN_ALL					0
-#define NBAN_NEWBIE					1
-
-#define NBAN_IP						1
-#define NBAN_HOST					0
-
-struct ban_data
-{
-	BAN_DATA *next;
-	bool valid;
-	long ban_flags[MAX_BITVECTOR];
-	sh_int level;
-	char *name;
-};
 
 struct buf_type
 {
@@ -3383,7 +3352,6 @@ extern QUEUE_DATA *global_queue;
 #define PENALTY_FILE				RIFT_AREA_DIR "/penal.not"
 #define NEWS_FILE					RIFT_AREA_DIR "/news.not"
 #define CHANGES_FILE				RIFT_AREA_DIR "/chang.not"
-#define BAN_FILE					RIFT_AREA_DIR "/ban.txt"
 #define MULT_EXP					5
 
 //**********************************************

--- a/code/recycle.c
+++ b/code/recycle.c
@@ -56,7 +56,6 @@
 const int buf_size[MAX_BUF_LIST] = {16, 32, 64, 128, 256, 1024, 2048, 4096, 8192, 16384};
 
 NOTE_DATA *note_free;
-BAN_DATA *ban_free;
 DESCRIPTOR_DATA *descriptor_free;
 GEN_DATA *gen_data_free;
 EXTRA_DESCR_DATA *extra_descr_free;
@@ -110,41 +109,6 @@ void free_note(NOTE_DATA *note)
 	note->valid = false;
 	note->next = note_free;
 	note_free = note;
-}
-
-/* stuff for recycling ban structures */
-BAN_DATA *new_ban(void)
-{
-	static BAN_DATA ban_zero;
-	BAN_DATA *ban;
-
-	if (ban_free == NULL)
-	{
-		ban = new BAN_DATA;
-	}
-	else
-	{
-		ban = ban_free;
-		ban_free = ban_free->next;
-	}
-
-	*ban = ban_zero;
-
-	ban->valid = true;
-	ban->name = &str_empty[0];
-	return ban;
-}
-
-void free_ban(BAN_DATA *ban)
-{
-	if (!(ban != NULL && ban->valid))
-		return;
-
-	free_pstring(ban->name);
-
-	ban->valid = false;
-	ban->next = ban_free;
-	ban_free = ban;
 }
 
 /* stuff for recycling descriptors */

--- a/code/recycle.h
+++ b/code/recycle.h
@@ -64,9 +64,6 @@ extern PC_DATA *pcdata_free;
 /* note recycling */
 NOTE_DATA *new_note(void);
 void free_note(NOTE_DATA *note);
-/* ban data recycling */
-BAN_DATA *new_ban(void);
-void free_ban(BAN_DATA *ban);
 /* descriptor recycling */
 DESCRIPTOR_DATA *new_descriptor(void);
 void free_descriptor(DESCRIPTOR_DATA *d);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -21,6 +21,7 @@ set(TEST_SRC_FILES act_obj_tests.c
 	standalone_tests.c
 	update_tests.c
 	test_helpers.c
+	ban_tests.c
 )
 
 ##

--- a/tests/ban_tests.c
+++ b/tests/ban_tests.c
@@ -1,0 +1,16 @@
+#include "catch.hpp"
+#include "../code/merc.h"
+#include "../code/ban.h"
+
+// TODO: These functions rely on database calls. Need to find a good c++ mocking framework for databases.
+
+// TODO: write tests
+//bool check_ban(char *usite, int type, int host)
+
+// TODO: write tests
+//void do_ban (CHAR_DATA *ch, char *argument);
+
+// TODO: write tests
+//void do_unban (CHAR_DATA *ch, char *argument);
+
+


### PR DESCRIPTION
This PR groups the ban functions and structures into the `ban.c`/`ban.h` files. It also removes a couple of unused functions. Also added missing documentation comments.
