### PR TITLE
Fix queue re-entrancy bugs

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,8 +5,10 @@
 	},
 	"runArgs": ["--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined"],
 
-	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	// "forwardPorts": [],
+	// Publishes the MUD port at the container runtime (equivalent to -p 9999:9999) so
+	// telnet works from the host whether or not VS Code is attached. Keep in sync with
+	// the "Port" value in config.json.
+	"appPort": [9999],
 
 	// Use 'postCreateCommand' to run commands after the container is created.
 	// "postCreateCommand": "gcc -v",

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -78,13 +78,15 @@ jobs:
       # ASAN halts on memory errors by default
       # detect_leaks=0: the codebase intentionally never frees; leak reports
       #   would be pure noise for now.
-      # detect_odr_violation=0: tolerates the one known ODR violation,
-      # UBSAN is print-only for now (halt_on_error unset) because of known UB
+      # detect_odr_violation=0: tolerates the one known ODR violation
+      #   (db_tests.c includes db.c); revisit after the merc.h split.
+      # UBSAN halt_on_error=1: the known UB this waited on was the queue
+      #   re-entrancy UAF, fixed in the queue safety commit. UB now gates CI.
       - name: Test under sanitizers
         run: ctest --test-dir build-asan --output-on-failure
         env:
           ASAN_OPTIONS: detect_leaks=0:detect_odr_violation=0
-          UBSAN_OPTIONS: print_stacktrace=1
+          UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=1
 
   smoke:
     name: smoke-boot-asan
@@ -136,4 +138,4 @@ jobs:
         env:
           RIFT_BIN: ${{ github.workspace }}/build-asan/code/rift
           ASAN_OPTIONS: detect_leaks=0:detect_odr_violation=0
-          UBSAN_OPTIONS: print_stacktrace=1
+          UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=1

--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ code/rift.exe
 area/rift.exe
 area/rift
 build/
