### PR TITLE
Refactored cmake file to bring it up to current standards

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,36 +1,27 @@
-# > cmake -B .
-# > make
-cmake_minimum_required(VERSION 3.12)
-
-# need to define the compiler before project because reasons
-if(WIN32)
-	set(CCOMPILER "c:\\MinGW\\bin\\gcc.exe")
-	set(CXXCOMPILER "c:\\MinGW\\bin\\gcc.exe")
-else()
-	set(CCOMPILER "/usr/bin/gcc")
-	set(CXXCOMPILER "/usr/bin/g++")
-endif()
-set(CMAKE_C_COMPILER "${CCOMPILER}")
-set(CMAKE_C_FLAGS "-O1 -g -DFMT_HEADER_ONLY")
-
-set(CMAKE_CXX_COMPILER "${CXXCOMPILER}")
-set(CMAKE_CXX_FLAGS "-O1 -g -Wno-write-strings -DFMT_HEADER_ONLY")
-
+cmake_minimum_required(VERSION 3.16)
 
 project(riftshadow)
 
 set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+	set(CMAKE_BUILD_TYPE Debug CACHE STRING "Build type" FORCE)
+endif()
+
+add_compile_definitions(FMT_HEADER_ONLY)
+add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Wno-write-strings>)
 
 if(WIN32)
-	include_directories("C:\\Program Files\\MariaDB 10.4\\include\\mysql" "C:\\MinGW\\msys\\1.0\\include" "${CMAKE_SOURCE_DIR}/code/include")
-	link_directories("c:\\MinGW\\lib" "c:\\MinGW\\msys\\1.0\\lib" "C:\\Program Files (x86)\\MySQL\\MySQL Connector C++ 8.0\\lib" "c:\\MinGW\\msys\\1.0\\lib\\openssl\\engines-1.0.0" "${CMAKE_BINARY_DIR}\\code" "${CMAKE_BINARY_DIR}\\tests")
+	set(MYSQL_INCLUDE_DIRS "C:/Program Files/MariaDB 10.4/include/mysql" "C:/MinGW/msys/1.0/include")
+	link_directories("c:/MinGW/lib" "c:/MinGW/msys/1.0/lib" "C:/Program Files (x86)/MySQL/MySQL Connector C++ 8.0/lib" "c:/MinGW/msys/1.0/lib/openssl/engines-1.0.0")
 	set(CRYPTOLIB "libcrypto")
 	set(MARIADBLIB "mysqlcppconn8-2-vs14")
 else()
-	include_directories("/usr/include" "/usr/include/mysql" "${CMAKE_SOURCE_DIR}/code/include")
-	link_directories("/usr/lib" "${CMAKE_BINARY_DIR}\\code" "${CMAKE_BINARY_DIR}\\tests")
-	set(CRYPTOLIB "crypt")
-	set(MARIADBLIB "mysqlclient")
+	set(MYSQL_INCLUDE_DIRS "/usr/include/mysql")
+	find_library(CRYPTOLIB NAMES crypt REQUIRED)
+	find_library(MARIADBLIB NAMES mysqlclient mariadb REQUIRED)
 endif()
 
 add_subdirectory(code)

--- a/code/CMakeLists.txt
+++ b/code/CMakeLists.txt
@@ -82,5 +82,10 @@ set_source_files_properties(${RIFT_SOURCE} main.c PROPERTIES LANGUAGE CXX)
 add_library(RiftCore SHARED ${RIFT_SOURCE})
 add_executable(rift main.c)
 
+target_include_directories(RiftCore PUBLIC
+	"${CMAKE_SOURCE_DIR}/code/include"
+	${MYSQL_INCLUDE_DIRS}
+)
+
 target_link_libraries(rift PRIVATE RiftCore ${CRYPTOLIB} ${MARIADBLIB} m)
 


### PR DESCRIPTION
This PR refactors our cmake files to bring them up to current standards. It also bumps up the version from 3.12 to 3.16.

A neat side effect is faster build times.

I built, ran tests, and played for about 15 minutes. The changes seem solid.