### PR TITLE
Refactored syscalls to native C++ library calls

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -5,8 +5,8 @@
             "includePath": [
                 "${workspaceFolder}/**",
                 "/usr/include/**",
-                "/usr/lib/gcc/x86_64-linux-gnu/9/../../../../include/c++/9",
-                "/usr/lib/gcc/x86_64-linux-gnu/9/include",
+                "/usr/lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11",
+                "/usr/lib/gcc/x86_64-linux-gnu/11/include",
                 "/usr/local/include"
             ],
 			"browse": {

--- a/code/CMakeLists.txt
+++ b/code/CMakeLists.txt
@@ -4,6 +4,7 @@ set(RIFT_SOURCE config.cpp
 	strings.c
 	file.c
 	cdirectory.c
+	cfilesystem.c
 	clogger.c
 	sql.c
 	bitvector.c

--- a/code/cfilesystem.c
+++ b/code/cfilesystem.c
@@ -1,0 +1,63 @@
+#include "stdlibs/cfilesystem.h"
+#include <filesystem>
+#include <fstream>
+#include <system_error>
+
+/// Tests whether a file or directory exists at the given path.
+/// @param path: The path to check.
+/// @return True if something exists at path, false otherwise.
+bool CFileSystem::Exists(const std::string &path)
+{
+	std::error_code ec;
+	bool exists = std::filesystem::exists(path, ec);
+	return exists && !ec;
+}
+
+/// Moves (renames) a file, overwriting the destination if it exists.
+/// @note Equivalent to "mv -f source destination".
+/// @param source: The path of the file to move.
+/// @param destination: The path to move the file to.
+/// @return True on success, false on failure.
+bool CFileSystem::Move(const std::string &source, const std::string &destination)
+{
+	std::error_code ec;
+	std::filesystem::rename(source, destination, ec);
+	return !ec;
+}
+
+/// Copies a file, overwriting the destination if it exists.
+/// @note Equivalent to "cp source destination".
+/// @param source: The path of the file to copy.
+/// @param destination: The path to copy the file to.
+/// @return True on success, false on failure.
+bool CFileSystem::Copy(const std::string &source, const std::string &destination)
+{
+	std::error_code ec;
+	std::filesystem::copy_file(source, destination,
+		std::filesystem::copy_options::overwrite_existing, ec);
+	return !ec;
+}
+
+/// Removes a file. Removing a non-existent file is treated as success.
+/// @note Equivalent to "rm path".
+/// @param path: The path of the file to remove.
+/// @return True on success, false on failure.
+bool CFileSystem::Remove(const std::string &path)
+{
+	std::error_code ec;
+	std::filesystem::remove(path, ec);
+	return !ec;
+}
+
+/// Ensures a file exists, creating an empty one if it does not.
+/// @note Equivalent to "touch path".
+/// @param path: The path of the file to create or update.
+/// @return True on success, false on failure.
+bool CFileSystem::Touch(const std::string &path)
+{
+	if (CFileSystem::Exists(path))
+		return true;
+
+	std::ofstream file(path, std::ios::app);
+	return file.good();
+}

--- a/code/db2.c
+++ b/code/db2.c
@@ -972,10 +972,10 @@ void bugout(char *reason)
 
 	RS.Logger.Warn(reason);
 
-	auto fp = fopen(RIFT_ROOT_DIR "../logs/bugout.txt", "a");
+	auto fp = fopen(RIFT_LOGS_DIR "/bugout.txt", "a");
 	if (fp == nullptr)
 	{
-		RS.Logger.Warn("Unable to open bug file: fopen {}: {}", RIFT_ROOT_DIR "../logs/bugout.txt", std::strerror(errno));
+		RS.Logger.Warn("Unable to open bug file: fopen {}: {}", RIFT_LOGS_DIR "/bugout.txt", std::strerror(errno));
 		return;
 	}
 

--- a/code/devextra.c
+++ b/code/devextra.c
@@ -10,6 +10,7 @@
 #include <iterator>
 #include "devextra.h"
 #include "rift.h"
+#include "stdlibs/cfilesystem.h"
 #include "magic.h"
 #include "recycle.h"
 #include "db.h"
@@ -63,7 +64,6 @@ void do_pswitch(CHAR_DATA *ch, char *argument)
 {
 	DESCRIPTOR_DATA *d;
 	char name[MAX_STRING_LENGTH];
-	char buf[MAX_STRING_LENGTH];
 	CHAR_DATA *victim;
 
 	argument = one_argument(argument, name);
@@ -96,11 +96,11 @@ void do_pswitch(CHAR_DATA *ch, char *argument)
 		return;
 	}
 
-	sprintf(buf, "cp %s/%s%s %s/pload.txt", RIFT_PLAYER_DIR, name, ".plr", RIFT_PLAYER_DIR);
+	auto ploadSource = fmt::format("{}/{}{}", RIFT_PLAYER_DIR, name, ".plr");
+	auto ploadDest = fmt::format("{}/pload.txt", RIFT_PLAYER_DIR);
 
-	auto returnCode = system(buf);
-	if(returnCode != 0) // cp returns 0 on SUCCESS, 1 on ERROR. system returns -1 on ERROR
-		RS.Logger.Warn("Command [{}] failed with exit code [{}]", buf, returnCode);
+	if (!CFileSystem::Copy(ploadSource, ploadDest))
+		RS.Logger.Warn("Failed to copy [{}] to [{}]", ploadSource, ploadDest);
 
 	d->character->desc = nullptr;
 	d->character->next = char_list;
@@ -760,19 +760,24 @@ void do_demo(CHAR_DATA *ch, char *name)
 
 void delete_char(char *name, bool save_pfile)
 {
-	char buf1[MSL], buf2[MSL], query[MSL];
+	char query[MSL];
 	name = capitalize(name);
 	int cres = 0;
 
 	// whack their pfile.. or maybe just move it to dead_char
-	if (save_pfile)
-		sprintf(buf2, "mv %s/%s.plr %s/dead_char/%s.plr", RIFT_PLAYER_DIR, name, RIFT_PLAYER_DIR, name);
-	else
-		sprintf(buf2, "rm %s/%s.plr", RIFT_PLAYER_DIR, name);
+	auto pfilePath = fmt::format("{}/{}.plr", RIFT_PLAYER_DIR, name);
 
-	auto returnCode = system(buf2);
-	if(returnCode != 0) // both mv and rm return 0 on SUCCESS, > 0 on ERROR. system returns -1 on ERROR
-		RS.Logger.Warn("Command [{}] failed with exit code [{}]", buf2, returnCode);
+	if (save_pfile)
+	{
+		auto deadPath = fmt::format("{}/dead_char/{}.plr", RIFT_PLAYER_DIR, name);
+		if (!CFileSystem::Move(pfilePath, deadPath))
+			RS.Logger.Warn("Failed to move [{}] to [{}]", pfilePath, deadPath);
+	}
+	else
+	{
+		if (!CFileSystem::Remove(pfilePath))
+			RS.Logger.Warn("Failed to remove [{}]", pfilePath);
+	}
 
 	cres = RS.SQL.Delete("players WHERE name='%s'", name);
 

--- a/code/dioextra.c
+++ b/code/dioextra.c
@@ -41,6 +41,7 @@
 #include <iterator>
 #include "dioextra.h"
 #include "handler.h"
+#include "stdlibs/cfilesystem.h"
 #include "recycle.h"
 #include "tables.h"
 #include "lookup.h"
@@ -1673,11 +1674,11 @@ void do_pload(CHAR_DATA *ch, char *argument)
 		return;
 	}
 
-	auto buffer = fmt::format("cp {}{}{} {}pload.txt", RIFT_PLAYER_DIR, name, ".plr", RIFT_PLAYER_DIR);
+	auto ploadSource = fmt::format("{}/{}{}", RIFT_PLAYER_DIR, name, ".plr");
+	auto ploadDest = fmt::format("{}/pload.txt", RIFT_PLAYER_DIR);
 
-	auto returnCode = system(buffer.c_str());
-	if(returnCode != 0) // cp returns 0 on SUCCESS, 1 on ERROR. system returns -1 on ERROR
-		RS.Logger.Warn("Command [{}] failed with exit code [{}]", buffer.data(), returnCode);
+	if (!CFileSystem::Copy(ploadSource, ploadDest))
+		RS.Logger.Warn("Failed to copy [{}] to [{}]", ploadSource, ploadDest);
 
 	d->character->desc = nullptr;
 	d->character->next = char_list;
@@ -1696,7 +1697,7 @@ void do_pload(CHAR_DATA *ch, char *argument)
 
 	interpret(ch, argument);
 
-	buffer = fmt::format("{}/{}{}", RIFT_PLAYER_DIR, name, ".plr");
+	auto buffer = fmt::format("{}/{}{}", RIFT_PLAYER_DIR, name, ".plr");
 
 	if (fopen(buffer.c_str(), "r") != nullptr)
 	{

--- a/code/olc_save.c
+++ b/code/olc_save.c
@@ -34,6 +34,7 @@
 #include <algorithm>
 #include "olc_save.h"
 #include "rift.h"
+#include "stdlibs/cfilesystem.h"
 #include "handler.h"
 #include "olc.h"
 #include "tables.h"
@@ -927,21 +928,15 @@ void save_shops(FILE *fp, AREA_DATA *pArea)
 
 void save_area(AREA_DATA *pArea)
 {
-	std::string buffer;
 	long long temp_bit;
-	char buf[MSL];
 	FILE *fp = nullptr;
 
-	sprintf(buf, "mv -f %s " RIFT_AREA_DIR "/backup/%s.bak", pArea->file_name, pArea->file_name);
+	std::string backupPath = std::string(RIFT_AREA_DIR "/backup/") + pArea->file_name + ".bak";
+	if (!CFileSystem::Move(pArea->file_name, backupPath))
+		RS.Logger.Warn("Failed to move [{}] to [{}]", pArea->file_name, backupPath);
 
-	auto returnCode = system(buf);
-	if(returnCode != 0) // mv returns 0 on SUCCESS, > 0 on ERROR. system returns -1 on ERROR
-		RS.Logger.Warn("Command [{}] failed with exit code [{}]", buf, returnCode);
-
-	buffer = std::string("touch " AREA_DUMP_FILE);
-	returnCode = system(buffer.c_str());
-	if(returnCode != 0) // couldn't find exit code for touch, assuming touch returns 0 on SUCCESS, > 0 on ERROR. system returns -1 on ERROR
-		RS.Logger.Warn("Command [{}] failed with exit code [{}]", buffer.data(), returnCode);
+	if (!CFileSystem::Touch(AREA_DUMP_FILE))
+		RS.Logger.Warn("Failed to touch [{}]", AREA_DUMP_FILE);
 
 	if (!(fp = fopen(pArea->file_name, "w")))
 	{

--- a/code/stdlibs/cfilesystem.h
+++ b/code/stdlibs/cfilesystem.h
@@ -1,0 +1,16 @@
+#ifndef CFILESYSTEM
+#define CFILESYSTEM
+
+#include <string>
+
+class CFileSystem
+{
+public:
+	static bool Exists(const std::string &path);
+	static bool Move(const std::string &source, const std::string &destination);
+	static bool Copy(const std::string &source, const std::string &destination);
+	static bool Remove(const std::string &path);
+	static bool Touch(const std::string &path);
+};
+
+#endif


### PR DESCRIPTION
This PR refactors most of the system calls in the code base into standard C++ filesystem calls. The previous system calls were brittle, non-portable, and was open to security issues.

Note that there is still 2 syscalls left. One to gzip and the other to grep. I left these in place because:

- replacing the gzip syscall would require importing an additional library ZLIB or equivalent.
- replacing the grep syscall requires some regex magic ot handle.

I feel like those would muddy the PR, so left them for a future date.