### PR TITLE
group note functions and structures

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -59,6 +59,26 @@
             }
         },
         {
+            "name": "Ban Tests Launch",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceRoot}/tests/ban_tests",
+            "args": [],
+            "stopAtEntry": false,
+            "cwd": "${workspaceRoot}/tests/",
+            "environment": [],
+            "linux": {
+                "MIMode": "gdb",
+                "miDebuggerPath": "/usr/bin/gdb"
+            },
+            "osx": {
+                "MIMode": "lldb"
+            },
+            "windows": {
+                "MIMode": "gdb"
+            }
+        },
+        {
             "name": "Cabal Tests Launch",
             "type": "cppdbg",
             "request": "launch",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -179,6 +179,26 @@
             }
         },
         {
+            "name": "Note Tests Launch",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceRoot}/tests/note_tests",
+            "args": [],
+            "stopAtEntry": false,
+            "cwd": "${workspaceRoot}/tests/",
+            "environment": [],
+            "linux": {
+                "MIMode": "gdb",
+                "miDebuggerPath": "/usr/bin/gdb"
+            },
+            "osx": {
+                "MIMode": "lldb"
+            },
+            "windows": {
+                "MIMode": "gdb"
+            }
+        },
+        {
             "name": "Prof Tests Launch",
             "type": "cppdbg",
             "request": "launch",

--- a/code/ban.h
+++ b/code/ban.h
@@ -4,6 +4,19 @@
 #include "merc.h"
 #include "newmem.h"
 
+//	== table layout ==
+//	CREATE TABLE `bans` (
+//		`site` varchar(254) NOT NULL default '',
+//		`by` varchar(50) NOT NULL default '',
+//		`reason` varchar(100) NOT NULL default '',
+//		`date` datetime default NULL,
+//		`duration` bigint(20) NOT NULL default '0',
+//		`ban_type` int(11) NOT NULL default '0',
+//		`host_type` int(11) NOT NULL default '0'
+//	) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+
+
+
 //
 // Site ban structure.
 //

--- a/code/merc.h
+++ b/code/merc.h
@@ -139,7 +139,6 @@ typedef struct mem_data			MEM_DATA;
 typedef struct mob_index_data	MOB_INDEX_DATA;
 typedef struct speech_data		SPEECH_DATA;
 typedef struct line_data		LINE_DATA;
-typedef struct note_data		NOTE_DATA;
 typedef struct obj_data			OBJ_DATA;
 typedef struct obj_index_data	OBJ_INDEX_DATA;
 typedef struct pc_data			PC_DATA;
@@ -716,31 +715,6 @@ struct old_char
 	OLD_CHAR *next;
 	OBJ_DATA *carrying;
 };
-
-//
-// Data structure for notes.
-//
-
-#define NOTE_NOTE					0
-#define NOTE_IDEA					1
-#define NOTE_PENALTY				2
-#define NOTE_NEWS					3
-#define NOTE_CHANGES				4
-
-struct note_data
-{
-	NOTE_DATA *next;
-	bool valid;
-	sh_int type;
-	char *sender;
-	char *date;
-	char *to_list;
-	char *subject;
-	char *text;
-	time_t date_stamp;
-};
-
-
 
 //
 // An affect.
@@ -3087,6 +3061,8 @@ struct pathfind_data
 	PATHFIND_DATA *dir_to[6];			// Points to up to 6 rooms, NEWSUD.
 };
 
+struct note_data;
+typedef struct note_data NOTE_DATA;
 
 //
 // One character (PC or NPC).
@@ -3347,7 +3323,6 @@ extern QUEUE_DATA *global_queue;
 #define BUG_FILE					RIFT_AREA_DIR "/bugs.txt"					// For 'bug' and bug()
 #define TYPO_FILE					RIFT_AREA_DIR "/typos.txt"					// For 'typo'
 #define IDEAS_FILE					RIFT_AREA_DIR "/ideas.txt"					// For ideas!
-#define NOTE_FILE					RIFT_AREA_DIR "/notes.not"					// For 'notes'
 #define IDEA_FILE					RIFT_AREA_DIR "/ideas.not"
 #define PENALTY_FILE				RIFT_AREA_DIR "/penal.not"
 #define NEWS_FILE					RIFT_AREA_DIR "/news.not"

--- a/code/note.h
+++ b/code/note.h
@@ -1,14 +1,44 @@
 #ifndef NOTE_H
 #define NOTE_H
 
-
 #include <stdio.h>
 #include "merc.h"
+#include "prof.h"
 
-//#include "prof.h"
-extern void add_prof_affect(CHAR_DATA *ch, char *name, int duration, bool fInvis);
-extern bool is_affected_prof(CHAR_DATA *ch, char *prof);
+//	== table layout ==
+//	CREATE TABLE `notes` (
+//		`type` tinyint(4) default NULL,
+//		`sender` tinytext,
+//		`date` tinytext,
+//		`to_list` tinytext,
+//		`subject` tinytext,
+//		`message` text,
+//		`timestamp` int(11) default NULL
+//	) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 
+#define NOTE_FILE RIFT_AREA_DIR "/notes.not"
+
+#define NOTE_NOTE		0
+#define NOTE_IDEA		1
+#define NOTE_PENALTY	2
+#define NOTE_NEWS		3
+#define NOTE_CHANGES	4
+
+typedef struct note_data NOTE_DATA;
+struct note_data
+{
+	NOTE_DATA *next;
+	bool valid;
+	sh_int type;
+	char *sender;
+	char *date;
+	char *to_list;
+	char *subject;
+	char *text;
+	time_t date_stamp;
+};
+
+extern NOTE_DATA *note_free;
 
 //
 // LOCAL FUNCTIONS
