### PR TITLE
Remove unused file pointer

### DIFF
--- a/code/comm.c
+++ b/code/comm.c
@@ -96,7 +96,6 @@
  */
 DESCRIPTOR_DATA *descriptor_list; /* All open descriptors		*/
 DESCRIPTOR_DATA *d_next;		  /* Next descriptor in loop	*/
-FILE *fpReserve;				  /* Reserved file handle		*/
 bool god;						  /* All new chars are gods!	*/
 bool merc_down;					  /* Shutdown					*/
 bool rebooting= false;

--- a/code/comm.h
+++ b/code/comm.h
@@ -67,7 +67,6 @@
 #endif
 
 extern DESCRIPTOR_DATA *descriptor_list;
-extern FILE *fpReserve;
 extern bool merc_down;
 extern bool rebooting;
 extern int reboot_num;

--- a/code/db.c
+++ b/code/db.c
@@ -3222,7 +3222,6 @@ void do_dump(CHAR_DATA *ch, char *argument)
 	FILE *fp;
 	int vnum, nMatch = 0;
 
-	fclose(fpReserve);
 	fp = fopen(MEM_DUMP_FILE, "w");
 	if (fp == nullptr)
 	{
@@ -3397,7 +3396,6 @@ void do_dump(CHAR_DATA *ch, char *argument)
 
 	/* close file */
 	fclose(fp);
-	fpReserve = fopen(NULL_FILE, "r");
 }
 
 /*
@@ -3733,8 +3731,6 @@ void append_file(CHAR_DATA *ch, char *file, char *str)
 	if (is_npc(ch) || str[0] == '\0')
 		return;
 
-	fclose(fpReserve);
-
 	fp = fopen(file, "a");
 
 	if (fp == nullptr)
@@ -3750,8 +3746,6 @@ void append_file(CHAR_DATA *ch, char *file, char *str)
 		fprintf(fp, "[%5d] %s: %s: %s\n", ch->in_room ? ch->in_room->vnum : 0, ch->true_name, buf, str);
 		fclose(fp);
 	}
-
-	fpReserve = fopen(NULL_FILE, "r");
 }
 
 /*

--- a/code/main.c
+++ b/code/main.c
@@ -33,15 +33,6 @@ int main(int argc, char **argv)
 	strcpy(str_boot_time, ctime(&current_time));
 
 	/*
-	 * Reserve one channel for our use.
-	 */
-	if ((fpReserve = fopen(NULL_FILE, "r")) == nullptr)
-	{
-		RS.Logger.Error("Main: fopen {}: {}", NULL_FILE, std::strerror(errno));
-		exit(0);
-	}
-
-	/*
 	 * Get the port number.
 	 */
 	port = atoi(RS.SQL.Settings.GetValue("Port").c_str());

--- a/code/olc_save.c
+++ b/code/olc_save.c
@@ -931,7 +931,6 @@ void save_area(AREA_DATA *pArea)
 	long long temp_bit;
 	char buf[MSL];
 	FILE *fp = nullptr;
-	fclose(fpReserve);
 
 	sprintf(buf, "mv -f %s " RIFT_AREA_DIR "/backup/%s.bak", pArea->file_name, pArea->file_name);
 
@@ -971,7 +970,6 @@ void save_area(AREA_DATA *pArea)
 	fprintf(fp, "#$\n");
 
 	fclose(fp);
-	fpReserve = fopen(NULL_FILE, "r"); // TODO: possible memory leak
 }
 
 void do_asave(CHAR_DATA *ch, char *argument)

--- a/code/save.c
+++ b/code/save.c
@@ -104,8 +104,6 @@ void save_char_obj(CHAR_DATA *ch)
 		wiznet("ALERT!! $N/$F name corrupt!!", ch, nullptr, 0, 0, 0);
 
 	/* create god log */
-	fclose(fpReserve);
-
 	if (!is_immortal(ch))
 	{
 		res = RS.SQL.Update(
@@ -159,11 +157,8 @@ void save_char_obj(CHAR_DATA *ch)
 		}
 
 		fprintf(fp, "#END\n");
-	}
-
-	if (fp != nullptr)
 		fclose(fp);
-	fpReserve = fopen(NULL_FILE, "r");
+	}
 }
 
 /*
@@ -1020,8 +1015,6 @@ bool load_char_obj(DESCRIPTOR_DATA *d, char *name)
 
 	found = false;
 
-	fclose(fpReserve);
-
 	/* decompress if .gz file exists */
 	sprintf(strsave, "%s%s%s", RIFT_PLAYER_DIR, capitalize(name), ".gz");
 
@@ -1106,8 +1099,6 @@ bool load_char_obj(DESCRIPTOR_DATA *d, char *name)
 
 	free_pstring(ch->backup_true_name);
 	ch->backup_true_name = palloc_string(name);
-
-	fpReserve = fopen(NULL_FILE, "r");
 
 	/* Morg - Valgrind fix */
 	zero_vector(ch->imm_flags);


### PR DESCRIPTION
This PR removes the unused file pointer, `fpReserve`. All the code did was open and close a handle to `NULL_FILE` which is an alias to `/dev/null`.

This looks like a vestige from the old merc code that this MUD uses. Ran several tests and played for about 30 minutes, nothing broke due to the removal of said code. 