### PR TITLE
Fix login banner

### DIFF
--- a/code/bootup.c
+++ b/code/bootup.c
@@ -4,6 +4,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include "rift.h"
+#include "newmem.h"
 #include "area.h"
 #include "room.h"
 #include "exit.h"
@@ -298,6 +299,7 @@ void CMud::LoadGreetingScreen()
 	buf[i-2] = '\0';
    	fclose(fp);
 	greeting_screen = buf;
+	help_greeting = palloc_string(buf);
 }
 
 void CMud::InitializeTables()

--- a/code/mud.c
+++ b/code/mud.c
@@ -13,7 +13,6 @@
 #include "mud.h"
 #include "merc.h"
 #include "update.h"
-#include "newmem.h"
 #include "dioextra.h"
 #include "db.h"
 #include "db2.h"
@@ -105,17 +104,7 @@ bool CMud::Bootup()
 		weather_update();
 		RS.Log("Priming weather");
 		reset_chessboard();
-		fp = fopen(LOGIN_BANNER_FILE, "r");
-		while(fgets(tempbuf,200,fp))
-		{
-			strcat(buf,tempbuf);
-			strcat(buf,"\r");
-		}
-		fclose(fp);
 		gold_constant = std::stol(Settings.GetValue("Gold"));
-		chop(buf);
-		chop(buf);
-		help_greeting = palloc_string(buf);
 		update_db_gold();
 
 		//CSocket::InitializeSockets();


### PR DESCRIPTION
This PR fixes the login banner by removing extra encoding characters that we're messing up the login banner.

It also removes the double loading of the login banner.