### PR TITLE
add missing use statement in data setup scripts

### DIFF
--- a/db/rift/data/setup.sql
+++ b/db/rift/data/setup.sql
@@ -1,4 +1,9 @@
 ---
+--- Set the database name
+---
+use rift;
+
+---
 --- Import data
 ---
 SELECT 'Importing bans data' AS ' ';

--- a/db/rift_core/data/setup.sql
+++ b/db/rift_core/data/setup.sql
@@ -1,4 +1,9 @@
 ---
+--- Set the database name
+---
+use rift_core;
+
+---
 --- Import data
 ---
 


### PR DESCRIPTION
Adds the missing `use <db_name>;` statement to the two data `setup.sql` files to fix a bug where data would try to write to a db named `mysql` instead of the appropriate db.  Associates with #193