### PR TITLE
Fix format-truncation Warning

### DIFF
--- a/code/act_info.c
+++ b/code/act_info.c
@@ -1073,7 +1073,7 @@ void do_socials(CHAR_DATA *ch, char *argument)
 	for (auto iSocial = 0; social_table[iSocial].name[0] != '\0'; iSocial++)
 	{
 		char buf[MAX_STRING_LENGTH];
-		sprintf(buf, "%-12s", social_table[iSocial].name);
+		sprintf(buf, "%-12.19s", social_table[iSocial].name);
 		send_to_char(buf, ch);
 
 		if (++col % 2 == 0)


### PR DESCRIPTION
We were getting the following warning:

code/act_info.c:1076:31: warning: ‘%-12s’ directive writing between 12 and 22439 bytes into a region of size 4608 [-Wformat-overflow=]

That was happening because of this code block:

char buf[MAX_STRING_LENGTH];
sprintf(buf, "%-12s", social_table[iSocial].name);

It shouldn't happen: MAX_STRING_LENGTH is 4608, while social_table is a struct from the social_type which devices its name like this:

struct social_type
{
    char name[20];
}

However, the compiler there does not know that its size is 20, on act_info.c it has decayed to char*. In fact, sprintf might very well read more than 20 chars - it will keep reading until it finds a \0.

To avoid all that - and this warning - I'm changing the call from %-12s to %-12.19s. I'm not happy to have the '19' hardcoded there, but the 20 is already a magic number...