@@ -25,5 +55,9 @@ void note_attach (CHAR_DATA *ch, int type);
 bool hide_note (CHAR_DATA *ch, MYSQL_ROW row);
 void update_read (CHAR_DATA *ch, long stamp, int type);
 void parse_note (CHAR_DATA *ch, char *argument, int type);
+
+/* note recycling */
+NOTE_DATA *new_note(void);
+void free_note(NOTE_DATA *note);
 
 #endif /* NOTE_H */

--- a/code/recycle.c
+++ b/code/recycle.c
@@ -55,7 +55,6 @@
 /* buffer sizes */
 const int buf_size[MAX_BUF_LIST] = {16, 32, 64, 128, 256, 1024, 2048, 4096, 8192, 16384};
 
-NOTE_DATA *note_free;
 DESCRIPTOR_DATA *descriptor_free;
 GEN_DATA *gen_data_free;
 EXTRA_DESCR_DATA *extra_descr_free;
@@ -75,41 +74,6 @@ BUFFER *buf_free;
 
 long last_pc_id;
 long last_mob_id;
-
-/* stuff for recyling notes */
-NOTE_DATA *new_note()
-{
-	NOTE_DATA *note;
-
-	if (note_free == NULL)
-	{
-		note = new NOTE_DATA;
-	}
-	else
-	{
-		note = note_free;
-		note_free = note_free->next;
-	}
-
-	note->valid = true;
-	return note;
-}
-
-void free_note(NOTE_DATA *note)
-{
-	if (!(note != NULL && note->valid))
-		return;
-
-	free_pstring(note->text);
-	free_pstring(note->subject);
-	free_pstring(note->to_list);
-	free_pstring(note->date);
-	free_pstring(note->sender);
-
-	note->valid = false;
-	note->next = note_free;
-	note_free = note;
-}
 
 /* stuff for recycling descriptors */
 DESCRIPTOR_DATA *new_descriptor(void)

--- a/code/recycle.h
+++ b/code/recycle.h
@@ -37,7 +37,6 @@
 #include "merc.h"
 
 /* externals for counting purposes */
-extern NOTE_DATA *note_free;
 extern DESCRIPTOR_DATA *descriptor_free;
 extern EXTRA_DESCR_DATA	*extra_descr_free;
 extern AFFECT_DATA *affect_free;
@@ -61,9 +60,6 @@ extern PC_DATA *pcdata_free;
 // LOCAL FUNCTIONS
 //
 
-/* note recycling */
-NOTE_DATA *new_note(void);
-void free_note(NOTE_DATA *note);
 /* descriptor recycling */
 DESCRIPTOR_DATA *new_descriptor(void);
 void free_descriptor(DESCRIPTOR_DATA *d);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,18 +10,19 @@ add_library(TestMain SHARED main.c)
 set_target_properties(TestMain PROPERTIES LINKER_LANGUAGE CXX)
 
 set(TEST_SRC_FILES act_obj_tests.c
+	ban_tests.c
 	cabal_tests.c
 	db_tests.c
 	fight_tests.c
 	handler_tests.c
 	magic_tests.c
+	note_tests.c
 	prof_tests.c
 	queue_tests.c
 	utility_tests.c
 	standalone_tests.c
-	update_tests.c
 	test_helpers.c
-	ban_tests.c
+	update_tests.c
 )
 
 ##

--- a/tests/note_tests.c
+++ b/tests/note_tests.c
@@ -1,0 +1,45 @@
+#include "catch.hpp"
+#include "../code/merc.h"
+#include "../code/note.h"
+
+
+// TODO: These functions rely on database calls. Need to find a good c++ mocking framework for databases.
+
+// TODO: write tests
+//int count_spool (CHAR_DATA *ch, int type);
+
+// TODO: write tests
+//void do_unread (CHAR_DATA *ch, char *arg);
+
+// TODO: write tests
+//void do_note (CHAR_DATA *ch,char *argument);
+
+// TODO: write tests
+//void do_news (CHAR_DATA *ch,char *argument);
+
+// TODO: write tests
+//void do_changes (CHAR_DATA *ch,char *argument);
+
+// TODO: write tests
+//void append_note (NOTE_DATA *pnote);
+
+// TODO: write tests
+//bool is_note_to (CHAR_DATA *ch, char *sender, char *to_list);
+
+// TODO: write tests
+//void note_attach (CHAR_DATA *ch, int type);
+
+// TODO: write tests
+//bool hide_note (CHAR_DATA *ch, MYSQL_ROW row);
+
+// TODO: write tests
+//void update_read (CHAR_DATA *ch, long stamp, int type);
+
+// TODO: write tests
+//void parse_note (CHAR_DATA *ch, char *argument, int type);
+
+// TODO: write tests
+//NOTE_DATA *new_note(void);
+
+// TODO: write tests
+//void free_note(NOTE_DATA *note);


### PR DESCRIPTION
This PR groups the note functions and structures into the note.c/note.h files. It also removes a couple of unused functions. Also added missing documentation comments. The notes_test bit is empty until we find a good database mock framework.

The other commit is cleaning up from my previous PR where I forgot to add debugger launch settings, etc.

