### PR TITLE
Updating the checkout step in the Cmake build

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v5
     
     - name: install ninja
       run: sudo apt install ninja-build


### PR DESCRIPTION
This updates actions/checkout from v2 to v5. Honestly, when I caught the need to update this, I thought we had more dependencies, so I just spent cogitation cycles on 1 char...

