### PR TITLE
Fix for various possible dereferencing of NULL pointer errors

### DIFF
--- a/code/act_info.c
+++ b/code/act_info.c
@@ -4519,7 +4519,15 @@ void do_password(CHAR_DATA *ch, char *argument)
 		return;
 	}
 
-	if (strcmp(crypt(arg1, ch->pcdata->pwd), ch->pcdata->pwd))
+	auto pwd = crypt(arg1, ch->pcdata->pwd);
+	if (pwd == nullptr)
+	{
+		send_to_char("Unable to process password.\n\r", ch);
+		RS.Logger.Warn("Possible issue with crypt lib when player [{}] tried inputting password. Error: {}", ch->name, std::strerror(errno));
+		return;
+	}
+
+	if (strcmp(pwd, ch->pcdata->pwd))
 	{
 		WAIT_STATE(ch, 40);
 		send_to_char("Wrong password.  Wait 10 seconds.\n\r", ch);
@@ -4536,6 +4544,13 @@ void do_password(CHAR_DATA *ch, char *argument)
 	 * No tilde allowed because of player file format.
 	*/
 	auto pwdnew = crypt(arg2, ch->name);
+	if (pwdnew == nullptr)
+	{
+		send_to_char("Unable to process new password.\n\r", ch);
+		RS.Logger.Warn("Possible issue with crypt lib when player [{}] tried changing passwords. Error: {}", ch->name, std::strerror(errno));
+		return;
+	}
+
 	for (auto p = pwdnew; *p != '\0'; p++)
 	{
 		if (*p == '~')

--- a/code/act_wiz.c
+++ b/code/act_wiz.c
@@ -6667,23 +6667,25 @@ void log_naughty(CHAR_DATA *ch, char *argument, int logtype)
 	strtime[strlen(strtime) - 1] = '\0';
 
 	fp = fopen(GOD_LOG_FILE, "a");
-
-	if (fp != nullptr)
+	if (fp == nullptr)
 	{
-		if (logtype == 1)
-			fprintf(fp, "%s: LOAD- %s is loading %s.\n", strtime, ch->name, argument);
-
-		if (logtype == 2)
-			fprintf(fp, "%s: SET- %s is setting %s.\n", strtime, ch->name, argument);
-
-		if (logtype == 3)
-			fprintf(fp, "%s: STRING- %s is stringing %s.\n", strtime, ch->name, argument);
-
-		if (logtype == 5)
-			fprintf(fp, "%s: INDUCT- %s is inducting %s.\n", strtime, ch->name, argument);
-
-		fclose(fp);
+		RS.Logger.Warn("Unable to open god log file: fopen {}: {}", GOD_LOG_FILE, std::strerror(errno));
+		return;
 	}
+
+	if (logtype == 1)
+		fprintf(fp, "%s: LOAD- %s is loading %s.\n", strtime, ch->name, argument);
+
+	if (logtype == 2)
+		fprintf(fp, "%s: SET- %s is setting %s.\n", strtime, ch->name, argument);
+
+	if (logtype == 3)
+		fprintf(fp, "%s: STRING- %s is stringing %s.\n", strtime, ch->name, argument);
+
+	if (logtype == 5)
+		fprintf(fp, "%s: INDUCT- %s is inducting %s.\n", strtime, ch->name, argument);
+
+	fclose(fp);
 }
 
 void do_vstat(CHAR_DATA *ch, char *argument)
@@ -7641,10 +7643,13 @@ void buglist_end_fun(CHAR_DATA *ch, char *argument)
 void do_constdump(CHAR_DATA *ch, char *argument)
 {
 	FILE *fp = fopen(CONST_DUMP_FILE, "w"), *fp2;
-	int sn, i;
-
-	if (!fp)
+	if (fp == nullptr)
+	{
+		RS.Logger.Warn("Unable to open const dump file: fopen {}: {}", CONST_DUMP_FILE, std::strerror(errno));
 		return;
+	}
+
+	int sn, i;
 
 	for (sn = 0;; sn++)
 	{
@@ -7716,6 +7721,12 @@ void do_constdump(CHAR_DATA *ch, char *argument)
 void do_interpdump(CHAR_DATA *ch, char *argument)
 {
 	FILE *fp = fopen(INTERP_DUMP_FILE, "w");
+	if (fp == nullptr)
+	{
+		RS.Logger.Warn("Unable to open interp dump file: fopen {}: {}", INTERP_DUMP_FILE, std::strerror(errno));
+		return;
+	}
+
 	int i = 0, j = 0, k = 0;
 	int bit = 0;
 
@@ -7734,6 +7745,11 @@ void do_interpdump(CHAR_DATA *ch, char *argument)
 	fclose(fp);
 
 	fp = fopen(CLIMATE_DUMP_FILE, "w");
+	if (fp == nullptr)
+	{
+		RS.Logger.Warn("Unable to open climate dump file: fopen {}: {}", CLIMATE_DUMP_FILE, std::strerror(errno));
+		return;
+	}
 
 	for (i = 0; climate_table[i].number != Climate::English; i++)
 	{
@@ -7778,6 +7794,12 @@ void do_interpdump(CHAR_DATA *ch, char *argument)
 void do_racedump(CHAR_DATA *ch, char *argument)
 {
 	FILE *fp = fopen(RACE_DUMP_FILE, "w");
+	if (fp == nullptr)
+	{
+		RS.Logger.Warn("Unable to open race dump file: fopen {}: {}", RACE_DUMP_FILE, std::strerror(errno));
+		return;
+	}
+
 	int race = 0, i = 0;
 	long temp_bit = 0;
 	char buf[MSL];

--- a/code/bootup.c
+++ b/code/bootup.c
@@ -283,14 +283,20 @@ void CMud::LoadGreetingScreen()
 {
 	//can't use cfile because of weird \r action
 	FILE *fp = fopen(LOGIN_BANNER_FILE, "r");
+	if (fp == nullptr)
+	{
+		RS.Logger.Warn("Unable to open banner file: fopen {}: {}", LOGIN_BANNER_FILE, std::strerror(errno));
+		return;
+	}
+
 	char tempbuf[210], buf[4096];
 	int i;
 	buf[0] = '\0';
 	while(fgets(tempbuf,200,fp))
  	{	
 		strcat(buf,tempbuf);
-       	strcat(buf,"\r");
-    }
+		strcat(buf,"\r");
+	}
 	for(i=0; buf[i] != '\0'; i++)
 		;
 	buf[i-2] = '\0';

--- a/code/comm.c
+++ b/code/comm.c
@@ -1438,6 +1438,7 @@ void nanny(DESCRIPTOR_DATA *d, char *argument)
 	CHAR_DATA *ch;
 	OBJ_DATA *fobj; /* For pfile limit bug */
 	OBJ_DATA *fobj_next;
+	char *pwd;
 	char *pwdnew;
 	char *p;
 	int iClass, race, i, type, sn, modif, modamt;
@@ -1582,7 +1583,17 @@ void nanny(DESCRIPTOR_DATA *d, char *argument)
 		case CON_GET_OLD_PASSWORD:
 			write_to_buffer(d, "\n\r", 2);
 
-			if (strcmp(crypt(argument, ch->pcdata->pwd), ch->pcdata->pwd))
+			pwd = crypt(argument, ch->pcdata->pwd);
+			if (pwd == nullptr)
+			{
+				write_to_buffer(d, "Unable to process password.\n\r", 0);
+				close_socket(d);
+
+				RS.Logger.Warn("Possible issue with crypt lib when player [{}] tried inputting password. Error: {}", ch->name, std::strerror(errno));
+				return;
+			}
+
+			if (strcmp(pwd, ch->pcdata->pwd))
 			{
 				write_to_buffer(d, "Wrong password.\n\r", 0);
 				/*
@@ -1742,6 +1753,14 @@ void nanny(DESCRIPTOR_DATA *d, char *argument)
 			}
 
 			pwdnew = crypt(argument, ch->name);
+			if (pwdnew == nullptr)
+			{
+				write_to_buffer(d, "Unable to process new password.\n\r", 0);
+
+				RS.Logger.Warn("Possible issue with crypt lib when player [{}] tried changing passwords. Error: {}", ch->name, std::strerror(errno));
+				return;
+			}
+
 			for (p = pwdnew; *p != '\0'; p++)
 			{
 				if (*p == '~')
@@ -1760,7 +1779,17 @@ void nanny(DESCRIPTOR_DATA *d, char *argument)
 		case CON_CONFIRM_NEW_PASSWORD:
 			write_to_buffer(d, "\n\r", 2);
 
-			if (strcmp(crypt(argument, ch->pcdata->pwd), ch->pcdata->pwd))
+			pwd = crypt(argument, ch->pcdata->pwd);
+			if (pwd == nullptr)
+			{
+				write_to_buffer(d, "Unable to process password.\n\r", 0);
+				close_socket(d);
+
+				RS.Logger.Warn("Possible issue with crypt lib when player [{}] tried confirming password. Error: {}", ch->name, std::strerror(errno));
+				return;
+			}
+
+			if (strcmp(pwd, ch->pcdata->pwd))
 			{
 				write_to_buffer(d, "Passwords don't match.\n\rRetype password: ", 0);
 				d->connected = CON_GET_NEW_PASSWORD;

--- a/code/db.c
+++ b/code/db.c
@@ -3224,6 +3224,12 @@ void do_dump(CHAR_DATA *ch, char *argument)
 
 	fclose(fpReserve);
 	fp = fopen(MEM_DUMP_FILE, "w");
+	if (fp == nullptr)
+	{
+		RS.Logger.Warn("Unable to open mem dump file: fopen {}: {}", MEM_DUMP_FILE, std::strerror(errno));
+		return;
+	}
+
 
 	/* report use of data structures */
 
@@ -3341,6 +3347,11 @@ void do_dump(CHAR_DATA *ch, char *argument)
 
 	/* start printing out mobile data */
 	fp = fopen(MOB_DUMP_FILE, "w");
+	if (fp == nullptr)
+	{
+		RS.Logger.Warn("Unable to open mob dump file: fopen {}: {}", MOB_DUMP_FILE, std::strerror(errno));
+		return;
+	}
 
 	fprintf(fp, "\nMobile Analysis\n");
 	fprintf(fp, "---------------\n");
@@ -3362,6 +3373,11 @@ void do_dump(CHAR_DATA *ch, char *argument)
 
 	/* start printing out object data */
 	fp = fopen(OBJ_DUMP_FILE, "w");
+	if (fp == nullptr)
+	{
+		RS.Logger.Warn("Unable to open obj dump file: fopen {}: {}", OBJ_DUMP_FILE, std::strerror(errno));
+		return;
+	}
 
 	fprintf(fp, "\nObject Analysis\n");
 	fprintf(fp, "---------------\n");

--- a/code/db2.c
+++ b/code/db2.c
@@ -974,6 +974,12 @@ void bugout(char *reason)
 	RS.Logger.Warn(reason);
 
 	auto fp = fopen(RIFT_ROOT_DIR "../logs/bugout.txt", "a");
+	if (fp == nullptr)
+	{
+		RS.Logger.Warn("Unable to open bug file: fopen {}: {}", RIFT_ROOT_DIR "../logs/bugout.txt", std::strerror(errno));
+		return;
+	}
+
 	fprintf(fp, "%s\n", reason);
 	fclose(fp);
 	exit(3);

--- a/code/dioextra.c
+++ b/code/dioextra.c
@@ -1487,8 +1487,14 @@ void do_ctrack(CHAR_DATA *ch, char *argument)
 
 		sprintf(buf2, "%s/%s.plr", RIFT_PLAYER_DIR, newbuf);
 		fpChar2 = fopen(buf2, "r");
+		if (fpChar2 == nullptr)
+		{
+			RS.Logger.Warn("Unable to open bug file: fopen {}: {}", buf2, std::strerror(errno));
+			return;
+		}
+
 		login = get_login(ch, fpChar2);
-		close(*((int *)fpChar2));
+		fclose(fpChar2);
 
 		numMatches++;
 


### PR DESCRIPTION
This PR contains fixes for possible dereferencing of NULL pointer errors.

These errors mainly center around our use of `crypt` and `fopen`. These functions return pointers that need to be checked before use. Since that wasn't done, possible game crashes could have occurred.

Also fixed a weird case were they were using `close` instead of `fclose` to close a file.