### PR TITLE
simplify lesser_demon_tick logic for MOB_VNUM_AAMON

### DIFF
--- a/code/characterClasses/ap.c
+++ b/code/characterClasses/ap.c
@@ -1570,8 +1570,8 @@ void lesser_demon_tick(CHAR_DATA *mob, AFFECT_DATA *af)
 				RS.Queue.AddToQueue(1, "lesser_demon_tick", "do_say_queue", do_say_queue, mob, "I'll be leaving now,  and leaving you to your thoughts.  You'll never know the answer to my riddle.");
 				RS.Queue.AddToQueue(2, "lesser_demon_tick", "act_queue", act_queue, "With a puff of hazy purple smoke and a sound like a cough, $n disappears.", mob, nullptr, nullptr, TO_ROOM);
 				RS.Queue.AddToQueue(3, "lesser_demon_tick", "delay_extract", delay_extract, mob);
-				break;
 			}
+			break;
 		case MOB_VNUM_MALAPHAR:
 			if (af->duration % 2 == 0)
 			{


### PR DESCRIPTION
This simple change makes the code more readable, making it clear that there is no mistake or bad side effects due to the positioning of the break. It also avoids unnecessary checks, optimizing the code.

The entire switch could be refactored, and perhaps no longer use ifs within but instead have inner switches as necessary, but, for now, with this change the case for MOB_VNUM_AAMON keeps the same stile we see in the rest of the cases within this switch.

Closes: #301