+build-asan/
 tests/*_tests
 tests/*_helpers
 tests/catch

--- a/code/mprog.c
+++ b/code/mprog.c
@@ -182,8 +182,10 @@ int mprog_drop(int inc, char *arg, OBJ_DATA *obj, CHAR_DATA *mob, CHAR_DATA *ch)
 		RS.Queue.AddToQueue(inc, "mprog_drop", "act_queue", act_queue, buffer, ch, nullptr, nullptr, TO_CHAR);
 	}
 
-	RS.Queue.AddToQueue(inc, "mprog_drop", "obj_to_room", obj_to_room, obj, mob->in_room);
+	// Unlink from the mob before placing it, not after: obj_to_room clears
+	// carried_by, so the reverse order left the object in both lists.
 	RS.Queue.AddToQueue(inc, "mprog_drop", "obj_from_char", obj_from_char, obj);
+	RS.Queue.AddToQueue(inc, "mprog_drop", "obj_to_room", obj_to_room, obj, mob->in_room);
 	RS.Queue.AddToQueue(inc, "mprog_drop", "act_queue", act_queue, "$n drops $p.", mob, obj, nullptr, TO_ROOM);
 	return 0;
 }
@@ -198,8 +200,8 @@ int mprog_give(int inc, char *arg, OBJ_DATA *obj, CHAR_DATA *mob, CHAR_DATA *ch)
 		RS.Queue.AddToQueue(inc, "mprog_give", "act_queue", act_queue, buffer, ch, nullptr, nullptr, TO_CHAR);
 	}
 
-	RS.Queue.AddToQueue(inc, "mprog_give", "obj_to_char", obj_to_char, obj, ch);
 	RS.Queue.AddToQueue(inc, "mprog_give", "obj_from_char", obj_from_char, obj);
+	RS.Queue.AddToQueue(inc, "mprog_give", "obj_to_char", obj_to_char, obj, ch);
 	RS.Queue.AddToQueue(inc, "mprog_give", "act_queue", act_queue, "$n gives you $p.", mob, obj, ch, TO_VICT);
 	return 0;
 }

--- a/code/queue.c
+++ b/code/queue.c
@@ -1,14 +1,39 @@
 #include "queue.h"
 #include "merc.h"
+#include <algorithm>
+#include <iterator>
 
-/// Processes all items on the queue. Any entry that has a timer of zero gets executed.
-/// Once all items are processed, those functions that have executed are removed from the queue.
+/// Processes all items on the queue. Any entry whose timer reaches zero gets executed.
+/// Entries that ran, and entries cancelled while the loop was running, are swept afterwards.
+///
+/// The loop must not mutate newQueue while walking it. Additions are staged by AddToQueue
+/// and merged below before iteration starts; removals are tombstones set on the entries
+/// themselves. Between them, no reallocation and no erase can happen mid-iteration.
 void CQueue::ProcessQueue()
 {
+	if (!stagedQueue.empty())
+	{
+		newQueue.insert(newQueue.end(),
+			std::make_move_iterator(stagedQueue.begin()),
+			std::make_move_iterator(stagedQueue.end()));
+
+		stagedQueue.clear();
+	}
+
 	for (auto& item : newQueue)
 	{
-		if (--item.timer == 0)
+		// A callee earlier in this same loop may have cancelled this entry.
+		if (item.cancelled)
+			continue;
+
+		// Changed to less-than-equals since we accept zero timers
+		// and equals would ignore them.
+		if (--item.timer <= 0)
 		{
+			item.executed = true;
+
+			// We need a copied handle to the function so that it
+			// can't get lost during queue processing.
 			auto func = item.function;
 			func();
 		}
@@ -17,47 +42,71 @@ void CQueue::ProcessQueue()
 	newQueue.erase(
 		std::remove_if(newQueue.begin(), newQueue.end(), [](const auto& item)
 		{
-			return item.timer < 0;
+			return item.executed || item.cancelled;
 		}), newQueue.end());
 }
 
-/// Determines if a specific character has any remaining entries in the queue.
-/// This function applies to both directions (eg. either character being affected or is affecting another pc or environment).
-/// @param qChar: The character to lookup in the queue.
-/// @return true if there are entries related to the character in the queue; otherwise false.
-bool CQueue::HasQueuePending(CHAR_DATA *qChar)
+/// @return true if any live entry in the container names qChar.
+bool CQueue::HasPendingIn(const std::vector<queueEntry_t>& entries, CHAR_DATA *qChar) const
 {
-	for (auto& item : newQueue)
+	for (const auto& item : entries)
 	{
-		auto delay = item.timer;
-		auto v = item.charList;
-		auto contains = std::find(v.begin(), v.end(), qChar) != v.end();
+		if (item.cancelled || item.executed)
+			continue;
 
-		if (contains && delay > 0)
+		const auto& v = item.charList;
+
+		if (std::find(v.begin(), v.end(), qChar) != v.end())
 			return true;
 	}
 
 	return false;
 }
 
+/// Determines if a specific character has any remaining entries in the queue.
+/// This function applies to both directions (eg. either character being affected
+/// or is affecting another pc or environment).
+/// @param qChar: The character to lookup in the queue.
+/// @return true if there are entries related to the character in the queue; otherwise false.
+bool CQueue::HasQueuePending(CHAR_DATA *qChar)
+{
+	return HasPendingIn(newQueue, qChar) || HasPendingIn(stagedQueue, qChar);
+}
+
+/// Marks every live entry naming qChar as cancelled.
+/// @return the number of entries tombstoned.
+int CQueue::CancelEntriesInvolving(std::vector<queueEntry_t>& entries, CHAR_DATA *qChar)
+{
+	int cancelled = 0;
+
+	for (auto& item : entries)
+	{
+		if (item.cancelled || item.executed)
+			continue;
+
+		const auto& v = item.charList;
+
+		if (std::find(v.begin(), v.end(), qChar) != v.end())
+		{
+			item.cancelled = true;
+			cancelled++;
+		}
+	}
+
+	return cancelled;
+}
+
 /// Deletes all entries in the queue pertaining to the specified character.
+/// Entries are tombstoned rather than erased so that we don't mutate the 
+/// queue while it's being processed. Tombstoning also lets an event due
+/// in the tick currently draining actually be cancelled, which an erase
+/// could not do.
 /// @param qChar: The character to lookup in the queue.
 void CQueue::DeleteQueuedEventsInvolving(CHAR_DATA *qChar)
 {
-	int deleted = 0;
-	newQueue.erase(
-		std::remove_if(newQueue.begin(), newQueue.end(), [&](const auto& item)
-		{
-			auto delay = item.timer;
-			auto v = item.charList;
-			auto contains = std::find(v.begin(), v.end(), qChar) != v.end();
+	auto cancelled = CancelEntriesInvolving(newQueue, qChar)
+		+ CancelEntriesInvolving(stagedQueue, qChar);
 
-			if (contains && delay > 0)
-			{
-				deleted++;
-				return true;
-			}
-
-			return false;
-		}), newQueue.end());
+	if (cancelled > 0)
+		RS.Logger.Info("Cancelled {} queued event(s) involving character.", cancelled);
 }

--- a/code/queue.c
+++ b/code/queue.c
@@ -1,66 +1,82 @@
 #include "queue.h"
 #include "merc.h"
 #include <algorithm>
-#include <iterator>
 
-/// Processes all items on the queue. Any entry whose timer reaches zero gets executed.
-/// Entries that ran, and entries cancelled while the loop was running, are swept afterwards.
-///
-/// The loop must not mutate newQueue while walking it. Additions are staged by AddToQueue
-/// and merged below before iteration starts; removals are tombstones set on the entries
-/// themselves. Between them, no reallocation and no erase can happen mid-iteration.
-void CQueue::ProcessQueue()
+/// Registers a new entry against every character it names.
+void CQueue::RegisterEntry(const std::vector<CHAR_DATA*>& chars, entryRef ref)
 {
-	if (!stagedQueue.empty())
+	for (auto *ch : chars)
 	{
-		newQueue.insert(newQueue.end(),
-			std::make_move_iterator(stagedQueue.begin()),
-			std::make_move_iterator(stagedQueue.end()));
-
-		stagedQueue.clear();
+		if (ch != nullptr)
+			charIndex[ch].push_back(ref);
 	}
+}
 
-	for (auto& item : newQueue)
+/// Removes an entry's refs from every character it names.
+/// Done for all of the entry's characters, not just the one being cancelled, so that
+/// charIndex only ever holds refs to entries that can still run.
+void CQueue::DropEntryRefs(const queueEntry_t& entry, entryRef ref)
+{
+	for (auto *ch : entry.charList)
 	{
-		// A callee earlier in this same loop may have cancelled this entry.
-		if (item.cancelled)
+		auto it = charIndex.find(ch);
+
+		if (it == charIndex.end())
 			continue;
 
-		// Changed to less-than-equals since we accept zero timers
-		// and equals would ignore them.
-		if (--item.timer <= 0)
+		auto& refs = it->second;
+		refs.erase(std::remove(refs.begin(), refs.end(), ref), refs.end());
+
+		if (refs.empty())
+			charIndex.erase(it);
+	}
+}
+
+/// @return the entry a ref points at, or nullptr if its bucket is already gone.
+CQueue::queueEntry_t* CQueue::ResolveEntry(entryRef ref)
+{
+	auto it = buckets.find(ref.tick);
+
+	if (it == buckets.end() || ref.index >= it->second.size())
+		return nullptr;
+
+	return &it->second[ref.index];
+}
+
+/// Processes everything due on this tick. Entries execute in the order they were queued.
+///
+/// The due bucket stays in the map while it drains, so a callee can still cancel entries
+/// due in this same tick. Nothing can be appended to it — AddToQueue always schedules at
+/// least one tick ahead — so the loop cannot be reallocated out from under itself.
+void CQueue::ProcessQueue()
+{
+	currentTick++;
+
+	while (!buckets.empty() && buckets.begin()->first <= currentTick)
+	{
+		auto tick = buckets.begin()->first;
+		auto& due = buckets.begin()->second;
+
+		for (size_t i = 0; i < due.size(); i++)
 		{
-			item.executed = true;
+			auto& item = due[i];
+
+			// A callee earlier in this same bucket may have cancelled this entry.
+			if (item.cancelled)
+				continue;
+
+			// Unregister before running: an entry that is executing is no longer
+			// pending, and must not be reachable for cancellation.
+			DropEntryRefs(item, {tick, i});
 
 			// We need a copied handle to the function so that it
 			// can't get lost during queue processing.
 			auto func = item.function;
 			func();
 		}
+
+		buckets.erase(tick);
 	}
-
-	newQueue.erase(
-		std::remove_if(newQueue.begin(), newQueue.end(), [](const auto& item)
-		{
-			return item.executed || item.cancelled;
-		}), newQueue.end());
-}
-
-/// @return true if any live entry in the container names qChar.
-bool CQueue::HasPendingIn(const std::vector<queueEntry_t>& entries, CHAR_DATA *qChar) const
-{
-	for (const auto& item : entries)
-	{
-		if (item.cancelled || item.executed)
-			continue;
-
-		const auto& v = item.charList;
-
-		if (std::find(v.begin(), v.end(), qChar) != v.end())
-			return true;
-	}
-
-	return false;
 }
 
 /// Determines if a specific character has any remaining entries in the queue.
@@ -70,42 +86,39 @@ bool CQueue::HasPendingIn(const std::vector<queueEntry_t>& entries, CHAR_DATA *q
 /// @return true if there are entries related to the character in the queue; otherwise false.
 bool CQueue::HasQueuePending(CHAR_DATA *qChar)
 {
-	return HasPendingIn(newQueue, qChar) || HasPendingIn(stagedQueue, qChar);
-}
+	auto it = charIndex.find(qChar);
 
-/// Marks every live entry naming qChar as cancelled.
-/// @return the number of entries tombstoned.
-int CQueue::CancelEntriesInvolving(std::vector<queueEntry_t>& entries, CHAR_DATA *qChar)
-{
-	int cancelled = 0;
-
-	for (auto& item : entries)
-	{
-		if (item.cancelled || item.executed)
-			continue;
-
-		const auto& v = item.charList;
-
-		if (std::find(v.begin(), v.end(), qChar) != v.end())
-		{
-			item.cancelled = true;
-			cancelled++;
-		}
-	}
-
-	return cancelled;
+	return it != charIndex.end() && !it->second.empty();
 }
 
 /// Deletes all entries in the queue pertaining to the specified character.
-/// Entries are tombstoned rather than erased so that we don't mutate the 
+/// Entries are tombstoned rather than erased so that we don't mutate the
 /// queue while it's being processed. Tombstoning also lets an event due
 /// in the tick currently draining actually be cancelled, which an erase
 /// could not do.
 /// @param qChar: The character to lookup in the queue.
 void CQueue::DeleteQueuedEventsInvolving(CHAR_DATA *qChar)
 {
-	auto cancelled = CancelEntriesInvolving(newQueue, qChar)
-		+ CancelEntriesInvolving(stagedQueue, qChar);
+	auto it = charIndex.find(qChar);
+
+	if (it == charIndex.end())
+		return;
+
+	// Copied because cancelling mutates charIndex, including this character's own refs.
+	auto refs = it->second;
+	int cancelled = 0;
+
+	for (auto ref : refs)
+	{
+		auto *item = ResolveEntry(ref);
+
+		if (item == nullptr || item->cancelled)
+			continue;
+
+		item->cancelled = true;
+		DropEntryRefs(*item, ref);
+		cancelled++;
+	}
 
 	if (cancelled > 0)
 		RS.Logger.Info("Cancelled {} queued event(s) involving character.", cancelled);

--- a/code/queue.h
+++ b/code/queue.h
@@ -3,10 +3,13 @@
 
 #include "rift.h"
 #include <stdarg.h>
+#include <cstdint>
 #include <functional>
+#include <map>
 #include <string>
 #include <tuple>
 #include <type_traits>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -36,15 +39,18 @@ public:
 		auto tuple = std::tuple<Args...>(args...);
 		auto chs = GetCharacterData(tuple);
 
-		// Stage rather than append directly. ProcessQueue merges staged entries
-		// before it starts iterating, so a callee that queues more work cannot
-		// reallocate the vector being walked. Timing is unaffected: an entry
-		// staged during tick N is merged at the top of tick N+1 and first
-		// decremented there, exactly as a direct push_back behaved.
-		stagedQueue.push_back({nTimer, from, funcName, chs, [=] () mutable
+		// Timers of 0 and 1 both mean "next tick", so nothing can ever be scheduled
+		// into the bucket currently draining. That is what keeps ProcessQueue's loop
+		// stable without a staging buffer.
+		auto expiry = currentTick + static_cast<uint64_t>(nTimer < 1 ? 1 : nTimer);
+		auto& bucket = buckets[expiry];
+
+		bucket.push_back({from, funcName, chs, [=] () mutable
 		{
 			std::apply(func, std::forward_as_tuple(std::forward<Args>(args)...));
 		}});
+
+		RegisterEntry(chs, {expiry, bucket.size() - 1});
 	}
 
 	/// Processes all items on the queue. Any entry that has a timer of zero gets executed.
@@ -63,34 +69,44 @@ public:
 private:
 	struct queueEntry_t
 	{
-		int timer;
 		std::string callerFuncName;
 		std::string calleeFuncName;
 		std::vector<CHAR_DATA*> charList;
 		std::function<void()> function;
 
-		/// Set by DeleteQueuedEventsInvolving instead of erasing the entry, so
-		/// cancellation is safe while ProcessQueue is mid-iteration.
+		/// tombstone flag
 		bool cancelled = false;
-
-		/// Set by ProcessQueue when the entry has run. Swept in the same pass.
-		bool executed = false;
 	};
 
-	/// The materialized queue of events.
-	/// This is the queue that is processed each tick.
-	std::vector<queueEntry_t> newQueue;
+	/// reference used to hold tick and index
+	/// information about a queue entry
+	struct entryRef
+	{
+		uint64_t tick;
+		size_t index;
 
-	/// The staging area for queued events. 
-	/// This is where new entries are added before being merged into the main queue.
-	std::vector<queueEntry_t> stagedQueue;
+		bool operator==(const entryRef& other) const
+		{
+			return tick == other.tick && index == other.index;
+		}
+	};
 
-	/// Marks every live entry for a specified character as cancelled.
-	/// @return the number of entries tombstoned.
-	int CancelEntriesInvolving(std::vector<queueEntry_t>& entries, CHAR_DATA *qChar);
+	/// queue's internal tick mechanism
+	uint64_t currentTick = 0;
 
-	/// @return true if any live entry in the container has a specified character.
-	bool HasPendingIn(const std::vector<queueEntry_t>& entries, CHAR_DATA *qChar) const;
+	/// Pending events keyed by the absolute tick they fire on. Ordered so the due
+	/// bucket is always at begin(), and so a missed pulse can still drain in order.
+	/// Insertion order within a bucket is the execution order callers depend on.
+	std::map<uint64_t, std::vector<queueEntry_t>> buckets;
+
+	/// Reverse lookup for cancellation. Holds refs to *live* entries only: refs are
+	/// dropped when an entry is cancelled or executed, so a non-empty entry here
+	/// means the character genuinely has work pending.
+	std::unordered_map<CHAR_DATA*, std::vector<entryRef>> charIndex;
+
+	void RegisterEntry(const std::vector<CHAR_DATA*>& chars, entryRef ref);
+	void DropEntryRefs(const queueEntry_t& entry, entryRef ref);
+	queueEntry_t* ResolveEntry(entryRef ref);
 
 	/// Helper function used to extract character data from the specfied tuple.
 	/// @note Main use is for extracting character data sent to the AddToQueue method.

--- a/code/queue.h
+++ b/code/queue.h
@@ -4,7 +4,10 @@
 #include "rift.h"
 #include <stdarg.h>
 #include <functional>
-#include <iostream>
+#include <string>
+#include <tuple>
+#include <type_traits>
+#include <utility>
 #include <vector>
 
 // forward declarations. Once char_data is separated to its own file, we can get rid of these and include the file.
@@ -27,17 +30,18 @@ public:
 	void AddToQueue(int nTimer, std::string from, std::string funcName, Func func, Args &&...args)
 	{
 		if(nTimer < 0)
-			return;	
-
-		// print parameters
-		//((std::cout << ' ' << args << std::endl), ...);
+			return;
 
 		// capture parameter pack
 		auto tuple = std::tuple<Args...>(args...);
 		auto chs = GetCharacterData(tuple);
 
-		// place on queue
-		newQueue.push_back({nTimer, from, funcName, chs, [=] () mutable
+		// Stage rather than append directly. ProcessQueue merges staged entries
+		// before it starts iterating, so a callee that queues more work cannot
+		// reallocate the vector being walked. Timing is unaffected: an entry
+		// staged during tick N is merged at the top of tick N+1 and first
+		// decremented there, exactly as a direct push_back behaved.
+		stagedQueue.push_back({nTimer, from, funcName, chs, [=] () mutable
 		{
 			std::apply(func, std::forward_as_tuple(std::forward<Args>(args)...));
 		}});
@@ -64,9 +68,29 @@ private:
 		std::string calleeFuncName;
 		std::vector<CHAR_DATA*> charList;
 		std::function<void()> function;
+
+		/// Set by DeleteQueuedEventsInvolving instead of erasing the entry, so
+		/// cancellation is safe while ProcessQueue is mid-iteration.
+		bool cancelled = false;
+
+		/// Set by ProcessQueue when the entry has run. Swept in the same pass.
+		bool executed = false;
 	};
 
+	/// The materialized queue of events.
+	/// This is the queue that is processed each tick.
 	std::vector<queueEntry_t> newQueue;
+
+	/// The staging area for queued events. 
+	/// This is where new entries are added before being merged into the main queue.
+	std::vector<queueEntry_t> stagedQueue;
+
+	/// Marks every live entry for a specified character as cancelled.
+	/// @return the number of entries tombstoned.
+	int CancelEntriesInvolving(std::vector<queueEntry_t>& entries, CHAR_DATA *qChar);
+
+	/// @return true if any live entry in the container has a specified character.
+	bool HasPendingIn(const std::vector<queueEntry_t>& entries, CHAR_DATA *qChar) const;
 
 	/// Helper function used to extract character data from the specfied tuple.
 	/// @note Main use is for extracting character data sent to the AddToQueue method.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -21,6 +21,7 @@ set(TEST_SRC_FILES act_obj_tests.c
 	induction_tests.c
 	login_tests.c
 	magic_tests.c
+	mprog_tests.c
 	note_tests.c
 	offering_tests.c
 	pklog_tests.c

--- a/tests/mprog_tests.c
+++ b/tests/mprog_tests.c
@@ -1,0 +1,93 @@
+#include "catch.hpp"
+#include "../code/merc.h"
+#include "../code/mprog.h"
+#include "../code/handler.h"
+
+static room_index_data* CreateTestRoom()
+{
+	auto room = new room_index_data();
+	room->light = 3;
+	room->area = new area_data();
+
+	return room;
+}
+
+static obj_data* CreateTestItem()
+{
+	auto item = new obj_data();
+	item->name = "test_trinket";
+	item->description = "A test item";
+	item->wear_loc = -1;
+
+	return item;
+}
+
+static char_data* CreateTestChar(char *name, room_index_data *room)
+{
+	auto ch = new char_data();
+	ch->name = name;
+	char_to_room(ch, room);
+
+	return ch;
+}
+
+// mprog_give and mprog_drop queue the unlink and the relink as two separate
+// events on the same tick, so their relative order decides which inventory the
+// object ends up in. Both were inverted: obj_to_char/obj_to_room repoint
+// carried_by, so the trailing obj_from_char acted on the destination instead of
+// the mob, leaving the object linked in two lists at once.
+SCENARIO("Testing a mob handing an object to a character", "[mprog_give]")
+{
+	GIVEN("a mob carrying an object, and a character in the same room")
+	{
+		auto room = CreateTestRoom();
+		auto mob = CreateTestChar((char*)"Mob", room);
+		auto ch = CreateTestChar((char*)"Player", room);
+		auto obj = CreateTestItem();
+
+		obj_to_char(obj, mob);
+
+		REQUIRE(mob->carrying == obj);
+
+		WHEN("mprog_give queues the handover and the queue is processed")
+		{
+			mprog_give(1, nullptr, obj, mob, ch);
+			RS.Queue.ProcessQueue();
+
+			THEN("the object leaves the mob and is carried by the character")
+			{
+				REQUIRE(obj->carried_by == ch);
+				REQUIRE(ch->carrying == obj);
+				REQUIRE(mob->carrying == nullptr);
+			}
+		}
+	}
+}
+
+SCENARIO("Testing a mob dropping an object", "[mprog_drop]")
+{
+	GIVEN("a mob carrying an object")
+	{
+		auto room = CreateTestRoom();
+		auto mob = CreateTestChar((char*)"Mob", room);
+		auto obj = CreateTestItem();
+
+		obj_to_char(obj, mob);
+
+		REQUIRE(mob->carrying == obj);
+
+		WHEN("mprog_drop queues the drop and the queue is processed")
+		{
+			mprog_drop(1, nullptr, obj, mob, mob);
+			RS.Queue.ProcessQueue();
+
+			THEN("the object leaves the mob and lies in the room")
+			{
+				REQUIRE(obj->carried_by == nullptr);
+				REQUIRE(obj->in_room == room);
+				REQUIRE(room->contents == obj);
+				REQUIRE(mob->carrying == nullptr);
+			}
+		}
+	}
+}

--- a/tests/queue_tests.c
+++ b/tests/queue_tests.c
@@ -60,6 +60,98 @@ void updateValueFunction(char_data *qChar, long value)
 	qChar->id = value;
 }
 
+// Reproduces a re-entrant add bug found in the code.
+static CQueue *activeSut = nullptr;
+
+void reentrantRequeueFunction(char_data *qChar)
+{
+	activeSut->AddToQueue(5, "reentrantRequeueFunction", "reentrantRequeueFunction", reentrantRequeueFunction, qChar);
+}
+
+static int inertCallCount = 0;
+
+void inertQueueFunction(char_data *qChar)
+{
+	inertCallCount++;
+	return;
+}
+
+// Reproduces a re-entrant erase bug found in the code.
+void wideArgQueueFunction(char_data *qChar, long a, long b, long c)
+{
+	inertCallCount++;
+	return;
+}
+
+void deleteEventsQueueFunction(char_data *qChar)
+{
+	activeSut->DeleteQueuedEventsInvolving(qChar);
+}
+
+SCENARIO("Testing a queued function that cancels other events for its own char", "[ProcessQueue]")
+{
+	GIVEN("a due entry that cancels its char's other events, with those still to walk")
+	{
+		CQueue sut;
+		activeSut = &sut;
+		char_data *mockVictim = new char_data();
+		mockVictim->name = "Victim";
+
+		// All four are due this tick and all name the same char. The first
+		// survives the cancel (its timer is already 0 by the time it runs, and
+		// DeleteQueuedEventsInvolving only removes delay > 0); the other three
+		// are erased out from under the loop while still due.
+		sut.AddToQueue(1, "queue_test", "deleteEventsQueueFunction", deleteEventsQueueFunction, mockVictim);
+		sut.AddToQueue(1, "queue_test", "wideArgQueueFunction", wideArgQueueFunction, mockVictim, 1L, 2L, 3L);
+		sut.AddToQueue(1, "queue_test", "wideArgQueueFunction", wideArgQueueFunction, mockVictim, 1L, 2L, 3L);
+		sut.AddToQueue(1, "queue_test", "wideArgQueueFunction", wideArgQueueFunction, mockVictim, 1L, 2L, 3L);
+
+		WHEN("ProcessQueue runs the cancelling entry")
+		{
+			inertCallCount = 0;
+			sut.ProcessQueue();
+
+			THEN("the cancelled entries are not executed and nothing dangles")
+			{
+				REQUIRE(inertCallCount == 0);
+				REQUIRE(sut.HasQueuePending(mockVictim) == false);
+			}
+		}
+
+		activeSut = nullptr;
+	}
+}
+
+SCENARIO("Testing a queued function that requeues itself", "[ProcessQueue]")
+{
+	GIVEN("a due entry that requeues itself, with later entries still to walk")
+	{
+		CQueue sut;
+		activeSut = &sut;
+		char_data *mockPlayer = new char_data();
+		mockPlayer->name = "Test";
+
+		// Four entries leaves the vector at size == capacity == 4, so the
+		// re-entrant add below is guaranteed to reallocate.
+		sut.AddToQueue(1, "queue_test", "reentrantRequeueFunction", reentrantRequeueFunction, mockPlayer);
+		sut.AddToQueue(5, "queue_test", "inertQueueFunction", inertQueueFunction, mockPlayer);
+		sut.AddToQueue(5, "queue_test", "inertQueueFunction", inertQueueFunction, mockPlayer);
+		sut.AddToQueue(5, "queue_test", "inertQueueFunction", inertQueueFunction, mockPlayer);
+
+		WHEN("ProcessQueue runs the due entry")
+		{
+			sut.ProcessQueue();
+
+			THEN("the remaining entries are still walked without touching freed memory")
+			{
+				REQUIRE(sut.HasQueuePending(mockPlayer));
+			}
+		}
+
+		activeSut = nullptr;
+	}
+}
+
 SCENARIO("Testing queue processing", "[ProcessQueue]")
 {
 	GIVEN("A queue with a ready-to-run function")

--- a/tests/queue_tests.c
+++ b/tests/queue_tests.c
@@ -97,10 +97,9 @@ SCENARIO("Testing a queued function that cancels other events for its own char",
 		char_data *mockVictim = new char_data();
 		mockVictim->name = "Victim";
 
-		// All four are due this tick and all name the same char. The first
-		// survives the cancel (its timer is already 0 by the time it runs, and
-		// DeleteQueuedEventsInvolving only removes delay > 0); the other three
-		// are erased out from under the loop while still due.
+		// All four are due this tick and all name the same char. The first is
+		// already running by the time it cancels, so it is unaffected; the other
+		// three are still queued behind it and must not fire.
 		sut.AddToQueue(1, "queue_test", "deleteEventsQueueFunction", deleteEventsQueueFunction, mockVictim);
 		sut.AddToQueue(1, "queue_test", "wideArgQueueFunction", wideArgQueueFunction, mockVictim, 1L, 2L, 3L);
 		sut.AddToQueue(1, "queue_test", "wideArgQueueFunction", wideArgQueueFunction, mockVictim, 1L, 2L, 3L);
@@ -131,8 +130,9 @@ SCENARIO("Testing a queued function that requeues itself", "[ProcessQueue]")
 		char_data *mockPlayer = new char_data();
 		mockPlayer->name = "Test";
 
-		// Four entries leaves the vector at size == capacity == 4, so the
-		// re-entrant add below is guaranteed to reallocate.
+		// Four entries, so the re-entrant add below happens while three more are
+		// still queued behind it. Against the old flat vector this reallocated
+		// mid-iteration; the later entries must survive it either way.
 		sut.AddToQueue(1, "queue_test", "reentrantRequeueFunction", reentrantRequeueFunction, mockPlayer);
 		sut.AddToQueue(5, "queue_test", "inertQueueFunction", inertQueueFunction, mockPlayer);
 		sut.AddToQueue(5, "queue_test", "inertQueueFunction", inertQueueFunction, mockPlayer);
@@ -149,6 +149,89 @@ SCENARIO("Testing a queued function that requeues itself", "[ProcessQueue]")
 		}
 
 		activeSut = nullptr;
+	}
+}
+
+// Same-tick execution order that must run in the order they were added.
+static std::vector<int> executionOrder;
+
+void recordOrderFunction(char_data *qChar, long tag)
+{
+	executionOrder.push_back(static_cast<int>(tag));
+}
+
+SCENARIO("Testing execution order of queued events", "[ProcessQueue]")
+{
+	GIVEN("four events queued at the same tick")
+	{
+		CQueue sut;
+		char_data *mockPlayer = new char_data();
+		mockPlayer->name = "Test";
+		executionOrder.clear();
+
+		sut.AddToQueue(3, "queue_test", "recordOrderFunction", recordOrderFunction, mockPlayer, 1L);
+		sut.AddToQueue(3, "queue_test", "recordOrderFunction", recordOrderFunction, mockPlayer, 2L);
+		sut.AddToQueue(3, "queue_test", "recordOrderFunction", recordOrderFunction, mockPlayer, 3L);
+		sut.AddToQueue(3, "queue_test", "recordOrderFunction", recordOrderFunction, mockPlayer, 4L);
+
+		WHEN("the queue is processed up to that tick")
+		{
+			sut.ProcessQueue();
+			sut.ProcessQueue();
+			sut.ProcessQueue();
+
+			THEN("they execute in insertion order, on the correct tick")
+			{
+				REQUIRE(executionOrder == std::vector<int>{1, 2, 3, 4});
+			}
+		}
+	}
+
+	GIVEN("events queued across several ticks, added out of order")
+	{
+		CQueue sut;
+		char_data *mockPlayer = new char_data();
+		mockPlayer->name = "Test";
+		executionOrder.clear();
+
+		sut.AddToQueue(3, "queue_test", "recordOrderFunction", recordOrderFunction, mockPlayer, 30L);
+		sut.AddToQueue(1, "queue_test", "recordOrderFunction", recordOrderFunction, mockPlayer, 10L);
+		sut.AddToQueue(2, "queue_test", "recordOrderFunction", recordOrderFunction, mockPlayer, 20L);
+		sut.AddToQueue(1, "queue_test", "recordOrderFunction", recordOrderFunction, mockPlayer, 11L);
+
+		WHEN("the queue is processed tick by tick")
+		{
+			sut.ProcessQueue();
+			sut.ProcessQueue();
+			sut.ProcessQueue();
+
+			THEN("they execute in tick order, insertion order within a tick")
+			{
+				REQUIRE(executionOrder == std::vector<int>{10, 11, 20, 30});
+			}
+		}
+	}
+
+	GIVEN("an event queued from inside a queued event")
+	{
+		CQueue sut;
+		char_data *mockPlayer = new char_data();
+		mockPlayer->name = "Test";
+		executionOrder.clear();
+
+		sut.AddToQueue(1, "queue_test", "recordOrderFunction", recordOrderFunction, mockPlayer, 1L);
+		sut.AddToQueue(2, "queue_test", "recordOrderFunction", recordOrderFunction, mockPlayer, 2L);
+
+		WHEN("the queue is processed")
+		{
+			sut.ProcessQueue();
+			sut.ProcessQueue();
+
+			THEN("a re-entrant timer counts from the tick that was draining")
+			{
+				REQUIRE(executionOrder == std::vector<int>{1, 2});
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
This PR fixes a few issues that the queue code had centered around re-entrancy and execution ordering.

While fixing those bugs, it exposed an exisitng execution order bug in mprog. Since I already fixing ordering, I incuded the fix here.


Note that the devcontainer edit was because VSCode was being weird about auto-forwarding of ports. So made it concrete.
