### PR TITLE
Improvements to dev-install

### DIFF
--- a/dev-install.sh
+++ b/dev-install.sh
@@ -1,4 +1,10 @@
 #!/bin/sh
+NOCOLOR='\033[0m'
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+
+echo "Setting up the riftshadow development environment"
 
 # If you would like to do some extra provisioning you may
 # add any commands you wish to this file and they will
@@ -26,20 +32,66 @@
 #sudo apt-get install -y nodejs
 
 # Get a copy of the signing key for cmake's developer
-sudo wget -O /etc/apt/trusted.gpg.d/kitware.asc https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null
+echo "Installing the CMake signing key"
+{
+	sudo wget -O /etc/apt/trusted.gpg.d/kitware.asc https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null
+	echo "${GREEN}CMake key installed\n"
+} || {
+	echo "${RED}Failed to install CMake signing key. Aborting."
+	exit
+}
 
 # Add the cmake repo to sources list
-sudo apt-add-repository 'deb https://apt.kitware.com/ubuntu bionic main'
+echo "${NOCOLOR}Adding CMake Repo"
+{
+	sudo apt-add-repository 'deb https://apt.kitware.com/ubuntu bionic main'
+	echo "${GREEN}CMake Repo Added\n"
+} || {
+	echo "${RED}Failed to add the CMake repo. Aborting."
+	exit
+}
 
 # Add another repo to sources list for gcc-9, g++-9, and update
 #sudo apt-add-repository ppa:ubuntu-toolchain-r/test
+echo "${NOCOLOR}Updating APT"
 sudo apt-get update
+echo "${GREEN}Update Complete${NOCOLOR}\n"
 
 # Install deps
-sudo apt-get install -y ninja-build make cmake gcc g++ libmariadb-dev libmariadb-dev-compat mariadb-client mariadb-server
+echo "Installing dependencies"
+sudo apt-get install -y ninja-build make cmake gcc g++ 
+echo "${GREEN}Finished installing\n"
+
+echo "${NOCOLOR}Checking environment for a MySQL distribution"
+mySqlPresent=$(type mysql >/dev/null 2>&1 && echo true || echo false)
+
+if $mySqlPresent; then
+	echo "${GREEN}A MySQL distribution found!"
+	echo "${GREEN}You are currently using: ${NOCOLOR}$(mysqld --version)\n"
+else
+	echo "${YELLOW}No MySQL distribution found, installing MariaDB now.\n${NOCOLOR}"
+	sudo apt-get install -y libmariadb-dev libmariadb-dev-compat mariadb-client mariadb-server
+
+	echo "${GREEN}Finished installing MariaDB server and client."
+	echo "${NOCOLOR} Starting MariaDB"
+
+	{
+		sudo service mariadb start
+		sudo service mariadb status
+	} || {
+		echo "${RED}Failed to start MariaDB, please check your service settings."
+		exit
+	}
+fi
 
 # Update alternatives
 #sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 60 --slave /usr/bin/g++ g++ /usr/bin/g++-9
 
 # Setup Database
-sudo mysql mysql < setup.sql
+echo "${NOCOLOR}Running setup.sql\n"
+{
+	sudo mysql -v mysql < setup.sql 
+} ||
+{ # log that there was an error and to check the MySQL settings
+	echo "${RED}There was a problem running setup.sql on your local server. Inspect the error above"
+}


### PR DESCRIPTION
- Color coded status messages
  - No color - information
  - Green - success
  - Red - error
  - Yellow - warning

- Auto-detection of `mysql`
  - conditional installation of MariaDB if not found

- Verbose output of `setup.sql` for better visibility into errors during setup