### PR TITLE
Don't assume that the config file has been loaded

### DIFF
--- a/code/config.cpp
+++ b/code/config.cpp
@@ -7,10 +7,13 @@
 void Config::Load()
 {
     FILE* fp = fopen(_FilePath,"r");
+    if (fp == NULL)
+        return;
     char buffer[65536];
     rapidjson::FileReadStream inputStream(fp,buffer, sizeof(buffer));
     Settings.ParseStream(inputStream);
     fclose(fp);
+    loaded = true;
 }
 std::string Config::GetValue(const char* key)
 {
@@ -47,5 +50,11 @@ DbConnection Config::GetDbConnection(const char* connection)
 Config::Config(const char* file)
 {
     _FilePath = file;
+    loaded = false;
     Load();
+}
+
+bool Config::isLoaded()
+{
+    return loaded;
 }

--- a/code/config.h
+++ b/code/config.h
@@ -11,11 +11,13 @@ class Config
 private: 
 	rapidjson::Document Settings;
 	const char* _FilePath;
+	bool loaded;
 	void Load();
 public:
 	Config(const char* file = "../config.json");
 	std::string GetValue(const char* key);
 	DbConnection GetDbConnection(const char* key);
+	bool isLoaded();
 };
 
 #endif /* CONFIG_H */

--- a/code/sql.c
+++ b/code/sql.c
@@ -8,6 +8,11 @@ CSQLInterface::CSQLInterface(void)
 	connstate = STATE_INVALID;
 	result_set = nullptr;
 	Settings = Config("../config.json");
+	if (!Settings.isLoaded())
+	{
+		RS.Bug("Unable to load configuration!\r\n");
+		exit(0);
+	}
 	return;
 }
 


### PR DESCRIPTION
If the file can't be found or loaded, then the server will crash, because it just assumes that the config file will be loaded correctly.

This commit changes that behavior, and after the config loading attempt it will finish the process if the loading was unsuccessful.