### PR TITLE
Replace some of the  easier strcpy calls with snprintf

### DIFF
--- a/code/act_comm.c
+++ b/code/act_comm.c
@@ -1579,7 +1579,7 @@ void do_pmote(CHAR_DATA *ch, char *argument)
 			continue;
 		}
 
-		strcpy(temp, argument);
+		snprintf(temp, sizeof(temp), "%s", argument);
 		temp[strlen(argument) - strlen(letter)] = '\0';
 		last[0] = '\0';
 		name = vch->name;

--- a/code/interp.c
+++ b/code/interp.c
@@ -681,7 +681,7 @@ void interpret(CHAR_DATA *ch, char *argument)
 	 * Special parsing so ' can be a command,
 	 *   also no spaces needed after punctuation.
 	 */
-	strcpy(logline, argument);
+	snprintf(logline, sizeof(logline), "%s", argument);
 
 	if (!isalpha(argument[0]) && !isdigit(argument[0]))
 	{
@@ -718,7 +718,7 @@ void interpret(CHAR_DATA *ch, char *argument)
 		}
 
 		auto qcommand = fmt::format("{} {}", command, argument);
-		strcpy(ch->pcdata->queue[ch->pcdata->write_next], qcommand.c_str());
+		snprintf(ch->pcdata->queue[ch->pcdata->write_next], sizeof(ch->pcdata->queue[ch->pcdata->write_next]), "%s", qcommand.c_str());
 		//		sprintf(buf,"Command '%s' queued.\n\r",qcommand.c_str());
 		//		send_to_char(buf,ch);
 		ch->pcdata->write_next++;
@@ -895,9 +895,12 @@ void interpret(CHAR_DATA *ch, char *argument)
 		}
 	}
 
-	strcpy(arg_dup, argument);
+	snprintf(arg_dup, sizeof(arg_dup), "%s", argument);
 
-	strcpy(arg_dup, one_argument(arg_dup, object));
+	// since source and dest overlap, 
+	// use memmove to safely shift the remainder forward.
+	char *arg_dup_rest = one_argument(arg_dup, object);
+	memmove(arg_dup, arg_dup_rest, strlen(arg_dup_rest) + 1);
 
 	if (vprog && ((vpobj = get_obj_here(ch, object)) != nullptr) && (vpobj->pIndexData->verb) &&
 		(!str_cmp(command, vpobj->pIndexData->verb) && (ch->position >= POS_RESTING)))

--- a/code/note.c
+++ b/code/note.c
@@ -566,7 +566,7 @@ void parse_note(CHAR_DATA *ch, char *argument, int type)
 			return;
 		}
 
-		strcpy(buf, ch->pnote->text);
+		snprintf(buf, sizeof(buf), "%s", ch->pnote->text);
 
 		for (len = strlen(buf); len > 0; len--)
 		{

--- a/code/olc.c
+++ b/code/olc.c
@@ -416,7 +416,7 @@ void aedit(CHAR_DATA *ch, char *argument)
 	EDIT_AREA(ch, pArea);
 
 	smash_tilde(argument);
-	strcpy(arg, argument);
+	snprintf(arg, sizeof(arg), "%s", argument);
 
 	argument = one_argument(argument, command);
 
@@ -488,7 +488,7 @@ void redit(CHAR_DATA *ch, char *argument)
 	pArea = pRoom->area;
 
 	smash_tilde(argument);
-	strcpy(arg, argument);
+	snprintf(arg, sizeof(arg), "%s", argument);
 	argument = one_argument(argument, command);
 
 	if (!IS_BUILDER(ch, pArea))
@@ -577,7 +577,7 @@ void oedit(CHAR_DATA *ch, char *argument)
 	/*  int  value;   ROM */
 
 	smash_tilde(argument);
-	strcpy(arg, argument);
+	snprintf(arg, sizeof(arg), "%s", argument);
 	argument = one_argument(argument, command);
 
 	EDIT_OBJ(ch, pObj);
@@ -640,7 +640,7 @@ void medit(CHAR_DATA *ch, char *argument)
 	/*  int  value;    ROM */
 
 	smash_tilde(argument);
-	strcpy(arg, argument);
+	snprintf(arg, sizeof(arg), "%s", argument);
 	argument = one_argument(argument, command);
 
 	EDIT_MOB(ch, pMob);


### PR DESCRIPTION
This PR fixes some of the potential buffer overflow warnings from the Snyk security scan.

It replaces a few of the `strcpy` calls with `snprintf`. The offered suggestion of using `strncpy` while technically correct, it doesn't absolve the buffer overflow since it's not NULL terminated. You would have to add an additional line for the NULL termination. `snprintf` is NULL terminated and thus the cleaner drop in replacement.

There are tons of `strcp` and `strcat` calls. I thought I'd start with just a few so as not to file bomb the PR. :)