### PR TITLE
Refactored host system commands into C++ code

### DIFF
--- a/code/CMakeLists.txt
+++ b/code/CMakeLists.txt
@@ -3,6 +3,7 @@ project(riftshadow_src)
 set(RIFT_SOURCE config.cpp
 	strings.c
 	file.c
+	cdirectory.c
 	sql.c
 	bitvector.c
 	act_comm.c

--- a/code/cdirectory.c
+++ b/code/cdirectory.c
@@ -1,0 +1,53 @@
+#include "stdlibs/cdirectory.h"
+#include <filesystem>
+#include <algorithm>
+
+/// Represents a directory in a file system.
+/// @param path: The path used to gather directory information.
+CDirectory::CDirectory(std::string path)
+{
+	_path = path;
+}
+
+/// Destructor
+CDirectory::~CDirectory()
+{
+}
+
+/// Retrieves the path used to gather directory information .
+/// @return The path of the directory used by this object.
+std::string CDirectory::GetPath()
+{
+	return _path;
+}
+
+/// Retrieves a list of all files from the directory.
+/// @return A list of files from the directory.
+std::vector<std::string> CDirectory::GetFiles()
+{
+	std::vector<std::string> files;
+	for (const auto & entry : std::filesystem::directory_iterator(_path))
+	{
+		if(entry.is_regular_file())
+			files.push_back(entry.path());
+	}
+
+	std::sort(files.begin(), files.end());
+	return files;
+}
+
+/// Retrieves a list of files from the directory with a specific extension.
+/// @param fileExtension: The extension used to filter the resulting file list.
+/// @return A list of files with the given fileExtension from the directory.
+std::vector<std::string> CDirectory::GetFiles(std::string fileExtension)
+{
+	std::vector<std::string> files;
+	for (const auto & entry : std::filesystem::directory_iterator(_path))
+	{
+		if(entry.is_regular_file() && entry.path().extension() == fileExtension)
+			files.push_back(entry.path());
+	}
+
+	std::sort(files.begin(), files.end());
+	return files;
+}

--- a/code/stdlibs/cdirectory.h
+++ b/code/stdlibs/cdirectory.h
@@ -1,0 +1,20 @@
+#ifndef CDIRECTORY
+#define CDIRECTORY
+
+#include <vector>
+#include <string>
+
+class CDirectory
+{
+public:
+	CDirectory(std::string path);
+	~CDirectory();
+
+	std::string GetPath();
+	std::vector<std::string> GetFiles();
+	std::vector<std::string> GetFiles(std::string fileExtension);
+private:
+	std::string _path;
+};
+
+#endif

--- a/cspell.json
+++ b/cspell.json
@@ -176,6 +176,7 @@
         "cavedweller",
         "ccorpses",
         "ccount",
+        "CDIRECTORY",
         "Celes",
         "Celest",
         "Ceran",


### PR DESCRIPTION
There are quite a few commands in the codebase that shell out to `system` mainly for file system manipulation purposes. This can lead to performance and security issues.

This PR is a first step in rooting out and refactoring those operations into a more C++ code friendly matter. The commands refactored in here use `ls` to redirect a list of files into a list that the code then uses to process player data.

