### PR TITLE
Fixed sql and shell glob syntax in labeler config

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -18,8 +18,8 @@ core:
 
 setup:
 - Makefile
-- *sql
-- *sh
+- '**/*.sql'
+- '**/*.sh'
 
 dev-install:
 - dev-install.sh


### PR DESCRIPTION
Auto labels on PRs should work after this goes through now. I had just forgotten that I have to wrap matching rules in quotes in order to start a line with a `*`