### PR TITLE
Potential fix for code scanning alert no. 48: Use of string after lifetime ends

### DIFF
--- a/tests/magic_tests.c
+++ b/tests/magic_tests.c
@@ -96,8 +96,8 @@ SCENARIO("testing skill lookup","[skill_lookup]")
 			auto skillName = skill_table[expected].name; 
 			auto firstHalf = AllLower(substr(skillName,0,3));
 			auto secondHalf = AllUpper(substr(skillName,3,(sizeof(skillName) - 3)));
-			auto finalSkillName = (std::string(firstHalf) + std::string(secondHalf)).c_str();
-			auto actual = skill_lookup(finalSkillName);
+			std::string combinedSkillName = std::string(firstHalf) + std::string(secondHalf);
+			auto actual = skill_lookup(combinedSkillName.c_str());
 			THEN("it should return the expected index")
 			{
 				REQUIRE(actual == expected);


### PR DESCRIPTION
Potential fix for [https://github.com/rezalas/riftshadow/security/code-scanning/48](https://github.com/rezalas/riftshadow/security/code-scanning/48)

To fix this problem, we need to ensure that the temporary `std::string` object resulting from the concatenation lives for as long as the C-string pointer returned by `.c_str()` is needed. The safest way is to assign the concatenated string to a `std::string` variable, then call `.c_str()` on that variable. This ensures the lifetime of the underlying data is long enough for its usage, and the pointer will remain valid throughout. Specifically, in tests/magic_tests.c, within the scenario on line 99, replace the direct assignment to `finalSkillName` with two steps: create a local `std::string` holding the concatenation, then use its `c_str()` for subsequent calls. No new methods or major changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
