### PR TITLE
Remove lingering return call

### DIFF
--- a/code/act_obj.c
+++ b/code/act_obj.c
@@ -135,8 +135,6 @@ bool can_loot(CHAR_DATA *ch, OBJ_DATA *obj)
 		return false;
 	}
 
-	return true;
-
 	owner = nullptr;
 	for (wch = char_list; wch != nullptr; wch = wch->next)
 	{


### PR DESCRIPTION
A cleanup was made in 68de621c , where, in the middle of it all, where before we had

>    if (owner == NULL || IS_NPC(owner))
>        return TRUE;

there was the intent to remove this check, but only the if line was removed, leaving the 'return TRUE' on the code. That made the code flow end there: reaching it, the code always returns true (where it never should), and the rest of the function isn't executed.

This change removes the return call that should have been removed back then, fixing the 'can_loot' behaviour.