### PR TITLE
fix behaviour of insane character

### DIFF
--- a/code/characterClasses/ap.c
+++ b/code/characterClasses/ap.c
@@ -1840,8 +1840,6 @@ void insanity_pulse(CHAR_DATA *ch, AFFECT_DATA *af)
 				do_cleave(ch, victim->name);
 				break;
 		}
-
-		break;
 	}
 }
 


### PR DESCRIPTION
I am not sure the entire insanity code is working as expected (or how insanity is expected to work), I have some doubts. But there is something that clearly was not designed to be working as it is - and it is how the insane character behaves in a room with several people.

In `insanity_pulse() we have a for loop so we consider, one at a time, each person in the room as a victim. This seems to make sense: the insane character will behave insanely towards each of them - and, if that was not the purpose, then the for loop would not exist in the first place. However, the for loop is structured like this:
```
for (each victim)
{
	// do some checks on the victim and react to that;
	switch (random generated number) {
		if 1:
			// do insane thing 1
			break;
		if 2:
			// do insane thing 2
			break;
	}
	break;
}

```
Now, see that last break, the one outside of the switch? That break is actually breaking the for loop, making it only run once - and so, instead of checking everyone in the room, the insane character will only act towards the 'first' victim in the room.

This patch removes the 'break' that is outside of the switch, ensuring everyone has the right to be a victim of an insane person.