### PR TITLE
validate DB connections and boot up process

### DIFF
--- a/code/devextra.c
+++ b/code/devextra.c
@@ -166,8 +166,10 @@ void clean_mud()
 	DESCRIPTOR_DATA *d;
 
 	DbConnection riftCore = nSQL.Settings.GetDbConnection("rift");
-	nSQL.StartSQLServer(riftCore.Host.c_str(),
-		riftCore.Db.c_str(), riftCore.User.c_str(), riftCore.Pwd.c_str());
+	if (!nSQL.StartSQLServer(riftCore.Host.c_str(),
+		riftCore.Db.c_str(), riftCore.User.c_str(), riftCore.Pwd.c_str()))
+		return RS.Bug("clean_mud: failed to establish a database connection.");
+
 	// 5184000 = one month
 
 	sprintf(buf, "DELETE FROM logins WHERE ctime + 5184000 < %ld", current_time);

--- a/code/main.c
+++ b/code/main.c
@@ -69,7 +69,12 @@ int main(int argc, char **argv)
 	control = init_socket(port);
 
 	// boot_db( );
-	RS.Bootup();
+	if (!RS.Bootup())
+	{
+		log_string("Riftshadow failed to boot, aborting.");
+		exit(0);
+		return 0;
+	}
 
 	sprintf(buf, "Riftshadow booted, binding on port %d.", port);
 	log_string(buf);

--- a/code/mud.c
+++ b/code/mud.c
@@ -32,7 +32,7 @@ CMud::~CMud()
 		RS.Shutdown();
 }
 
-void CMud::Bootup()
+bool CMud::Bootup()
 {
 	FILE *fp;
 	char tempbuf[MSL], buf[MSL];
@@ -43,8 +43,12 @@ void CMud::Bootup()
 
 		RS.Log("Creating persistent SQL connection...");
 		DbConnection riftCore = RS.SQL.Settings.GetDbConnection("rift_core");
-		RS.SQL.StartSQLServer(riftCore.Host.c_str(),
-		riftCore.Db.c_str(), riftCore.User.c_str(), riftCore.Pwd.c_str());
+		if (!RS.SQL.StartSQLServer(riftCore.Host.c_str(),
+		riftCore.Db.c_str(), riftCore.User.c_str(), riftCore.Pwd.c_str()))
+		{
+			RS.Log("Failed to create a SQL connection.");
+			return false;
+		}
 		
 		game_up = true;
 		
@@ -132,6 +136,7 @@ void CMud::Bootup()
 		//RS.SQL.IQuery("UNLOCK TABLES");
 #endif
 		//RS.GameEngine.GameLoop();
+		return true;
 }
 
 inline bool CMud::RunGame()

--- a/code/mud.h
+++ b/code/mud.h
@@ -36,7 +36,7 @@ public:
 //	CInterpreter		Interpreter;
 	CQueue				Queue;
 
-	void				Bootup();
+	bool				Bootup();
 	void				Shutdown();
 
 	void				LoadGreetingScreen();

--- a/code/sql.c
+++ b/code/sql.c
@@ -25,14 +25,18 @@ inline bool CSQLInterface::SQLValid(void)
 	return connstate > STATE_INVALID;
 }
 
-void CSQLInterface::StartSQLServer(const char* host, const char* db, const char* user, const char* pass)
+bool CSQLInterface::StartSQLServer(const char* host, const char* db, const char* user, const char* pass)
 {
 	connection = mysql_init(nullptr);
 
 	if(!mysql_real_connect(connection, host, user, pass, db, 0, nullptr, 0))
-		return RS.Bug("Unable to connect to mysql database: %s", mysql_error(connection));
+	{
+		RS.Bug("Unable to connect to mysql database: %s\r\n", mysql_error(connection));
+		return false;
+	}
 	
 	connstate = STATE_VALID;
+	return true;
 }
 
 void CSQLInterface::FreeResults(void)

--- a/code/stdlibs/sql.h
+++ b/code/stdlibs/sql.h
@@ -25,7 +25,7 @@ class CSQLInterface
 public:
 	CSQLInterface();
 	~CSQLInterface();
-	void 		StartSQLServer(const char* host, const char* db, const char* user, const char* pass);		//called at boot
+	bool 		StartSQLServer(const char* host, const char* db, const char* user, const char* pass);		//called at boot
 	void 		FreeResults(void);			//self explanatory
 	
 	Config					Settings;


### PR DESCRIPTION
Until now, every attempt to connect to the database was assumed to work well, and every attempt to boot up the MUD was assumed to end up successfully.

This commit changes that by making those two functions return a bool value, which is also now validated by its callers.

This also works as groundwork for further validations tha might lead to future enhancements, like #4.