### PR TITLE
Fix logging of DEBUG and TRACE messages

### DIFF
--- a/code/clogger.c
+++ b/code/clogger.c
@@ -20,17 +20,20 @@ void CLogger::Initialize()
 {
 	if (spdlog::get("rs") == nullptr)
 	{
+		auto level = spdlog::level::trace;
+		spdlog::set_level(level);
+
 		auto console_sink = std::make_shared<spdlog::sinks::stdout_color_sink_mt>();
-		console_sink->set_level(spdlog::level::info);
+		console_sink->set_level(level);
 		console_sink->set_pattern("[%^%l%$] %v");
 
 		auto file_sink = std::make_shared<spdlog::sinks::basic_file_sink_mt>(RS_LOG_FILE, true);
-		file_sink->set_level(spdlog::level::info);
+		file_sink->set_level(level);
 
 		std::vector<spdlog::sink_ptr> sinks{ console_sink, file_sink };
 		auto logger = std::make_shared<spdlog::logger>("rs", sinks.begin(), sinks.end());
-		logger->set_level(spdlog::level::info);
-		logger->flush_on(spdlog::level::info);
+		logger->set_level(level);
+		logger->flush_on(level);
 
 		spdlog::register_logger(logger);
 	}
@@ -40,4 +43,13 @@ void CLogger::Initialize()
 void CLogger::Shutdown()
 {
 	spdlog::shutdown();
+}
+
+void CLogger::SetLevel(spdlog::level::level_enum level)
+{
+	if (spdlog::get("rs") != nullptr)
+	{
+		spdlog::get("rs")->set_level(level);
+		spdlog::get("rs")->flush_on(level);
+	}
 }

--- a/code/main.c
+++ b/code/main.c
@@ -8,12 +8,15 @@
 #include "comm.h"
 #include "interp.h"
 #include "db.h"
+#include "./include/spdlog/spdlog.h"
 
 int main(int argc, char **argv)
 {
 	struct timeval now_time;
 	int port = 0;
 	int control;
+
+	RS.Logger.SetLevel(spdlog::level::info);
 
 	/*
 	 * Memory debugging if needed.
@@ -51,6 +54,7 @@ int main(int argc, char **argv)
 		}
 		else if ((port = atoi(argv[1])) == 666)
 		{
+			RS.Logger.SetLevel(spdlog::level::debug);
 			bDebug = true;
 		}
 		else if (port <= 1024)

--- a/code/recycle.c
+++ b/code/recycle.c
@@ -700,8 +700,8 @@ CHAR_DATA *new_char(void)
 	{
 		ch = new CHAR_DATA;
 
-		if (bDebug)
-			RS.Logger.Debug("Char free is null.  . . . . !");
+		// if (bDebug)
+		// 	RS.Logger.Debug("Char free is null.  . . . . !");
 	}
 	else
 	{

--- a/code/stdlibs/clogger.h
+++ b/code/stdlibs/clogger.h
@@ -15,6 +15,11 @@
 	log.Shutdown();
 */
 
+#ifdef SPDLOG_ACTIVE_LEVEL
+	#undef SPDLOG_ACTIVE_LEVEL
+	#define SPDLOG_ACTIVE_LEVEL SPDLOG_LEVEL_TRACE
+#endif
+
 class CLogger
 {
 public:
@@ -23,6 +28,7 @@ public:
 
 	void Initialize();
 	void Shutdown();
+	void SetLevel(spdlog::level::level_enum level);
 
 	template <typename... Args>
 	void Bug(std::string_view fmt, Args &&...args)


### PR DESCRIPTION
This PR fixes the logging of messages with DEBUG and TRACE levels. Before these changes, `spdlog` was only configured to log INFO and above messages. These changes ensure that all log messages can be logged.

Commented out the Debug statement in `recycle.c` since it provided no real detail and needlessly spams the logs.