### PR TITLE
Merc header defines to enums

### DIFF
--- a/code/act_info.c
+++ b/code/act_info.c
@@ -730,7 +730,10 @@ void show_char_to_char_1(CHAR_DATA *victim, CHAR_DATA *ch)
 						&& IS_SET(tObj->extra_flags, ITEM_UNDER_CLOTHES)
 						&& is_worn(worn_over))
 					{
-						if (worn_over->wear_flags[0] + pow(2, ITEM_WEAR_COSMETIC) == tObj->wear_flags[0])
+						// (int) cast: ITEM_WEAR_COSMETIC is an enumerator, and std::pow has no
+						// (int, enum) overload -- every floating overload is an equally good
+						// match, so the call is ambiguous without it. Behaviour is unchanged.
+						if (worn_over->wear_flags[0] + pow(2, (int)ITEM_WEAR_COSMETIC) == tObj->wear_flags[0])
 							break;
 					}
 				}

--- a/code/act_move.c
+++ b/code/act_move.c
@@ -993,7 +993,7 @@ void move_char(CHAR_DATA *ch, int door, bool automatic, bool fcharm)
 
 	if (!is_npc(ch) && ch->Profs()->HasProf("trap detecting"))
 	{
-		for (auto i = 0; i < MAX_EXITS; i++)
+		for (auto i = 0; i < MAX_EXIT; i++)
 		{
 			if (to_room->exit[i])
 			{

--- a/code/act_obj.c
+++ b/code/act_obj.c
@@ -1927,7 +1927,9 @@ bool remove_obj(CHAR_DATA *ch, int iWear, bool fReplace)
 		{
 			if (IS_SET(revealed->extra_flags, ITEM_UNDER_CLOTHES))
 			{
-				if (revealed->wear_flags[0] - pow(2, ITEM_WEAR_COSMETIC) == obj->wear_flags[0])
+				// (int) cast: see the matching site in act_info.c. std::pow has no
+				// (int, enum) overload, so the call is ambiguous without it.
+				if (revealed->wear_flags[0] - pow(2, (int)ITEM_WEAR_COSMETIC) == obj->wear_flags[0])
 					break;
 			}
 		}

--- a/code/ban.h
+++ b/code/ban.h
@@ -29,14 +29,10 @@
 #define BAN_PERMANENT				F
 
 //
-// New ban defines
+// New ban defines -- moved to banflags.h (phase-02 3.3) so tests and the
+// repository can use them without pulling in merc.h.
 //
-
-#define NBAN_ALL					0
-#define NBAN_NEWBIE					1
-
-#define NBAN_IP						1
-#define NBAN_HOST					0
+#include "banflags.h"
 
 typedef struct ban_data BAN_DATA;
 struct ban_data

--- a/code/banflags.h
+++ b/code/banflags.h
@@ -1,0 +1,26 @@
+#ifndef BANFLAGS_H
+#define BANFLAGS_H
+
+//
+// Ban classification enums, split out of ban.h (phase-02 3.3) so they can be
+// included without dragging in merc.h. Dependency-free by construction: every
+// enumerator is a literal, this header includes nothing, and it compiles in
+// isolation. The values are persisted in the `bans` table (ban_type/host_type
+// columns) -- rename freely, never renumber.
+//
+
+// bans.ban_type -- what the ban applies to.
+enum BanType : int
+{
+	NBAN_ALL					= 0,
+	NBAN_NEWBIE					= 1,
+};
+
+// bans.host_type -- how the site string is matched.
+enum HostType : int
+{
+	NBAN_HOST					= 0,
+	NBAN_IP						= 1,
+};
+
+#endif /* BANFLAGS_H */

--- a/code/enums.h
+++ b/code/enums.h
@@ -1,0 +1,1587 @@
+#ifndef ENUMS_H
+#define ENUMS_H
+
+
+// Scoped constant enums, extracted verbatim from merc.h
+//
+// Dependency-free by construction: every enumerator is a literal, so this
+// header includes nothing and compiles in isolation. Kept in the original
+// merc.h source order (which is already roughly domain-clustered) rather 
+// than reordered. The values are a wire format for player and area files:
+// rename freely, never renumber.
+
+
+// Mob-program trigger bit indices into mob_index_data::progtypes. One of four
+// prog-trigger families (mprog/iprog/rprog/aprog), each on its own entity's
+// progtypes field. Wire format - rename freely, never renumber.
+enum MProgTrigger : int
+{
+	MPROG_BRIBE					= 0,
+	MPROG_ENTRY					= 1,
+	MPROG_GREET					= 2,
+	MPROG_GIVE					= 3,
+	MPROG_FIGHT					= 4,
+	MPROG_DEATH					= 5,
+	MPROG_PULSE					= 6,
+	MPROG_SPEECH				= 7,
+	MPROG_ATTACK				= 8,
+	MPROG_MOVE					= 9,
+	MPROG_BEAT					= 10,
+	MPROG_AGGRESS				= 11,
+};
+
+// Item-program trigger bit indices into obj_index_data::progtypes.
+// Wire format - rename freely, never renumber. Gap at 16.
+enum IProgTrigger : int
+{
+	IPROG_WEAR					= 0,
+	IPROG_REMOVE				= 1,
+	IPROG_DROP					= 2,
+	IPROG_SAC					= 3,
+	IPROG_GIVE					= 4,
+	IPROG_GREET					= 5,
+	IPROG_FIGHT					= 6,
+	IPROG_DEATH					= 7,
+	IPROG_SPEECH				= 8,
+	IPROG_ENTRY					= 9,
+	IPROG_GET					= 10,
+	IPROG_PULSE					= 11,
+	IPROG_INVOKE				= 12,
+	IPROG_VERB					= 13,
+	IPROG_LOOT					= 14,
+	IPROG_OPEN					= 15,
+	IPROG_LOOK					= 17,
+	IPROG_HIT					= 18,
+};
+
+// Room-program trigger bit indices into room_index_data::progtypes.
+enum RProgTrigger : int
+{
+	RPROG_PULSE					= 0,
+	RPROG_ENTRY					= 1,
+	RPROG_MOVE					= 2,
+	RPROG_DROP					= 3,
+	RPROG_SPEECH				= 4,
+	RPROG_OPEN					= 5,
+};
+
+// Area-program trigger bit indices into area_data::progtypes.
+enum AProgTrigger : int
+{
+	APROG_PULSE					= 0,
+	APROG_RESET					= 1,
+	APROG_SUN					= 2,
+	APROG_TICK					= 3,
+	APROG_AGGRESS				= 4,
+	APROG_MYELL					= 5,
+};
+
+// Yes/no prompt reply ordinal. Wire format - never renumber.
+enum ReplyType : int
+{
+	REPLY_YES					= 1,
+	REPLY_NO					= 2,
+	REPLY_NEITHER				= 3,
+};
+
+// Descriptor connection state, an ordinal in descriptor_data::connected;
+// switched on in nanny(). NOTE: CON_DIE_BOUND (defined far above, near the level
+// constants) is NOT part of this family. It is a constitution-stat threshold
+// that shares the CON_ prefix by accident, and keeps its #define.
+// Wire format - never renumber.
+enum ConnectionState : int
+{
+	CON_PLAYING					= 0,
+	CON_GET_NAME				= 1,
+	CON_GET_OLD_PASSWORD		= 2,
+	CON_CONFIRM_NEW_NAME		= 3,
+	CON_GET_NEW_PASSWORD		= 4,
+	CON_CONFIRM_NEW_PASSWORD	= 5,
+	CON_GET_NEW_RACE			= 6,
+	CON_GET_NEW_SEX				= 7,
+	CON_GET_NEW_CLASS			= 8,
+	CON_ALLOCATE_STATS			= 9,
+	CON_GET_ALIGNMENT			= 10,
+	CON_GET_ETHOS				= 11,
+	CON_DEFAULT_CHOICE			= 12,
+	CON_GEN_GROUPS				= 13,
+	CON_NEW_CHAR				= 14,
+	CON_READ_IMOTD				= 15,
+	CON_READ_MOTD				= 16,
+	CON_BREAK_CONNECT			= 17,
+	CON_GET_CABAL				= 18,
+	CON_GET_SPEC_ONE			= 19,
+	CON_GET_SPEC_TWO			= 20,
+	CON_GET_THERMAL				= 21,
+	CON_GET_MATERIAL			= 22,
+	CON_GET_DYNAMIC				= 23,
+	CON_CHOOSE_ELE				= 24,
+	CON_LEGIT_NAME				= 25,
+	CON_GET_BEAUTY				= 26,
+	CON_CHOOSE_WEAPON			= 27,
+};
+
+// act() message target ordinal. A separate family from the TO_* "where" values
+// below (which discriminate affect_data::bitvector); values 0-5 collide.
+enum ActTarget : int
+{
+	TO_ROOM						= 0,
+	TO_NOTVICT					= 1,
+	TO_VICT						= 2,
+	TO_CHAR						= 3,
+	TO_ALL						= 4,
+	TO_IMMINROOM				= 5,
+	TO_GROUP					= 6,
+	TO_NOTGROUP					= 7,
+	TO_AREA						= 8,
+};
+
+// Door-bar restriction criterion. Three separate BAR_ families follow, colliding
+// in value; each is its own enum. Wire format - never renumber.
+enum BarCriterion : int
+{
+	BAR_CLASS					= 0,
+	BAR_CABAL					= 1,
+	BAR_SIZE					= 2,
+	BAR_TATTOO					= 3,
+	BAR_LEVEL					= 4,
+};
+
+// Bar comparison operator.
+enum BarComparison : int
+{
+	BAR_EQUAL_TO				= 0,
+	BAR_LESS_THAN				= 1,
+	BAR_GREATER_THAN			= 2,
+};
+
+// Bar rejection-message style.
+enum BarMessage : int
+{
+	BAR_SAY						= 0,
+	BAR_ECHO					= 1,
+	BAR_EMOTE					= 2,
+};
+
+// Primary-stat index into char_data::perm_stat[] / mod_stat[]. Wire format -
+// rename freely, never renumber.
+enum StatType : int
+{
+	STAT_STR					= 0,
+	STAT_INT					= 1,
+	STAT_WIS					= 2,
+	STAT_DEX					= 3,
+	STAT_CON					= 4,
+};
+
+// Affect-type ordinal, in affect_data::aftype. Wire format - never renumber.
+enum AffectType : int
+{
+	AFT_SPELL					= 0,
+	AFT_SKILL					= 1,
+	AFT_POWER					= 2,
+	AFT_MALADY					= 3,
+	AFT_COMMUNE					= 4,
+	AFT_INVIS					= 5,
+	AFT_RUNE					= 6,
+	AFT_TIMER					= 7,
+};
+
+// Spellcasting-class ordinal (how a class channels magic). Separate family from
+// the character-class CLASS_NONE.. list and from CLASS_OPEN/CLOSED.
+enum SpellClass : int
+{
+	CLASS_NEITHER				= 0,
+	CLASS_CASTER				= 1,
+	CLASS_COMMUNER				= 2,
+};
+
+// Whether a class is open for selection. A two-value ordinal, separate family.
+enum ClassAvailability : int
+{
+	CLASS_OPEN					= 1,
+	CLASS_CLOSED				= 0,
+};
+
+// Magic command-type ordinal. Wire format - never renumber.
+enum MagicCommand : int
+{
+	CMD_NONE					= 0,
+	CMD_SPELL					= 1,
+	CMD_COMMUNE					= 2,
+	CMD_POWER					= 3,
+	CMD_BOTH					= 4,
+	CMD_RUNE					= 5,
+};
+
+// affect_data::where - the discriminator that decides which family the sibling
+// bitvector holds and which field it applies to (handler.c dispatches on it).
+enum AffectWhere : int
+{
+	TO_AFFECTS					= 0,
+	TO_OBJECT					= 1,
+	TO_IMMUNE					= 2,
+	TO_RESIST					= 3,
+	TO_VULN						= 4,
+	TO_WEAPON					= 5,
+};
+
+// What a rune is applied to - an ordinal. Separate family from RUNE_TRIGGER_*
+// and the RUNE_* masks below (all three collide in value).
+enum RuneTarget : int
+{
+	RUNE_TO_WEAPON				= 0,
+	RUNE_TO_ARMOR				= 1,
+	RUNE_TO_PORTAL				= 2,
+	RUNE_TO_ROOM				= 3,
+};
+
+// When a rune fires - an ordinal.
+enum RuneTrigger : int
+{
+	RUNE_TRIGGER_ENTRY			= 0,
+	RUNE_TRIGGER_EXIT			= 1,
+};
+
+// room_affect_data::where - discriminator for a room affect's bitvector.
+enum RoomAffectWhere : int
+{
+	TO_ROOM_AFFECTS				= 0,
+	TO_ROOM_CONST				= 1,
+	TO_ROOM_FLAGS				= 2,
+};
+
+// obj_affect_data::where - discriminator for an object affect's bitvector.
+enum ObjAffectWhere : int
+{
+	TO_OBJ_AFFECTS				= 0,
+	TO_OBJ_APPLY				= 1,
+};
+
+// Room-affect apply locations. A separate family from the main APPLY_* below:
+// values 0-4 collide with APPLY_NONE..APPLY_WIS, so it must be its own enum.
+enum ApplyRoomLocation : int
+{
+	APPLY_ROOM_NONE				= 0,
+	APPLY_ROOM_HEAL				= 1,
+	APPLY_ROOM_MANA				= 2,
+	APPLY_ROOM_SECT				= 3,
+	APPLY_ROOM_NOPE				= 4,
+};
+
+// Object apply locations (the obj->value[] slots). Another separate family -
+// values 0-6 collide with both APPLY_ROOM_* and the main APPLY_*. Note
+// APPLY_OBJ_PROPERTIES (100) below belongs with this family by name but sits
+// far outside the range; kept where the source had it.
+enum ApplyObjLocation : int
+{
+	APPLY_OBJ_NONE				= 0,
+	APPLY_OBJ_V0				= 1,
+	APPLY_OBJ_V1				= 2,
+	APPLY_OBJ_V2				= 3,
+	APPLY_OBJ_V3				= 4,
+	APPLY_OBJ_V4				= 5,
+	APPLY_OBJ_WEIGHT			= 6,
+};
+
+// Cabal identity ordinal, in char_data::cabal. NOTE: CABAL_LEADER (defined among
+// the MAX_ constants below) is NOT part of this family - it is an induct rank
+// compared against pcdata->induct, and keeps its #define. Wire format - never
+// renumber. Gap at 7.
+enum Cabal : int
+{
+	CABAL_NONE					= 0,
+	CABAL_GUILD					= 1,
+	CABAL_SCION					= 2,
+	CABAL_HORDE					= 3,
+	CABAL_BOUNTY				= 4,
+	CABAL_THEATRE				= 5,
+	CABAL_PHALANX				= 6,
+	CABAL_NEGATIVE				= 8,
+};
+
+// Bit indices into char_data::act, mob_index_data::act and race_data::act.
+// NOTE: char_data::act carries PlrFlag as well - the two families are disjoint
+// interpretations of one word, chosen by is_npc(). See flags.c's "act" vs "plr".
+// The values are a wire format (player files store them as letters keyed to the
+// index; area files resolve names through act_flags[]), so they may be renamed
+// but never renumbered. Gaps at 12, 13 and 23 are retired bits - do not reuse
+// without checking existing player and area data.
+enum ActFlag : int
+{
+	ACT_IS_NPC					= 0,	// Auto set for mobs
+	ACT_SENTINEL				= 1,	// Stays in one room
+	ACT_SCAVENGER				= 2,	// Picks up objects
+	ACT_WARD_MOB				= 3,	// Ward mobs
+	ACT_WANDER					= 4,	// wanders
+	ACT_AGGRESSIVE				= 5,	// Attacks PC's
+	ACT_STAY_AREA				= 6,	// Won't leave area
+	ACT_WIMPY					= 7,
+	ACT_PET						= 8,	// Auto set for pets
+	ACT_TRAIN					= 9,	// Can train PC's
+	ACT_PRACTICE				= 10,	// Can practice PC's
+	ACT_SMARTTRACK				= 11,	// Will use pathfinding
+	ACT_UNDEAD					= 14,
+	ACT_INNER_GUARDIAN			= 15,	// yay.
+	ACT_CLERIC					= 16,
+	ACT_MAGE					= 17,
+	ACT_INTELLIGENT 			= 18,
+	ACT_FAST_TRACK				= 19,
+	ACT_NOALIGN					= 20,
+	ACT_NOPURGE					= 21,
+	ACT_OUTDOORS				= 22,
+	ACT_INDOORS					= 24,
+	ACT_GUILDGUARD				= 25,
+	ACT_IS_HEALER				= 26,
+	ACT_GAIN					= 27,
+	ACT_UPDATE_ALWAYS			= 28,
+	ACT_DETECT_SPECIAL			= 29,
+	ACT_BANKER					= 30,
+	ACT_NOCTURNAL				= 31,
+	ACT_DIURNAL					= 32,
+	ACT_FASTWANDER				= 33,
+	ACT_LAW						= 34,
+};
+
+// Damage classes - an ordinal passed around as an int and switched on. Wire
+// format - rename freely, never renumber.
+enum DamageType : int
+{
+	DAM_NONE					= 0,
+	DAM_BASH					= 1,
+	DAM_PIERCE					= 2,
+	DAM_SLASH					= 3,
+	DAM_FIRE					= 4,
+	DAM_COLD					= 5,
+	DAM_LIGHTNING				= 6,
+	DAM_ACID					= 7,
+	DAM_POISON					= 8,
+	DAM_NEGATIVE				= 9,
+	DAM_HOLY					= 10,
+	DAM_ENERGY					= 11,
+	DAM_MENTAL					= 12,
+	DAM_DISEASE					= 13,
+	DAM_DROWNING				= 14,
+	DAM_LIGHT					= 15,
+	DAM_OTHER					= 16,
+	DAM_CHARM					= 17,
+	DAM_SOUND					= 18,
+	DAM_TRUESTRIKE				= 19,
+};
+
+// Offensive/assist bit indices into char_data::off_flags and
+// mob_index_data::off_flags. One contiguous 0-26 numbering carrying five name
+// prefixes (OFF_, ASSIST_, NO_, STATIC_, SPAM_) - they are a single family that
+// was never given a single prefix, not distinct families. Kept as one enum with
+// the original names. Wire format - rename freely, never renumber.
+enum OffFlag : int
+{
+	OFF_AREA_ATTACK				= 0,
+	OFF_BACKSTAB				= 1,
+	OFF_BASH					= 2,
+	OFF_BERSERK					= 3,
+	OFF_DISARM					= 4,
+	OFF_DODGE					= 5,
+	OFF_FADE					= 6,	// UNUSED
+	OFF_FAST					= 7,
+	OFF_KICK					= 8,
+	OFF_KICK_DIRT				= 9,
+	OFF_PARRY					= 10,
+	OFF_RESCUE					= 11,
+	OFF_TAIL					= 12,
+	OFF_TRIP					= 13,
+	OFF_CRUSH					= 14,
+	ASSIST_ALL					= 15,
+	ASSIST_ALIGN				= 16,
+	ASSIST_RACE					= 17,
+	ASSIST_PLAYERS				= 18,
+	ASSIST_GUARD				= 19,
+	ASSIST_VNUM					= 20,
+	NO_TRACK					= 21,
+	STATIC_TRACKING				= 22,
+	SPAM_MURDER					= 23,
+	OFF_INTIMIDATED				= 24,
+	OFF_UNDEAD_DRAIN			= 25,	// True undead drain, very powerful
+	ASSIST_GROUP				= 26,
+};
+
+// Damage-susceptibility result ordinal (check_immune etc.). Wire format -
+// never renumber.
+enum Susceptibility : int
+{
+	IS_NORMAL					= 0,
+	IS_IMMUNE					= 1,
+	IS_RESISTANT				= 2,
+	IS_VULNERABLE				= 3,
+};
+
+// Immunity bit indices, into char_data::imm_flags (and affect_data::bitvector
+// where where == TO_IMMUNE). IMM_/RES_/VULN_ are three value-identical parallel
+// families - same damage domain, three storages. The flag tables and the area
+// file format route all three through the imm_flags table (flags.c, db2.c), so
+// they are effectively one namespace on disk; they are kept as three enums here
+// only because their C names differ (IMM_SUMMON vs RES_SUMMON) and renaming call
+// sites is out of scope. Wire format - never renumber.
+enum ImmuneFlag : int
+{
+	IMM_SUMMON					= 0,
+	IMM_CHARM					= 1,
+	IMM_MAGIC					= 2,
+	IMM_WEAPON					= 3,
+	IMM_BASH					= 4,
+	IMM_PIERCE					= 5,
+	IMM_SLASH					= 6,
+	IMM_FIRE					= 7,
+	IMM_COLD					= 8,
+	IMM_LIGHTNING				= 9,
+	IMM_ACID					= 10,
+	IMM_POISON					= 11,
+	IMM_NEGATIVE				= 12,
+	IMM_HOLY					= 13,
+	IMM_ENERGY					= 14,
+	IMM_MENTAL					= 15,
+	IMM_DISEASE					= 16,
+	IMM_DROWNING				= 17,
+	IMM_LIGHT					= 18,
+	IMM_SOUND					= 19,
+	IMM_INTERNAL				= 20,
+	IMM_MITHRIL					= 23,
+	IMM_SILVER					= 24,
+	IMM_IRON					= 25,
+	IMM_SLEEP					= 26,	// no RES_/VULN_ counterpart
+};
+
+// Resistance bit indices, into char_data::res_flags. Parallel to ImmuneFlag -
+// see the note there. Stops at 25; no RES_SLEEP.
+enum ResistFlag : int
+{
+	RES_SUMMON					= 0,
+	RES_CHARM					= 1,
+	RES_MAGIC					= 2,
+	RES_WEAPON					= 3,
+	RES_BASH					= 4,
+	RES_PIERCE					= 5,
+	RES_SLASH					= 6,
+	RES_FIRE					= 7,
+	RES_COLD					= 8,
+	RES_LIGHTNING				= 9,
+	RES_ACID					= 10,
+	RES_POISON					= 11,
+	RES_NEGATIVE				= 12,
+	RES_HOLY					= 13,
+	RES_ENERGY					= 14,
+	RES_MENTAL					= 15,
+	RES_DISEASE					= 16,
+	RES_DROWNING				= 17,
+	RES_LIGHT					= 18,
+	RES_SOUND					= 19,
+	RES_INTERNAL				= 20,
+	RES_MITHRIL					= 23,
+	RES_SILVER					= 24,
+	RES_IRON					= 25,
+};
+
+// Vulnerability bit indices, into char_data::vuln_flags. Parallel to ImmuneFlag
+// - see the note there. Stops at 25; no VULN_SLEEP.
+enum VulnFlag : int
+{
+	VULN_SUMMON					= 0,
+	VULN_CHARM					= 1,
+	VULN_MAGIC					= 2,
+	VULN_WEAPON					= 3,
+	VULN_BASH					= 4,
+	VULN_PIERCE					= 5,
+	VULN_SLASH					= 6,
+	VULN_FIRE					= 7,
+	VULN_COLD					= 8,
+	VULN_LIGHTNING				= 9,
+	VULN_ACID					= 10,
+	VULN_POISON					= 11,
+	VULN_NEGATIVE				= 12,
+	VULN_HOLY					= 13,
+	VULN_ENERGY					= 14,
+	VULN_MENTAL					= 15,
+	VULN_DISEASE				= 16,
+	VULN_DROWNING				= 17,
+	VULN_LIGHT					= 18,
+	VULN_SOUND					= 19,
+	VULN_INTERNAL				= 20,
+	VULN_MITHRIL				= 23,
+	VULN_SILVER					= 24,
+	VULN_IRON					= 25,
+};
+
+// Body-form bit indices into char_data::form (and race_type::form). Note this
+// is a DIFFERENT field from char_data::act despite magic.c:1408 testing
+// ACT_UNDEAD against it. Wire format - never renumber.
+enum FormFlag : int
+{
+	// material form
+	FORM_EDIBLE					= 0,
+	FORM_POISON					= 1,
+	FORM_MAGICAL				= 2,
+	FORM_INSTANT_DECAY			= 3,
+	FORM_OTHER					= 4,	// defined by material bit
+
+	// actual form
+	FORM_ANIMAL					= 6,
+	FORM_SENTIENT				= 7,
+	FORM_UNDEAD					= 8,
+	FORM_CONSTRUCT				= 9,
+	FORM_MIST					= 10,
+	FORM_INTANGIBLE				= 11,
+
+	FORM_BIPED					= 12,
+	FORM_AQUATIC				= 13,
+	FORM_INSECT					= 14,
+	FORM_SPIDER					= 15,
+	FORM_CRUSTACEAN				= 16,
+	FORM_WORM					= 17,
+	FORM_BLOB					= 18,
+
+	FORM_MAMMAL					= 21,
+	FORM_BIRD					= 22,
+	FORM_REPTILE				= 23,
+	FORM_SNAKE					= 24,
+	FORM_DRAGON					= 25,
+	FORM_AMPHIBIAN				= 26,
+	FORM_FISH					= 27,
+	FORM_COLD_BLOOD				= 28,
+	FORM_NOSPEECH				= 29,
+};
+
+// Body-part bit indices into char_data::parts (and race_type::parts). Wire
+// format - rename freely, never renumber. Gaps at 17-19.
+enum PartFlag : int
+{
+	PART_HEAD					= 0,
+	PART_ARMS					= 1,
+	PART_LEGS					= 2,
+	PART_HEART					= 3,
+	PART_BRAINS					= 4,
+	PART_GUTS					= 5,
+	PART_HANDS					= 6,
+	PART_FEET					= 7,
+	PART_FINGERS				= 8,
+	PART_EAR					= 9,
+	PART_EYE					= 10,
+	PART_LONG_TONGUE			= 11,
+	PART_EYESTALKS				= 12,
+	PART_TENTACLES				= 13,
+	PART_FINS					= 14,
+	PART_WINGS					= 15,
+	PART_TAIL					= 16,
+
+	// for combat
+	PART_CLAWS					= 20,
+	PART_FANGS					= 21,
+	PART_HORNS					= 22,
+	PART_SCALES					= 23,
+	PART_TUSKS					= 24,
+};
+
+// Bit indices for character affects. Reached through several storages:
+// char_data::affected_by, affect_data::bitvector (when where == TO_AFFECTS),
+// and race_type::aff[] - which holds bit INDICES in a plain array, not a bit
+// vector. act_move.c:3149 confuses the two.
+// Wire format - rename freely, never renumber.
+enum AffectFlag : int
+{
+	AFF_BLIND					= 0,
+	AFF_INVISIBLE				= 1,
+	AFF_DETECT_EVIL				= 2,
+	AFF_DETECT_INVIS			= 3,
+	AFF_DETECT_MAGIC			= 4,
+	AFF_DETECT_HIDDEN			= 5,
+	AFF_DETECT_GOOD				= 6,
+	AFF_SANCTUARY				= 7,
+	AFF_DETECT_CAMO				= 8,
+	AFF_INFRARED				= 9,	// unused!
+	AFF_CURSE					= 10,
+	AFF_CAMOUFLAGE				= 11,
+	AFF_POISON					= 12,
+	AFF_PROTECTION				= 13,
+	AFF_RAGE					= 14,
+	AFF_SNEAK					= 15,
+	AFF_HIDE					= 16,
+	AFF_SLEEP					= 17,
+	AFF_CHARM					= 18,
+	AFF_FLYING					= 19,
+	AFF_PASS_DOOR				= 20,
+	AFF_HASTE					= 21,
+	AFF_CALM					= 22,
+	AFF_PLAGUE					= 23,
+	AFF_PERMANENT				= 24,
+	AFF_DARK_VISION				= 25,
+	AFF_BERSERK					= 26,
+	AFF_WATERBREATH				= 27,
+	AFF_REGENERATION			= 28,
+	AFF_SLOW					= 29,
+	AFF_NOSHOW					= 30,
+};
+
+// Bit indices into room_index_data::affected_by, and into
+// room_affect_data::bitvector when where == TO_ROOM_AFFECTS.
+//
+// These reuse AffectFlag's numbering space but are NOT aliases of it: this is a
+// separate family on separate storage. Five of the six happen to share a name
+// with their AffectFlag counterpart (CURSE, POISON, SLEEP, PLAGUE, SLOW) and
+// the same bit, but AFF_ROOM_RANDOMIZER == 0 collides with AFF_BLIND == 0 while
+// meaning something completely unrelated. Kept as its own enum for that reason.
+enum AffectRoomFlag : int
+{
+	AFF_ROOM_RANDOMIZER			= 0,
+	AFF_ROOM_CURSE				= 10,
+	AFF_ROOM_POISON				= 12,
+	AFF_ROOM_SLEEP				= 17,
+	AFF_ROOM_PLAGUE				= 23,
+	AFF_ROOM_SLOW				= 29,
+};
+
+// Bit indices into obj_data::affected_by, and into obj_affect_data::bitvector
+// when where == TO_OBJ_AFFECTS. A third family in AffectFlag's numbering space,
+// on a third storage. One member so far.
+enum AffectObjFlag : int
+{
+	AFF_OBJ_BURNING				= 0,
+};
+
+// Sex ordinal, in char_data::sex. Wire format - never renumber.
+enum Sex : int
+{
+	SEX_NEUTRAL					= 0,
+	SEX_MALE					= 1,
+	SEX_FEMALE					= 2,
+};
+
+// Armor-class index into char_data::armor[]. Wire format - never renumber.
+enum ArmorClass : int
+{
+	AC_PIERCE					= 0,
+	AC_BASH						= 1,
+	AC_SLASH					= 2,
+	AC_EXOTIC					= 3,
+};
+
+// Index into a dice spec's value triple (number/type/bonus). Wire format -
+// never renumber.
+enum DiceField : int
+{
+	DICE_NUMBER					= 0,
+	DICE_TYPE					= 1,
+	DICE_BONUS					= 2,
+};
+
+// Creature size, an ordinal in char_data::size; compared relationally. Wire
+// format - never renumber. Kept ascending so size comparisons hold.
+enum Size : int
+{
+	SIZE_TINY					= 0,
+	SIZE_SMALL					= 1,
+	SIZE_MEDIUM					= 2,
+	SIZE_LARGE					= 3,
+	SIZE_HUGE					= 4,
+	SIZE_GIANT					= 5,
+	SIZE_IMMENSE				= 6,
+};
+
+// Item TYPES - an ordinal scalar stored in obj_data::item_type (a short), not
+// a bit field. Compared with == and switched on; never passed to IS_SET.
+//
+// The ITEM_ prefix covers THREE unrelated families (types here, extra flags and
+// wear flags below) whose values collide: ITEM_LIGHT == 1 is a type,
+// ITEM_HUM == 1 is an extra-flag bit, ITEM_WEAR_FINGER == 1 is a wear bit.
+// They are separate enums for that reason. Names are unchanged, so no call site
+// moves; the split is documentation the compiler happens to hold.
+// Wire format (area files) - rename freely, never renumber.
+enum ItemType : int
+{
+	ITEM_LIGHT					= 1,
+	ITEM_SCROLL					= 2,
+	ITEM_WAND					= 3,
+	ITEM_STAFF					= 4,
+	ITEM_WEAPON					= 5,
+	ITEM_NULL6					= 6,
+	ITEM_DICE					= 7,
+	ITEM_TREASURE				= 8,
+	ITEM_ARMOR					= 9,
+	ITEM_POTION					= 10,
+	ITEM_CLOTHING				= 11,
+	ITEM_FURNITURE				= 12,
+	ITEM_TRASH					= 13,
+	ITEM_CONTAINER				= 15,
+	ITEM_DRINK_CON				= 17,
+	ITEM_KEY					= 18,
+	ITEM_FOOD					= 19,
+	ITEM_MONEY					= 20,
+	ITEM_BOAT					= 22,
+	ITEM_CORPSE_NPC				= 23,
+	ITEM_CORPSE_PC				= 24,
+	ITEM_FOUNTAIN				= 25,
+	ITEM_PILL					= 26,
+	ITEM_PROTECT				= 27,
+	ITEM_MAP					= 28,
+	ITEM_PORTAL					= 29,
+	ITEM_WARP_STONE				= 30,
+	ITEM_ROOM_KEY				= 31,
+	ITEM_GEM					= 32,
+	ITEM_JEWELRY				= 33,
+	ITEM_CAMPFIRE				= 34,
+	ITEM_CABAL_ITEM				= 35,
+	ITEM_SKELETON				= 36,
+	ITEM_URN					= 37,
+	ITEM_GRAVITYWELL			= 38,
+	ITEM_BOOK					= 39,
+	ITEM_PEN					= 40,
+	ITEM_ALTAR					= 41,
+	// 42 was ITEM_DONATION_PIT - retired. Note ITEM_DONATION_PIT now exists as
+	// an *extra flag* with value 33, which is a different family entirely.
+	ITEM_STONE					= 43,
+};
+
+// Extra flags - bit indices into obj_data::extra_flags, and into
+// obj_index_data's affect bitvector where ITEM_EVIL / ITEM_BURN_PROOF are set
+// (magic.c). Distinct from ItemType above despite the shared prefix.
+// Wire format - rename freely, never renumber. Gap at 23.
+//
+// CORPSE_NO_ANIMATE is a member of THIS family despite its different prefix:
+// value 27 sits between ITEM_BRAND (26) and ITEM_ANTI_LAWFUL (28), and it is
+// set on extra_flags at fight.c:3025. Note characterClasses/necro.c sets and
+// tests it on *wear_flags* instead, where bit 27 is outside the wear range
+// (0-18).
+enum ItemExtraFlag : int
+{
+	ITEM_GLOW					= 0,
+	ITEM_HUM					= 1,
+	ITEM_DARK					= 2,
+	ITEM_NOSHOW					= 3,
+	ITEM_EVIL					= 4,
+	ITEM_INVIS					= 5,
+	ITEM_MAGIC					= 6,
+	ITEM_NODROP					= 7,
+	ITEM_BLESS					= 8,
+	ITEM_ANTI_GOOD				= 9,
+	ITEM_ANTI_EVIL				= 10,
+	ITEM_ANTI_NEUTRAL			= 11,
+	ITEM_NOREMOVE				= 12,
+	ITEM_INVENTORY				= 13,
+	ITEM_NOPURGE				= 14,
+	ITEM_ROT_DEATH				= 15,
+	ITEM_VIS_DEATH				= 16,
+	ITEM_FIXED					= 17,
+	ITEM_NODISARM				= 18,
+	ITEM_NOLOCATE				= 19,
+	ITEM_MELT_DROP				= 20,
+	ITEM_UNDER_CLOTHES			= 21,
+	ITEM_SELL_EXTRACT			= 22,
+	ITEM_BURN_PROOF				= 24,
+	ITEM_NOUNCURSE				= 25,
+	ITEM_BRAND					= 26,
+	CORPSE_NO_ANIMATE			= 27,
+	ITEM_ANTI_LAWFUL			= 28,
+	ITEM_ANTI_NEUT				= 29,
+	ITEM_ANTI_CHAOTIC			= 30,
+	ITEM_NO_STASH				= 31,
+	ITEM_NO_SAC					= 32,
+	ITEM_DONATION_PIT			= 33,
+};
+
+// Wear flags - bit indices into obj_data::wear_flags. The third and last
+// family under the ITEM_ prefix. Range is 0-18, which is why necro.c's use of
+// CORPSE_NO_ANIMATE (27) on this field cannot work (§0.8.1).
+// Wire format - rename freely, never renumber.
+enum ItemWearFlag : int
+{
+	ITEM_TAKE					= 0,
+	ITEM_WEAR_FINGER			= 1,
+	ITEM_WEAR_NECK				= 2,
+	ITEM_WEAR_BODY				= 3,
+	ITEM_WEAR_HEAD				= 4,
+	ITEM_WEAR_LEGS				= 5,
+	ITEM_WEAR_FEET				= 6,
+	ITEM_WEAR_HANDS				= 7,
+	ITEM_WEAR_ARMS				= 8,
+	ITEM_WEAR_SHIELD			= 9,
+	ITEM_WEAR_ABOUT				= 10,
+	ITEM_WEAR_WAIST				= 11,
+	ITEM_WEAR_WRIST				= 12,
+	ITEM_WEAR_WIELD				= 13,
+	ITEM_WEAR_HOLD				= 14,
+	ITEM_WEAR_FLOAT				= 15,
+	ITEM_WEAR_BRAND				= 16,
+	ITEM_WEAR_STRAPPED			= 17,
+	ITEM_WEAR_COSMETIC			= 18,	// cosmetic, misc, up to 5/person
+};
+
+// Object-restriction criterion ordinal. Wire format - never renumber.
+enum RestrictType : int
+{
+	RESTRICT_OTHER				= 0,
+	RESTRICT_CLASS				= 1,
+	RESTRICT_RACE				= 2,
+	RESTRICT_CABAL				= 3,
+};
+
+// Shapeshifter tribe ordinal. Wire format - never renumber.
+enum Tribe : int
+{
+	TRIBE_NONE					= 0,
+	TRIBE_BOAR					= 1,
+	TRIBE_WOLF					= 2,
+	TRIBE_BEAR					= 3,
+	TRIBE_HAWK					= 4,
+	TRIBE_LION					= 5,
+	TRIBE_ELK					= 6,
+	TRIBE_JACKAL				= 7,
+	TRIBE_FOX					= 8,
+	TRIBE_BULL					= 9,
+	TRIBE_PANTHER				= 10,
+};
+
+// Paladin-order ordinal. Wire format - never renumber.
+enum PaladinOrder : int
+{
+	PALADIN_NONE				= 0,
+	PALADIN_PROTECTOR			= 1,
+	PALADIN_CRUSADER			= 2,
+};
+
+// Combat-style ordinal. STYLE_NONE is the -1 sentinel (hence : int). Wire
+// format - never renumber.
+enum CombatStyle : int
+{
+	STYLE_NONE					= -1,
+	STYLE_GLADIATOR				= 0,
+	STYLE_BARBARIAN				= 1,
+	STYLE_DUELIST				= 2,
+	STYLE_SKIRMISHER			= 3,
+	STYLE_DRAGOON				= 4,
+	STYLE_TACTICIAN				= 5,
+};
+
+// Weapon CLASS - an ordinal scalar in obj->value[0], compared with ==. This is
+// a separate family from the weapon-flag bits below, whose values 0-10 collide
+// with these completely. (The source's own "weapon class" / "weapon types"
+// comments have these two backwards; the names are kept, the labels corrected.)
+enum WeaponClass : int
+{
+	WEAPON_EXOTIC				= 0,
+	WEAPON_SWORD				= 1,
+	WEAPON_DAGGER				= 2,
+	WEAPON_SPEAR				= 3,
+	WEAPON_MACE					= 4,
+	WEAPON_AXE					= 5,
+	WEAPON_FLAIL				= 6,
+	WEAPON_WHIP					= 7,
+	WEAPON_POLEARM				= 8,
+	WEAPON_STAFF				= 9,
+	WEAPON_HAND					= 10,
+};
+
+// Weapon FLAGS - bit indices tested with IS_SET_OLD on obj->value[4] (a scalar
+// int field, hence the _OLD operators). Separate family from WeaponClass above.
+enum WeaponFlag : int
+{
+	WEAPON_FLAMING				= 0,
+	WEAPON_FROST				= 1,
+	WEAPON_VAMPIRIC				= 2,
+	WEAPON_SHARP				= 3,
+	WEAPON_VORPAL				= 4,
+	WEAPON_TWO_HANDS			= 5,
+	WEAPON_SHOCKING				= 6,
+	WEAPON_POISON				= 7,
+	WEAPON_AVENGER				= 8,
+	WEAPON_SHADOWBANE			= 9,
+	WEAPON_LIGHTBRINGER			= 10,
+};
+
+// Portal gate flags - bit indices tested with IS_SET_OLD on a portal's
+// obj->value[] scalar. Wire format - rename freely, never renumber.
+enum GateFlag : int
+{
+	GATE_NORMAL_EXIT			= 0,
+	GATE_NOCURSE				= 1,
+	GATE_GOWITH					= 2,
+	GATE_BUGGY					= 3,
+	GATE_RANDOM					= 4,
+};
+
+// Furniture position flags - bit indices tested with IS_SET_OLD on a piece of
+// furniture's obj->value[2] (act_info.c). One family across six prefixes
+// (STAND_/SIT_/REST_/SLEEP_/PUT_/LOUNGE_), a single 0-16 numbering. Kept as one
+// enum with the original names. Wire format - rename freely, never renumber.
+enum FurniturePosition : int
+{
+	STAND_AT					= 0,
+	STAND_ON					= 1,
+	STAND_IN					= 2,
+	SIT_AT						= 3,
+	SIT_ON						= 4,
+	SIT_IN						= 5,
+	REST_AT						= 6,
+	REST_ON						= 7,
+	REST_IN						= 8,
+	SLEEP_AT					= 9,
+	SLEEP_ON					= 10,
+	SLEEP_IN					= 11,
+	PUT_AT						= 12,
+	PUT_ON						= 13,
+	PUT_IN						= 14,
+	PUT_INSIDE					= 15,
+	LOUNGE_ON					= 16,
+};
+
+// The main apply-location family: affect_data::location, an ordinal scalar
+// (short), not a bit field. Compared with == and switched on. APPLY_ROOM_* and
+// APPLY_OBJ_* (above) are separate families on separate location fields.
+// Wire format - rename freely, never renumber.
+enum ApplyLocation : int
+{
+	APPLY_NONE					= 0,
+	APPLY_STR					= 1,
+	APPLY_DEX					= 2,
+	APPLY_INT					= 3,
+	APPLY_WIS					= 4,
+	APPLY_CON					= 5,
+	APPLY_SEX					= 6,
+	APPLY_CLASS					= 7,
+	APPLY_LUCK					= 8,	// UNUSED!!
+	APPLY_AGE					= 9,
+	APPLY_HEIGHT				= 10,
+	APPLY_WEIGHT				= 11,
+	APPLY_MANA					= 12,
+	APPLY_HIT					= 13,
+	APPLY_MOVE					= 14,
+	APPLY_GOLD					= 15,
+	APPLY_EXP					= 16,
+	APPLY_AC					= 17,
+	APPLY_HITROLL				= 18,
+	APPLY_DAMROLL				= 19,
+	APPLY_SAVES					= 20,
+	APPLY_SAVING_PARA			= 21,
+	APPLY_SAVING_ROD			= 22,
+	APPLY_SAVING_PETRI			= 23,
+	APPLY_SAVING_BREATH			= 24,
+	APPLY_SAVING_SPELL			= 25,
+	APPLY_SPELL_AFFECT			= 26,
+	APPLY_CARRY_WEIGHT			= 27,
+	APPLY_DEFENSE				= 28,
+	APPLY_REGENERATION			= 29,
+	APPLY_SIZE					= 30,
+	APPLY_ENERGYSTATE			= 31,
+	APPLY_DAM_MOD				= 32,
+	APPLY_LEGS					= 33,
+	APPLY_ARMS					= 34,
+	APPLY_BEAUTY				= 35,
+	APPLY_ALIGNMENT				= 36,
+	APPLY_ETHOS					= 37,
+	// APPLY_OBJ_PROPERTIES == 100 lived here originally, in the main family's
+	// numbering despite its APPLY_OBJ_ name. Kept in this enum, at its value.
+	APPLY_OBJ_PROPERTIES		= 100,
+};
+
+// Spell/effect modifier type, an ordinal. MOD_NONE is the -1 sentinel, hence
+// the required : int underlying type. Wire format - never renumber.
+enum ModType : int
+{
+	MOD_NONE					= -1,
+	MOD_VISION					= 0,
+	MOD_MOVEMENT				= 1,
+	MOD_TOUGHNESS				= 2,
+	MOD_SPEED					= 3,
+	MOD_LEVITATION				= 4,
+	MOD_VISIBILITY				= 5,
+	MOD_PHASE					= 6,
+	MOD_CONC					= 7,
+	MOD_PROTECTION				= 8,
+	MOD_APPEARANCE				= 9,
+	MOD_HEARING					= 10,
+	MOD_PERCEPTION				= 11,
+	MOD_RESISTANCE				= 12,
+	MOD_ENERGY_STATE			= 13,
+	MOD_SPEECH					= 14,
+	MOD_REGEN					= 15,
+	MOD_WARDROBE				= 16,
+};
+
+// Container flags - bit indices tested with IS_SET_OLD on a container's
+// obj->value[1] scalar. Wire format - rename freely, never renumber.
+enum ContainerFlag : int
+{
+	CONT_CLOSEABLE				= 0,
+	CONT_PICKPROOF				= 1,
+	CONT_CLOSED					= 2,
+	CONT_LOCKED					= 3,
+	CONT_PUT_ON					= 4,
+};
+
+// Wield-hand ordinal. Wire format - never renumber.
+enum WieldType : int
+{
+	WIELD_ONE					= 1,
+	WIELD_TWO					= 2,
+	WIELD_PRIMARY				= 3,
+};
+
+// Bit indices into room_index_data::room_flags. Also reachable through
+// room_affect_data::bitvector via TO_ROOM_FLAGS (handler.c).
+// Wire format - rename freely, never renumber. Gaps at 1, 5-8, 24 and 26 are
+// retired bits; check existing area data before reusing any of them.
+//
+// NOTE: the ROOM_VNUM_* constants above are NOT part of this family. They are
+// room virtual numbers (values into the thousands), not bit indices, and they
+// share the prefix only by accident. ROOM_VNUM_LIMBO == 2 collides with
+// ROOM_NO_MOB == 2 harmlessly because the two are never used on the same thing.
+enum RoomFlag : int
+{
+	ROOM_DARK					= 0,
+	ROOM_NO_MOB					= 2,
+	ROOM_INDOORS				= 3,
+	ROOM_NO_CONSECRATE			= 4,
+	ROOM_PRIVATE				= 9,
+	ROOM_SAFE					= 10,
+	ROOM_SOLITARY				= 11,
+	ROOM_PET_SHOP				= 12,
+	ROOM_NO_RECALL				= 13,
+	ROOM_IMP_ONLY				= 14,
+	ROOM_GODS_ONLY				= 15,
+	ROOM_HEROES_ONLY			= 16,
+	ROOM_NEWBIES_ONLY			= 17,
+	ROOM_LAW					= 18,
+	ROOM_NOWHERE				= 19,
+	ROOM_NO_GATE				= 20,
+	ROOM_SILENCE				= 21,
+	ROOM_NO_SUMMON_TO			= 22,
+	ROOM_NO_SUMMON_FROM			= 23,
+	ROOM_NO_ALARM				= 25,
+	ROOM_FORCE_DUEL				= 27,
+	ROOM_NO_MAGIC				= 28,
+	ROOM_AREA_EXPLORE			= 29,	// Don't use - Use area flags instead
+	ROOM_NO_COMMUNE				= 30,
+};
+
+// Exit flags - bit indices tested with IS_SET_OLD on exit_data::exit_info (a
+// scalar int). Wire format - rename freely, never renumber.
+enum ExitFlag : int
+{
+	EX_ISDOOR					= 0,
+	EX_CLOSED					= 1,
+	EX_LOCKED					= 2,
+	EX_PICKPROOF				= 3,
+	EX_NOPASS					= 4,
+	EX_NOCLOSE					= 5,
+	EX_NOLOCK					= 6,
+	EX_NOBASH					= 7,
+	EX_NONOBVIOUS				= 8,
+	EX_TRANSLUCENT				= 9,
+	EX_JAMMED					= 10,
+};
+
+// Area sector/category ordinal. Wire format - never renumber.
+enum AreaSector : int
+{
+	ARE_NORMAL					= 0,
+	ARE_ROAD_RIVER				= 1,
+	ARE_CABAL					= 2,
+	ARE_QUEST					= 3,
+	ARE_CITY					= 4,
+	ARE_UNOPENED				= 5,
+	ARE_SHRINE					= 6,
+};
+
+// Sector (terrain) types, an ordinal in room_index_data::sector_type. Note the
+// deliberate collision: SECT_INSIDE and SECT_UNUSED are both 7. SECT_MAX (21) is
+// a count/sentinel, not a terrain. Wire format - never renumber.
+enum SectorType : int
+{
+	SECT_INSIDE					= 7,
+	SECT_CITY					= 1,
+	SECT_FIELD					= 2,
+	SECT_FOREST					= 3,
+	SECT_HILLS					= 4,
+	SECT_MOUNTAIN				= 5,
+	SECT_WATER					= 6,
+	SECT_UNUSED					= 7,
+	SECT_UNDERWATER				= 8,
+	SECT_AIR					= 9,
+	SECT_DESERT					= 10,
+	SECT_ROAD					= 11,
+	SECT_CONFLAGRATION			= 12,
+	SECT_BURNING				= 13,
+	SECT_TRAIL					= 14,
+	SECT_SWAMP					= 15,
+	SECT_PARK					= 16,
+	SECT_VERTICAL				= 17,
+	SECT_ICE					= 18,
+	SECT_SNOW					= 19,
+	SECT_CAVE					= 20,
+	SECT_MAX					= 21,	// count/sentinel, not a terrain
+};
+
+// Trap effect ordinal. Wire format - never renumber.
+enum TrapType : int
+{
+	TRAP_NONE					= 0,
+	TRAP_DART					= 1,
+	TRAP_PDART					= 2,
+	TRAP_FIREBALL				= 3,
+	TRAP_LIGHTNING				= 4,
+	TRAP_SLEEPGAS				= 5,
+	TRAP_POISONGAS				= 6,
+	TRAP_ACID					= 7,
+	TRAP_PIT					= 8,
+	TRAP_BOULDER				= 9,
+	TRAP_DRAIN					= 10,
+};
+
+// Alignment SELECTION values (creation/OLC choices), an ordinal. Distinct from
+// the raw alignment scale ALIGN_NEUTRAL sits on above. ALIGN_NONE is the -1
+// sentinel (hence : int). Wire format - never renumber.
+enum AlignmentChoice : int
+{
+	ALIGN_NONE					= -1,
+	ALIGN_ANY					= 0,
+	ALIGN_GN					= 1,
+	ALIGN_NE					= 2,
+	ALIGN_GE					= 3,
+	ALIGN_G						= 4,
+	ALIGN_N						= 5,
+	ALIGN_E						= 6,
+};
+
+// Ethos SELECTION values (creation/OLC choices), an ordinal. Distinct from the
+// raw ethos scale ETHOS_NEUTRAL sits on. ETHOS_NONE is the -1 sentinel.
+enum EthosChoice : int
+{
+	ETHOS_NONE					= -1,
+	ETHOS_ANY					= 0,
+	ETHOS_LN					= 1,
+	ETHOS_NC					= 2,
+	ETHOS_LC					= 3,
+	ETHOS_L						= 4,
+	ETHOS_N						= 5,
+	ETHOS_C						= 6,
+};
+
+// Guild ordinal (room guild-guard associations). Wire format - never renumber.
+enum Guild : int
+{
+	GUILD_WARRIOR				= 1,
+	GUILD_THIEF					= 2,
+	GUILD_CLERIC				= 3,
+	GUILD_PALADIN				= 4,
+	GUILD_ANTI_PALADIN			= 5,
+	GUILD_RANGER				= 6,
+	GUILD_MONK					= 7,
+	GUILD_SHAPESHIFTER			= 8,
+	GUILD_ASSASSIN				= 9,
+	GUILD_NECROMANCER			= 10,
+	GUILD_SORCERER				= 11,
+};
+
+// Character class, an ordinal in char_data::Class()/class. The main CLASS_
+// family. Wire format - rename freely, never renumber.
+enum CharClass : int
+{
+	CLASS_NONE					= 0,
+	CLASS_WARRIOR				= 1,
+	CLASS_THIEF					= 2,
+	CLASS_ZEALOT				= 3,
+	CLASS_PALADIN				= 4,
+	CLASS_ANTI_PALADIN			= 5,
+	CLASS_RANGER				= 6,
+	CLASS_ASSASSIN				= 7,
+	CLASS_SHAPESHIFTER			= 8,
+	CLASS_HEALER				= 9,
+	CLASS_NECROMANCER			= 10,
+	CLASS_SORCERER				= 11,
+};
+
+// Worn-equipment slot index into char_data::equipment[]. WEAR_NONE is the -1
+// sentinel (hence : int); WEAR_DUAL_WIELD and WEAR_FLOAT deliberately share slot
+// 18. Wire format - rename freely, never renumber.
+enum WearLocation : int
+{
+	WEAR_NONE					= -1,
+	WEAR_LIGHT					= 0,
+	WEAR_FINGER_L				= 1,
+	WEAR_FINGER_R				= 2,
+	WEAR_NECK_1					= 3,
+	WEAR_NECK_2					= 4,
+	WEAR_BODY					= 5,
+	WEAR_HEAD					= 6,
+	WEAR_LEGS					= 7,
+	WEAR_FEET					= 8,
+	WEAR_HANDS					= 9,
+	WEAR_ARMS					= 10,
+	WEAR_SHIELD					= 11,
+	WEAR_ABOUT					= 12,
+	WEAR_WAIST					= 13,
+	WEAR_WRIST_L				= 14,
+	WEAR_WRIST_R				= 15,
+	WEAR_WIELD					= 16,
+	WEAR_HOLD					= 17,
+	WEAR_DUAL_WIELD				= 18,
+	WEAR_FLOAT					= 18,
+	WEAR_BRAND					= 19,
+	WEAR_STRAPPED				= 20,
+	WEAR_COSMETIC				= 21,
+};
+
+// damage_new() flag arguments. Three independent two-value families, passed
+// positionally. Kept as three enums matching their argument slots.
+enum HitBlockable : int
+{
+	HIT_UNBLOCKABLE				= 0,
+	HIT_BLOCKABLE				= 1,
+};
+
+enum HitSpecials : int
+{
+	HIT_NOSPECIALS				= 0,
+	HIT_SPECIALS				= 1,
+};
+
+enum HitModifier : int
+{
+	HIT_NOMULT					= 1,
+	HIT_NOADD					= 0,
+};
+
+// Combat posture, an ordinal spanning -1..1. POSTURE_DEFENSE is -1 (hence : int).
+enum Posture : int
+{
+	POSTURE_OFFENSE				= 1,
+	POSTURE_NONE				= 0,
+	POSTURE_DEFENSE				= -1,
+};
+
+// Condition index into pc_data::condition[]. COND_HUNGRY (50) is an outlier
+// value, not adjacent to the rest. Wire format - never renumber.
+enum ConditionType : int
+{
+	COND_DRUNK					= 0,
+	COND_FULL					= 1,
+	COND_THIRST					= 2,
+	COND_HUNGER					= 3,
+	COND_STARVING				= 4,
+	COND_DEHYDRATED				= 5,
+	COND_HUNGRY					= 50,
+};
+
+// Character position, an ordinal in char_data::position (a short). Ordering is
+// load-bearing: ~96 relational comparisons (position >= POS_RESTING etc.) and it
+// is stored in cmd_type::position for the command table. Wire format - never
+// renumber. Kept ascending exactly as-is so all comparisons hold.
+enum Position : int
+{
+	POS_DEAD					= 0,
+	POS_MORTAL					= 1,
+	POS_INCAP					= 2,
+	POS_STUNNED					= 3,
+	POS_SLEEPING				= 4,
+	POS_RESTING					= 5,
+	POS_SITTING					= 6,
+	POS_FIGHTING				= 7,
+	POS_STANDING				= 8,
+};
+
+// PK alignment-kill counters. Separate family from the killed[] index pair
+// below. Wire format - never renumber.
+enum PkKillType : int
+{
+	PK_KILLS					= 0,
+	PK_GOOD						= 1,
+	PK_NEUTRAL					= 2,
+	PK_EVIL						= 3,
+};
+
+// Index into pcdata::killed[]: player kills vs mob kills. One family, two
+// prefixes (PK_/MOB_).
+enum KilledIndex : int
+{
+	PK_KILLED					= 0,
+	MOB_KILLED					= 1,
+};
+
+// Bit indices into char_data::act - the SAME field ActFlag uses, disambiguated
+// at runtime by is_npc(). Values collide with ActFlag deliberately and must not
+// be reconciled: PLR_AUTOABORT and ACT_SENTINEL are both bit 1 with unrelated
+// meanings. Wire format, as ActFlag - rename freely, never renumber.
+// Gap at 18: see the "2 bits reserved" note, of which only 19 was ever taken.
+enum PlrFlag : int
+{
+	PLR_IS_NPC					= 0,	// Don't EVER set.
+
+	// RT auto flags
+	PLR_AUTOABORT				= 1,
+	PLR_AUTOASSIST				= 2,
+	PLR_AUTOEXIT				= 3,
+	PLR_AUTOLOOT				= 4,
+	PLR_AUTOSAC					= 5,
+	PLR_AUTOGOLD				= 6,
+	PLR_AUTOSPLIT				= 7,
+	PLR_COLOR					= 8,
+	PLR_IGNORANT				= 9,
+	PLR_BETRAYER				= 10,
+
+	// RT personal flags
+	PLR_CODER					= 11,
+	PLR_HEROIMM					= 12,
+	PLR_HOLYLIGHT				= 13,
+	PLR_EMPOWERED				= 14,
+	PLR_NOVOID					= 15,
+	PLR_NOSUMMON				= 16,
+	PLR_NOFOLLOW				= 17,
+
+	// 2 bits reserved, S-T
+	PLR_NO_TRANSFER				= 19,
+
+	// Bad flags
+	PLR_PERMIT					= 20,
+	PLR_MORON					= 21,
+	PLR_LOG						= 22,
+	PLR_DENY					= 23,
+	PLR_FREEZE					= 24,
+	PLR_THIEF					= 25,
+	PLR_KILLER					= 26,
+	PLR_CRIMINAL				= 27,
+};
+
+// Bit indices into char_data::comm. The values are a wire format - they are
+// written to player files as letters keyed to the index (save.c print_flags),
+// so they may be renamed but never renumbered. Note the gap at 17.
+enum CommFlag : int
+{
+	COMM_QUIET					= 0,
+	COMM_DEAF					= 1,
+	COMM_NOWIZ					= 2,
+	COMM_NOAUCTION				= 3,
+	COMM_NOGOSSIP				= 4,
+	COMM_NOQUESTION				= 5,
+	COMM_NONEWBIE				= 6,
+	COMM_NOCABAL				= 7,
+	COMM_NOQUOTE				= 8,
+	COMM_SHOUTSOFF				= 9,
+	COMM_ANSI					= 10,
+
+	// display flags
+	COMM_COMPACT				= 11,
+	COMM_BRIEF					= 12,
+	COMM_PROMPT					= 13,
+	COMM_COMBINE				= 14,
+	COMM_TELNET_GA				= 15,
+	COMM_SHOW_AFFECTS			= 16,
+	COMM_IMMORTAL				= 18,
+
+	// penalties
+	COMM_NOEMOTE				= 19,
+	COMM_NOSHOUT				= 20,
+	COMM_NOTELL					= 21,
+	COMM_NOCHANNELS				= 22,
+	COMM_BUILDER				= 23,
+	COMM_SNOOP_PROOF			= 24,
+	COMM_AFK					= 25,
+	COMM_ALL_CABALS				= 26,
+	COMM_NOSOCKET				= 27,
+	COMM_SWITCHSKILLS			= 28,
+	COMM_NOBUILDER				= 29,
+	COMM_LOTS_O_COLOR			= 30,
+};
+
+// Wiznet channel bit indices into char_data::wiznet, and passed as `long flag`
+// to wiznet(). Wire format - rename freely, never renumber. Gap at 23.
+enum WiznetFlag : int
+{
+	WIZ_ON						= 0,
+	WIZ_TICKS					= 1,
+	WIZ_LOGINS					= 2,
+	WIZ_SITES					= 3,
+	WIZ_LINKS					= 4,
+	WIZ_DEATHS					= 5,
+	WIZ_RESETS					= 6,
+	WIZ_MOBDEATHS					= 7,
+	WIZ_FLAGS					= 8,
+	WIZ_PENALTIES					= 9,
+	WIZ_SACCING					= 10,
+	WIZ_LEVELS					= 11,
+	WIZ_SECURE					= 12,
+	WIZ_SWITCHES					= 13,
+	WIZ_SNOOPS					= 14,
+	WIZ_RESTORE					= 15,
+	WIZ_LOAD					= 16,
+	WIZ_NEWBIE					= 17,
+	WIZ_PREFIX					= 18,
+	WIZ_SPAM					= 19,
+	WIZ_CABAL					= 20,
+	WIZ_PERCENT					= 21,
+	WIZ_LOG						= 22,
+	WIZ_OOC						= 23,
+	WIZ_DEBUG					= 24,
+};
+
+// Devil-patron ordinal. Wire format - never renumber.
+enum Devil : int
+{
+	DEVIL_ASMODEUS				= 0,
+	DEVIL_MOLOCH				= 1,
+	DEVIL_BAAL					= 2,
+	DEVIL_DISPATER				= 3,
+	DEVIL_MEPHISTO				= 4,
+};
+
+// Lesser-demon name ordinal. MAX_LESSER stays a #define (constexpr commit).
+enum LesserDemon : int
+{
+	LESSER_BARBAS				= 0,
+	LESSER_AAMON				= 1,
+	LESSER_MALAPHAR				= 2,
+	LESSER_FURCAS				= 3,
+	LESSER_IPOS					= 4,
+};
+
+// Greater-demon name ordinal. Separate family from GreaterDemon-tier below.
+enum GreaterDemon : int
+{
+	GREATER_OZE					= 0,
+	GREATER_GAMYGYN				= 1,
+	GREATER_OROBAS				= 2,
+	GREATER_GERYON				= 3,
+	GREATER_CIMERIES			= 4,
+};
+
+// Demon tier discriminator (lesser vs greater). LESSER_DEMON/GREATER_DEMON share
+// the LESSER_/GREATER_ prefixes with the name families above but are a distinct
+// two-value family.
+enum DemonTier : int
+{
+	LESSER_DEMON				= 0,
+	GREATER_DEMON				= 1,
+};
+
+// Favor/quest-state ordinal. FAVOR_FAILED is the -1 sentinel (hence : int).
+enum FavorState : int
+{
+	FAVOR_NONE					= 0,
+	FAVOR_FAILED				= -1,
+	FAVOR_IN_PROGRESS			= 1,
+	FAVOR_GRANTED				= 2,
+};
+
+// Elemental type, an ordinal. Separate from ELE_TYPE_* below (which collide in
+// value). Wire format - never renumber.
+enum Element : int
+{
+	ELE_HEAT					= 0,
+	ELE_COLD					= 1,
+	ELE_AIR						= 2,
+	ELE_EARTH					= 3,
+	ELE_WATER					= 4,
+	ELE_ELECTRICITY				= 5,
+	ELE_SMOKE					= 6,
+	ELE_MAGMA					= 7,
+	ELE_PLASMA					= 8,
+	ELE_ACID					= 9,
+	ELE_BLIZZARD				= 10,
+	ELE_FROST					= 11,
+	ELE_CRYSTAL					= 12,
+	ELE_ICE						= 13,
+	ELE_LIGHTNING				= 14,
+	ELE_MIST					= 15,
+	ELE_METAL					= 16,
+	ELE_OOZE					= 17,
+	ELE_NONE					= 18,
+};
+
+// Elemental slot type, an ordinal. Separate family from Element above.
+enum ElementSlot : int
+{
+	ELE_TYPE_NONE				= 0,
+	ELE_TYPE_PRIMARY			= 1,
+	ELE_TYPE_PARA				= 2,
+};
+
+// Material optical property. Separate family from MAT_SOLID.. below (collide).
+enum MaterialOptical : int
+{
+	MAT_TRANSLUCENT				= 0,
+	MAT_TRANSPARENT				= 1,
+	MAT_EDIBLE					= 2,
+};
+
+// Material state of matter.
+enum MaterialState : int
+{
+	MAT_SOLID					= 0,
+	MAT_LIQUID					= 1,
+	MAT_GAS						= 2,
+	MAT_PLASMA					= 3,
+};
+
+// Speech-act ordinal. Wire format - never renumber.
+enum SpeechType : int
+{
+	SPEECH_SAY					= 0,
+	SPEECH_SAYTO				= 1,
+	SPEECH_TELL					= 2,
+	SPEECH_WHISPER				= 3,
+	SPEECH_YELL					= 4,
+	SPEECH_EMOTE				= 5,
+	SPEECH_ECHO					= 6,
+	SPEECH_SING					= 7,
+};
+
+// Skill/spell target-type ordinal, in skill_type::target. TAR_END (666) is a
+// deliberate sentinel, not adjacent. Wire format - never renumber.
+enum SkillTarget : int
+{
+	TAR_IGNORE					= 0,
+	TAR_CHAR_OFFENSIVE			= 1,
+	TAR_CHAR_DEFENSIVE			= 2,
+	TAR_CHAR_SELF				= 3,
+	TAR_OBJ_INV					= 4,
+	TAR_OBJ_CHAR_DEF			= 5,
+	TAR_OBJ_CHAR_OFF			= 6,
+	TAR_DIR						= 7,
+	TAR_CHAR_AMBIGUOUS			= 8,
+	TAR_CHAR_GENERAL			= 9,
+	TAR_END						= 666,	// don't touch
+};
+
+// Spell effect target-type ordinal. Separate family from SkillTarget above.
+enum TargetType : int
+{
+	TARGET_CHAR					= 0,
+	TARGET_OBJ					= 1,
+	TARGET_ROOM					= 2,
+	TARGET_NONE					= 3,
+	TARGET_RUNE					= 4,
+	TARGET_DIR					= 5,
+};
+
+// Rune target bitmasks - these are pre-shifted MASKS (1,2,4,8,16), not bit
+// indices, tested with IS_SET_OLD directly and compared with <. A third RUNE_
+// family, distinct from RuneTarget/RuneTrigger. Wire format - never renumber.
+enum RuneMask : int
+{
+	RUNE_CAST					= 1,
+	RUNE_ARMOR					= 2,
+	RUNE_WEAPON					= 4,
+	RUNE_DOOR					= 8,
+	RUNE_ROOM					= 16,
+};
+
+// Area flags - bit indices into area_data::area_flags. AREA_NONE and
+// AREA_EXPLORE are both 0 by design (alias). Wire format - never renumber.
+enum AreaFlag : int
+{
+	AREA_NONE					= 0,
+	AREA_EXPLORE				= 0,	// So far, only that gear returns to newbies
+	AREA_NO_NEWBIES				= 1,	// Newbies can't go in
+	AREA_UNGHOST				= 2,	// Walking in unghosts you
+	AREA_CHANGED				= 3,	// Area has been modified.
+	AREA_ADDED					= 4,	// Area has been added to.
+	AREA_LOADING				= 5,	// Used for counting in db.c
+};
+
+#endif /* ENUMS_H */

--- a/code/fight.c
+++ b/code/fight.c
@@ -5253,7 +5253,10 @@ void do_bash(CHAR_DATA *ch, char *argument)
 		if (!is_npc(ch))
 		{
 			ch->pcdata->condition[COND_THIRST] += 8;
-			ch->pcdata->condition[COND_THIRST] = std::min((int)ch->pcdata->condition[COND_THIRST], COND_HUNGRY);
+			// (int) cast: COND_HUNGRY is a ConditionType enumerator now, and std::min
+			// needs both arguments the same type. Its numeric value (50) is used here
+			// as a clamp ceiling rather than as an index. Behaviour unchanged.
+			ch->pcdata->condition[COND_THIRST] = std::min((int)ch->pcdata->condition[COND_THIRST], (int)COND_HUNGRY);
 		}
 
 		return;
@@ -6789,7 +6792,10 @@ void do_throw(CHAR_DATA *ch, char *argument)
 		if (!is_npc(ch))
 		{
 			ch->pcdata->condition[COND_THIRST] += 8;
-			ch->pcdata->condition[COND_THIRST] = std::min((int)ch->pcdata->condition[COND_THIRST], COND_HUNGRY);
+			// (int) cast: COND_HUNGRY is a ConditionType enumerator now, and std::min
+			// needs both arguments the same type. Its numeric value (50) is used here
+			// as a clamp ceiling rather than as an index. Behaviour unchanged.
+			ch->pcdata->condition[COND_THIRST] = std::min((int)ch->pcdata->condition[COND_THIRST], (int)COND_HUNGRY);
 		}
 
 		return;

--- a/code/magic.c
+++ b/code/magic.c
@@ -1405,7 +1405,7 @@ void spell_blindness(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 	}
 
 	if (saves_spell(level - 3, victim, DAM_OTHER)
-		|| IS_SET(victim->form, ACT_UNDEAD)
+		|| (is_npc(victim) && IS_SET(victim->act, ACT_UNDEAD))
 		|| IS_SET(victim->form, FORM_UNDEAD))
 	{
 		act("You failed to blind $N.", ch, 0, victim, TO_CHAR);

--- a/code/merc.h
+++ b/code/merc.h
@@ -325,82 +325,22 @@ typedef void APROG_FUN_MYELL (AREA_DATA *area, CHAR_DATA *ch, CHAR_DATA *victim)
 // mprog stuff
 //
 
-// Mob-program trigger bit indices into mob_index_data::progtypes. One of four
-// prog-trigger families (mprog/iprog/rprog/aprog), each on its own entity's
-// progtypes field. Wire format -- rename freely, never renumber.
-enum MProgTrigger : int
-{
-	MPROG_BRIBE					= 0,
-	MPROG_ENTRY					= 1,
-	MPROG_GREET					= 2,
-	MPROG_GIVE					= 3,
-	MPROG_FIGHT					= 4,
-	MPROG_DEATH					= 5,
-	MPROG_PULSE					= 6,
-	MPROG_SPEECH				= 7,
-	MPROG_ATTACK				= 8,
-	MPROG_MOVE					= 9,
-	MPROG_BEAT					= 10,
-	MPROG_AGGRESS				= 11,
-};
+#include "enums.h"  // scoped constant enums (phase-02 3.3)
 
 //
 // iprog stuff
 //
 
-// Item-program trigger bit indices into obj_index_data::progtypes. Wire format
-// -- rename freely, never renumber. Gap at 16.
-enum IProgTrigger : int
-{
-	IPROG_WEAR					= 0,
-	IPROG_REMOVE				= 1,
-	IPROG_DROP					= 2,
-	IPROG_SAC					= 3,
-	IPROG_GIVE					= 4,
-	IPROG_GREET					= 5,
-	IPROG_FIGHT					= 6,
-	IPROG_DEATH					= 7,
-	IPROG_SPEECH				= 8,
-	IPROG_ENTRY					= 9,
-	IPROG_GET					= 10,
-	IPROG_PULSE					= 11,
-	IPROG_INVOKE				= 12,
-	IPROG_VERB					= 13,
-	IPROG_LOOT					= 14,
-	IPROG_OPEN					= 15,
-	IPROG_LOOK					= 17,
-	IPROG_HIT					= 18,
-};
 
 //
 // rprog stuff
 //
 
-// Room-program trigger bit indices into room_index_data::progtypes.
-enum RProgTrigger : int
-{
-	RPROG_PULSE					= 0,
-	RPROG_ENTRY					= 1,
-	RPROG_MOVE					= 2,
-	RPROG_DROP					= 3,
-	RPROG_SPEECH				= 4,
-	RPROG_OPEN					= 5,
-};
 
 //
 // aprog stuff
 //
 
-// Area-program trigger bit indices into area_data::progtypes.
-enum AProgTrigger : int
-{
-	APROG_PULSE					= 0,
-	APROG_RESET					= 1,
-	APROG_SUN					= 2,
-	APROG_TICK					= 3,
-	APROG_AGGRESS				= 4,
-	APROG_MYELL					= 5,
-};
 
 //
 // Quests!
@@ -414,13 +354,6 @@ enum AProgTrigger : int
 #define SMITH_QUEST					6
 #define RING_QUEST					7
 
-// Yes/no prompt reply ordinal. Wire format -- never renumber.
-enum ReplyType : int
-{
-	REPLY_YES					= 1,
-	REPLY_NO					= 2,
-	REPLY_NEITHER				= 3,
-};
 
 #define NOTE_UNSTARTED				0
 #define NOTE_IN_PROGRESS			1
@@ -455,42 +388,6 @@ struct time_info_data
 // Connected state for a channel.
 //
 
-// Descriptor connection state, an ordinal in descriptor_data::connected;
-// switched on in nanny(). NOTE: CON_DIE_BOUND (defined far above, near the level
-// constants) is NOT part of this family -- it is a constitution-stat threshold
-// that shares the CON_ prefix by accident, and keeps its #define. Wire format
-// -- never renumber.
-enum ConnectionState : int
-{
-	CON_PLAYING					= 0,
-	CON_GET_NAME				= 1,
-	CON_GET_OLD_PASSWORD		= 2,
-	CON_CONFIRM_NEW_NAME		= 3,
-	CON_GET_NEW_PASSWORD		= 4,
-	CON_CONFIRM_NEW_PASSWORD	= 5,
-	CON_GET_NEW_RACE			= 6,
-	CON_GET_NEW_SEX				= 7,
-	CON_GET_NEW_CLASS			= 8,
-	CON_ALLOCATE_STATS			= 9,
-	CON_GET_ALIGNMENT			= 10,
-	CON_GET_ETHOS				= 11,
-	CON_DEFAULT_CHOICE			= 12,
-	CON_GEN_GROUPS				= 13,
-	CON_NEW_CHAR				= 14,
-	CON_READ_IMOTD				= 15,
-	CON_READ_MOTD				= 16,
-	CON_BREAK_CONNECT			= 17,
-	CON_GET_CABAL				= 18,
-	CON_GET_SPEC_ONE			= 19,
-	CON_GET_SPEC_TWO			= 20,
-	CON_GET_THERMAL				= 21,
-	CON_GET_MATERIAL			= 22,
-	CON_GET_DYNAMIC				= 23,
-	CON_CHOOSE_ELE				= 24,
-	CON_LEGIT_NAME				= 25,
-	CON_GET_BEAUTY				= 26,
-	CON_CHOOSE_WEAPON			= 27,
-};
 
 //
 // Descriptor (channel) structure.
@@ -576,20 +473,6 @@ struct bounty
 // TO types for act.
 //
 
-// act() message target ordinal. A separate family from the TO_* "where" values
-// below (which discriminate affect_data::bitvector); values 0-5 collide.
-enum ActTarget : int
-{
-	TO_ROOM						= 0,
-	TO_NOTVICT					= 1,
-	TO_VICT						= 2,
-	TO_CHAR						= 3,
-	TO_ALL						= 4,
-	TO_IMMINROOM				= 5,
-	TO_GROUP					= 6,
-	TO_NOTGROUP					= 7,
-	TO_AREA						= 8,
-};
 
 //
 // Help table types.
@@ -621,32 +504,8 @@ struct shop_data
 	short direction;			// exit dir
 };
 
-// Door-bar restriction criterion. Three separate BAR_ families follow, colliding
-// in value; each is its own enum. Wire format -- never renumber.
-enum BarCriterion : int
-{
-	BAR_CLASS					= 0,
-	BAR_CABAL					= 1,
-	BAR_SIZE					= 2,
-	BAR_TATTOO					= 3,
-	BAR_LEVEL					= 4,
-};
 
-// Bar comparison operator.
-enum BarComparison : int
-{
-	BAR_EQUAL_TO				= 0,
-	BAR_LESS_THAN				= 1,
-	BAR_GREATER_THAN			= 2,
-};
 
-// Bar rejection-message style.
-enum BarMessage : int
-{
-	BAR_SAY						= 0,
-	BAR_ECHO					= 1,
-	BAR_EMOTE					= 2,
-};
 
 struct barred_data
 {
@@ -666,16 +525,6 @@ struct barred_data
 
 #define MAX_GUILD					8
 #define MAX_STATS					5
-// Primary-stat index into char_data::perm_stat[] / mod_stat[]. Wire format --
-// rename freely, never renumber.
-enum StatType : int
-{
-	STAT_STR					= 0,
-	STAT_INT					= 1,
-	STAT_WIS					= 2,
-	STAT_DEX					= 3,
-	STAT_CON					= 4,
-};
 #define MAX_SPECS					8
 #define MAX_SPEC_SKILLS				1
 #define MAX_ZOMBIE					10
@@ -842,42 +691,16 @@ struct obj_affect_data
 // affect types
 //
 
-// Affect-type ordinal, in affect_data::aftype. Wire format -- never renumber.
-enum AffectType : int
-{
-	AFT_SPELL					= 0,
-	AFT_SKILL					= 1,
-	AFT_POWER					= 2,
-	AFT_MALADY					= 3,
-	AFT_COMMUNE					= 4,
-	AFT_INVIS					= 5,
-	AFT_RUNE					= 6,
-	AFT_TIMER					= 7,
-};
 
 //
 // class types
 //
 
-// Spellcasting-class ordinal (how a class channels magic). Separate family from
-// the character-class CLASS_NONE.. list and from CLASS_OPEN/CLOSED.
-enum SpellClass : int
-{
-	CLASS_NEITHER				= 0,
-	CLASS_CASTER				= 1,
-	CLASS_COMMUNER				= 2,
-};
 
 //
 // open or closed
 //
 
-// Whether a class is open for selection. A two-value ordinal, separate family.
-enum ClassAvailability : int
-{
-	CLASS_OPEN					= 1,
-	CLASS_CLOSED				= 0,
-};
 
 //
 // open or closed  race
@@ -890,16 +713,6 @@ enum ClassAvailability : int
 // const.c skill table types
 //
 
-// Magic command-type ordinal. Wire format -- never renumber.
-enum MagicCommand : int
-{
-	CMD_NONE					= 0,
-	CMD_SPELL					= 1,
-	CMD_COMMUNE					= 2,
-	CMD_POWER					= 3,
-	CMD_BOTH					= 4,
-	CMD_RUNE					= 5,
-};
 
 #define CAN_DISPEL					(1 << ASCII_A)
 #define CAN_CANCEL					(1 << ASCII_B)
@@ -910,63 +723,22 @@ enum MagicCommand : int
 // wear definitions
 //
 
-// affect_data::where -- the discriminator that decides which family the sibling
-// bitvector holds and which field it applies to (handler.c dispatches on it).
-// This is the tag of the six-family union described in phase-02 §0.8.1; typing
-// the union itself is deferred, but the tag values are a plain ordinal.
-enum AffectWhere : int
-{
-	TO_AFFECTS					= 0,
-	TO_OBJECT					= 1,
-	TO_IMMUNE					= 2,
-	TO_RESIST					= 3,
-	TO_VULN						= 4,
-	TO_WEAPON					= 5,
-};
 
 //
 // runes only
 //
 
-// What a rune is applied to -- an ordinal. Separate family from RUNE_TRIGGER_*
-// and the RUNE_* masks below (all three collide in value).
-enum RuneTarget : int
-{
-	RUNE_TO_WEAPON				= 0,
-	RUNE_TO_ARMOR				= 1,
-	RUNE_TO_PORTAL				= 2,
-	RUNE_TO_ROOM				= 3,
-};
 
-// When a rune fires -- an ordinal.
-enum RuneTrigger : int
-{
-	RUNE_TRIGGER_ENTRY			= 0,
-	RUNE_TRIGGER_EXIT			= 1,
-};
 
 //
 // where definitions for room
 //
 
-// room_affect_data::where -- discriminator for a room affect's bitvector.
-enum RoomAffectWhere : int
-{
-	TO_ROOM_AFFECTS				= 0,
-	TO_ROOM_CONST				= 1,
-	TO_ROOM_FLAGS				= 2,
-};
 
 //
 // where definitions for objs
 //
 
-// obj_affect_data::where -- discriminator for an object affect's bitvector.
-enum ObjAffectWhere : int
-{
-	TO_OBJ_AFFECTS				= 0,
-	TO_OBJ_APPLY				= 1,
-};
 
 //
 // where definitions for area
@@ -978,35 +750,11 @@ enum ObjAffectWhere : int
 /// room applies
 //
 
-// Room-affect apply locations. A separate family from the main APPLY_* below:
-// values 0-4 collide with APPLY_NONE..APPLY_WIS, so it must be its own enum.
-enum ApplyRoomLocation : int
-{
-	APPLY_ROOM_NONE				= 0,
-	APPLY_ROOM_HEAL				= 1,
-	APPLY_ROOM_MANA				= 2,
-	APPLY_ROOM_SECT				= 3,
-	APPLY_ROOM_NOPE				= 4,
-};
 
 //
 // obj applies
 //
 
-// Object apply locations (the obj->value[] slots). Another separate family --
-// values 0-6 collide with both APPLY_ROOM_* and the main APPLY_*. Note
-// APPLY_OBJ_PROPERTIES (100) below belongs with this family by name but sits
-// far outside the range; kept where the source had it.
-enum ApplyObjLocation : int
-{
-	APPLY_OBJ_NONE				= 0,
-	APPLY_OBJ_V0				= 1,
-	APPLY_OBJ_V1				= 2,
-	APPLY_OBJ_V2				= 3,
-	APPLY_OBJ_V3				= 4,
-	APPLY_OBJ_V4				= 5,
-	APPLY_OBJ_WEIGHT			= 6,
-};
 
 //
 // area applies
@@ -1021,21 +769,6 @@ enum ApplyObjLocation : int
 // Cabal definitions
 //
 
-// Cabal identity ordinal, in char_data::cabal. NOTE: CABAL_LEADER (defined among
-// the MAX_ constants below) is NOT part of this family -- it is an induct rank
-// compared against pcdata->induct, and keeps its #define. Wire format -- never
-// renumber. Gap at 7.
-enum Cabal : int
-{
-	CABAL_NONE					= 0,
-	CABAL_GUILD					= 1,
-	CABAL_SCION					= 2,
-	CABAL_HORDE					= 3,
-	CABAL_BOUNTY				= 4,
-	CABAL_THEATRE				= 5,
-	CABAL_PHALANX				= 6,
-	CABAL_NEGATIVE				= 8,
-};
 
 #define MAX_EMPIRE					8
 #define MAX_BOUNTY					5
@@ -1200,385 +933,58 @@ struct kill_data
 // Used in #MOBILES.
 //
 
-// Bit indices into char_data::act, mob_index_data::act and race_data::act.
-// NOTE: char_data::act carries PlrFlag as well -- the two families are disjoint
-// interpretations of one word, chosen by is_npc(). See flags.c's "act" vs "plr".
-// The values are a wire format (player files store them as letters keyed to the
-// index; area files resolve names through act_flags[]), so they may be renamed
-// but never renumbered. Gaps at 12, 13 and 23 are retired bits -- do not reuse
-// without checking existing player and area data.
-enum ActFlag : int
-{
-	ACT_IS_NPC					= 0,	// Auto set for mobs
-	ACT_SENTINEL				= 1,	// Stays in one room
-	ACT_SCAVENGER				= 2,	// Picks up objects
-	ACT_WARD_MOB				= 3,	// Ward mobs
-	ACT_WANDER					= 4,	// wanders
-	ACT_AGGRESSIVE				= 5,	// Attacks PC's
-	ACT_STAY_AREA				= 6,	// Won't leave area
-	ACT_WIMPY					= 7,
-	ACT_PET						= 8,	// Auto set for pets
-	ACT_TRAIN					= 9,	// Can train PC's
-	ACT_PRACTICE				= 10,	// Can practice PC's
-	ACT_SMARTTRACK				= 11,	// Will use pathfinding
-	ACT_UNDEAD					= 14,
-	ACT_INNER_GUARDIAN			= 15,	// yay.
-	ACT_CLERIC					= 16,
-	ACT_MAGE					= 17,
-	ACT_INTELLIGENT 			= 18,
-	ACT_FAST_TRACK				= 19,
-	ACT_NOALIGN					= 20,
-	ACT_NOPURGE					= 21,
-	ACT_OUTDOORS				= 22,
-	ACT_INDOORS					= 24,
-	ACT_GUILDGUARD				= 25,
-	ACT_IS_HEALER				= 26,
-	ACT_GAIN					= 27,
-	ACT_UPDATE_ALWAYS			= 28,
-	ACT_DETECT_SPECIAL			= 29,
-	ACT_BANKER					= 30,
-	ACT_NOCTURNAL				= 31,
-	ACT_DIURNAL					= 32,
-	ACT_FASTWANDER				= 33,
-	ACT_LAW						= 34,
-};
 
 //
 // damage classes
 //
 
-// Damage classes -- an ordinal passed around as an int and switched on. Wire
-// format -- rename freely, never renumber.
-enum DamageType : int
-{
-	DAM_NONE					= 0,
-	DAM_BASH					= 1,
-	DAM_PIERCE					= 2,
-	DAM_SLASH					= 3,
-	DAM_FIRE					= 4,
-	DAM_COLD					= 5,
-	DAM_LIGHTNING				= 6,
-	DAM_ACID					= 7,
-	DAM_POISON					= 8,
-	DAM_NEGATIVE				= 9,
-	DAM_HOLY					= 10,
-	DAM_ENERGY					= 11,
-	DAM_MENTAL					= 12,
-	DAM_DISEASE					= 13,
-	DAM_DROWNING				= 14,
-	DAM_LIGHT					= 15,
-	DAM_OTHER					= 16,
-	DAM_CHARM					= 17,
-	DAM_SOUND					= 18,
-	DAM_TRUESTRIKE				= 19,
-};
 #define	DAM_INTERNAL				20
 
 //
 // OFF bits for mobiles
 //
 
-// Offensive/assist bit indices into char_data::off_flags and
-// mob_index_data::off_flags. One contiguous 0-26 numbering carrying five name
-// prefixes (OFF_, ASSIST_, NO_, STATIC_, SPAM_) -- they are a single family that
-// was never given a single prefix, not distinct families. Kept as one enum with
-// the original names. Wire format -- rename freely, never renumber.
-enum OffFlag : int
-{
-	OFF_AREA_ATTACK				= 0,
-	OFF_BACKSTAB				= 1,
-	OFF_BASH					= 2,
-	OFF_BERSERK					= 3,
-	OFF_DISARM					= 4,
-	OFF_DODGE					= 5,
-	OFF_FADE					= 6,	// UNUSED
-	OFF_FAST					= 7,
-	OFF_KICK					= 8,
-	OFF_KICK_DIRT				= 9,
-	OFF_PARRY					= 10,
-	OFF_RESCUE					= 11,
-	OFF_TAIL					= 12,
-	OFF_TRIP					= 13,
-	OFF_CRUSH					= 14,
-	ASSIST_ALL					= 15,
-	ASSIST_ALIGN				= 16,
-	ASSIST_RACE					= 17,
-	ASSIST_PLAYERS				= 18,
-	ASSIST_GUARD				= 19,
-	ASSIST_VNUM					= 20,
-	NO_TRACK					= 21,
-	STATIC_TRACKING				= 22,
-	SPAM_MURDER					= 23,
-	OFF_INTIMIDATED				= 24,
-	OFF_UNDEAD_DRAIN			= 25,	// True undead drain, very powerful
-	ASSIST_GROUP				= 26,
-};
 
 //
 // return values for check_imm
 //
 
-// Damage-susceptibility result ordinal (check_immune etc.). Wire format --
-// never renumber.
-enum Susceptibility : int
-{
-	IS_NORMAL					= 0,
-	IS_IMMUNE					= 1,
-	IS_RESISTANT				= 2,
-	IS_VULNERABLE				= 3,
-};
 
 //
 // IMM bits for mobs
 //
 
-// Immunity bit indices, into char_data::imm_flags (and affect_data::bitvector
-// where where == TO_IMMUNE). IMM_/RES_/VULN_ are three value-identical parallel
-// families -- same damage domain, three storages. The flag tables and the area
-// file format route all three through the imm_flags table (flags.c, db2.c), so
-// they are effectively one namespace on disk; they are kept as three enums here
-// only because their C names differ (IMM_SUMMON vs RES_SUMMON) and renaming call
-// sites is out of scope. See phase-02 §0.8.2. Wire format -- never renumber.
-enum ImmuneFlag : int
-{
-	IMM_SUMMON					= 0,
-	IMM_CHARM					= 1,
-	IMM_MAGIC					= 2,
-	IMM_WEAPON					= 3,
-	IMM_BASH					= 4,
-	IMM_PIERCE					= 5,
-	IMM_SLASH					= 6,
-	IMM_FIRE					= 7,
-	IMM_COLD					= 8,
-	IMM_LIGHTNING				= 9,
-	IMM_ACID					= 10,
-	IMM_POISON					= 11,
-	IMM_NEGATIVE				= 12,
-	IMM_HOLY					= 13,
-	IMM_ENERGY					= 14,
-	IMM_MENTAL					= 15,
-	IMM_DISEASE					= 16,
-	IMM_DROWNING				= 17,
-	IMM_LIGHT					= 18,
-	IMM_SOUND					= 19,
-	IMM_INTERNAL				= 20,
-	IMM_MITHRIL					= 23,
-	IMM_SILVER					= 24,
-	IMM_IRON					= 25,
-	IMM_SLEEP					= 26,	// no RES_/VULN_ counterpart
-};
 
 //
 // RES bits for mobs
 //
 
-// Resistance bit indices, into char_data::res_flags. Parallel to ImmuneFlag --
-// see the note there. Stops at 25; no RES_SLEEP.
-enum ResistFlag : int
-{
-	RES_SUMMON					= 0,
-	RES_CHARM					= 1,
-	RES_MAGIC					= 2,
-	RES_WEAPON					= 3,
-	RES_BASH					= 4,
-	RES_PIERCE					= 5,
-	RES_SLASH					= 6,
-	RES_FIRE					= 7,
-	RES_COLD					= 8,
-	RES_LIGHTNING				= 9,
-	RES_ACID					= 10,
-	RES_POISON					= 11,
-	RES_NEGATIVE				= 12,
-	RES_HOLY					= 13,
-	RES_ENERGY					= 14,
-	RES_MENTAL					= 15,
-	RES_DISEASE					= 16,
-	RES_DROWNING				= 17,
-	RES_LIGHT					= 18,
-	RES_SOUND					= 19,
-	RES_INTERNAL				= 20,
-	RES_MITHRIL					= 23,
-	RES_SILVER					= 24,
-	RES_IRON					= 25,
-};
  
 //
 // VULN bits for mobs
 //
 
-// Vulnerability bit indices, into char_data::vuln_flags. Parallel to ImmuneFlag
-// -- see the note there. Stops at 25; no VULN_SLEEP.
-enum VulnFlag : int
-{
-	VULN_SUMMON					= 0,
-	VULN_CHARM					= 1,
-	VULN_MAGIC					= 2,
-	VULN_WEAPON					= 3,
-	VULN_BASH					= 4,
-	VULN_PIERCE					= 5,
-	VULN_SLASH					= 6,
-	VULN_FIRE					= 7,
-	VULN_COLD					= 8,
-	VULN_LIGHTNING				= 9,
-	VULN_ACID					= 10,
-	VULN_POISON					= 11,
-	VULN_NEGATIVE				= 12,
-	VULN_HOLY					= 13,
-	VULN_ENERGY					= 14,
-	VULN_MENTAL					= 15,
-	VULN_DISEASE				= 16,
-	VULN_DROWNING				= 17,
-	VULN_LIGHT					= 18,
-	VULN_SOUND					= 19,
-	VULN_INTERNAL				= 20,
-	VULN_MITHRIL				= 23,
-	VULN_SILVER					= 24,
-	VULN_IRON					= 25,
-};
 
 //
 // body form
 //
 
-// Body-form bit indices into char_data::form (and race_type::form). Note this
-// is a DIFFERENT field from char_data::act despite magic.c:1408 testing
-// ACT_UNDEAD against it -- see phase-02 §0.8.6. Wire format -- never renumber.
-enum FormFlag : int
-{
-	// material form
-	FORM_EDIBLE					= 0,
-	FORM_POISON					= 1,
-	FORM_MAGICAL				= 2,
-	FORM_INSTANT_DECAY			= 3,
-	FORM_OTHER					= 4,	// defined by material bit
-
-	// actual form
-	FORM_ANIMAL					= 6,
-	FORM_SENTIENT				= 7,
-	FORM_UNDEAD					= 8,
-	FORM_CONSTRUCT				= 9,
-	FORM_MIST					= 10,
-	FORM_INTANGIBLE				= 11,
-
-	FORM_BIPED					= 12,
-	FORM_AQUATIC				= 13,
-	FORM_INSECT					= 14,
-	FORM_SPIDER					= 15,
-	FORM_CRUSTACEAN				= 16,
-	FORM_WORM					= 17,
-	FORM_BLOB					= 18,
-
-	FORM_MAMMAL					= 21,
-	FORM_BIRD					= 22,
-	FORM_REPTILE				= 23,
-	FORM_SNAKE					= 24,
-	FORM_DRAGON					= 25,
-	FORM_AMPHIBIAN				= 26,
-	FORM_FISH					= 27,
-	FORM_COLD_BLOOD				= 28,
-	FORM_NOSPEECH				= 29,
-};
 
 //
 // body parts
 //
 
-// Body-part bit indices into char_data::parts (and race_type::parts). Wire
-// format -- rename freely, never renumber. Gaps at 17-19.
-enum PartFlag : int
-{
-	PART_HEAD					= 0,
-	PART_ARMS					= 1,
-	PART_LEGS					= 2,
-	PART_HEART					= 3,
-	PART_BRAINS					= 4,
-	PART_GUTS					= 5,
-	PART_HANDS					= 6,
-	PART_FEET					= 7,
-	PART_FINGERS				= 8,
-	PART_EAR					= 9,
-	PART_EYE					= 10,
-	PART_LONG_TONGUE			= 11,
-	PART_EYESTALKS				= 12,
-	PART_TENTACLES				= 13,
-	PART_FINS					= 14,
-	PART_WINGS					= 15,
-	PART_TAIL					= 16,
-
-	// for combat
-	PART_CLAWS					= 20,
-	PART_FANGS					= 21,
-	PART_HORNS					= 22,
-	PART_SCALES					= 23,
-	PART_TUSKS					= 24,
-};
 
 //
 // Bits for 'affected_by'.
 // Used in #MOBILES.
 //
 
-// Bit indices for character affects. Reached through several storages:
-// char_data::affected_by, affect_data::bitvector (when where == TO_AFFECTS),
-// and race_type::aff[] -- which holds bit INDICES in a plain array, not a bit
-// vector. See phase-02 §0.8.2; act_move.c:3149 confuses the two.
-// Wire format -- rename freely, never renumber.
-enum AffectFlag : int
-{
-	AFF_BLIND					= 0,
-	AFF_INVISIBLE				= 1,
-	AFF_DETECT_EVIL				= 2,
-	AFF_DETECT_INVIS			= 3,
-	AFF_DETECT_MAGIC			= 4,
-	AFF_DETECT_HIDDEN			= 5,
-	AFF_DETECT_GOOD				= 6,
-	AFF_SANCTUARY				= 7,
-	AFF_DETECT_CAMO				= 8,
-	AFF_INFRARED				= 9,	// unused!
-	AFF_CURSE					= 10,
-	AFF_CAMOUFLAGE				= 11,
-	AFF_POISON					= 12,
-	AFF_PROTECTION				= 13,
-	AFF_RAGE					= 14,
-	AFF_SNEAK					= 15,
-	AFF_HIDE					= 16,
-	AFF_SLEEP					= 17,
-	AFF_CHARM					= 18,
-	AFF_FLYING					= 19,
-	AFF_PASS_DOOR				= 20,
-	AFF_HASTE					= 21,
-	AFF_CALM					= 22,
-	AFF_PLAGUE					= 23,
-	AFF_PERMANENT				= 24,
-	AFF_DARK_VISION				= 25,
-	AFF_BERSERK					= 26,
-	AFF_WATERBREATH				= 27,
-	AFF_REGENERATION			= 28,
-	AFF_SLOW					= 29,
-	AFF_NOSHOW					= 30,
-};
 
 //
 // AFF bits for rooms
 //
 
-// Bit indices into room_index_data::affected_by, and into
-// room_affect_data::bitvector when where == TO_ROOM_AFFECTS.
-//
-// These reuse AffectFlag's numbering space but are NOT aliases of it: this is a
-// separate family on separate storage. Five of the six happen to share a name
-// with their AffectFlag counterpart (CURSE, POISON, SLEEP, PLAGUE, SLOW) and
-// the same bit, but AFF_ROOM_RANDOMIZER == 0 collides with AFF_BLIND == 0 while
-// meaning something completely unrelated. Kept as its own enum for that reason.
-enum AffectRoomFlag : int
-{
-	AFF_ROOM_RANDOMIZER			= 0,
-	AFF_ROOM_CURSE				= 10,
-	AFF_ROOM_POISON				= 12,
-	AFF_ROOM_SLEEP				= 17,
-	AFF_ROOM_PLAGUE				= 23,
-	AFF_ROOM_SLOW				= 29,
-};
 
 // Aff bits for.. AREAS!
 // -- None currently. --
@@ -1588,70 +994,28 @@ enum AffectRoomFlag : int
 // Aff bits for OBJS
 //
 
-// Bit indices into obj_data::affected_by, and into obj_affect_data::bitvector
-// when where == TO_OBJ_AFFECTS. A third family in AffectFlag's numbering space,
-// on a third storage. One member so far.
-enum AffectObjFlag : int
-{
-	AFF_OBJ_BURNING				= 0,
-};
 
 //
 // Sex.
 // Used in #MOBILES.
 //
 
-// Sex ordinal, in char_data::sex. Wire format -- never renumber.
-enum Sex : int
-{
-	SEX_NEUTRAL					= 0,
-	SEX_MALE					= 1,
-	SEX_FEMALE					= 2,
-};
 
 //
 // AC types
 //
 
-// Armor-class index into char_data::armor[]. Wire format -- never renumber.
-enum ArmorClass : int
-{
-	AC_PIERCE					= 0,
-	AC_BASH						= 1,
-	AC_SLASH					= 2,
-	AC_EXOTIC					= 3,
-};
 #define MAX_AC						4
 
 //
 // dice
 //
 
-// Index into a dice spec's value triple (number/type/bonus). Wire format --
-// never renumber.
-enum DiceField : int
-{
-	DICE_NUMBER					= 0,
-	DICE_TYPE					= 1,
-	DICE_BONUS					= 2,
-};
 
 //
 // size
 //
 
-// Creature size, an ordinal in char_data::size; compared relationally. Wire
-// format -- never renumber. Kept ascending so size comparisons hold.
-enum Size : int
-{
-	SIZE_TINY					= 0,
-	SIZE_SMALL					= 1,
-	SIZE_MEDIUM					= 2,
-	SIZE_LARGE					= 3,
-	SIZE_HUGE					= 4,
-	SIZE_GIANT					= 5,
-	SIZE_IMMENSE				= 6,
-};
 
 //
 // Well known object virtual numbers.
@@ -1772,189 +1136,22 @@ enum Size : int
 // Used in #OBJECTS.
 //
 
-// Item TYPES -- an ordinal scalar stored in obj_data::item_type (a short), not
-// a bit field. Compared with == and switched on; never passed to IS_SET.
-//
-// The ITEM_ prefix covers THREE unrelated families (types here, extra flags and
-// wear flags below) whose values collide: ITEM_LIGHT == 1 is a type,
-// ITEM_HUM == 1 is an extra-flag bit, ITEM_WEAR_FINGER == 1 is a wear bit.
-// They are separate enums for that reason. Names are unchanged, so no call site
-// moves; the split is documentation the compiler happens to hold.
-// Wire format (area files) -- rename freely, never renumber.
-enum ItemType : int
-{
-	ITEM_LIGHT					= 1,
-	ITEM_SCROLL					= 2,
-	ITEM_WAND					= 3,
-	ITEM_STAFF					= 4,
-	ITEM_WEAPON					= 5,
-	ITEM_NULL6					= 6,
-	ITEM_DICE					= 7,
-	ITEM_TREASURE				= 8,
-	ITEM_ARMOR					= 9,
-	ITEM_POTION					= 10,
-	ITEM_CLOTHING				= 11,
-	ITEM_FURNITURE				= 12,
-	ITEM_TRASH					= 13,
-	ITEM_CONTAINER				= 15,
-	ITEM_DRINK_CON				= 17,
-	ITEM_KEY					= 18,
-	ITEM_FOOD					= 19,
-	ITEM_MONEY					= 20,
-	ITEM_BOAT					= 22,
-	ITEM_CORPSE_NPC				= 23,
-	ITEM_CORPSE_PC				= 24,
-	ITEM_FOUNTAIN				= 25,
-	ITEM_PILL					= 26,
-	ITEM_PROTECT				= 27,
-	ITEM_MAP					= 28,
-	ITEM_PORTAL					= 29,
-	ITEM_WARP_STONE				= 30,
-	ITEM_ROOM_KEY				= 31,
-	ITEM_GEM					= 32,
-	ITEM_JEWELRY				= 33,
-	ITEM_CAMPFIRE				= 34,
-	ITEM_CABAL_ITEM				= 35,
-	ITEM_SKELETON				= 36,
-	ITEM_URN					= 37,
-	ITEM_GRAVITYWELL			= 38,
-	ITEM_BOOK					= 39,
-	ITEM_PEN					= 40,
-	ITEM_ALTAR					= 41,
-	// 42 was ITEM_DONATION_PIT -- retired. Note ITEM_DONATION_PIT now exists as
-	// an *extra flag* with value 33, which is a different family entirely.
-	ITEM_STONE					= 43,
-};
 
 //
 // Extra flags.
 // Used in #OBJECTS.
 ///
 
-// Extra flags -- bit indices into obj_data::extra_flags, and into
-// obj_index_data's affect bitvector where ITEM_EVIL / ITEM_BURN_PROOF are set
-// (magic.c). Distinct from ItemType above despite the shared prefix.
-// Wire format -- rename freely, never renumber. Gap at 23.
-//
-// CORPSE_NO_ANIMATE is a member of THIS family despite its different prefix:
-// value 27 sits between ITEM_BRAND (26) and ITEM_ANTI_LAWFUL (28), and it is
-// set on extra_flags at fight.c:3025. Note characterClasses/necro.c sets and
-// tests it on *wear_flags* instead, where bit 27 is outside the wear range
-// (0-18) -- see phase-02 §0.8.1. Left as found; that is a bug fix, not a rename.
-enum ItemExtraFlag : int
-{
-	ITEM_GLOW					= 0,
-	ITEM_HUM					= 1,
-	ITEM_DARK					= 2,
-	ITEM_NOSHOW					= 3,
-	ITEM_EVIL					= 4,
-	ITEM_INVIS					= 5,
-	ITEM_MAGIC					= 6,
-	ITEM_NODROP					= 7,
-	ITEM_BLESS					= 8,
-	ITEM_ANTI_GOOD				= 9,
-	ITEM_ANTI_EVIL				= 10,
-	ITEM_ANTI_NEUTRAL			= 11,
-	ITEM_NOREMOVE				= 12,
-	ITEM_INVENTORY				= 13,
-	ITEM_NOPURGE				= 14,
-	ITEM_ROT_DEATH				= 15,
-	ITEM_VIS_DEATH				= 16,
-	ITEM_FIXED					= 17,
-	ITEM_NODISARM				= 18,
-	ITEM_NOLOCATE				= 19,
-	ITEM_MELT_DROP				= 20,
-	ITEM_UNDER_CLOTHES			= 21,
-	ITEM_SELL_EXTRACT			= 22,
-	ITEM_BURN_PROOF				= 24,
-	ITEM_NOUNCURSE				= 25,
-	ITEM_BRAND					= 26,
-	CORPSE_NO_ANIMATE			= 27,
-	ITEM_ANTI_LAWFUL			= 28,
-	ITEM_ANTI_NEUT				= 29,
-	ITEM_ANTI_CHAOTIC			= 30,
-	ITEM_NO_STASH				= 31,
-	ITEM_NO_SAC					= 32,
-	ITEM_DONATION_PIT			= 33,
-};
 
 //
 // Wear flags.
 // Used in #OBJECTS.
 //
 
-// Wear flags -- bit indices into obj_data::wear_flags. The third and last
-// family under the ITEM_ prefix. Range is 0-18, which is why necro.c's use of
-// CORPSE_NO_ANIMATE (27) on this field cannot work (§0.8.1).
-// Wire format -- rename freely, never renumber.
-enum ItemWearFlag : int
-{
-	ITEM_TAKE					= 0,
-	ITEM_WEAR_FINGER			= 1,
-	ITEM_WEAR_NECK				= 2,
-	ITEM_WEAR_BODY				= 3,
-	ITEM_WEAR_HEAD				= 4,
-	ITEM_WEAR_LEGS				= 5,
-	ITEM_WEAR_FEET				= 6,
-	ITEM_WEAR_HANDS				= 7,
-	ITEM_WEAR_ARMS				= 8,
-	ITEM_WEAR_SHIELD			= 9,
-	ITEM_WEAR_ABOUT				= 10,
-	ITEM_WEAR_WAIST				= 11,
-	ITEM_WEAR_WRIST				= 12,
-	ITEM_WEAR_WIELD				= 13,
-	ITEM_WEAR_HOLD				= 14,
-	ITEM_WEAR_FLOAT				= 15,
-	ITEM_WEAR_BRAND				= 16,
-	ITEM_WEAR_STRAPPED			= 17,
-	ITEM_WEAR_COSMETIC			= 18,	// cosmetic, misc, up to 5/person
-};
 
-// Object-restriction criterion ordinal. Wire format -- never renumber.
-enum RestrictType : int
-{
-	RESTRICT_OTHER				= 0,
-	RESTRICT_CLASS				= 1,
-	RESTRICT_RACE				= 2,
-	RESTRICT_CABAL				= 3,
-};
 
-// Shapeshifter tribe ordinal. Wire format -- never renumber.
-enum Tribe : int
-{
-	TRIBE_NONE					= 0,
-	TRIBE_BOAR					= 1,
-	TRIBE_WOLF					= 2,
-	TRIBE_BEAR					= 3,
-	TRIBE_HAWK					= 4,
-	TRIBE_LION					= 5,
-	TRIBE_ELK					= 6,
-	TRIBE_JACKAL				= 7,
-	TRIBE_FOX					= 8,
-	TRIBE_BULL					= 9,
-	TRIBE_PANTHER				= 10,
-};
 
-// Paladin-order ordinal. Wire format -- never renumber.
-enum PaladinOrder : int
-{
-	PALADIN_NONE				= 0,
-	PALADIN_PROTECTOR			= 1,
-	PALADIN_CRUSADER			= 2,
-};
 
-// Combat-style ordinal. STYLE_NONE is the -1 sentinel (hence : int). Wire
-// format -- never renumber.
-enum CombatStyle : int
-{
-	STYLE_NONE					= -1,
-	STYLE_GLADIATOR				= 0,
-	STYLE_BARBARIAN				= 1,
-	STYLE_DUELIST				= 2,
-	STYLE_SKIRMISHER			= 3,
-	STYLE_DRAGOON				= 4,
-	STYLE_TACTICIAN				= 5,
-};
 #define MAX_STYLE					7
 #define MAX_STYLE_SKILL				38
 
@@ -1962,143 +1159,27 @@ enum CombatStyle : int
 // weapon class
 //
 
-// Weapon CLASS -- an ordinal scalar in obj->value[0], compared with ==. This is
-// a separate family from the weapon-flag bits below, whose values 0-10 collide
-// with these completely. (The source's own "weapon class" / "weapon types"
-// comments have these two backwards; the names are kept, the labels corrected.)
-enum WeaponClass : int
-{
-	WEAPON_EXOTIC				= 0,
-	WEAPON_SWORD				= 1,
-	WEAPON_DAGGER				= 2,
-	WEAPON_SPEAR				= 3,
-	WEAPON_MACE					= 4,
-	WEAPON_AXE					= 5,
-	WEAPON_FLAIL				= 6,
-	WEAPON_WHIP					= 7,
-	WEAPON_POLEARM				= 8,
-	WEAPON_STAFF				= 9,
-	WEAPON_HAND					= 10,
-};
 
 //
 // weapon types
 //
 
-// Weapon FLAGS -- bit indices tested with IS_SET_OLD on obj->value[4] (a scalar
-// int field, hence the _OLD operators). Separate family from WeaponClass above.
-enum WeaponFlag : int
-{
-	WEAPON_FLAMING				= 0,
-	WEAPON_FROST				= 1,
-	WEAPON_VAMPIRIC				= 2,
-	WEAPON_SHARP				= 3,
-	WEAPON_VORPAL				= 4,
-	WEAPON_TWO_HANDS			= 5,
-	WEAPON_SHOCKING				= 6,
-	WEAPON_POISON				= 7,
-	WEAPON_AVENGER				= 8,
-	WEAPON_SHADOWBANE			= 9,
-	WEAPON_LIGHTBRINGER			= 10,
-};
 
 //
 // gate flags
 //
 
-// Portal gate flags -- bit indices tested with IS_SET_OLD on a portal's
-// obj->value[] scalar. Wire format -- rename freely, never renumber.
-enum GateFlag : int
-{
-	GATE_NORMAL_EXIT			= 0,
-	GATE_NOCURSE				= 1,
-	GATE_GOWITH					= 2,
-	GATE_BUGGY					= 3,
-	GATE_RANDOM					= 4,
-};
 
 //
 // furniture flags
 //
 
-// Furniture position flags -- bit indices tested with IS_SET_OLD on a piece of
-// furniture's obj->value[2] (act_info.c). One family across six prefixes
-// (STAND_/SIT_/REST_/SLEEP_/PUT_/LOUNGE_), a single 0-16 numbering. Kept as one
-// enum with the original names. Wire format -- rename freely, never renumber.
-enum FurniturePosition : int
-{
-	STAND_AT					= 0,
-	STAND_ON					= 1,
-	STAND_IN					= 2,
-	SIT_AT						= 3,
-	SIT_ON						= 4,
-	SIT_IN						= 5,
-	REST_AT						= 6,
-	REST_ON						= 7,
-	REST_IN						= 8,
-	SLEEP_AT					= 9,
-	SLEEP_ON					= 10,
-	SLEEP_IN					= 11,
-	PUT_AT						= 12,
-	PUT_ON						= 13,
-	PUT_IN						= 14,
-	PUT_INSIDE					= 15,
-	LOUNGE_ON					= 16,
-};
 	
 //
 // Apply types (for affects).
 // Used in #OBJECTS.
 //
 
-// The main apply-location family: affect_data::location, an ordinal scalar
-// (short), not a bit field. Compared with == and switched on. APPLY_ROOM_* and
-// APPLY_OBJ_* (above) are separate families on separate location fields.
-// Wire format -- rename freely, never renumber.
-enum ApplyLocation : int
-{
-	APPLY_NONE					= 0,
-	APPLY_STR					= 1,
-	APPLY_DEX					= 2,
-	APPLY_INT					= 3,
-	APPLY_WIS					= 4,
-	APPLY_CON					= 5,
-	APPLY_SEX					= 6,
-	APPLY_CLASS					= 7,
-	APPLY_LUCK					= 8,	// UNUSED!!
-	APPLY_AGE					= 9,
-	APPLY_HEIGHT				= 10,
-	APPLY_WEIGHT				= 11,
-	APPLY_MANA					= 12,
-	APPLY_HIT					= 13,
-	APPLY_MOVE					= 14,
-	APPLY_GOLD					= 15,
-	APPLY_EXP					= 16,
-	APPLY_AC					= 17,
-	APPLY_HITROLL				= 18,
-	APPLY_DAMROLL				= 19,
-	APPLY_SAVES					= 20,
-	APPLY_SAVING_PARA			= 21,
-	APPLY_SAVING_ROD			= 22,
-	APPLY_SAVING_PETRI			= 23,
-	APPLY_SAVING_BREATH			= 24,
-	APPLY_SAVING_SPELL			= 25,
-	APPLY_SPELL_AFFECT			= 26,
-	APPLY_CARRY_WEIGHT			= 27,
-	APPLY_DEFENSE				= 28,
-	APPLY_REGENERATION			= 29,
-	APPLY_SIZE					= 30,
-	APPLY_ENERGYSTATE			= 31,
-	APPLY_DAM_MOD				= 32,
-	APPLY_LEGS					= 33,
-	APPLY_ARMS					= 34,
-	APPLY_BEAUTY				= 35,
-	APPLY_ALIGNMENT				= 36,
-	APPLY_ETHOS					= 37,
-	// APPLY_OBJ_PROPERTIES == 100 lived here originally, in the main family's
-	// numbering despite its APPLY_OBJ_ name. Kept in this enum, at its value.
-	APPLY_OBJ_PROPERTIES		= 100,
-};
 
 // APPLY_OBJ_PROPERTIES (== 100) moved into enum ApplyLocation above -- it was
 // always numbered in that family despite its name.
@@ -2107,53 +1188,13 @@ enum ApplyLocation : int
 // Modifier Names
 //
 
-// Spell/effect modifier type, an ordinal. MOD_NONE is the -1 sentinel, hence
-// the required : int underlying type. Wire format -- never renumber.
-enum ModType : int
-{
-	MOD_NONE					= -1,
-	MOD_VISION					= 0,
-	MOD_MOVEMENT				= 1,
-	MOD_TOUGHNESS				= 2,
-	MOD_SPEED					= 3,
-	MOD_LEVITATION				= 4,
-	MOD_VISIBILITY				= 5,
-	MOD_PHASE					= 6,
-	MOD_CONC					= 7,
-	MOD_PROTECTION				= 8,
-	MOD_APPEARANCE				= 9,
-	MOD_HEARING					= 10,
-	MOD_PERCEPTION				= 11,
-	MOD_RESISTANCE				= 12,
-	MOD_ENERGY_STATE			= 13,
-	MOD_SPEECH					= 14,
-	MOD_REGEN					= 15,
-	MOD_WARDROBE				= 16,
-};
 
 //
 // Values for containers (value[1]).
 // Used in #OBJECTS.
 //
 
-// Container flags -- bit indices tested with IS_SET_OLD on a container's
-// obj->value[1] scalar. Wire format -- rename freely, never renumber.
-enum ContainerFlag : int
-{
-	CONT_CLOSEABLE				= 0,
-	CONT_PICKPROOF				= 1,
-	CONT_CLOSED					= 2,
-	CONT_LOCKED					= 3,
-	CONT_PUT_ON					= 4,
-};
 
-// Wield-hand ordinal. Wire format -- never renumber.
-enum WieldType : int
-{
-	WIELD_ONE					= 1,
-	WIELD_TWO					= 2,
-	WIELD_PRIMARY				= 3,
-};
 
 #define HAS_DIED					8
 
@@ -2196,130 +1237,24 @@ enum WieldType : int
 // Used in #ROOMS.
 //
 
-// Bit indices into room_index_data::room_flags. Also reachable through
-// room_affect_data::bitvector via TO_ROOM_FLAGS (handler.c).
-// Wire format -- rename freely, never renumber. Gaps at 1, 5-8, 24 and 26 are
-// retired bits; check existing area data before reusing any of them.
-//
-// NOTE: the ROOM_VNUM_* constants above are NOT part of this family. They are
-// room virtual numbers (values into the thousands), not bit indices, and they
-// share the prefix only by accident. ROOM_VNUM_LIMBO == 2 collides with
-// ROOM_NO_MOB == 2 harmlessly because the two are never used on the same thing.
-enum RoomFlag : int
-{
-	ROOM_DARK					= 0,
-	ROOM_NO_MOB					= 2,
-	ROOM_INDOORS				= 3,
-	ROOM_NO_CONSECRATE			= 4,
-	ROOM_PRIVATE				= 9,
-	ROOM_SAFE					= 10,
-	ROOM_SOLITARY				= 11,
-	ROOM_PET_SHOP				= 12,
-	ROOM_NO_RECALL				= 13,
-	ROOM_IMP_ONLY				= 14,
-	ROOM_GODS_ONLY				= 15,
-	ROOM_HEROES_ONLY			= 16,
-	ROOM_NEWBIES_ONLY			= 17,
-	ROOM_LAW					= 18,
-	ROOM_NOWHERE				= 19,
-	ROOM_NO_GATE				= 20,
-	ROOM_SILENCE				= 21,
-	ROOM_NO_SUMMON_TO			= 22,
-	ROOM_NO_SUMMON_FROM			= 23,
-	ROOM_NO_ALARM				= 25,
-	ROOM_FORCE_DUEL				= 27,
-	ROOM_NO_MAGIC				= 28,
-	ROOM_AREA_EXPLORE			= 29,	// Don't use - Use area flags instead
-	ROOM_NO_COMMUNE				= 30,
-};
 
 //
 // Exit flags.
 // Used in #ROOMS.
 //
 
-// Exit flags -- bit indices tested with IS_SET_OLD on exit_data::exit_info (a
-// scalar int). Wire format -- rename freely, never renumber.
-enum ExitFlag : int
-{
-	EX_ISDOOR					= 0,
-	EX_CLOSED					= 1,
-	EX_LOCKED					= 2,
-	EX_PICKPROOF				= 3,
-	EX_NOPASS					= 4,
-	EX_NOCLOSE					= 5,
-	EX_NOLOCK					= 6,
-	EX_NOBASH					= 7,
-	EX_NONOBVIOUS				= 8,
-	EX_TRANSLUCENT				= 9,
-	EX_JAMMED					= 10,
-};
 
-// Area sector/category ordinal. Wire format -- never renumber.
-enum AreaSector : int
-{
-	ARE_NORMAL					= 0,
-	ARE_ROAD_RIVER				= 1,
-	ARE_CABAL					= 2,
-	ARE_QUEST					= 3,
-	ARE_CITY					= 4,
-	ARE_UNOPENED				= 5,
-	ARE_SHRINE					= 6,
-};
 
 //
 // Sector types.
 // Used in #ROOMS.
 //
 
-// Sector (terrain) types, an ordinal in room_index_data::sector_type. Note the
-// deliberate collision: SECT_INSIDE and SECT_UNUSED are both 7. SECT_MAX (21) is
-// a count/sentinel, not a terrain. Wire format -- never renumber.
-enum SectorType : int
-{
-	SECT_INSIDE					= 7,
-	SECT_CITY					= 1,
-	SECT_FIELD					= 2,
-	SECT_FOREST					= 3,
-	SECT_HILLS					= 4,
-	SECT_MOUNTAIN				= 5,
-	SECT_WATER					= 6,
-	SECT_UNUSED					= 7,
-	SECT_UNDERWATER				= 8,
-	SECT_AIR					= 9,
-	SECT_DESERT					= 10,
-	SECT_ROAD					= 11,
-	SECT_CONFLAGRATION			= 12,
-	SECT_BURNING				= 13,
-	SECT_TRAIL					= 14,
-	SECT_SWAMP					= 15,
-	SECT_PARK					= 16,
-	SECT_VERTICAL				= 17,
-	SECT_ICE					= 18,
-	SECT_SNOW					= 19,
-	SECT_CAVE					= 20,
-	SECT_MAX					= 21,	// count/sentinel, not a terrain
-};
 
 //
 // Trap types
 //
 
-// Trap effect ordinal. Wire format -- never renumber.
-enum TrapType : int
-{
-	TRAP_NONE					= 0,
-	TRAP_DART					= 1,
-	TRAP_PDART					= 2,
-	TRAP_FIREBALL				= 3,
-	TRAP_LIGHTNING				= 4,
-	TRAP_SLEEPGAS				= 5,
-	TRAP_POISONGAS				= 6,
-	TRAP_ACID					= 7,
-	TRAP_PIT					= 8,
-	TRAP_BOULDER				= 9,
-	TRAP_DRAIN					= 10,
-};
 #define MAX_TRAP					11
 
 #define ALIGN_NEUTRAL				0
@@ -2329,77 +1264,18 @@ enum TrapType : int
 // Alignment selections
 //
 
-// Alignment SELECTION values (creation/OLC choices), an ordinal. Distinct from
-// the raw alignment scale ALIGN_NEUTRAL sits on above. ALIGN_NONE is the -1
-// sentinel (hence : int). Wire format -- never renumber.
-enum AlignmentChoice : int
-{
-	ALIGN_NONE					= -1,
-	ALIGN_ANY					= 0,
-	ALIGN_GN					= 1,
-	ALIGN_NE					= 2,
-	ALIGN_GE					= 3,
-	ALIGN_G						= 4,
-	ALIGN_N						= 5,
-	ALIGN_E						= 6,
-};
 
 //
 // Ethos selections
 //
 
-// Ethos SELECTION values (creation/OLC choices), an ordinal. Distinct from the
-// raw ethos scale ETHOS_NEUTRAL sits on. ETHOS_NONE is the -1 sentinel.
-enum EthosChoice : int
-{
-	ETHOS_NONE					= -1,
-	ETHOS_ANY					= 0,
-	ETHOS_LN					= 1,
-	ETHOS_NC					= 2,
-	ETHOS_LC					= 3,
-	ETHOS_L						= 4,
-	ETHOS_N						= 5,
-	ETHOS_C						= 6,
-};
 
 
 //
 // Class guild used in the room 'G'  flags
 //
 
-// Guild ordinal (room guild-guard associations). Wire format -- never renumber.
-enum Guild : int
-{
-	GUILD_WARRIOR				= 1,
-	GUILD_THIEF					= 2,
-	GUILD_CLERIC				= 3,
-	GUILD_PALADIN				= 4,
-	GUILD_ANTI_PALADIN			= 5,
-	GUILD_RANGER				= 6,
-	GUILD_MONK					= 7,
-	GUILD_SHAPESHIFTER			= 8,
-	GUILD_ASSASSIN				= 9,
-	GUILD_NECROMANCER			= 10,
-	GUILD_SORCERER				= 11,
-};
 
-// Character class, an ordinal in char_data::Class()/class. The main CLASS_
-// family. Wire format -- rename freely, never renumber.
-enum CharClass : int
-{
-	CLASS_NONE					= 0,
-	CLASS_WARRIOR				= 1,
-	CLASS_THIEF					= 2,
-	CLASS_ZEALOT				= 3,
-	CLASS_PALADIN				= 4,
-	CLASS_ANTI_PALADIN			= 5,
-	CLASS_RANGER				= 6,
-	CLASS_ASSASSIN				= 7,
-	CLASS_SHAPESHIFTER			= 8,
-	CLASS_HEALER				= 9,
-	CLASS_NECROMANCER			= 10,
-	CLASS_SORCERER				= 11,
-};
 
 
 //
@@ -2407,36 +1283,6 @@ enum CharClass : int
 // Used in #RESETS.
 //
 
-// Worn-equipment slot index into char_data::equipment[]. WEAR_NONE is the -1
-// sentinel (hence : int); WEAR_DUAL_WIELD and WEAR_FLOAT deliberately share slot
-// 18. Wire format -- rename freely, never renumber.
-enum WearLocation : int
-{
-	WEAR_NONE					= -1,
-	WEAR_LIGHT					= 0,
-	WEAR_FINGER_L				= 1,
-	WEAR_FINGER_R				= 2,
-	WEAR_NECK_1					= 3,
-	WEAR_NECK_2					= 4,
-	WEAR_BODY					= 5,
-	WEAR_HEAD					= 6,
-	WEAR_LEGS					= 7,
-	WEAR_FEET					= 8,
-	WEAR_HANDS					= 9,
-	WEAR_ARMS					= 10,
-	WEAR_SHIELD					= 11,
-	WEAR_ABOUT					= 12,
-	WEAR_WAIST					= 13,
-	WEAR_WRIST_L				= 14,
-	WEAR_WRIST_R				= 15,
-	WEAR_WIELD					= 16,
-	WEAR_HOLD					= 17,
-	WEAR_DUAL_WIELD				= 18,
-	WEAR_FLOAT					= 18,
-	WEAR_BRAND					= 19,
-	WEAR_STRAPPED				= 20,
-	WEAR_COSMETIC				= 21,
-};
 #define MAX_WEAR					22
 
 
@@ -2445,33 +1291,9 @@ enum WearLocation : int
 
 #define NORM						1
 
-// damage_new() flag arguments. Three independent two-value families, passed
-// positionally. Kept as three enums matching their argument slots.
-enum HitBlockable : int
-{
-	HIT_UNBLOCKABLE				= 0,
-	HIT_BLOCKABLE				= 1,
-};
 
-enum HitSpecials : int
-{
-	HIT_NOSPECIALS				= 0,
-	HIT_SPECIALS				= 1,
-};
 
-enum HitModifier : int
-{
-	HIT_NOMULT					= 1,
-	HIT_NOADD					= 0,
-};
 
-// Combat posture, an ordinal spanning -1..1. POSTURE_DEFENSE is -1 (hence : int).
-enum Posture : int
-{
-	POSTURE_OFFENSE				= 1,
-	POSTURE_NONE				= 0,
-	POSTURE_DEFENSE				= -1,
-};
 
 #define MAX_QUEUE					20
 
@@ -2485,153 +1307,26 @@ enum Posture : int
 // Conditions.
 //
 
-// Condition index into pc_data::condition[]. COND_HUNGRY (50) is an outlier
-// value, not adjacent to the rest. Wire format -- never renumber.
-enum ConditionType : int
-{
-	COND_DRUNK					= 0,
-	COND_FULL					= 1,
-	COND_THIRST					= 2,
-	COND_HUNGER					= 3,
-	COND_STARVING				= 4,
-	COND_DEHYDRATED				= 5,
-	COND_HUNGRY					= 50,
-};
 
 //
 // Positions.
 //
 
-// Character position, an ordinal in char_data::position (a short). Ordering is
-// load-bearing: ~96 relational comparisons (position >= POS_RESTING etc.) and it
-// is stored in cmd_type::position for the command table. Wire format -- never
-// renumber. Kept ascending exactly as-is so all comparisons hold.
-enum Position : int
-{
-	POS_DEAD					= 0,
-	POS_MORTAL					= 1,
-	POS_INCAP					= 2,
-	POS_STUNNED					= 3,
-	POS_SLEEPING				= 4,
-	POS_RESTING					= 5,
-	POS_SITTING					= 6,
-	POS_FIGHTING				= 7,
-	POS_STANDING				= 8,
-};
 
 #define MIN_PK_XP					9999	// min xp players need to start PKing
 #define MIN_LEVEL_TO_PK				23		// Minimum level for players to pk
 
-// PK alignment-kill counters. Separate family from the killed[] index pair
-// below. Wire format -- never renumber.
-enum PkKillType : int
-{
-	PK_KILLS					= 0,
-	PK_GOOD						= 1,
-	PK_NEUTRAL					= 2,
-	PK_EVIL						= 3,
-};
 
-// Index into pcdata::killed[]: player kills vs mob kills. One family, two
-// prefixes (PK_/MOB_).
-enum KilledIndex : int
-{
-	PK_KILLED					= 0,
-	MOB_KILLED					= 1,
-};
 
 //
 // ACT bits for players.
 //
 
-// Bit indices into char_data::act -- the SAME field ActFlag uses, disambiguated
-// at runtime by is_npc(). Values collide with ActFlag deliberately and must not
-// be reconciled: PLR_AUTOABORT and ACT_SENTINEL are both bit 1 with unrelated
-// meanings. Wire format, as ActFlag -- rename freely, never renumber.
-// Gap at 18: see the "2 bits reserved" note, of which only 19 was ever taken.
-enum PlrFlag : int
-{
-	PLR_IS_NPC					= 0,	// Don't EVER set.
-
-	// RT auto flags
-	PLR_AUTOABORT				= 1,
-	PLR_AUTOASSIST				= 2,
-	PLR_AUTOEXIT				= 3,
-	PLR_AUTOLOOT				= 4,
-	PLR_AUTOSAC					= 5,
-	PLR_AUTOGOLD				= 6,
-	PLR_AUTOSPLIT				= 7,
-	PLR_COLOR					= 8,
-	PLR_IGNORANT				= 9,
-	PLR_BETRAYER				= 10,
-
-	// RT personal flags
-	PLR_CODER					= 11,
-	PLR_HEROIMM					= 12,
-	PLR_HOLYLIGHT				= 13,
-	PLR_EMPOWERED				= 14,
-	PLR_NOVOID					= 15,
-	PLR_NOSUMMON				= 16,
-	PLR_NOFOLLOW				= 17,
-
-	// 2 bits reserved, S-T
-	PLR_NO_TRANSFER				= 19,
-
-	// Bad flags
-	PLR_PERMIT					= 20,
-	PLR_MORON					= 21,
-	PLR_LOG						= 22,
-	PLR_DENY					= 23,
-	PLR_FREEZE					= 24,
-	PLR_THIEF					= 25,
-	PLR_KILLER					= 26,
-	PLR_CRIMINAL				= 27,
-};
 
 //
 // RT comm flags -- may be used on both mobs and chars
 //
 
-// Bit indices into char_data::comm. The values are a wire format -- they are
-// written to player files as letters keyed to the index (save.c print_flags),
-// so they may be renamed but never renumbered. Note the gap at 17.
-enum CommFlag : int
-{
-	COMM_QUIET					= 0,
-	COMM_DEAF					= 1,
-	COMM_NOWIZ					= 2,
-	COMM_NOAUCTION				= 3,
-	COMM_NOGOSSIP				= 4,
-	COMM_NOQUESTION				= 5,
-	COMM_NONEWBIE				= 6,
-	COMM_NOCABAL				= 7,
-	COMM_NOQUOTE				= 8,
-	COMM_SHOUTSOFF				= 9,
-	COMM_ANSI					= 10,
-
-	// display flags
-	COMM_COMPACT				= 11,
-	COMM_BRIEF					= 12,
-	COMM_PROMPT					= 13,
-	COMM_COMBINE				= 14,
-	COMM_TELNET_GA				= 15,
-	COMM_SHOW_AFFECTS			= 16,
-	COMM_IMMORTAL				= 18,
-
-	// penalties
-	COMM_NOEMOTE				= 19,
-	COMM_NOSHOUT				= 20,
-	COMM_NOTELL					= 21,
-	COMM_NOCHANNELS				= 22,
-	COMM_BUILDER				= 23,
-	COMM_SNOOP_PROOF			= 24,
-	COMM_AFK					= 25,
-	COMM_ALL_CABALS				= 26,
-	COMM_NOSOCKET				= 27,
-	COMM_SWITCHSKILLS			= 28,
-	COMM_NOBUILDER				= 29,
-	COMM_LOTS_O_COLOR			= 30,
-};
 
 //
 // Trust flags
@@ -2644,91 +1339,18 @@ enum CommFlag : int
 // WIZnet flags
 //
 
-// Wiznet channel bit indices into char_data::wiznet, and passed as `long flag`
-// to wiznet(). Wire format -- rename freely, never renumber. Gap at 23.
-enum WiznetFlag : int
-{
-	WIZ_ON						= 0,
-	WIZ_TICKS					= 1,
-	WIZ_LOGINS					= 2,
-	WIZ_SITES					= 3,
-	WIZ_LINKS					= 4,
-	WIZ_DEATHS					= 5,
-	WIZ_RESETS					= 6,
-	WIZ_MOBDEATHS					= 7,
-	WIZ_FLAGS					= 8,
-	WIZ_PENALTIES					= 9,
-	WIZ_SACCING					= 10,
-	WIZ_LEVELS					= 11,
-	WIZ_SECURE					= 12,
-	WIZ_SWITCHES					= 13,
-	WIZ_SNOOPS					= 14,
-	WIZ_RESTORE					= 15,
-	WIZ_LOAD					= 16,
-	WIZ_NEWBIE					= 17,
-	WIZ_PREFIX					= 18,
-	WIZ_SPAM					= 19,
-	WIZ_CABAL					= 20,
-	WIZ_PERCENT					= 21,
-	WIZ_LOG						= 22,
-	WIZ_OOC						= 23,
-	WIZ_DEBUG					= 24,
-};
 
 //
 // AP Demonic Favors Defines
 //
 
-// Devil-patron ordinal. Wire format -- never renumber.
-enum Devil : int
-{
-	DEVIL_ASMODEUS				= 0,
-	DEVIL_MOLOCH				= 1,
-	DEVIL_BAAL					= 2,
-	DEVIL_DISPATER				= 3,
-	DEVIL_MEPHISTO				= 4,
-};
 #define MAX_DEVIL					5
 
-// Lesser-demon name ordinal. MAX_LESSER stays a #define (constexpr commit).
-enum LesserDemon : int
-{
-	LESSER_BARBAS				= 0,
-	LESSER_AAMON				= 1,
-	LESSER_MALAPHAR				= 2,
-	LESSER_FURCAS				= 3,
-	LESSER_IPOS					= 4,
-};
 #define MAX_LESSER					5
 
-// Greater-demon name ordinal. Separate family from GreaterDemon-tier below.
-enum GreaterDemon : int
-{
-	GREATER_OZE					= 0,
-	GREATER_GAMYGYN				= 1,
-	GREATER_OROBAS				= 2,
-	GREATER_GERYON				= 3,
-	GREATER_CIMERIES			= 4,
-};
 #define MAX_GREATER					5
 
-// Demon tier discriminator (lesser vs greater). LESSER_DEMON/GREATER_DEMON share
-// the LESSER_/GREATER_ prefixes with the name families above but are a distinct
-// two-value family.
-enum DemonTier : int
-{
-	LESSER_DEMON				= 0,
-	GREATER_DEMON				= 1,
-};
 
-// Favor/quest-state ordinal. FAVOR_FAILED is the -1 sentinel (hence : int).
-enum FavorState : int
-{
-	FAVOR_NONE					= 0,
-	FAVOR_FAILED				= -1,
-	FAVOR_IN_PROGRESS			= 1,
-	FAVOR_GRANTED				= 2,
-};
 
 #define GERYON_EYE					2
 #define GERYON_FINGER				3
@@ -2739,56 +1361,10 @@ enum FavorState : int
 // Sorcerer Elemental Groups
 //
 
-// Elemental type, an ordinal. Separate from ELE_TYPE_* below (which collide in
-// value). Wire format -- never renumber.
-enum Element : int
-{
-	ELE_HEAT					= 0,
-	ELE_COLD					= 1,
-	ELE_AIR						= 2,
-	ELE_EARTH					= 3,
-	ELE_WATER					= 4,
-	ELE_ELECTRICITY				= 5,
-	ELE_SMOKE					= 6,
-	ELE_MAGMA					= 7,
-	ELE_PLASMA					= 8,
-	ELE_ACID					= 9,
-	ELE_BLIZZARD				= 10,
-	ELE_FROST					= 11,
-	ELE_CRYSTAL					= 12,
-	ELE_ICE						= 13,
-	ELE_LIGHTNING				= 14,
-	ELE_MIST					= 15,
-	ELE_METAL					= 16,
-	ELE_OOZE					= 17,
-	ELE_NONE					= 18,
-};
 #define MAX_ELE						19
 
-// Elemental slot type, an ordinal. Separate family from Element above.
-enum ElementSlot : int
-{
-	ELE_TYPE_NONE				= 0,
-	ELE_TYPE_PRIMARY			= 1,
-	ELE_TYPE_PARA				= 2,
-};
 
-// Material optical property. Separate family from MAT_SOLID.. below (collide).
-enum MaterialOptical : int
-{
-	MAT_TRANSLUCENT				= 0,
-	MAT_TRANSPARENT				= 1,
-	MAT_EDIBLE					= 2,
-};
 
-// Material state of matter.
-enum MaterialState : int
-{
-	MAT_SOLID					= 0,
-	MAT_LIQUID					= 1,
-	MAT_GAS						= 2,
-	MAT_PLASMA					= 3,
-};
 
 //
 // Prototype for a mob.
@@ -2877,18 +1453,6 @@ private:
 // Speech info for progs
 //
 
-// Speech-act ordinal. Wire format -- never renumber.
-enum SpeechType : int
-{
-	SPEECH_SAY					= 0,
-	SPEECH_SAYTO				= 1,
-	SPEECH_TELL					= 2,
-	SPEECH_WHISPER				= 3,
-	SPEECH_YELL					= 4,
-	SPEECH_EMOTE				= 5,
-	SPEECH_ECHO					= 6,
-	SPEECH_SING					= 7,
-};
 
 struct speech_data
 {
@@ -3659,49 +2223,12 @@ private:
 //  Target types.
 //
 
-// Skill/spell target-type ordinal, in skill_type::target. TAR_END (666) is a
-// deliberate sentinel, not adjacent. Wire format -- never renumber.
-enum SkillTarget : int
-{
-	TAR_IGNORE					= 0,
-	TAR_CHAR_OFFENSIVE			= 1,
-	TAR_CHAR_DEFENSIVE			= 2,
-	TAR_CHAR_SELF				= 3,
-	TAR_OBJ_INV					= 4,
-	TAR_OBJ_CHAR_DEF			= 5,
-	TAR_OBJ_CHAR_OFF			= 6,
-	TAR_DIR						= 7,
-	TAR_CHAR_AMBIGUOUS			= 8,
-	TAR_CHAR_GENERAL			= 9,
-	TAR_END						= 666,	// don't touch
-};
 
-// Spell effect target-type ordinal. Separate family from SkillTarget above.
-enum TargetType : int
-{
-	TARGET_CHAR					= 0,
-	TARGET_OBJ					= 1,
-	TARGET_ROOM					= 2,
-	TARGET_NONE					= 3,
-	TARGET_RUNE					= 4,
-	TARGET_DIR					= 5,
-};
 
 //
 //rune target bitvectors
 //
 
-// Rune target bitmasks -- these are pre-shifted MASKS (1,2,4,8,16), not bit
-// indices, tested with IS_SET_OLD directly and compared with <. A third RUNE_
-// family, distinct from RuneTarget/RuneTrigger. Wire format -- never renumber.
-enum RuneMask : int
-{
-	RUNE_CAST					= 1,
-	RUNE_ARMOR					= 2,
-	RUNE_WEAPON					= 4,
-	RUNE_DOOR					= 8,
-	RUNE_ROOM					= 16,
-};
 
 
 //
@@ -3749,18 +2276,6 @@ extern QUEUE_DATA *global_queue;
 // Area flags.
 //
 
-// Area flags -- bit indices into area_data::area_flags. AREA_NONE and
-// AREA_EXPLORE are both 0 by design (alias). Wire format -- never renumber.
-enum AreaFlag : int
-{
-	AREA_NONE					= 0,
-	AREA_EXPLORE				= 0,	// So far, only that gear returns to newbies
-	AREA_NO_NEWBIES				= 1,	// Newbies can't go in
-	AREA_UNGHOST				= 2,	// Walking in unghosts you
-	AREA_CHANGED				= 3,	// Area has been modified.
-	AREA_ADDED					= 4,	// Area has been added to.
-	AREA_LOADING				= 5,	// Used for counting in db.c
-};
 
 #define MAX_DIR						6
 #define NO_FLAG						-99		// Must not be used in flags or stats.

--- a/code/merc.h
+++ b/code/merc.h
@@ -325,63 +325,82 @@ typedef void APROG_FUN_MYELL (AREA_DATA *area, CHAR_DATA *ch, CHAR_DATA *victim)
 // mprog stuff
 //
 
-#define MPROG_BRIBE					0
-#define MPROG_ENTRY					1
-#define MPROG_GREET					2
-#define MPROG_GIVE					3
-#define MPROG_FIGHT					4
-#define MPROG_DEATH					5
-#define MPROG_PULSE					6
-#define MPROG_SPEECH				7
-#define MPROG_ATTACK				8
-#define MPROG_MOVE					9
-#define MPROG_BEAT					10
-#define MPROG_AGGRESS				11
+// Mob-program trigger bit indices into mob_index_data::progtypes. One of four
+// prog-trigger families (mprog/iprog/rprog/aprog), each on its own entity's
+// progtypes field. Wire format -- rename freely, never renumber.
+enum MProgTrigger : int
+{
+	MPROG_BRIBE					= 0,
+	MPROG_ENTRY					= 1,
+	MPROG_GREET					= 2,
+	MPROG_GIVE					= 3,
+	MPROG_FIGHT					= 4,
+	MPROG_DEATH					= 5,
+	MPROG_PULSE					= 6,
+	MPROG_SPEECH				= 7,
+	MPROG_ATTACK				= 8,
+	MPROG_MOVE					= 9,
+	MPROG_BEAT					= 10,
+	MPROG_AGGRESS				= 11,
+};
 
 //
 // iprog stuff
 //
 
-#define IPROG_WEAR					0
-#define IPROG_REMOVE				1
-#define IPROG_DROP					2
-#define IPROG_SAC					3
-#define IPROG_GIVE					4
-#define IPROG_GREET					5
-#define IPROG_FIGHT					6
-#define IPROG_DEATH					7
-#define IPROG_SPEECH				8
-#define IPROG_ENTRY					9
-#define IPROG_GET					10
-#define IPROG_PULSE					11
-#define IPROG_INVOKE				12
-#define IPROG_VERB					13
-#define IPROG_LOOT					14
-#define IPROG_OPEN					15
-#define IPROG_LOOK					17
-#define IPROG_HIT					18
+// Item-program trigger bit indices into obj_index_data::progtypes. Wire format
+// -- rename freely, never renumber. Gap at 16.
+enum IProgTrigger : int
+{
+	IPROG_WEAR					= 0,
+	IPROG_REMOVE				= 1,
+	IPROG_DROP					= 2,
+	IPROG_SAC					= 3,
+	IPROG_GIVE					= 4,
+	IPROG_GREET					= 5,
+	IPROG_FIGHT					= 6,
+	IPROG_DEATH					= 7,
+	IPROG_SPEECH				= 8,
+	IPROG_ENTRY					= 9,
+	IPROG_GET					= 10,
+	IPROG_PULSE					= 11,
+	IPROG_INVOKE				= 12,
+	IPROG_VERB					= 13,
+	IPROG_LOOT					= 14,
+	IPROG_OPEN					= 15,
+	IPROG_LOOK					= 17,
+	IPROG_HIT					= 18,
+};
 
 //
 // rprog stuff
 //
 
-#define RPROG_PULSE					0
-#define RPROG_ENTRY					1
-#define RPROG_MOVE					2
-#define RPROG_DROP					3
-#define RPROG_SPEECH				4
-#define RPROG_OPEN					5
+// Room-program trigger bit indices into room_index_data::progtypes.
+enum RProgTrigger : int
+{
+	RPROG_PULSE					= 0,
+	RPROG_ENTRY					= 1,
+	RPROG_MOVE					= 2,
+	RPROG_DROP					= 3,
+	RPROG_SPEECH				= 4,
+	RPROG_OPEN					= 5,
+};
 
 //
 // aprog stuff
 //
 
-#define APROG_PULSE					0
-#define APROG_RESET					1
-#define APROG_SUN					2
-#define APROG_TICK					3
-#define APROG_AGGRESS				4
-#define APROG_MYELL					5
+// Area-program trigger bit indices into area_data::progtypes.
+enum AProgTrigger : int
+{
+	APROG_PULSE					= 0,
+	APROG_RESET					= 1,
+	APROG_SUN					= 2,
+	APROG_TICK					= 3,
+	APROG_AGGRESS				= 4,
+	APROG_MYELL					= 5,
+};
 
 //
 // Quests!
@@ -432,34 +451,42 @@ struct time_info_data
 // Connected state for a channel.
 //
 
-#define CON_PLAYING					0
-#define CON_GET_NAME				1
-#define CON_GET_OLD_PASSWORD		2
-#define CON_CONFIRM_NEW_NAME		3
-#define CON_GET_NEW_PASSWORD		4
-#define CON_CONFIRM_NEW_PASSWORD	5
-#define CON_GET_NEW_RACE			6
-#define CON_GET_NEW_SEX				7
-#define CON_GET_NEW_CLASS			8
-#define CON_ALLOCATE_STATS			9
-#define CON_GET_ALIGNMENT			10
-#define CON_GET_ETHOS				11
-#define CON_DEFAULT_CHOICE			12
-#define CON_GEN_GROUPS				13
-#define CON_NEW_CHAR				14
-#define CON_READ_IMOTD				15
-#define CON_READ_MOTD				16
-#define CON_BREAK_CONNECT			17
-#define CON_GET_CABAL				18
-#define CON_GET_SPEC_ONE			19
-#define CON_GET_SPEC_TWO			20
-#define	CON_GET_THERMAL				21
-#define	CON_GET_MATERIAL			22
-#define CON_GET_DYNAMIC				23
-#define	CON_CHOOSE_ELE				24
-#define CON_LEGIT_NAME				25
-#define CON_GET_BEAUTY				26
-#define CON_CHOOSE_WEAPON			27
+// Descriptor connection state, an ordinal in descriptor_data::connected;
+// switched on in nanny(). NOTE: CON_DIE_BOUND (defined far above, near the level
+// constants) is NOT part of this family -- it is a constitution-stat threshold
+// that shares the CON_ prefix by accident, and keeps its #define. Wire format
+// -- never renumber.
+enum ConnectionState : int
+{
+	CON_PLAYING					= 0,
+	CON_GET_NAME				= 1,
+	CON_GET_OLD_PASSWORD		= 2,
+	CON_CONFIRM_NEW_NAME		= 3,
+	CON_GET_NEW_PASSWORD		= 4,
+	CON_CONFIRM_NEW_PASSWORD	= 5,
+	CON_GET_NEW_RACE			= 6,
+	CON_GET_NEW_SEX				= 7,
+	CON_GET_NEW_CLASS			= 8,
+	CON_ALLOCATE_STATS			= 9,
+	CON_GET_ALIGNMENT			= 10,
+	CON_GET_ETHOS				= 11,
+	CON_DEFAULT_CHOICE			= 12,
+	CON_GEN_GROUPS				= 13,
+	CON_NEW_CHAR				= 14,
+	CON_READ_IMOTD				= 15,
+	CON_READ_MOTD				= 16,
+	CON_BREAK_CONNECT			= 17,
+	CON_GET_CABAL				= 18,
+	CON_GET_SPEC_ONE			= 19,
+	CON_GET_SPEC_TWO			= 20,
+	CON_GET_THERMAL				= 21,
+	CON_GET_MATERIAL			= 22,
+	CON_GET_DYNAMIC				= 23,
+	CON_CHOOSE_ELE				= 24,
+	CON_LEGIT_NAME				= 25,
+	CON_GET_BEAUTY				= 26,
+	CON_CHOOSE_WEAPON			= 27,
+};
 
 //
 // Descriptor (channel) structure.
@@ -545,15 +572,20 @@ struct bounty
 // TO types for act.
 //
 
-#define TO_ROOM						0
-#define TO_NOTVICT					1
-#define TO_VICT						2
-#define TO_CHAR						3
-#define TO_ALL						4
-#define TO_IMMINROOM				5
-#define TO_GROUP					6
-#define TO_NOTGROUP					7
-#define TO_AREA						8
+// act() message target ordinal. A separate family from the TO_* "where" values
+// below (which discriminate affect_data::bitvector); values 0-5 collide.
+enum ActTarget : int
+{
+	TO_ROOM						= 0,
+	TO_NOTVICT					= 1,
+	TO_VICT						= 2,
+	TO_CHAR						= 3,
+	TO_ALL						= 4,
+	TO_IMMINROOM				= 5,
+	TO_GROUP					= 6,
+	TO_NOTGROUP					= 7,
+	TO_AREA						= 8,
+};
 
 //
 // Help table types.
@@ -788,14 +820,18 @@ struct obj_affect_data
 // affect types
 //
 
-#define AFT_SPELL					0
-#define AFT_SKILL					1
-#define AFT_POWER					2
-#define AFT_MALADY					3
-#define AFT_COMMUNE					4
-#define AFT_INVIS					5
-#define AFT_RUNE					6
-#define AFT_TIMER					7
+// Affect-type ordinal, in affect_data::aftype. Wire format -- never renumber.
+enum AffectType : int
+{
+	AFT_SPELL					= 0,
+	AFT_SKILL					= 1,
+	AFT_POWER					= 2,
+	AFT_MALADY					= 3,
+	AFT_COMMUNE					= 4,
+	AFT_INVIS					= 5,
+	AFT_RUNE					= 6,
+	AFT_TIMER					= 7,
+};
 
 //
 // class types
@@ -839,12 +875,19 @@ struct obj_affect_data
 // wear definitions
 //
 
-#define TO_AFFECTS					0
-#define TO_OBJECT					1
-#define TO_IMMUNE					2
-#define TO_RESIST					3
-#define TO_VULN						4
-#define TO_WEAPON					5
+// affect_data::where -- the discriminator that decides which family the sibling
+// bitvector holds and which field it applies to (handler.c dispatches on it).
+// This is the tag of the six-family union described in phase-02 §0.8.1; typing
+// the union itself is deferred, but the tag values are a plain ordinal.
+enum AffectWhere : int
+{
+	TO_AFFECTS					= 0,
+	TO_OBJECT					= 1,
+	TO_IMMUNE					= 2,
+	TO_RESIST					= 3,
+	TO_VULN						= 4,
+	TO_WEAPON					= 5,
+};
 
 //
 // runes only
@@ -862,16 +905,24 @@ struct obj_affect_data
 // where definitions for room
 //
 
-#define TO_ROOM_AFFECTS				0
-#define TO_ROOM_CONST				1
-#define TO_ROOM_FLAGS				2
+// room_affect_data::where -- discriminator for a room affect's bitvector.
+enum RoomAffectWhere : int
+{
+	TO_ROOM_AFFECTS				= 0,
+	TO_ROOM_CONST				= 1,
+	TO_ROOM_FLAGS				= 2,
+};
 
 //
 // where definitions for objs
 //
 
-#define TO_OBJ_AFFECTS				0
-#define TO_OBJ_APPLY				1
+// obj_affect_data::where -- discriminator for an object affect's bitvector.
+enum ObjAffectWhere : int
+{
+	TO_OBJ_AFFECTS				= 0,
+	TO_OBJ_APPLY				= 1,
+};
 
 //
 // where definitions for area
@@ -1145,26 +1196,31 @@ enum ActFlag : int
 // damage classes
 //
 
-#define DAM_NONE					0
-#define DAM_BASH					1
-#define DAM_PIERCE					2
-#define DAM_SLASH					3
-#define DAM_FIRE					4
-#define DAM_COLD					5
-#define DAM_LIGHTNING				6
-#define DAM_ACID					7
-#define DAM_POISON					8
-#define DAM_NEGATIVE				9
-#define DAM_HOLY					10
-#define DAM_ENERGY					11
-#define DAM_MENTAL					12
-#define DAM_DISEASE					13
-#define DAM_DROWNING				14
-#define DAM_LIGHT					15
-#define DAM_OTHER					16
-#define DAM_CHARM					17
-#define DAM_SOUND					18
-#define DAM_TRUESTRIKE				19
+// Damage classes -- an ordinal passed around as an int and switched on. Wire
+// format -- rename freely, never renumber.
+enum DamageType : int
+{
+	DAM_NONE					= 0,
+	DAM_BASH					= 1,
+	DAM_PIERCE					= 2,
+	DAM_SLASH					= 3,
+	DAM_FIRE					= 4,
+	DAM_COLD					= 5,
+	DAM_LIGHTNING				= 6,
+	DAM_ACID					= 7,
+	DAM_POISON					= 8,
+	DAM_NEGATIVE				= 9,
+	DAM_HOLY					= 10,
+	DAM_ENERGY					= 11,
+	DAM_MENTAL					= 12,
+	DAM_DISEASE					= 13,
+	DAM_DROWNING				= 14,
+	DAM_LIGHT					= 15,
+	DAM_OTHER					= 16,
+	DAM_CHARM					= 17,
+	DAM_SOUND					= 18,
+	DAM_TRUESTRIKE				= 19,
+};
 #define	DAM_INTERNAL				20
 
 //
@@ -1489,9 +1545,13 @@ enum AffectObjFlag : int
 // Used in #MOBILES.
 //
 
-#define SEX_NEUTRAL					0
-#define SEX_MALE					1
-#define SEX_FEMALE					2
+// Sex ordinal, in char_data::sex. Wire format -- never renumber.
+enum Sex : int
+{
+	SEX_NEUTRAL					= 0,
+	SEX_MALE					= 1,
+	SEX_FEMALE					= 2,
+};
 
 //
 // AC types
@@ -1515,13 +1575,18 @@ enum AffectObjFlag : int
 // size
 //
 
-#define SIZE_TINY					0
-#define SIZE_SMALL					1
-#define SIZE_MEDIUM					2
-#define SIZE_LARGE					3
-#define SIZE_HUGE					4
-#define SIZE_GIANT					5
-#define SIZE_IMMENSE				6
+// Creature size, an ordinal in char_data::size; compared relationally. Wire
+// format -- never renumber. Kept ascending so size comparisons hold.
+enum Size : int
+{
+	SIZE_TINY					= 0,
+	SIZE_SMALL					= 1,
+	SIZE_MEDIUM					= 2,
+	SIZE_LARGE					= 3,
+	SIZE_HUGE					= 4,
+	SIZE_GIANT					= 5,
+	SIZE_IMMENSE				= 6,
+};
 
 //
 // Well known object virtual numbers.
@@ -2092,41 +2157,51 @@ enum ExitFlag : int
 	EX_JAMMED					= 10,
 };
 
-#define ARE_NORMAL					0
-#define ARE_ROAD_RIVER				1
-#define ARE_CABAL					2
-#define ARE_QUEST					3
-#define ARE_CITY					4
-#define ARE_UNOPENED				5
-#define ARE_SHRINE					6
+// Area sector/category ordinal. Wire format -- never renumber.
+enum AreaSector : int
+{
+	ARE_NORMAL					= 0,
+	ARE_ROAD_RIVER				= 1,
+	ARE_CABAL					= 2,
+	ARE_QUEST					= 3,
+	ARE_CITY					= 4,
+	ARE_UNOPENED				= 5,
+	ARE_SHRINE					= 6,
+};
 
 //
 // Sector types.
 // Used in #ROOMS.
 //
 
-#define SECT_INSIDE					7
-#define SECT_CITY					1
-#define SECT_FIELD					2
-#define SECT_FOREST					3
-#define SECT_HILLS					4
-#define SECT_MOUNTAIN				5
-#define SECT_WATER					6
-#define SECT_UNUSED					7
-#define SECT_UNDERWATER				8
-#define SECT_AIR					9
-#define SECT_DESERT					10
-#define SECT_ROAD					11
-#define SECT_CONFLAGRATION			12
-#define SECT_BURNING				13
-#define SECT_TRAIL					14
-#define SECT_SWAMP					15
-#define SECT_PARK					16
-#define SECT_VERTICAL				17
-#define	SECT_ICE					18
-#define	SECT_SNOW					19
-#define SECT_CAVE					20
-#define SECT_MAX					21
+// Sector (terrain) types, an ordinal in room_index_data::sector_type. Note the
+// deliberate collision: SECT_INSIDE and SECT_UNUSED are both 7. SECT_MAX (21) is
+// a count/sentinel, not a terrain. Wire format -- never renumber.
+enum SectorType : int
+{
+	SECT_INSIDE					= 7,
+	SECT_CITY					= 1,
+	SECT_FIELD					= 2,
+	SECT_FOREST					= 3,
+	SECT_HILLS					= 4,
+	SECT_MOUNTAIN				= 5,
+	SECT_WATER					= 6,
+	SECT_UNUSED					= 7,
+	SECT_UNDERWATER				= 8,
+	SECT_AIR					= 9,
+	SECT_DESERT					= 10,
+	SECT_ROAD					= 11,
+	SECT_CONFLAGRATION			= 12,
+	SECT_BURNING				= 13,
+	SECT_TRAIL					= 14,
+	SECT_SWAMP					= 15,
+	SECT_PARK					= 16,
+	SECT_VERTICAL				= 17,
+	SECT_ICE					= 18,
+	SECT_SNOW					= 19,
+	SECT_CAVE					= 20,
+	SECT_MAX					= 21,	// count/sentinel, not a terrain
+};
 
 //
 // Trap types
@@ -2280,15 +2355,22 @@ enum ExitFlag : int
 // Positions.
 //
 
-#define POS_DEAD					0
-#define POS_MORTAL					1
-#define POS_INCAP					2
-#define POS_STUNNED					3
-#define POS_SLEEPING				4
-#define POS_RESTING					5
-#define POS_SITTING					6
-#define POS_FIGHTING				7
-#define POS_STANDING				8
+// Character position, an ordinal in char_data::position (a short). Ordering is
+// load-bearing: ~96 relational comparisons (position >= POS_RESTING etc.) and it
+// is stored in cmd_type::position for the command table. Wire format -- never
+// renumber. Kept ascending exactly as-is so all comparisons hold.
+enum Position : int
+{
+	POS_DEAD					= 0,
+	POS_MORTAL					= 1,
+	POS_INCAP					= 2,
+	POS_STUNNED					= 3,
+	POS_SLEEPING				= 4,
+	POS_RESTING					= 5,
+	POS_SITTING					= 6,
+	POS_FIGHTING				= 7,
+	POS_STANDING				= 8,
+};
 
 #define MIN_PK_XP					9999	// min xp players need to start PKing
 #define MIN_LEVEL_TO_PK				23		// Minimum level for players to pk

--- a/code/merc.h
+++ b/code/merc.h
@@ -1360,48 +1360,67 @@ enum ActFlag : int
 // Used in #MOBILES.
 //
 
-#define AFF_BLIND					0
-#define AFF_INVISIBLE				1
-#define AFF_DETECT_EVIL				2
-#define AFF_DETECT_INVIS			3
-#define AFF_DETECT_MAGIC			4
-#define AFF_DETECT_HIDDEN			5
-#define AFF_DETECT_GOOD				6
-#define AFF_SANCTUARY				7
-#define AFF_DETECT_CAMO				8
-#define AFF_INFRARED				9 // unused!
-#define AFF_CURSE					10
-#define AFF_CAMOUFLAGE				11
-#define AFF_POISON					12
-#define AFF_PROTECTION				13
-#define AFF_RAGE					14
-#define AFF_SNEAK					15
-#define AFF_HIDE					16
-#define AFF_SLEEP					17
-#define AFF_CHARM					18
-#define AFF_FLYING					19
-#define AFF_PASS_DOOR				20
-#define AFF_HASTE					21
-#define AFF_CALM					22
-#define AFF_PLAGUE					23
-#define AFF_PERMANENT				24
-#define AFF_DARK_VISION				25
-#define AFF_BERSERK					26
-#define AFF_WATERBREATH				27
-#define AFF_REGENERATION			28
-#define AFF_SLOW					29
-#define AFF_NOSHOW					30
+// Bit indices for character affects. Reached through several storages:
+// char_data::affected_by, affect_data::bitvector (when where == TO_AFFECTS),
+// and race_type::aff[] -- which holds bit INDICES in a plain array, not a bit
+// vector. See phase-02 §0.8.2; act_move.c:3149 confuses the two.
+// Wire format -- rename freely, never renumber.
+enum AffectFlag : int
+{
+	AFF_BLIND					= 0,
+	AFF_INVISIBLE				= 1,
+	AFF_DETECT_EVIL				= 2,
+	AFF_DETECT_INVIS			= 3,
+	AFF_DETECT_MAGIC			= 4,
+	AFF_DETECT_HIDDEN			= 5,
+	AFF_DETECT_GOOD				= 6,
+	AFF_SANCTUARY				= 7,
+	AFF_DETECT_CAMO				= 8,
+	AFF_INFRARED				= 9,	// unused!
+	AFF_CURSE					= 10,
+	AFF_CAMOUFLAGE				= 11,
+	AFF_POISON					= 12,
+	AFF_PROTECTION				= 13,
+	AFF_RAGE					= 14,
+	AFF_SNEAK					= 15,
+	AFF_HIDE					= 16,
+	AFF_SLEEP					= 17,
+	AFF_CHARM					= 18,
+	AFF_FLYING					= 19,
+	AFF_PASS_DOOR				= 20,
+	AFF_HASTE					= 21,
+	AFF_CALM					= 22,
+	AFF_PLAGUE					= 23,
+	AFF_PERMANENT				= 24,
+	AFF_DARK_VISION				= 25,
+	AFF_BERSERK					= 26,
+	AFF_WATERBREATH				= 27,
+	AFF_REGENERATION			= 28,
+	AFF_SLOW					= 29,
+	AFF_NOSHOW					= 30,
+};
 
 //
 // AFF bits for rooms
 //
 
-#define AFF_ROOM_RANDOMIZER			0
-#define AFF_ROOM_CURSE				10
-#define AFF_ROOM_POISON				12
-#define AFF_ROOM_SLEEP				17
-#define AFF_ROOM_PLAGUE				23
-#define AFF_ROOM_SLOW				29
+// Bit indices into room_index_data::affected_by, and into
+// room_affect_data::bitvector when where == TO_ROOM_AFFECTS.
+//
+// These reuse AffectFlag's numbering space but are NOT aliases of it: this is a
+// separate family on separate storage. Five of the six happen to share a name
+// with their AffectFlag counterpart (CURSE, POISON, SLEEP, PLAGUE, SLOW) and
+// the same bit, but AFF_ROOM_RANDOMIZER == 0 collides with AFF_BLIND == 0 while
+// meaning something completely unrelated. Kept as its own enum for that reason.
+enum AffectRoomFlag : int
+{
+	AFF_ROOM_RANDOMIZER			= 0,
+	AFF_ROOM_CURSE				= 10,
+	AFF_ROOM_POISON				= 12,
+	AFF_ROOM_SLEEP				= 17,
+	AFF_ROOM_PLAGUE				= 23,
+	AFF_ROOM_SLOW				= 29,
+};
 
 // Aff bits for.. AREAS!
 // -- None currently. --
@@ -1411,7 +1430,13 @@ enum ActFlag : int
 // Aff bits for OBJS
 //
 
-#define	AFF_OBJ_BURNING				0
+// Bit indices into obj_data::affected_by, and into obj_affect_data::bitvector
+// when where == TO_OBJ_AFFECTS. A third family in AffectFlag's numbering space,
+// on a third storage. One member so far.
+enum AffectObjFlag : int
+{
+	AFF_OBJ_BURNING				= 0,
+};
 
 //
 // Sex.
@@ -1571,110 +1596,143 @@ enum ActFlag : int
 // Used in #OBJECTS.
 //
 
-#define ITEM_LIGHT					1
-#define ITEM_SCROLL					2
-#define ITEM_WAND					3
-#define ITEM_STAFF					4
-#define ITEM_WEAPON					5
-#define ITEM_NULL6					6
-#define	ITEM_DICE					7
-#define ITEM_TREASURE				8
-#define ITEM_ARMOR					9
-#define ITEM_POTION					10
-#define ITEM_CLOTHING				11
-#define ITEM_FURNITURE				12
-#define ITEM_TRASH					13
-#define ITEM_CONTAINER				15
-#define ITEM_DRINK_CON				17
-#define ITEM_KEY					18
-#define ITEM_FOOD					19
-#define ITEM_MONEY					20
-#define ITEM_BOAT					22
-#define ITEM_CORPSE_NPC				23
-#define ITEM_CORPSE_PC				24
-#define ITEM_FOUNTAIN				25
-#define ITEM_PILL					26
-#define ITEM_PROTECT				27
-#define ITEM_MAP					28
-#define ITEM_PORTAL					29
-#define ITEM_WARP_STONE				30
-#define ITEM_ROOM_KEY				31
-#define ITEM_GEM					32
-#define ITEM_JEWELRY				33
-#define ITEM_CAMPFIRE				34
-#define ITEM_CABAL_ITEM				35
-#define ITEM_SKELETON				36
-#define ITEM_URN					37
-#define ITEM_GRAVITYWELL			38
-#define ITEM_BOOK					39
-#define ITEM_PEN					40
-#define ITEM_ALTAR					41
-//#define ITEM_DONATION_PIT			42
-#define ITEM_STONE					43
+// Item TYPES -- an ordinal scalar stored in obj_data::item_type (a short), not
+// a bit field. Compared with == and switched on; never passed to IS_SET.
+//
+// The ITEM_ prefix covers THREE unrelated families (types here, extra flags and
+// wear flags below) whose values collide: ITEM_LIGHT == 1 is a type,
+// ITEM_HUM == 1 is an extra-flag bit, ITEM_WEAR_FINGER == 1 is a wear bit.
+// They are separate enums for that reason. Names are unchanged, so no call site
+// moves; the split is documentation the compiler happens to hold.
+// Wire format (area files) -- rename freely, never renumber.
+enum ItemType : int
+{
+	ITEM_LIGHT					= 1,
+	ITEM_SCROLL					= 2,
+	ITEM_WAND					= 3,
+	ITEM_STAFF					= 4,
+	ITEM_WEAPON					= 5,
+	ITEM_NULL6					= 6,
+	ITEM_DICE					= 7,
+	ITEM_TREASURE				= 8,
+	ITEM_ARMOR					= 9,
+	ITEM_POTION					= 10,
+	ITEM_CLOTHING				= 11,
+	ITEM_FURNITURE				= 12,
+	ITEM_TRASH					= 13,
+	ITEM_CONTAINER				= 15,
+	ITEM_DRINK_CON				= 17,
+	ITEM_KEY					= 18,
+	ITEM_FOOD					= 19,
+	ITEM_MONEY					= 20,
+	ITEM_BOAT					= 22,
+	ITEM_CORPSE_NPC				= 23,
+	ITEM_CORPSE_PC				= 24,
+	ITEM_FOUNTAIN				= 25,
+	ITEM_PILL					= 26,
+	ITEM_PROTECT				= 27,
+	ITEM_MAP					= 28,
+	ITEM_PORTAL					= 29,
+	ITEM_WARP_STONE				= 30,
+	ITEM_ROOM_KEY				= 31,
+	ITEM_GEM					= 32,
+	ITEM_JEWELRY				= 33,
+	ITEM_CAMPFIRE				= 34,
+	ITEM_CABAL_ITEM				= 35,
+	ITEM_SKELETON				= 36,
+	ITEM_URN					= 37,
+	ITEM_GRAVITYWELL			= 38,
+	ITEM_BOOK					= 39,
+	ITEM_PEN					= 40,
+	ITEM_ALTAR					= 41,
+	// 42 was ITEM_DONATION_PIT -- retired. Note ITEM_DONATION_PIT now exists as
+	// an *extra flag* with value 33, which is a different family entirely.
+	ITEM_STONE					= 43,
+};
 
 //
 // Extra flags.
 // Used in #OBJECTS.
 ///
 
-#define ITEM_GLOW					0
-#define ITEM_HUM					1
-#define ITEM_DARK					2
-#define ITEM_NOSHOW					3
-#define ITEM_EVIL					4
-#define ITEM_INVIS					5
-#define ITEM_MAGIC					6
-#define ITEM_NODROP					7
-#define ITEM_BLESS					8
-#define ITEM_ANTI_GOOD				9
-#define ITEM_ANTI_EVIL				10
-#define ITEM_ANTI_NEUTRAL			11
-#define ITEM_NOREMOVE				12
-#define ITEM_INVENTORY				13
-#define ITEM_NOPURGE				14
-#define ITEM_ROT_DEATH				15
-#define ITEM_VIS_DEATH				16
-#define ITEM_FIXED					17
-#define ITEM_NODISARM				18
-#define ITEM_NOLOCATE				19
-#define ITEM_MELT_DROP				20
-#define ITEM_UNDER_CLOTHES			21
-#define ITEM_SELL_EXTRACT			22
-#define ITEM_BURN_PROOF				24
-#define ITEM_NOUNCURSE				25
-#define ITEM_BRAND					26
-#define CORPSE_NO_ANIMATE			27
-#define ITEM_ANTI_LAWFUL			28
-#define ITEM_ANTI_NEUT				29
-#define ITEM_ANTI_CHAOTIC			30
-#define ITEM_NO_STASH				31
-#define ITEM_NO_SAC					32
-#define ITEM_DONATION_PIT			33
+// Extra flags -- bit indices into obj_data::extra_flags, and into
+// obj_index_data's affect bitvector where ITEM_EVIL / ITEM_BURN_PROOF are set
+// (magic.c). Distinct from ItemType above despite the shared prefix.
+// Wire format -- rename freely, never renumber. Gap at 23.
+//
+// CORPSE_NO_ANIMATE is a member of THIS family despite its different prefix:
+// value 27 sits between ITEM_BRAND (26) and ITEM_ANTI_LAWFUL (28), and it is
+// set on extra_flags at fight.c:3025. Note characterClasses/necro.c sets and
+// tests it on *wear_flags* instead, where bit 27 is outside the wear range
+// (0-18) -- see phase-02 §0.8.1. Left as found; that is a bug fix, not a rename.
+enum ItemExtraFlag : int
+{
+	ITEM_GLOW					= 0,
+	ITEM_HUM					= 1,
+	ITEM_DARK					= 2,
+	ITEM_NOSHOW					= 3,
+	ITEM_EVIL					= 4,
+	ITEM_INVIS					= 5,
+	ITEM_MAGIC					= 6,
+	ITEM_NODROP					= 7,
+	ITEM_BLESS					= 8,
+	ITEM_ANTI_GOOD				= 9,
+	ITEM_ANTI_EVIL				= 10,
+	ITEM_ANTI_NEUTRAL			= 11,
+	ITEM_NOREMOVE				= 12,
+	ITEM_INVENTORY				= 13,
+	ITEM_NOPURGE				= 14,
+	ITEM_ROT_DEATH				= 15,
+	ITEM_VIS_DEATH				= 16,
+	ITEM_FIXED					= 17,
+	ITEM_NODISARM				= 18,
+	ITEM_NOLOCATE				= 19,
+	ITEM_MELT_DROP				= 20,
+	ITEM_UNDER_CLOTHES			= 21,
+	ITEM_SELL_EXTRACT			= 22,
+	ITEM_BURN_PROOF				= 24,
+	ITEM_NOUNCURSE				= 25,
+	ITEM_BRAND					= 26,
+	CORPSE_NO_ANIMATE			= 27,
+	ITEM_ANTI_LAWFUL			= 28,
+	ITEM_ANTI_NEUT				= 29,
+	ITEM_ANTI_CHAOTIC			= 30,
+	ITEM_NO_STASH				= 31,
+	ITEM_NO_SAC					= 32,
+	ITEM_DONATION_PIT			= 33,
+};
 
 //
 // Wear flags.
 // Used in #OBJECTS.
 //
 
-#define ITEM_TAKE					0
-#define ITEM_WEAR_FINGER			1
-#define ITEM_WEAR_NECK				2
-#define ITEM_WEAR_BODY				3
-#define ITEM_WEAR_HEAD				4
-#define ITEM_WEAR_LEGS				5
-#define ITEM_WEAR_FEET				6
-#define ITEM_WEAR_HANDS				7
-#define ITEM_WEAR_ARMS				8
-#define ITEM_WEAR_SHIELD			9
-#define ITEM_WEAR_ABOUT				10
-#define ITEM_WEAR_WAIST				11
-#define ITEM_WEAR_WRIST				12
-#define ITEM_WEAR_WIELD				13
-#define ITEM_WEAR_HOLD				14
-#define ITEM_WEAR_FLOAT				15
-#define ITEM_WEAR_BRAND				16
-#define ITEM_WEAR_STRAPPED			17
-#define ITEM_WEAR_COSMETIC			18 //cosmetic, misc, up to 5/person
+// Wear flags -- bit indices into obj_data::wear_flags. The third and last
+// family under the ITEM_ prefix. Range is 0-18, which is why necro.c's use of
+// CORPSE_NO_ANIMATE (27) on this field cannot work (§0.8.1).
+// Wire format -- rename freely, never renumber.
+enum ItemWearFlag : int
+{
+	ITEM_TAKE					= 0,
+	ITEM_WEAR_FINGER			= 1,
+	ITEM_WEAR_NECK				= 2,
+	ITEM_WEAR_BODY				= 3,
+	ITEM_WEAR_HEAD				= 4,
+	ITEM_WEAR_LEGS				= 5,
+	ITEM_WEAR_FEET				= 6,
+	ITEM_WEAR_HANDS				= 7,
+	ITEM_WEAR_ARMS				= 8,
+	ITEM_WEAR_SHIELD			= 9,
+	ITEM_WEAR_ABOUT				= 10,
+	ITEM_WEAR_WAIST				= 11,
+	ITEM_WEAR_WRIST				= 12,
+	ITEM_WEAR_WIELD				= 13,
+	ITEM_WEAR_HOLD				= 14,
+	ITEM_WEAR_FLOAT				= 15,
+	ITEM_WEAR_BRAND				= 16,
+	ITEM_WEAR_STRAPPED			= 17,
+	ITEM_WEAR_COSMETIC			= 18,	// cosmetic, misc, up to 5/person
+};
 
 #define RESTRICT_OTHER				0
 #define RESTRICT_CLASS				1

--- a/code/merc.h
+++ b/code/merc.h
@@ -617,19 +617,32 @@ struct shop_data
 	short direction;			// exit dir
 };
 
-#define BAR_CLASS					0
-#define BAR_CABAL					1
-#define BAR_SIZE					2
-#define BAR_TATTOO					3
-#define BAR_LEVEL					4
+// Door-bar restriction criterion. Three separate BAR_ families follow, colliding
+// in value; each is its own enum. Wire format -- never renumber.
+enum BarCriterion : int
+{
+	BAR_CLASS					= 0,
+	BAR_CABAL					= 1,
+	BAR_SIZE					= 2,
+	BAR_TATTOO					= 3,
+	BAR_LEVEL					= 4,
+};
 
-#define BAR_EQUAL_TO				0
-#define BAR_LESS_THAN				1
-#define BAR_GREATER_THAN			2
+// Bar comparison operator.
+enum BarComparison : int
+{
+	BAR_EQUAL_TO				= 0,
+	BAR_LESS_THAN				= 1,
+	BAR_GREATER_THAN			= 2,
+};
 
-#define BAR_SAY						0
-#define BAR_ECHO					1
-#define BAR_EMOTE					2
+// Bar rejection-message style.
+enum BarMessage : int
+{
+	BAR_SAY						= 0,
+	BAR_ECHO					= 1,
+	BAR_EMOTE					= 2,
+};
 
 struct barred_data
 {
@@ -1000,14 +1013,21 @@ enum ApplyObjLocation : int
 // Cabal definitions
 //
 
-#define CABAL_NONE					0
-#define CABAL_GUILD					1
-#define CABAL_SCION					2
-#define CABAL_HORDE					3
-#define CABAL_BOUNTY				4
-#define CABAL_THEATRE				5
-#define CABAL_PHALANX				6
-#define CABAL_NEGATIVE				8
+// Cabal identity ordinal, in char_data::cabal. NOTE: CABAL_LEADER (defined among
+// the MAX_ constants below) is NOT part of this family -- it is an induct rank
+// compared against pcdata->induct, and keeps its #define. Wire format -- never
+// renumber. Gap at 7.
+enum Cabal : int
+{
+	CABAL_NONE					= 0,
+	CABAL_GUILD					= 1,
+	CABAL_SCION					= 2,
+	CABAL_HORDE					= 3,
+	CABAL_BOUNTY				= 4,
+	CABAL_THEATRE				= 5,
+	CABAL_PHALANX				= 6,
+	CABAL_NEGATIVE				= 8,
+};
 
 #define MAX_EMPIRE					8
 #define MAX_BOUNTY					5
@@ -1877,29 +1897,42 @@ enum ItemWearFlag : int
 #define RESTRICT_RACE				2
 #define RESTRICT_CABAL				3
 
-#define TRIBE_NONE					0
-#define TRIBE_BOAR					1
-#define TRIBE_WOLF					2
-#define TRIBE_BEAR					3
-#define TRIBE_HAWK					4
-#define TRIBE_LION					5
-#define TRIBE_ELK					6
-#define TRIBE_JACKAL				7
-#define TRIBE_FOX					8
-#define TRIBE_BULL					9
-#define TRIBE_PANTHER				10
+// Shapeshifter tribe ordinal. Wire format -- never renumber.
+enum Tribe : int
+{
+	TRIBE_NONE					= 0,
+	TRIBE_BOAR					= 1,
+	TRIBE_WOLF					= 2,
+	TRIBE_BEAR					= 3,
+	TRIBE_HAWK					= 4,
+	TRIBE_LION					= 5,
+	TRIBE_ELK					= 6,
+	TRIBE_JACKAL				= 7,
+	TRIBE_FOX					= 8,
+	TRIBE_BULL					= 9,
+	TRIBE_PANTHER				= 10,
+};
 
-#define PALADIN_NONE				0
-#define PALADIN_PROTECTOR			1
-#define PALADIN_CRUSADER			2
+// Paladin-order ordinal. Wire format -- never renumber.
+enum PaladinOrder : int
+{
+	PALADIN_NONE				= 0,
+	PALADIN_PROTECTOR			= 1,
+	PALADIN_CRUSADER			= 2,
+};
 
-#define STYLE_NONE					-1
-#define STYLE_GLADIATOR				0
-#define STYLE_BARBARIAN				1
-#define STYLE_DUELIST				2
-#define STYLE_SKIRMISHER			3
-#define STYLE_DRAGOON				4
-#define STYLE_TACTICIAN				5
+// Combat-style ordinal. STYLE_NONE is the -1 sentinel (hence : int). Wire
+// format -- never renumber.
+enum CombatStyle : int
+{
+	STYLE_NONE					= -1,
+	STYLE_GLADIATOR				= 0,
+	STYLE_BARBARIAN				= 1,
+	STYLE_DUELIST				= 2,
+	STYLE_SKIRMISHER			= 3,
+	STYLE_DRAGOON				= 4,
+	STYLE_TACTICIAN				= 5,
+};
 #define MAX_STYLE					7
 #define MAX_STYLE_SKILL				38
 
@@ -2246,17 +2279,21 @@ enum SectorType : int
 // Trap types
 //
 
-#define TRAP_NONE					0
-#define TRAP_DART					1
-#define TRAP_PDART					2
-#define TRAP_FIREBALL				3
-#define TRAP_LIGHTNING				4
-#define TRAP_SLEEPGAS				5
-#define TRAP_POISONGAS				6
-#define TRAP_ACID					7
-#define TRAP_PIT					8
-#define TRAP_BOULDER				9
-#define TRAP_DRAIN					10
+// Trap effect ordinal. Wire format -- never renumber.
+enum TrapType : int
+{
+	TRAP_NONE					= 0,
+	TRAP_DART					= 1,
+	TRAP_PDART					= 2,
+	TRAP_FIREBALL				= 3,
+	TRAP_LIGHTNING				= 4,
+	TRAP_SLEEPGAS				= 5,
+	TRAP_POISONGAS				= 6,
+	TRAP_ACID					= 7,
+	TRAP_PIT					= 8,
+	TRAP_BOULDER				= 9,
+	TRAP_DRAIN					= 10,
+};
 #define MAX_TRAP					11
 
 #define ALIGN_NEUTRAL				0
@@ -2591,11 +2628,15 @@ enum WiznetFlag : int
 // AP Demonic Favors Defines
 //
 
-#define DEVIL_ASMODEUS				0
-#define DEVIL_MOLOCH				1
-#define DEVIL_BAAL					2
-#define DEVIL_DISPATER				3
-#define DEVIL_MEPHISTO				4
+// Devil-patron ordinal. Wire format -- never renumber.
+enum Devil : int
+{
+	DEVIL_ASMODEUS				= 0,
+	DEVIL_MOLOCH				= 1,
+	DEVIL_BAAL					= 2,
+	DEVIL_DISPATER				= 3,
+	DEVIL_MEPHISTO				= 4,
+};
 #define MAX_DEVIL					5
 
 #define LESSER_BARBAS				0
@@ -2615,10 +2656,14 @@ enum WiznetFlag : int
 #define LESSER_DEMON				0
 #define GREATER_DEMON				1
 
-#define FAVOR_NONE					0
-#define FAVOR_FAILED				-1
-#define FAVOR_IN_PROGRESS			1
-#define FAVOR_GRANTED				2
+// Favor/quest-state ordinal. FAVOR_FAILED is the -1 sentinel (hence : int).
+enum FavorState : int
+{
+	FAVOR_NONE					= 0,
+	FAVOR_FAILED				= -1,
+	FAVOR_IN_PROGRESS			= 1,
+	FAVOR_GRANTED				= 2,
+};
 
 #define GERYON_EYE					2
 #define GERYON_FINGER				3
@@ -2663,14 +2708,22 @@ enum ElementSlot : int
 	ELE_TYPE_PARA				= 2,
 };
 
-#define MAT_TRANSLUCENT				0
-#define MAT_TRANSPARENT				1
-#define MAT_EDIBLE					2
+// Material optical property. Separate family from MAT_SOLID.. below (collide).
+enum MaterialOptical : int
+{
+	MAT_TRANSLUCENT				= 0,
+	MAT_TRANSPARENT				= 1,
+	MAT_EDIBLE					= 2,
+};
 
-#define MAT_SOLID					0
-#define MAT_LIQUID					1
-#define MAT_GAS						2
-#define MAT_PLASMA					3
+// Material state of matter.
+enum MaterialState : int
+{
+	MAT_SOLID					= 0,
+	MAT_LIQUID					= 1,
+	MAT_GAS						= 2,
+	MAT_PLASMA					= 3,
+};
 
 //
 // Prototype for a mob.
@@ -2759,14 +2812,18 @@ private:
 // Speech info for progs
 //
 
-#define SPEECH_SAY					0
-#define SPEECH_SAYTO				1
-#define SPEECH_TELL					2
-#define SPEECH_WHISPER				3
-#define SPEECH_YELL					4
-#define SPEECH_EMOTE				5
-#define SPEECH_ECHO					6
-#define SPEECH_SING					7
+// Speech-act ordinal. Wire format -- never renumber.
+enum SpeechType : int
+{
+	SPEECH_SAY					= 0,
+	SPEECH_SAYTO				= 1,
+	SPEECH_TELL					= 2,
+	SPEECH_WHISPER				= 3,
+	SPEECH_YELL					= 4,
+	SPEECH_EMOTE				= 5,
+	SPEECH_ECHO					= 6,
+	SPEECH_SING					= 7,
+};
 
 struct speech_data
 {

--- a/code/merc.h
+++ b/code/merc.h
@@ -1328,72 +1328,78 @@ enum VulnFlag : int
 // body form
 //
 
-#define FORM_EDIBLE					0
-#define FORM_POISON					1
-#define FORM_MAGICAL				2
-#define FORM_INSTANT_DECAY			3
-#define FORM_OTHER					4 // defined by material bit
+// Body-form bit indices into char_data::form (and race_type::form). Note this
+// is a DIFFERENT field from char_data::act despite magic.c:1408 testing
+// ACT_UNDEAD against it -- see phase-02 §0.8.6. Wire format -- never renumber.
+enum FormFlag : int
+{
+	// material form
+	FORM_EDIBLE					= 0,
+	FORM_POISON					= 1,
+	FORM_MAGICAL				= 2,
+	FORM_INSTANT_DECAY			= 3,
+	FORM_OTHER					= 4,	// defined by material bit
 
-//
-// actual form
-//
+	// actual form
+	FORM_ANIMAL					= 6,
+	FORM_SENTIENT				= 7,
+	FORM_UNDEAD					= 8,
+	FORM_CONSTRUCT				= 9,
+	FORM_MIST					= 10,
+	FORM_INTANGIBLE				= 11,
 
-#define FORM_ANIMAL					6
-#define FORM_SENTIENT				7
-#define FORM_UNDEAD					8
-#define FORM_CONSTRUCT				9
-#define FORM_MIST					10
-#define FORM_INTANGIBLE				11
+	FORM_BIPED					= 12,
+	FORM_AQUATIC				= 13,
+	FORM_INSECT					= 14,
+	FORM_SPIDER					= 15,
+	FORM_CRUSTACEAN				= 16,
+	FORM_WORM					= 17,
+	FORM_BLOB					= 18,
 
-#define FORM_BIPED					12
-#define FORM_AQUATIC				13
-#define FORM_INSECT					14
-#define FORM_SPIDER					15
-#define FORM_CRUSTACEAN				16
-#define FORM_WORM					17
-#define FORM_BLOB					18
-
-#define FORM_MAMMAL					21
-#define FORM_BIRD					22
-#define FORM_REPTILE				23
-#define FORM_SNAKE					24
-#define FORM_DRAGON					25
-#define FORM_AMPHIBIAN				26
-#define FORM_FISH					27
-#define FORM_COLD_BLOOD				28
-#define FORM_NOSPEECH				29
+	FORM_MAMMAL					= 21,
+	FORM_BIRD					= 22,
+	FORM_REPTILE				= 23,
+	FORM_SNAKE					= 24,
+	FORM_DRAGON					= 25,
+	FORM_AMPHIBIAN				= 26,
+	FORM_FISH					= 27,
+	FORM_COLD_BLOOD				= 28,
+	FORM_NOSPEECH				= 29,
+};
 
 //
 // body parts
 //
 
-#define PART_HEAD					0
-#define PART_ARMS					1
-#define PART_LEGS					2
-#define PART_HEART					3
-#define PART_BRAINS					4
-#define PART_GUTS					5
-#define PART_HANDS					6
-#define PART_FEET					7
-#define PART_FINGERS				8
-#define PART_EAR					9
-#define PART_EYE					10
-#define PART_LONG_TONGUE			11
-#define PART_EYESTALKS				12
-#define PART_TENTACLES				13
-#define PART_FINS					14
-#define PART_WINGS					15
-#define PART_TAIL					16
+// Body-part bit indices into char_data::parts (and race_type::parts). Wire
+// format -- rename freely, never renumber. Gaps at 17-19.
+enum PartFlag : int
+{
+	PART_HEAD					= 0,
+	PART_ARMS					= 1,
+	PART_LEGS					= 2,
+	PART_HEART					= 3,
+	PART_BRAINS					= 4,
+	PART_GUTS					= 5,
+	PART_HANDS					= 6,
+	PART_FEET					= 7,
+	PART_FINGERS				= 8,
+	PART_EAR					= 9,
+	PART_EYE					= 10,
+	PART_LONG_TONGUE			= 11,
+	PART_EYESTALKS				= 12,
+	PART_TENTACLES				= 13,
+	PART_FINS					= 14,
+	PART_WINGS					= 15,
+	PART_TAIL					= 16,
 
-//
-// for combat
-//
-
-#define PART_CLAWS					20
-#define PART_FANGS					21
-#define PART_HORNS					22
-#define PART_SCALES					23
-#define PART_TUSKS					24
+	// for combat
+	PART_CLAWS					= 20,
+	PART_FANGS					= 21,
+	PART_HORNS					= 22,
+	PART_SCALES					= 23,
+	PART_TUSKS					= 24,
+};
 
 //
 // Bits for 'affected_by'.
@@ -1809,43 +1815,60 @@ enum ItemWearFlag : int
 // weapon class
 //
 
-#define WEAPON_EXOTIC				0
-#define WEAPON_SWORD				1
-#define WEAPON_DAGGER				2
-#define WEAPON_SPEAR				3
-#define WEAPON_MACE					4
-#define WEAPON_AXE					5
-#define WEAPON_FLAIL				6
-#define WEAPON_WHIP					7
-#define WEAPON_POLEARM				8
-#define WEAPON_STAFF				9
-#define WEAPON_HAND					10
+// Weapon CLASS -- an ordinal scalar in obj->value[0], compared with ==. This is
+// a separate family from the weapon-flag bits below, whose values 0-10 collide
+// with these completely. (The source's own "weapon class" / "weapon types"
+// comments have these two backwards; the names are kept, the labels corrected.)
+enum WeaponClass : int
+{
+	WEAPON_EXOTIC				= 0,
+	WEAPON_SWORD				= 1,
+	WEAPON_DAGGER				= 2,
+	WEAPON_SPEAR				= 3,
+	WEAPON_MACE					= 4,
+	WEAPON_AXE					= 5,
+	WEAPON_FLAIL				= 6,
+	WEAPON_WHIP					= 7,
+	WEAPON_POLEARM				= 8,
+	WEAPON_STAFF				= 9,
+	WEAPON_HAND					= 10,
+};
 
 //
 // weapon types
 //
 
-#define WEAPON_FLAMING				0
-#define WEAPON_FROST				1
-#define WEAPON_VAMPIRIC				2
-#define WEAPON_SHARP				3
-#define WEAPON_VORPAL				4
-#define WEAPON_TWO_HANDS			5
-#define WEAPON_SHOCKING				6
-#define WEAPON_POISON				7
-#define WEAPON_AVENGER				8
-#define WEAPON_SHADOWBANE			9
-#define WEAPON_LIGHTBRINGER			10
+// Weapon FLAGS -- bit indices tested with IS_SET_OLD on obj->value[4] (a scalar
+// int field, hence the _OLD operators). Separate family from WeaponClass above.
+enum WeaponFlag : int
+{
+	WEAPON_FLAMING				= 0,
+	WEAPON_FROST				= 1,
+	WEAPON_VAMPIRIC				= 2,
+	WEAPON_SHARP				= 3,
+	WEAPON_VORPAL				= 4,
+	WEAPON_TWO_HANDS			= 5,
+	WEAPON_SHOCKING				= 6,
+	WEAPON_POISON				= 7,
+	WEAPON_AVENGER				= 8,
+	WEAPON_SHADOWBANE			= 9,
+	WEAPON_LIGHTBRINGER			= 10,
+};
 
 //
 // gate flags
 //
 
-#define GATE_NORMAL_EXIT			0
-#define GATE_NOCURSE				1
-#define GATE_GOWITH					2
-#define GATE_BUGGY					3
-#define GATE_RANDOM					4
+// Portal gate flags -- bit indices tested with IS_SET_OLD on a portal's
+// obj->value[] scalar. Wire format -- rename freely, never renumber.
+enum GateFlag : int
+{
+	GATE_NORMAL_EXIT			= 0,
+	GATE_NOCURSE				= 1,
+	GATE_GOWITH					= 2,
+	GATE_BUGGY					= 3,
+	GATE_RANDOM					= 4,
+};
 
 //
 // furniture flags
@@ -1954,11 +1977,16 @@ enum ApplyLocation : int
 // Used in #OBJECTS.
 //
 
-#define CONT_CLOSEABLE				0
-#define CONT_PICKPROOF				1
-#define CONT_CLOSED					2
-#define CONT_LOCKED					3
-#define CONT_PUT_ON					4
+// Container flags -- bit indices tested with IS_SET_OLD on a container's
+// obj->value[1] scalar. Wire format -- rename freely, never renumber.
+enum ContainerFlag : int
+{
+	CONT_CLOSEABLE				= 0,
+	CONT_PICKPROOF				= 1,
+	CONT_CLOSED					= 2,
+	CONT_LOCKED					= 3,
+	CONT_PUT_ON					= 4,
+};
 
 #define WIELD_ONE					1
 #define WIELD_TWO					2
@@ -2047,17 +2075,22 @@ enum RoomFlag : int
 // Used in #ROOMS.
 //
 
-#define EX_ISDOOR					0
-#define EX_CLOSED					1
-#define EX_LOCKED					2
-#define EX_PICKPROOF				3
-#define EX_NOPASS					4
-#define EX_NOCLOSE					5
-#define EX_NOLOCK					6
-#define EX_NOBASH					7
-#define EX_NONOBVIOUS				8
-#define EX_TRANSLUCENT				9
-#define EX_JAMMED					10
+// Exit flags -- bit indices tested with IS_SET_OLD on exit_data::exit_info (a
+// scalar int). Wire format -- rename freely, never renumber.
+enum ExitFlag : int
+{
+	EX_ISDOOR					= 0,
+	EX_CLOSED					= 1,
+	EX_LOCKED					= 2,
+	EX_PICKPROOF				= 3,
+	EX_NOPASS					= 4,
+	EX_NOCLOSE					= 5,
+	EX_NOLOCK					= 6,
+	EX_NOBASH					= 7,
+	EX_NONOBVIOUS				= 8,
+	EX_TRANSLUCENT				= 9,
+	EX_JAMMED					= 10,
+};
 
 #define ARE_NORMAL					0
 #define ARE_ROAD_RIVER				1
@@ -3416,13 +3449,18 @@ extern QUEUE_DATA *global_queue;
 // Area flags.
 //
 
-#define AREA_NONE					0
-#define AREA_EXPLORE				0		// So far, only that gear returns to newbies
-#define AREA_NO_NEWBIES				1		// Newbies can't go in
-#define AREA_UNGHOST				2		// Walking in unghosts you
-#define AREA_CHANGED				3		// Area has been modified.
-#define AREA_ADDED					4		// Area has been added to.
-#define AREA_LOADING				5		// Used for counting in db.c
+// Area flags -- bit indices into area_data::area_flags. AREA_NONE and
+// AREA_EXPLORE are both 0 by design (alias). Wire format -- never renumber.
+enum AreaFlag : int
+{
+	AREA_NONE					= 0,
+	AREA_EXPLORE				= 0,	// So far, only that gear returns to newbies
+	AREA_NO_NEWBIES				= 1,	// Newbies can't go in
+	AREA_UNGHOST				= 2,	// Walking in unghosts you
+	AREA_CHANGED				= 3,	// Area has been modified.
+	AREA_ADDED					= 4,	// Area has been added to.
+	AREA_LOADING				= 5,	// Used for counting in db.c
+};
 
 #define MAX_DIR						6
 #define NO_FLAG						-99		// Must not be used in flags or stats.

--- a/code/merc.h
+++ b/code/merc.h
@@ -414,9 +414,13 @@ enum AProgTrigger : int
 #define SMITH_QUEST					6
 #define RING_QUEST					7
 
-#define REPLY_YES					1
-#define REPLY_NO					2
-#define REPLY_NEITHER				3
+// Yes/no prompt reply ordinal. Wire format -- never renumber.
+enum ReplyType : int
+{
+	REPLY_YES					= 1,
+	REPLY_NO					= 2,
+	REPLY_NEITHER				= 3,
+};
 
 #define NOTE_UNSTARTED				0
 #define NOTE_IN_PROGRESS			1
@@ -886,12 +890,16 @@ enum ClassAvailability : int
 // const.c skill table types
 //
 
-#define CMD_NONE 					0
-#define CMD_SPELL					1
-#define CMD_COMMUNE					2
-#define CMD_POWER					3
-#define CMD_BOTH					4
-#define CMD_RUNE					5
+// Magic command-type ordinal. Wire format -- never renumber.
+enum MagicCommand : int
+{
+	CMD_NONE					= 0,
+	CMD_SPELL					= 1,
+	CMD_COMMUNE					= 2,
+	CMD_POWER					= 3,
+	CMD_BOTH					= 4,
+	CMD_RUNE					= 5,
+};
 
 #define CAN_DISPEL					(1 << ASCII_A)
 #define CAN_CANCEL					(1 << ASCII_B)
@@ -1310,10 +1318,15 @@ enum OffFlag : int
 // return values for check_imm
 //
 
-#define IS_NORMAL					0
-#define IS_IMMUNE					1
-#define IS_RESISTANT				2
-#define IS_VULNERABLE				3
+// Damage-susceptibility result ordinal (check_immune etc.). Wire format --
+// never renumber.
+enum Susceptibility : int
+{
+	IS_NORMAL					= 0,
+	IS_IMMUNE					= 1,
+	IS_RESISTANT				= 2,
+	IS_VULNERABLE				= 3,
+};
 
 //
 // IMM bits for mobs
@@ -1614,9 +1627,14 @@ enum ArmorClass : int
 // dice
 //
 
-#define DICE_NUMBER					0
-#define DICE_TYPE					1
-#define DICE_BONUS					2
+// Index into a dice spec's value triple (number/type/bonus). Wire format --
+// never renumber.
+enum DiceField : int
+{
+	DICE_NUMBER					= 0,
+	DICE_TYPE					= 1,
+	DICE_BONUS					= 2,
+};
 
 //
 // size
@@ -1892,10 +1910,14 @@ enum ItemWearFlag : int
 	ITEM_WEAR_COSMETIC			= 18,	// cosmetic, misc, up to 5/person
 };
 
-#define RESTRICT_OTHER				0
-#define RESTRICT_CLASS				1
-#define RESTRICT_RACE				2
-#define RESTRICT_CABAL				3
+// Object-restriction criterion ordinal. Wire format -- never renumber.
+enum RestrictType : int
+{
+	RESTRICT_OTHER				= 0,
+	RESTRICT_CLASS				= 1,
+	RESTRICT_RACE				= 2,
+	RESTRICT_CABAL				= 3,
+};
 
 // Shapeshifter tribe ordinal. Wire format -- never renumber.
 enum Tribe : int
@@ -2125,9 +2147,13 @@ enum ContainerFlag : int
 	CONT_PUT_ON					= 4,
 };
 
-#define WIELD_ONE					1
-#define WIELD_TWO					2
-#define WIELD_PRIMARY				3
+// Wield-hand ordinal. Wire format -- never renumber.
+enum WieldType : int
+{
+	WIELD_ONE					= 1,
+	WIELD_TWO					= 2,
+	WIELD_PRIMARY				= 3,
+};
 
 #define HAS_DIED					8
 
@@ -2419,18 +2445,33 @@ enum WearLocation : int
 
 #define NORM						1
 
-#define HIT_UNBLOCKABLE				0
-#define HIT_BLOCKABLE				1
+// damage_new() flag arguments. Three independent two-value families, passed
+// positionally. Kept as three enums matching their argument slots.
+enum HitBlockable : int
+{
+	HIT_UNBLOCKABLE				= 0,
+	HIT_BLOCKABLE				= 1,
+};
 
-#define HIT_NOSPECIALS				0
-#define HIT_SPECIALS				1
+enum HitSpecials : int
+{
+	HIT_NOSPECIALS				= 0,
+	HIT_SPECIALS				= 1,
+};
 
-#define HIT_NOMULT					1
-#define HIT_NOADD 0
+enum HitModifier : int
+{
+	HIT_NOMULT					= 1,
+	HIT_NOADD					= 0,
+};
 
-#define POSTURE_OFFENSE				1
-#define POSTURE_NONE				0
-#define POSTURE_DEFENSE				-1
+// Combat posture, an ordinal spanning -1..1. POSTURE_DEFENSE is -1 (hence : int).
+enum Posture : int
+{
+	POSTURE_OFFENSE				= 1,
+	POSTURE_NONE				= 0,
+	POSTURE_DEFENSE				= -1,
+};
 
 #define MAX_QUEUE					20
 
@@ -2481,13 +2522,23 @@ enum Position : int
 #define MIN_PK_XP					9999	// min xp players need to start PKing
 #define MIN_LEVEL_TO_PK				23		// Minimum level for players to pk
 
-#define PK_KILLS					0
-#define PK_GOOD						1
-#define PK_NEUTRAL					2
-#define PK_EVIL						3
+// PK alignment-kill counters. Separate family from the killed[] index pair
+// below. Wire format -- never renumber.
+enum PkKillType : int
+{
+	PK_KILLS					= 0,
+	PK_GOOD						= 1,
+	PK_NEUTRAL					= 2,
+	PK_EVIL						= 3,
+};
 
-#define PK_KILLED					0
-#define MOB_KILLED					1
+// Index into pcdata::killed[]: player kills vs mob kills. One family, two
+// prefixes (PK_/MOB_).
+enum KilledIndex : int
+{
+	PK_KILLED					= 0,
+	MOB_KILLED					= 1,
+};
 
 //
 // ACT bits for players.
@@ -2639,22 +2690,36 @@ enum Devil : int
 };
 #define MAX_DEVIL					5
 
-#define LESSER_BARBAS				0
-#define LESSER_AAMON				1
-#define LESSER_MALAPHAR				2
-#define LESSER_FURCAS				3
-#define LESSER_IPOS					4
+// Lesser-demon name ordinal. MAX_LESSER stays a #define (constexpr commit).
+enum LesserDemon : int
+{
+	LESSER_BARBAS				= 0,
+	LESSER_AAMON				= 1,
+	LESSER_MALAPHAR				= 2,
+	LESSER_FURCAS				= 3,
+	LESSER_IPOS					= 4,
+};
 #define MAX_LESSER					5
 
-#define GREATER_OZE					0
-#define GREATER_GAMYGYN				1
-#define GREATER_OROBAS				2
-#define GREATER_GERYON				3
-#define GREATER_CIMERIES			4
+// Greater-demon name ordinal. Separate family from GreaterDemon-tier below.
+enum GreaterDemon : int
+{
+	GREATER_OZE					= 0,
+	GREATER_GAMYGYN				= 1,
+	GREATER_OROBAS				= 2,
+	GREATER_GERYON				= 3,
+	GREATER_CIMERIES			= 4,
+};
 #define MAX_GREATER					5
 
-#define LESSER_DEMON				0
-#define GREATER_DEMON				1
+// Demon tier discriminator (lesser vs greater). LESSER_DEMON/GREATER_DEMON share
+// the LESSER_/GREATER_ prefixes with the name families above but are a distinct
+// two-value family.
+enum DemonTier : int
+{
+	LESSER_DEMON				= 0,
+	GREATER_DEMON				= 1,
+};
 
 // Favor/quest-state ordinal. FAVOR_FAILED is the -1 sentinel (hence : int).
 enum FavorState : int
@@ -3594,26 +3659,33 @@ private:
 //  Target types.
 //
 
-#define TAR_IGNORE					0
-#define TAR_CHAR_OFFENSIVE			1
-#define TAR_CHAR_DEFENSIVE			2
-#define TAR_CHAR_SELF				3
-#define TAR_OBJ_INV					4
-#define TAR_OBJ_CHAR_DEF			5
-#define TAR_OBJ_CHAR_OFF			6
-#define TAR_DIR						7
-#define TAR_CHAR_AMBIGUOUS			8
-#define TAR_CHAR_GENERAL			9
+// Skill/spell target-type ordinal, in skill_type::target. TAR_END (666) is a
+// deliberate sentinel, not adjacent. Wire format -- never renumber.
+enum SkillTarget : int
+{
+	TAR_IGNORE					= 0,
+	TAR_CHAR_OFFENSIVE			= 1,
+	TAR_CHAR_DEFENSIVE			= 2,
+	TAR_CHAR_SELF				= 3,
+	TAR_OBJ_INV					= 4,
+	TAR_OBJ_CHAR_DEF			= 5,
+	TAR_OBJ_CHAR_OFF			= 6,
+	TAR_DIR						= 7,
+	TAR_CHAR_AMBIGUOUS			= 8,
+	TAR_CHAR_GENERAL			= 9,
+	TAR_END						= 666,	// don't touch
+};
 
-
-#define TAR_END						666 //don't touch
-
-#define TARGET_CHAR					0
-#define TARGET_OBJ					1
-#define TARGET_ROOM					2
-#define TARGET_NONE					3
-#define TARGET_RUNE					4
-#define TARGET_DIR					5
+// Spell effect target-type ordinal. Separate family from SkillTarget above.
+enum TargetType : int
+{
+	TARGET_CHAR					= 0,
+	TARGET_OBJ					= 1,
+	TARGET_ROOM					= 2,
+	TARGET_NONE					= 3,
+	TARGET_RUNE					= 4,
+	TARGET_DIR					= 5,
+};
 
 //
 //rune target bitvectors

--- a/code/merc.h
+++ b/code/merc.h
@@ -893,13 +893,22 @@ enum AffectWhere : int
 // runes only
 //
 
-#define RUNE_TO_WEAPON				0
-#define RUNE_TO_ARMOR				1
-#define RUNE_TO_PORTAL				2
-#define RUNE_TO_ROOM				3
+// What a rune is applied to -- an ordinal. Separate family from RUNE_TRIGGER_*
+// and the RUNE_* masks below (all three collide in value).
+enum RuneTarget : int
+{
+	RUNE_TO_WEAPON				= 0,
+	RUNE_TO_ARMOR				= 1,
+	RUNE_TO_PORTAL				= 2,
+	RUNE_TO_ROOM				= 3,
+};
 
-#define RUNE_TRIGGER_ENTRY			0
-#define RUNE_TRIGGER_EXIT			1
+// When a rune fires -- an ordinal.
+enum RuneTrigger : int
+{
+	RUNE_TRIGGER_ENTRY			= 0,
+	RUNE_TRIGGER_EXIT			= 1,
+};
 
 //
 // where definitions for room
@@ -1939,23 +1948,30 @@ enum GateFlag : int
 // furniture flags
 //
 
-#define STAND_AT					0
-#define STAND_ON					1
-#define STAND_IN					2
-#define SIT_AT						3
-#define SIT_ON						4
-#define SIT_IN						5
-#define REST_AT						6
-#define REST_ON						7
-#define REST_IN						8
-#define SLEEP_AT					9
-#define SLEEP_ON					10
-#define SLEEP_IN					11
-#define PUT_AT						12
-#define PUT_ON						13
-#define PUT_IN						14
-#define PUT_INSIDE					15
-#define LOUNGE_ON					16
+// Furniture position flags -- bit indices tested with IS_SET_OLD on a piece of
+// furniture's obj->value[2] (act_info.c). One family across six prefixes
+// (STAND_/SIT_/REST_/SLEEP_/PUT_/LOUNGE_), a single 0-16 numbering. Kept as one
+// enum with the original names. Wire format -- rename freely, never renumber.
+enum FurniturePosition : int
+{
+	STAND_AT					= 0,
+	STAND_ON					= 1,
+	STAND_IN					= 2,
+	SIT_AT						= 3,
+	SIT_ON						= 4,
+	SIT_IN						= 5,
+	REST_AT						= 6,
+	REST_ON						= 7,
+	REST_IN						= 8,
+	SLEEP_AT					= 9,
+	SLEEP_ON					= 10,
+	SLEEP_IN					= 11,
+	PUT_AT						= 12,
+	PUT_ON						= 13,
+	PUT_IN						= 14,
+	PUT_INSIDE					= 15,
+	LOUNGE_ON					= 16,
+};
 	
 //
 // Apply types (for affects).
@@ -2487,31 +2503,36 @@ enum CommFlag : int
 // WIZnet flags
 //
 
-#define WIZ_ON						0
-#define WIZ_TICKS					1
-#define WIZ_LOGINS					2
-#define WIZ_SITES					3
-#define WIZ_LINKS					4
-#define WIZ_DEATHS					5
-#define WIZ_RESETS					6
-#define WIZ_MOBDEATHS				7
-#define WIZ_FLAGS					8
-#define WIZ_PENALTIES				9
-#define WIZ_SACCING					10
-#define WIZ_LEVELS					11
-#define WIZ_SECURE					12
-#define WIZ_SWITCHES				13
-#define WIZ_SNOOPS					14
-#define WIZ_RESTORE					15
-#define WIZ_LOAD					16
-#define WIZ_NEWBIE					17
-#define WIZ_PREFIX					18
-#define WIZ_SPAM					19
-#define WIZ_CABAL					20
-#define WIZ_PERCENT					21
-#define WIZ_LOG						22
-#define	WIZ_OOC						23
-#define WIZ_DEBUG					24
+// Wiznet channel bit indices into char_data::wiznet, and passed as `long flag`
+// to wiznet(). Wire format -- rename freely, never renumber. Gap at 23.
+enum WiznetFlag : int
+{
+	WIZ_ON						= 0,
+	WIZ_TICKS					= 1,
+	WIZ_LOGINS					= 2,
+	WIZ_SITES					= 3,
+	WIZ_LINKS					= 4,
+	WIZ_DEATHS					= 5,
+	WIZ_RESETS					= 6,
+	WIZ_MOBDEATHS					= 7,
+	WIZ_FLAGS					= 8,
+	WIZ_PENALTIES					= 9,
+	WIZ_SACCING					= 10,
+	WIZ_LEVELS					= 11,
+	WIZ_SECURE					= 12,
+	WIZ_SWITCHES					= 13,
+	WIZ_SNOOPS					= 14,
+	WIZ_RESTORE					= 15,
+	WIZ_LOAD					= 16,
+	WIZ_NEWBIE					= 17,
+	WIZ_PREFIX					= 18,
+	WIZ_SPAM					= 19,
+	WIZ_CABAL					= 20,
+	WIZ_PERCENT					= 21,
+	WIZ_LOG						= 22,
+	WIZ_OOC						= 23,
+	WIZ_DEBUG					= 24,
+};
 
 //
 // AP Demonic Favors Defines
@@ -3479,11 +3500,17 @@ private:
 //rune target bitvectors
 //
 
-#define RUNE_CAST					1
-#define RUNE_ARMOR					2
-#define RUNE_WEAPON					4
-#define RUNE_DOOR					8
-#define RUNE_ROOM					16
+// Rune target bitmasks -- these are pre-shifted MASKS (1,2,4,8,16), not bit
+// indices, tested with IS_SET_OLD directly and compared with <. A third RUNE_
+// family, distinct from RuneTarget/RuneTrigger. Wire format -- never renumber.
+enum RuneMask : int
+{
+	RUNE_CAST					= 1,
+	RUNE_ARMOR					= 2,
+	RUNE_WEAPON					= 4,
+	RUNE_DOOR					= 8,
+	RUNE_ROOM					= 16,
+};
 
 
 //

--- a/code/merc.h
+++ b/code/merc.h
@@ -2197,46 +2197,46 @@ struct kill_data
 // RT comm flags -- may be used on both mobs and chars
 //
 
-#define COMM_QUIET					0
-#define COMM_DEAF					1
-#define COMM_NOWIZ					2
-#define COMM_NOAUCTION				3
-#define COMM_NOGOSSIP				4
-#define COMM_NOQUESTION				5
-#define COMM_NONEWBIE				6
-#define COMM_NOCABAL				7
-#define COMM_NOQUOTE				8
-#define COMM_SHOUTSOFF				9
-#define COMM_ANSI					10
+// Bit indices into char_data::comm. The values are a wire format -- they are
+// written to player files as letters keyed to the index (save.c print_flags),
+// so they may be renamed but never renumbered. Note the gap at 17.
+enum CommFlag : long
+{
+	COMM_QUIET					= 0,
+	COMM_DEAF					= 1,
+	COMM_NOWIZ					= 2,
+	COMM_NOAUCTION				= 3,
+	COMM_NOGOSSIP				= 4,
+	COMM_NOQUESTION				= 5,
+	COMM_NONEWBIE				= 6,
+	COMM_NOCABAL				= 7,
+	COMM_NOQUOTE				= 8,
+	COMM_SHOUTSOFF				= 9,
+	COMM_ANSI					= 10,
 
-//
-// display flags
-//
+	// display flags
+	COMM_COMPACT				= 11,
+	COMM_BRIEF					= 12,
+	COMM_PROMPT					= 13,
+	COMM_COMBINE				= 14,
+	COMM_TELNET_GA				= 15,
+	COMM_SHOW_AFFECTS			= 16,
+	COMM_IMMORTAL				= 18,
 
-#define COMM_COMPACT				11
-#define COMM_BRIEF					12
-#define COMM_PROMPT					13
-#define COMM_COMBINE				14
-#define COMM_TELNET_GA				15
-#define COMM_SHOW_AFFECTS			16
-#define COMM_IMMORTAL				18
-
-//
-// penalties
-//
-
-#define COMM_NOEMOTE				19
-#define COMM_NOSHOUT				20
-#define COMM_NOTELL					21
-#define COMM_NOCHANNELS				22 
-#define COMM_BUILDER				23
-#define COMM_SNOOP_PROOF			24
-#define COMM_AFK					25
-#define COMM_ALL_CABALS				26
-#define COMM_NOSOCKET				27
-#define COMM_SWITCHSKILLS			28
-#define COMM_NOBUILDER				29
-#define COMM_LOTS_O_COLOR			30
+	// penalties
+	COMM_NOEMOTE				= 19,
+	COMM_NOSHOUT				= 20,
+	COMM_NOTELL					= 21,
+	COMM_NOCHANNELS				= 22,
+	COMM_BUILDER				= 23,
+	COMM_SNOOP_PROOF			= 24,
+	COMM_AFK					= 25,
+	COMM_ALL_CABALS				= 26,
+	COMM_NOSOCKET				= 27,
+	COMM_SWITCHSKILLS			= 28,
+	COMM_NOBUILDER				= 29,
+	COMM_LOTS_O_COLOR			= 30,
+};
 
 //
 // Trust flags

--- a/code/merc.h
+++ b/code/merc.h
@@ -3255,12 +3255,19 @@ private:
 #define URANGE(a, b, c)				(b < a ? a : (b > c ? c : b))
 #define LOWER(c)					(c >= 'A' && c <= 'Z' ? c + 'a' - 'A' : c)
 #define UPPER(c)					(c >= 'a' && c <= 'z' ? c + 'A' - 'a' : c)
-#define IS_SET(flag, bit)			((flag[(int)(bit/32)]) & ((long)pow(2,(bit % 32))))
-#define IS_SET_OLD(flag, bit) 		(flag & ((long)pow(2,bit)))
-#define SET_BIT(var, bit)			((var[(int)bit/32]) |= ((long)pow(2,bit % 32)))
-#define SET_BIT_OLD(var, bit) 		(var |= (long)pow(2,bit))
-#define REMOVE_BIT(var, bit)		((var[bit/32]) &= ~((long)pow(2,bit % 32)))
-#define REMOVE_BIT_OLD(var,bit) 	(var &= ~((long)pow(2,bit)))
+// Array flags -- operate on a long[MAX_BITVECTOR]; the bit is split into a word
+// index and an offset. `act`, `affected_by`, `bitvector` and friends.
+#define IS_SET(flag, bit)			((flag)[(bit) / 32] &   (1L << ((bit) % 32)))
+#define SET_BIT(var, bit)			((var)[(bit) / 32]  |=  (1L << ((bit) % 32)))
+#define REMOVE_BIT(var, bit)		((var)[(bit) / 32]  &= ~(1L << ((bit) % 32)))
+
+// Scalar flags -- operate on a single integer field, overwhelmingly obj->value[N]
+// (the furniture flags in act_info.c among them). The bit is an absolute shift,
+// with no word split. The _OLD suffix names the representation, NOT deprecation:
+// these three have 134 live call sites (140 counting TOGGLE_BIT_OLD below).
+#define IS_SET_OLD(flag, bit) 		((flag) &   (1L << (bit)))
+#define SET_BIT_OLD(var, bit) 		((var)  |=  (1L << (bit)))
+#define REMOVE_BIT_OLD(var,bit) 	((var)  &= ~(1L << (bit)))
 #define TOGGLE_BIT(var, bit)		(IS_SET(var,bit) ? REMOVE_BIT(var,bit) : SET_BIT(var,bit))
 #define TOGGLE_BIT_OLD(var, bit)	(IS_SET_OLD(var,bit) ? REMOVE_BIT_OLD(var,bit) : SET_BIT_OLD(var,bit))
 

--- a/code/merc.h
+++ b/code/merc.h
@@ -649,11 +649,16 @@ struct barred_data
 
 #define MAX_GUILD					8
 #define MAX_STATS					5
-#define STAT_STR					0
-#define STAT_INT					1
-#define STAT_WIS					2
-#define STAT_DEX					3
-#define STAT_CON					4
+// Primary-stat index into char_data::perm_stat[] / mod_stat[]. Wire format --
+// rename freely, never renumber.
+enum StatType : int
+{
+	STAT_STR					= 0,
+	STAT_INT					= 1,
+	STAT_WIS					= 2,
+	STAT_DEX					= 3,
+	STAT_CON					= 4,
+};
 #define MAX_SPECS					8
 #define MAX_SPEC_SKILLS				1
 #define MAX_ZOMBIE					10
@@ -837,16 +842,25 @@ enum AffectType : int
 // class types
 //
 
-#define CLASS_NEITHER				0
-#define CLASS_CASTER				1
-#define CLASS_COMMUNER				2
+// Spellcasting-class ordinal (how a class channels magic). Separate family from
+// the character-class CLASS_NONE.. list and from CLASS_OPEN/CLOSED.
+enum SpellClass : int
+{
+	CLASS_NEITHER				= 0,
+	CLASS_CASTER				= 1,
+	CLASS_COMMUNER				= 2,
+};
 
 //
 // open or closed
 //
 
-#define CLASS_OPEN					1
-#define CLASS_CLOSED				0
+// Whether a class is open for selection. A two-value ordinal, separate family.
+enum ClassAvailability : int
+{
+	CLASS_OPEN					= 1,
+	CLASS_CLOSED				= 0,
+};
 
 //
 // open or closed  race
@@ -1566,10 +1580,14 @@ enum Sex : int
 // AC types
 //
 
-#define AC_PIERCE					0
-#define AC_BASH						1
-#define AC_SLASH					2
-#define AC_EXOTIC					3
+// Armor-class index into char_data::armor[]. Wire format -- never renumber.
+enum ArmorClass : int
+{
+	AC_PIERCE					= 0,
+	AC_BASH						= 1,
+	AC_SLASH					= 2,
+	AC_EXOTIC					= 3,
+};
 #define MAX_AC						4
 
 //
@@ -2034,24 +2052,29 @@ enum ApplyLocation : int
 // Modifier Names
 //
 
-#define MOD_NONE					-1
-#define MOD_VISION					0
-#define MOD_MOVEMENT				1
-#define MOD_TOUGHNESS				2
-#define MOD_SPEED					3
-#define MOD_LEVITATION				4
-#define MOD_VISIBILITY				5
-#define MOD_PHASE					6
-#define MOD_CONC					7
-#define MOD_PROTECTION				8
-#define MOD_APPEARANCE				9
-#define MOD_HEARING					10
-#define MOD_PERCEPTION				11
-#define MOD_RESISTANCE				12
-#define MOD_ENERGY_STATE			13
-#define MOD_SPEECH					14
-#define MOD_REGEN					15
-#define MOD_WARDROBE				16
+// Spell/effect modifier type, an ordinal. MOD_NONE is the -1 sentinel, hence
+// the required : int underlying type. Wire format -- never renumber.
+enum ModType : int
+{
+	MOD_NONE					= -1,
+	MOD_VISION					= 0,
+	MOD_MOVEMENT				= 1,
+	MOD_TOUGHNESS				= 2,
+	MOD_SPEED					= 3,
+	MOD_LEVITATION				= 4,
+	MOD_VISIBILITY				= 5,
+	MOD_PHASE					= 6,
+	MOD_CONC					= 7,
+	MOD_PROTECTION				= 8,
+	MOD_APPEARANCE				= 9,
+	MOD_HEARING					= 10,
+	MOD_PERCEPTION				= 11,
+	MOD_RESISTANCE				= 12,
+	MOD_ENERGY_STATE			= 13,
+	MOD_SPEECH					= 14,
+	MOD_REGEN					= 15,
+	MOD_WARDROBE				= 16,
+};
 
 //
 // Values for containers (value[1]).
@@ -2243,57 +2266,77 @@ enum SectorType : int
 // Alignment selections
 //
 
-#define ALIGN_NONE					-1
-#define ALIGN_ANY					0
-#define ALIGN_GN					1
-#define ALIGN_NE					2
-#define ALIGN_GE					3
-#define ALIGN_G						4
-#define ALIGN_N						5
-#define ALIGN_E						6
+// Alignment SELECTION values (creation/OLC choices), an ordinal. Distinct from
+// the raw alignment scale ALIGN_NEUTRAL sits on above. ALIGN_NONE is the -1
+// sentinel (hence : int). Wire format -- never renumber.
+enum AlignmentChoice : int
+{
+	ALIGN_NONE					= -1,
+	ALIGN_ANY					= 0,
+	ALIGN_GN					= 1,
+	ALIGN_NE					= 2,
+	ALIGN_GE					= 3,
+	ALIGN_G						= 4,
+	ALIGN_N						= 5,
+	ALIGN_E						= 6,
+};
 
 //
 // Ethos selections
 //
 
-#define ETHOS_NONE					-1
-#define ETHOS_ANY					0
-#define ETHOS_LN					1
-#define ETHOS_NC					2
-#define ETHOS_LC					3
-#define ETHOS_L						4
-#define ETHOS_N						5
-#define ETHOS_C						6
+// Ethos SELECTION values (creation/OLC choices), an ordinal. Distinct from the
+// raw ethos scale ETHOS_NEUTRAL sits on. ETHOS_NONE is the -1 sentinel.
+enum EthosChoice : int
+{
+	ETHOS_NONE					= -1,
+	ETHOS_ANY					= 0,
+	ETHOS_LN					= 1,
+	ETHOS_NC					= 2,
+	ETHOS_LC					= 3,
+	ETHOS_L						= 4,
+	ETHOS_N						= 5,
+	ETHOS_C						= 6,
+};
 
 
 //
 // Class guild used in the room 'G'  flags
 //
 
-#define GUILD_WARRIOR				1
-#define GUILD_THIEF					2
-#define GUILD_CLERIC				3
-#define GUILD_PALADIN				4
-#define GUILD_ANTI_PALADIN			5
-#define GUILD_RANGER				6
-#define GUILD_MONK					7
-#define GUILD_SHAPESHIFTER			8
-#define GUILD_ASSASSIN				9
-#define GUILD_NECROMANCER			10
-#define GUILD_SORCERER				11
+// Guild ordinal (room guild-guard associations). Wire format -- never renumber.
+enum Guild : int
+{
+	GUILD_WARRIOR				= 1,
+	GUILD_THIEF					= 2,
+	GUILD_CLERIC				= 3,
+	GUILD_PALADIN				= 4,
+	GUILD_ANTI_PALADIN			= 5,
+	GUILD_RANGER				= 6,
+	GUILD_MONK					= 7,
+	GUILD_SHAPESHIFTER			= 8,
+	GUILD_ASSASSIN				= 9,
+	GUILD_NECROMANCER			= 10,
+	GUILD_SORCERER				= 11,
+};
 
-#define CLASS_NONE					0
-#define CLASS_WARRIOR 				1
-#define CLASS_THIEF 				2
-#define CLASS_ZEALOT 				3
-#define CLASS_PALADIN 				4
-#define CLASS_ANTI_PALADIN			5
-#define CLASS_RANGER 				6
-#define CLASS_ASSASSIN 				7
-#define CLASS_SHAPESHIFTER			8
-#define CLASS_HEALER				9
-#define CLASS_NECROMANCER 			10
-#define CLASS_SORCERER				11
+// Character class, an ordinal in char_data::Class()/class. The main CLASS_
+// family. Wire format -- rename freely, never renumber.
+enum CharClass : int
+{
+	CLASS_NONE					= 0,
+	CLASS_WARRIOR				= 1,
+	CLASS_THIEF					= 2,
+	CLASS_ZEALOT				= 3,
+	CLASS_PALADIN				= 4,
+	CLASS_ANTI_PALADIN			= 5,
+	CLASS_RANGER				= 6,
+	CLASS_ASSASSIN				= 7,
+	CLASS_SHAPESHIFTER			= 8,
+	CLASS_HEALER				= 9,
+	CLASS_NECROMANCER			= 10,
+	CLASS_SORCERER				= 11,
+};
 
 
 //
@@ -2301,30 +2344,36 @@ enum SectorType : int
 // Used in #RESETS.
 //
 
-#define WEAR_NONE					-1
-#define WEAR_LIGHT					0
-#define WEAR_FINGER_L				1
-#define WEAR_FINGER_R				2
-#define WEAR_NECK_1					3
-#define WEAR_NECK_2					4
-#define WEAR_BODY					5
-#define WEAR_HEAD					6
-#define WEAR_LEGS					7
-#define WEAR_FEET					8
-#define WEAR_HANDS					9
-#define WEAR_ARMS					10
-#define WEAR_SHIELD					11
-#define WEAR_ABOUT					12
-#define WEAR_WAIST					13
-#define WEAR_WRIST_L				14
-#define WEAR_WRIST_R				15
-#define WEAR_WIELD					16
-#define WEAR_HOLD					17
-#define WEAR_DUAL_WIELD				18
-#define WEAR_FLOAT					18
-#define WEAR_BRAND					19
-#define WEAR_STRAPPED				20
-#define WEAR_COSMETIC				21
+// Worn-equipment slot index into char_data::equipment[]. WEAR_NONE is the -1
+// sentinel (hence : int); WEAR_DUAL_WIELD and WEAR_FLOAT deliberately share slot
+// 18. Wire format -- rename freely, never renumber.
+enum WearLocation : int
+{
+	WEAR_NONE					= -1,
+	WEAR_LIGHT					= 0,
+	WEAR_FINGER_L				= 1,
+	WEAR_FINGER_R				= 2,
+	WEAR_NECK_1					= 3,
+	WEAR_NECK_2					= 4,
+	WEAR_BODY					= 5,
+	WEAR_HEAD					= 6,
+	WEAR_LEGS					= 7,
+	WEAR_FEET					= 8,
+	WEAR_HANDS					= 9,
+	WEAR_ARMS					= 10,
+	WEAR_SHIELD					= 11,
+	WEAR_ABOUT					= 12,
+	WEAR_WAIST					= 13,
+	WEAR_WRIST_L				= 14,
+	WEAR_WRIST_R				= 15,
+	WEAR_WIELD					= 16,
+	WEAR_HOLD					= 17,
+	WEAR_DUAL_WIELD				= 18,
+	WEAR_FLOAT					= 18,
+	WEAR_BRAND					= 19,
+	WEAR_STRAPPED				= 20,
+	WEAR_COSMETIC				= 21,
+};
 #define MAX_WEAR					22
 
 
@@ -2358,14 +2407,18 @@ enum SectorType : int
 // Conditions.
 //
 
-#define COND_DRUNK					0
-#define COND_FULL					1
-#define COND_THIRST					2
-#define COND_HUNGER					3
-#define COND_STARVING				4
-#define COND_DEHYDRATED				5
-
-#define COND_HUNGRY					50
+// Condition index into pc_data::condition[]. COND_HUNGRY (50) is an outlier
+// value, not adjacent to the rest. Wire format -- never renumber.
+enum ConditionType : int
+{
+	COND_DRUNK					= 0,
+	COND_FULL					= 1,
+	COND_THIRST					= 2,
+	COND_HUNGER					= 3,
+	COND_STARVING				= 4,
+	COND_DEHYDRATED				= 5,
+	COND_HUNGRY					= 50,
+};
 
 //
 // Positions.
@@ -2576,30 +2629,39 @@ enum WiznetFlag : int
 // Sorcerer Elemental Groups
 //
 
-#define ELE_HEAT					0
-#define ELE_COLD					1
-#define ELE_AIR						2
-#define ELE_EARTH					3
-#define ELE_WATER					4
-#define ELE_ELECTRICITY				5
-#define ELE_SMOKE					6
-#define ELE_MAGMA					7
-#define ELE_PLASMA					8
-#define ELE_ACID					9
-#define ELE_BLIZZARD				10
-#define ELE_FROST					11
-#define ELE_CRYSTAL					12
-#define ELE_ICE						13
-#define ELE_LIGHTNING				14
-#define ELE_MIST					15
-#define ELE_METAL					16
-#define ELE_OOZE					17
-#define ELE_NONE					18
+// Elemental type, an ordinal. Separate from ELE_TYPE_* below (which collide in
+// value). Wire format -- never renumber.
+enum Element : int
+{
+	ELE_HEAT					= 0,
+	ELE_COLD					= 1,
+	ELE_AIR						= 2,
+	ELE_EARTH					= 3,
+	ELE_WATER					= 4,
+	ELE_ELECTRICITY				= 5,
+	ELE_SMOKE					= 6,
+	ELE_MAGMA					= 7,
+	ELE_PLASMA					= 8,
+	ELE_ACID					= 9,
+	ELE_BLIZZARD				= 10,
+	ELE_FROST					= 11,
+	ELE_CRYSTAL					= 12,
+	ELE_ICE						= 13,
+	ELE_LIGHTNING				= 14,
+	ELE_MIST					= 15,
+	ELE_METAL					= 16,
+	ELE_OOZE					= 17,
+	ELE_NONE					= 18,
+};
 #define MAX_ELE						19
 
-#define ELE_TYPE_NONE				0
-#define ELE_TYPE_PRIMARY			1
-#define ELE_TYPE_PARA				2
+// Elemental slot type, an ordinal. Separate family from Element above.
+enum ElementSlot : int
+{
+	ELE_TYPE_NONE				= 0,
+	ELE_TYPE_PRIMARY			= 1,
+	ELE_TYPE_PARA				= 2,
+};
 
 #define MAT_TRANSLUCENT				0
 #define MAT_TRANSPARENT				1

--- a/code/merc.h
+++ b/code/merc.h
@@ -1086,38 +1086,48 @@ struct kill_data
 // Used in #MOBILES.
 //
 
-#define ACT_IS_NPC					0	// Auto set for mobs
-#define ACT_SENTINEL				1	// Stays in one room
-#define ACT_SCAVENGER				2	// Picks up objects
-#define ACT_WARD_MOB				3	// Ward mobs
-#define ACT_WANDER					4	// wanders
-#define ACT_AGGRESSIVE				5	// Attacks PC's
-#define ACT_STAY_AREA				6	// Won't leave area
-#define ACT_WIMPY					7
-#define ACT_PET						8	// Auto set for pets
-#define ACT_TRAIN					9	// Can train PC's
-#define ACT_PRACTICE				10	// Can practice PC's
-#define ACT_SMARTTRACK				11	// Will use pathfinding
-#define ACT_UNDEAD					14
-#define ACT_INNER_GUARDIAN			15	// yay.
-#define ACT_CLERIC					16
-#define ACT_MAGE					17
-#define ACT_INTELLIGENT 			18
-#define ACT_FAST_TRACK				19
-#define ACT_NOALIGN					20
-#define ACT_NOPURGE					21
-#define ACT_OUTDOORS				22
-#define ACT_INDOORS					24
-#define ACT_GUILDGUARD				25
-#define ACT_IS_HEALER				26
-#define ACT_GAIN					27
-#define ACT_UPDATE_ALWAYS			28
-#define ACT_DETECT_SPECIAL			29
-#define ACT_BANKER					30
-#define ACT_NOCTURNAL				31
-#define ACT_DIURNAL					32
-#define ACT_FASTWANDER				33
-#define ACT_LAW						34
+// Bit indices into char_data::act, mob_index_data::act and race_data::act.
+// NOTE: char_data::act carries PlrFlag as well -- the two families are disjoint
+// interpretations of one word, chosen by is_npc(). See flags.c's "act" vs "plr".
+// The values are a wire format (player files store them as letters keyed to the
+// index; area files resolve names through act_flags[]), so they may be renamed
+// but never renumbered. Gaps at 12, 13 and 23 are retired bits -- do not reuse
+// without checking existing player and area data.
+enum ActFlag : int
+{
+	ACT_IS_NPC					= 0,	// Auto set for mobs
+	ACT_SENTINEL				= 1,	// Stays in one room
+	ACT_SCAVENGER				= 2,	// Picks up objects
+	ACT_WARD_MOB				= 3,	// Ward mobs
+	ACT_WANDER					= 4,	// wanders
+	ACT_AGGRESSIVE				= 5,	// Attacks PC's
+	ACT_STAY_AREA				= 6,	// Won't leave area
+	ACT_WIMPY					= 7,
+	ACT_PET						= 8,	// Auto set for pets
+	ACT_TRAIN					= 9,	// Can train PC's
+	ACT_PRACTICE				= 10,	// Can practice PC's
+	ACT_SMARTTRACK				= 11,	// Will use pathfinding
+	ACT_UNDEAD					= 14,
+	ACT_INNER_GUARDIAN			= 15,	// yay.
+	ACT_CLERIC					= 16,
+	ACT_MAGE					= 17,
+	ACT_INTELLIGENT 			= 18,
+	ACT_FAST_TRACK				= 19,
+	ACT_NOALIGN					= 20,
+	ACT_NOPURGE					= 21,
+	ACT_OUTDOORS				= 22,
+	ACT_INDOORS					= 24,
+	ACT_GUILDGUARD				= 25,
+	ACT_IS_HEALER				= 26,
+	ACT_GAIN					= 27,
+	ACT_UPDATE_ALWAYS			= 28,
+	ACT_DETECT_SPECIAL			= 29,
+	ACT_BANKER					= 30,
+	ACT_NOCTURNAL				= 31,
+	ACT_DIURNAL					= 32,
+	ACT_FASTWANDER				= 33,
+	ACT_LAW						= 34,
+};
 
 //
 // damage classes
@@ -1890,30 +1900,42 @@ struct kill_data
 // Used in #ROOMS.
 //
 
-#define ROOM_DARK					0
-#define ROOM_NO_MOB					2
-#define ROOM_INDOORS				3
-#define ROOM_NO_CONSECRATE			4
-#define ROOM_PRIVATE				9
-#define ROOM_SAFE					10
-#define ROOM_SOLITARY				11
-#define ROOM_PET_SHOP				12
-#define ROOM_NO_RECALL				13
-#define ROOM_IMP_ONLY				14
-#define ROOM_GODS_ONLY				15
-#define ROOM_HEROES_ONLY			16
-#define ROOM_NEWBIES_ONLY			17
-#define ROOM_LAW					18
-#define ROOM_NOWHERE				19
-#define ROOM_NO_GATE				20
-#define ROOM_SILENCE				21
-#define ROOM_NO_SUMMON_TO			22
-#define ROOM_NO_SUMMON_FROM			23
-#define ROOM_NO_ALARM				25
-#define ROOM_FORCE_DUEL				27
-#define ROOM_NO_MAGIC				28
-#define ROOM_AREA_EXPLORE			29 // Don't use - Use area flags instead
-#define ROOM_NO_COMMUNE				30
+// Bit indices into room_index_data::room_flags. Also reachable through
+// room_affect_data::bitvector via TO_ROOM_FLAGS (handler.c).
+// Wire format -- rename freely, never renumber. Gaps at 1, 5-8, 24 and 26 are
+// retired bits; check existing area data before reusing any of them.
+//
+// NOTE: the ROOM_VNUM_* constants above are NOT part of this family. They are
+// room virtual numbers (values into the thousands), not bit indices, and they
+// share the prefix only by accident. ROOM_VNUM_LIMBO == 2 collides with
+// ROOM_NO_MOB == 2 harmlessly because the two are never used on the same thing.
+enum RoomFlag : int
+{
+	ROOM_DARK					= 0,
+	ROOM_NO_MOB					= 2,
+	ROOM_INDOORS				= 3,
+	ROOM_NO_CONSECRATE			= 4,
+	ROOM_PRIVATE				= 9,
+	ROOM_SAFE					= 10,
+	ROOM_SOLITARY				= 11,
+	ROOM_PET_SHOP				= 12,
+	ROOM_NO_RECALL				= 13,
+	ROOM_IMP_ONLY				= 14,
+	ROOM_GODS_ONLY				= 15,
+	ROOM_HEROES_ONLY			= 16,
+	ROOM_NEWBIES_ONLY			= 17,
+	ROOM_LAW					= 18,
+	ROOM_NOWHERE				= 19,
+	ROOM_NO_GATE				= 20,
+	ROOM_SILENCE				= 21,
+	ROOM_NO_SUMMON_TO			= 22,
+	ROOM_NO_SUMMON_FROM			= 23,
+	ROOM_NO_ALARM				= 25,
+	ROOM_FORCE_DUEL				= 27,
+	ROOM_NO_MAGIC				= 28,
+	ROOM_AREA_EXPLORE			= 29,	// Don't use - Use area flags instead
+	ROOM_NO_COMMUNE				= 30,
+};
 
 //
 // Exit flags.
@@ -2145,53 +2167,49 @@ struct kill_data
 // ACT bits for players.
 //
 
-#define PLR_IS_NPC					0 // Don't EVER set.
+// Bit indices into char_data::act -- the SAME field ActFlag uses, disambiguated
+// at runtime by is_npc(). Values collide with ActFlag deliberately and must not
+// be reconciled: PLR_AUTOABORT and ACT_SENTINEL are both bit 1 with unrelated
+// meanings. Wire format, as ActFlag -- rename freely, never renumber.
+// Gap at 18: see the "2 bits reserved" note, of which only 19 was ever taken.
+enum PlrFlag : int
+{
+	PLR_IS_NPC					= 0,	// Don't EVER set.
 
-//
-// RT auto flags
-//
+	// RT auto flags
+	PLR_AUTOABORT				= 1,
+	PLR_AUTOASSIST				= 2,
+	PLR_AUTOEXIT				= 3,
+	PLR_AUTOLOOT				= 4,
+	PLR_AUTOSAC					= 5,
+	PLR_AUTOGOLD				= 6,
+	PLR_AUTOSPLIT				= 7,
+	PLR_COLOR					= 8,
+	PLR_IGNORANT				= 9,
+	PLR_BETRAYER				= 10,
 
-#define PLR_AUTOABORT				1
-#define PLR_AUTOASSIST				2
-#define PLR_AUTOEXIT				3
-#define PLR_AUTOLOOT				4
-#define PLR_AUTOSAC					5
-#define PLR_AUTOGOLD				6
-#define PLR_AUTOSPLIT				7
-#define PLR_COLOR					8
-#define PLR_IGNORANT				9
-#define PLR_BETRAYER				10
+	// RT personal flags
+	PLR_CODER					= 11,
+	PLR_HEROIMM					= 12,
+	PLR_HOLYLIGHT				= 13,
+	PLR_EMPOWERED				= 14,
+	PLR_NOVOID					= 15,
+	PLR_NOSUMMON				= 16,
+	PLR_NOFOLLOW				= 17,
 
-//
-// RT personal flags
-//
+	// 2 bits reserved, S-T
+	PLR_NO_TRANSFER				= 19,
 
-#define PLR_CODER					11
-#define PLR_HEROIMM					12
-#define PLR_HOLYLIGHT				13
-#define PLR_EMPOWERED				14
-#define PLR_NOVOID					15
-#define PLR_NOSUMMON				16
-#define PLR_NOFOLLOW				17
-
-//
-// 2 bits reserved, S-T
-//
-
-#define PLR_NO_TRANSFER				19
-
-//
-// Bad flags
-//
-
-#define PLR_PERMIT					20
-#define PLR_MORON					21
-#define PLR_LOG						22
-#define PLR_DENY					23
-#define PLR_FREEZE					24
-#define PLR_THIEF					25
-#define PLR_KILLER					26
-#define PLR_CRIMINAL				27
+	// Bad flags
+	PLR_PERMIT					= 20,
+	PLR_MORON					= 21,
+	PLR_LOG						= 22,
+	PLR_DENY					= 23,
+	PLR_FREEZE					= 24,
+	PLR_THIEF					= 25,
+	PLR_KILLER					= 26,
+	PLR_CRIMINAL				= 27,
+};
 
 //
 // RT comm flags -- may be used on both mobs and chars
@@ -2200,7 +2218,7 @@ struct kill_data
 // Bit indices into char_data::comm. The values are a wire format -- they are
 // written to player files as letters keyed to the index (save.c print_flags),
 // so they may be renamed but never renumbered. Note the gap at 17.
-enum CommFlag : long
+enum CommFlag : int
 {
 	COMM_QUIET					= 0,
 	COMM_DEAF					= 1,

--- a/code/merc.h
+++ b/code/merc.h
@@ -883,23 +883,35 @@ struct obj_affect_data
 /// room applies
 //
 
-#define APPLY_ROOM_NONE				0
-#define APPLY_ROOM_HEAL				1
-#define APPLY_ROOM_MANA				2
-#define APPLY_ROOM_SECT				3
-#define APPLY_ROOM_NOPE				4
+// Room-affect apply locations. A separate family from the main APPLY_* below:
+// values 0-4 collide with APPLY_NONE..APPLY_WIS, so it must be its own enum.
+enum ApplyRoomLocation : int
+{
+	APPLY_ROOM_NONE				= 0,
+	APPLY_ROOM_HEAL				= 1,
+	APPLY_ROOM_MANA				= 2,
+	APPLY_ROOM_SECT				= 3,
+	APPLY_ROOM_NOPE				= 4,
+};
 
 //
 // obj applies
 //
 
-#define	APPLY_OBJ_NONE				0
-#define	APPLY_OBJ_V0				1
-#define	APPLY_OBJ_V1				2
-#define APPLY_OBJ_V2				3
-#define APPLY_OBJ_V3				4
-#define APPLY_OBJ_V4				5
-#define APPLY_OBJ_WEIGHT			6
+// Object apply locations (the obj->value[] slots). Another separate family --
+// values 0-6 collide with both APPLY_ROOM_* and the main APPLY_*. Note
+// APPLY_OBJ_PROPERTIES (100) below belongs with this family by name but sits
+// far outside the range; kept where the source had it.
+enum ApplyObjLocation : int
+{
+	APPLY_OBJ_NONE				= 0,
+	APPLY_OBJ_V0				= 1,
+	APPLY_OBJ_V1				= 2,
+	APPLY_OBJ_V2				= 3,
+	APPLY_OBJ_V3				= 4,
+	APPLY_OBJ_V4				= 5,
+	APPLY_OBJ_WEIGHT			= 6,
+};
 
 //
 // area applies
@@ -1834,50 +1846,57 @@ enum ItemWearFlag : int
 // Used in #OBJECTS.
 //
 
-#define APPLY_NONE					0
-#define APPLY_STR					1
-#define APPLY_DEX					2
-#define APPLY_INT					3
-#define APPLY_WIS					4
-#define APPLY_CON					5
-#define APPLY_SEX					6
-#define APPLY_CLASS					7
-#define APPLY_LUCK					8 // UNUSED!!
-#define APPLY_AGE					9
-#define APPLY_HEIGHT				10
-#define APPLY_WEIGHT				11
-#define APPLY_MANA					12
-#define APPLY_HIT					13
-#define APPLY_MOVE					14
-#define APPLY_GOLD					15
-#define APPLY_EXP					16
-#define APPLY_AC					17
-#define APPLY_HITROLL				18
-#define APPLY_DAMROLL				19
-#define APPLY_SAVES					20
-#define APPLY_SAVING_PARA			21
-#define APPLY_SAVING_ROD			22
-#define APPLY_SAVING_PETRI			23
-#define APPLY_SAVING_BREATH			24
-#define APPLY_SAVING_SPELL			25
-#define APPLY_SPELL_AFFECT			26
-#define APPLY_CARRY_WEIGHT			27
-#define APPLY_DEFENSE				28
-#define APPLY_REGENERATION			29
-#define APPLY_SIZE					30
-#define APPLY_ENERGYSTATE			31
-#define APPLY_DAM_MOD				32
-#define APPLY_LEGS					33
-#define APPLY_ARMS					34
-#define APPLY_BEAUTY				35
-#define APPLY_ALIGNMENT				36
-#define APPLY_ETHOS					37
+// The main apply-location family: affect_data::location, an ordinal scalar
+// (short), not a bit field. Compared with == and switched on. APPLY_ROOM_* and
+// APPLY_OBJ_* (above) are separate families on separate location fields.
+// Wire format -- rename freely, never renumber.
+enum ApplyLocation : int
+{
+	APPLY_NONE					= 0,
+	APPLY_STR					= 1,
+	APPLY_DEX					= 2,
+	APPLY_INT					= 3,
+	APPLY_WIS					= 4,
+	APPLY_CON					= 5,
+	APPLY_SEX					= 6,
+	APPLY_CLASS					= 7,
+	APPLY_LUCK					= 8,	// UNUSED!!
+	APPLY_AGE					= 9,
+	APPLY_HEIGHT				= 10,
+	APPLY_WEIGHT				= 11,
+	APPLY_MANA					= 12,
+	APPLY_HIT					= 13,
+	APPLY_MOVE					= 14,
+	APPLY_GOLD					= 15,
+	APPLY_EXP					= 16,
+	APPLY_AC					= 17,
+	APPLY_HITROLL				= 18,
+	APPLY_DAMROLL				= 19,
+	APPLY_SAVES					= 20,
+	APPLY_SAVING_PARA			= 21,
+	APPLY_SAVING_ROD			= 22,
+	APPLY_SAVING_PETRI			= 23,
+	APPLY_SAVING_BREATH			= 24,
+	APPLY_SAVING_SPELL			= 25,
+	APPLY_SPELL_AFFECT			= 26,
+	APPLY_CARRY_WEIGHT			= 27,
+	APPLY_DEFENSE				= 28,
+	APPLY_REGENERATION			= 29,
+	APPLY_SIZE					= 30,
+	APPLY_ENERGYSTATE			= 31,
+	APPLY_DAM_MOD				= 32,
+	APPLY_LEGS					= 33,
+	APPLY_ARMS					= 34,
+	APPLY_BEAUTY				= 35,
+	APPLY_ALIGNMENT				= 36,
+	APPLY_ETHOS					= 37,
+	// APPLY_OBJ_PROPERTIES == 100 lived here originally, in the main family's
+	// numbering despite its APPLY_OBJ_ name. Kept in this enum, at its value.
+	APPLY_OBJ_PROPERTIES		= 100,
+};
 
-//
-// object affect applies.
-//
-
-#define APPLY_OBJ_PROPERTIES		100
+// APPLY_OBJ_PROPERTIES (== 100) moved into enum ApplyLocation above -- it was
+// always numbered in that family despite its name.
 
 //
 // Modifier Names

--- a/code/merc.h
+++ b/code/merc.h
@@ -1171,33 +1171,41 @@ enum ActFlag : int
 // OFF bits for mobiles
 //
 
-#define OFF_AREA_ATTACK				0
-#define OFF_BACKSTAB				1
-#define OFF_BASH					2
-#define OFF_BERSERK					3
-#define OFF_DISARM					4
-#define OFF_DODGE					5
-#define OFF_FADE					6 // UNUSED
-#define OFF_FAST					7
-#define OFF_KICK					8
-#define OFF_KICK_DIRT				9
-#define OFF_PARRY					10
-#define OFF_RESCUE					11
-#define OFF_TAIL					12
-#define OFF_TRIP					13
-#define OFF_CRUSH					14
-#define ASSIST_ALL					15
-#define ASSIST_ALIGN				16
-#define ASSIST_RACE					17
-#define ASSIST_PLAYERS				18
-#define ASSIST_GUARD				19
-#define ASSIST_VNUM					20
-#define NO_TRACK					21
-#define STATIC_TRACKING				22
-#define SPAM_MURDER					23
-#define OFF_INTIMIDATED				24
-#define OFF_UNDEAD_DRAIN			25	// True undead drain, very powerful
-#define ASSIST_GROUP				26
+// Offensive/assist bit indices into char_data::off_flags and
+// mob_index_data::off_flags. One contiguous 0-26 numbering carrying five name
+// prefixes (OFF_, ASSIST_, NO_, STATIC_, SPAM_) -- they are a single family that
+// was never given a single prefix, not distinct families. Kept as one enum with
+// the original names. Wire format -- rename freely, never renumber.
+enum OffFlag : int
+{
+	OFF_AREA_ATTACK				= 0,
+	OFF_BACKSTAB				= 1,
+	OFF_BASH					= 2,
+	OFF_BERSERK					= 3,
+	OFF_DISARM					= 4,
+	OFF_DODGE					= 5,
+	OFF_FADE					= 6,	// UNUSED
+	OFF_FAST					= 7,
+	OFF_KICK					= 8,
+	OFF_KICK_DIRT				= 9,
+	OFF_PARRY					= 10,
+	OFF_RESCUE					= 11,
+	OFF_TAIL					= 12,
+	OFF_TRIP					= 13,
+	OFF_CRUSH					= 14,
+	ASSIST_ALL					= 15,
+	ASSIST_ALIGN				= 16,
+	ASSIST_RACE					= 17,
+	ASSIST_PLAYERS				= 18,
+	ASSIST_GUARD				= 19,
+	ASSIST_VNUM					= 20,
+	NO_TRACK					= 21,
+	STATIC_TRACKING				= 22,
+	SPAM_MURDER					= 23,
+	OFF_INTIMIDATED				= 24,
+	OFF_UNDEAD_DRAIN			= 25,	// True undead drain, very powerful
+	ASSIST_GROUP				= 26,
+};
 
 //
 // return values for check_imm
@@ -1212,89 +1220,109 @@ enum ActFlag : int
 // IMM bits for mobs
 //
 
-#define IMM_SUMMON					0
-#define IMM_CHARM					1
-#define IMM_MAGIC					2
-#define IMM_WEAPON					3
-#define IMM_BASH					4
-#define IMM_PIERCE					5
-#define IMM_SLASH					6
-#define IMM_FIRE					7
-#define IMM_COLD					8
-#define IMM_LIGHTNING				9
-#define IMM_ACID					10
-#define IMM_POISON					11
-#define IMM_NEGATIVE				12
-#define IMM_HOLY					13
-#define IMM_ENERGY					14
-#define IMM_MENTAL					15
-#define IMM_DISEASE					16
-#define IMM_DROWNING				17
-#define IMM_LIGHT					18
-#define IMM_SOUND					19
-#define IMM_INTERNAL				20
-#define IMM_MITHRIL					23
-#define IMM_SILVER					24
-#define IMM_IRON					25
-#define IMM_SLEEP					26
+// Immunity bit indices, into char_data::imm_flags (and affect_data::bitvector
+// where where == TO_IMMUNE). IMM_/RES_/VULN_ are three value-identical parallel
+// families -- same damage domain, three storages. The flag tables and the area
+// file format route all three through the imm_flags table (flags.c, db2.c), so
+// they are effectively one namespace on disk; they are kept as three enums here
+// only because their C names differ (IMM_SUMMON vs RES_SUMMON) and renaming call
+// sites is out of scope. See phase-02 §0.8.2. Wire format -- never renumber.
+enum ImmuneFlag : int
+{
+	IMM_SUMMON					= 0,
+	IMM_CHARM					= 1,
+	IMM_MAGIC					= 2,
+	IMM_WEAPON					= 3,
+	IMM_BASH					= 4,
+	IMM_PIERCE					= 5,
+	IMM_SLASH					= 6,
+	IMM_FIRE					= 7,
+	IMM_COLD					= 8,
+	IMM_LIGHTNING				= 9,
+	IMM_ACID					= 10,
+	IMM_POISON					= 11,
+	IMM_NEGATIVE				= 12,
+	IMM_HOLY					= 13,
+	IMM_ENERGY					= 14,
+	IMM_MENTAL					= 15,
+	IMM_DISEASE					= 16,
+	IMM_DROWNING				= 17,
+	IMM_LIGHT					= 18,
+	IMM_SOUND					= 19,
+	IMM_INTERNAL				= 20,
+	IMM_MITHRIL					= 23,
+	IMM_SILVER					= 24,
+	IMM_IRON					= 25,
+	IMM_SLEEP					= 26,	// no RES_/VULN_ counterpart
+};
 
 //
 // RES bits for mobs
 //
 
-#define RES_SUMMON					0
-#define RES_CHARM					1
-#define RES_MAGIC					2
-#define RES_WEAPON					3
-#define RES_BASH					4
-#define RES_PIERCE					5
-#define RES_SLASH					6
-#define RES_FIRE					7
-#define RES_COLD					8
-#define RES_LIGHTNING				9
-#define RES_ACID					10
-#define RES_POISON					11
-#define RES_NEGATIVE				12
-#define RES_HOLY					13
-#define RES_ENERGY					14
-#define RES_MENTAL					15
-#define RES_DISEASE					16
-#define RES_DROWNING				17
-#define RES_LIGHT					18
-#define RES_SOUND					19
-#define RES_INTERNAL				20
-#define RES_MITHRIL					23
-#define RES_SILVER					24
-#define RES_IRON					25
+// Resistance bit indices, into char_data::res_flags. Parallel to ImmuneFlag --
+// see the note there. Stops at 25; no RES_SLEEP.
+enum ResistFlag : int
+{
+	RES_SUMMON					= 0,
+	RES_CHARM					= 1,
+	RES_MAGIC					= 2,
+	RES_WEAPON					= 3,
+	RES_BASH					= 4,
+	RES_PIERCE					= 5,
+	RES_SLASH					= 6,
+	RES_FIRE					= 7,
+	RES_COLD					= 8,
+	RES_LIGHTNING				= 9,
+	RES_ACID					= 10,
+	RES_POISON					= 11,
+	RES_NEGATIVE				= 12,
+	RES_HOLY					= 13,
+	RES_ENERGY					= 14,
+	RES_MENTAL					= 15,
+	RES_DISEASE					= 16,
+	RES_DROWNING				= 17,
+	RES_LIGHT					= 18,
+	RES_SOUND					= 19,
+	RES_INTERNAL				= 20,
+	RES_MITHRIL					= 23,
+	RES_SILVER					= 24,
+	RES_IRON					= 25,
+};
  
 //
 // VULN bits for mobs
 //
 
-#define VULN_SUMMON					0
-#define VULN_CHARM					1
-#define VULN_MAGIC					2
-#define VULN_WEAPON					3
-#define VULN_BASH					4
-#define VULN_PIERCE					5
-#define VULN_SLASH					6
-#define VULN_FIRE					7
-#define VULN_COLD					8
-#define VULN_LIGHTNING				9
-#define VULN_ACID					10
-#define VULN_POISON					11
-#define VULN_NEGATIVE				12
-#define VULN_HOLY					13
-#define VULN_ENERGY					14
-#define VULN_MENTAL					15
-#define VULN_DISEASE				16
-#define VULN_DROWNING				17
-#define VULN_LIGHT					18
-#define VULN_SOUND					19
-#define VULN_INTERNAL				20
-#define VULN_MITHRIL				23
-#define VULN_SILVER					24
-#define VULN_IRON					25
+// Vulnerability bit indices, into char_data::vuln_flags. Parallel to ImmuneFlag
+// -- see the note there. Stops at 25; no VULN_SLEEP.
+enum VulnFlag : int
+{
+	VULN_SUMMON					= 0,
+	VULN_CHARM					= 1,
+	VULN_MAGIC					= 2,
+	VULN_WEAPON					= 3,
+	VULN_BASH					= 4,
+	VULN_PIERCE					= 5,
+	VULN_SLASH					= 6,
+	VULN_FIRE					= 7,
+	VULN_COLD					= 8,
+	VULN_LIGHTNING				= 9,
+	VULN_ACID					= 10,
+	VULN_POISON					= 11,
+	VULN_NEGATIVE				= 12,
+	VULN_HOLY					= 13,
+	VULN_ENERGY					= 14,
+	VULN_MENTAL					= 15,
+	VULN_DISEASE				= 16,
+	VULN_DROWNING				= 17,
+	VULN_LIGHT					= 18,
+	VULN_SOUND					= 19,
+	VULN_INTERNAL				= 20,
+	VULN_MITHRIL				= 23,
+	VULN_SILVER					= 24,
+	VULN_IRON					= 25,
+};
 
 //
 // body form

--- a/code/rift.h
+++ b/code/rift.h
@@ -4,7 +4,8 @@
 #define STATE_INVALID	0
 #define STATE_VALID		1
 
-#define MAX_EXITS		6
+// MAX_EXITS removed -- it duplicated MAX_EXIT (direction.h), which is the count
+// of the Directions enum and the natural home. Both were 6.
 
 #include "stdlibs/bitvector.h"
 #include "stdlibs/strings.h"

--- a/code/save.c
+++ b/code/save.c
@@ -363,15 +363,15 @@ void fwrite_char(CHAR_DATA *ch, FILE *fp)
 
 		fprintf(fp, "Exp  %d\n", ch->exp);
 
-		if (ch->act != 0)
+		if (!IS_ZERO_VECTOR(ch->act))
 			fprintf(fp, "Act  %s\n", print_flags(ch->act));
 
-		if (ch->affected_by != 0)
+		if (!IS_ZERO_VECTOR(ch->affected_by))
 			fprintf(fp, "AfBy %s\n", print_flags(ch->affected_by));
 
 		fprintf(fp, "Comm %s\n", print_flags(ch->comm));
 
-		if (ch->wiznet)
+		if (!IS_ZERO_VECTOR(ch->wiznet))
 			fprintf(fp, "Wizn %s\n", print_flags(ch->wiznet));
 
 		if (ch->invis_level)
@@ -689,13 +689,13 @@ void fwrite_pet(CHAR_DATA *pet, FILE *fp)
 	if (pet->exp > 0)
 		fprintf(fp, "Exp  %d\n", pet->exp);
 
-	if (pet->act != pet->pIndexData->act)
+	if (!vector_equal(pet->act, pet->pIndexData->act))
 		fprintf(fp, "Act  %s\n", print_flags(pet->act));
 
-	if (pet->affected_by != pet->pIndexData->affected_by)
+	if (!vector_equal(pet->affected_by, pet->pIndexData->affected_by))
 		fprintf(fp, "AfBy %s\n", print_flags(pet->affected_by));
 
-	if (pet->comm != 0)
+	if (!IS_ZERO_VECTOR(pet->comm))
 		fprintf(fp, "Comm %s\n", print_flags(pet->comm));
 
 	fprintf(fp, "Pos  %d\n", pet->position = POS_FIGHTING ? POS_STANDING : pet->position);

--- a/code/stdlibs/bitvector.h
+++ b/code/stdlibs/bitvector.h
@@ -1,7 +1,7 @@
 #ifndef BITVECTOR_H
 #define BITVECTOR_H
 
-#define ARR(x) x < 32 ? 0 : 1
+#define ARR(x) ((x) < 32 ? 0 : 1)
 
 class CBitvector
 {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -11,6 +11,7 @@ set_target_properties(TestMain PROPERTIES LINKER_LANGUAGE CXX)
 
 set(TEST_SRC_FILES act_obj_tests.c
 	ban_tests.c
+	bitflag_tests.c
 	bug_tests.c
 	cabal_tests.c
 	class_tests.c

--- a/tests/ban_tests.c
+++ b/tests/ban_tests.c
@@ -2,16 +2,7 @@
 #include <algorithm>
 #include "db_mocks.h"
 #include "../code/repositories/banrepository.h"
-
-// These NBAN_* values mirror ban.h because if we include that header, 
-// it pulls in merc.h which leads to compilation errors. Once we break 
-// the dependency on merc.h, we can remove these duplicates and include 
-// ban.h instead.
-
-static const int TEST_NBAN_ALL		= 0;
-static const int TEST_NBAN_NEWBIE	= 1;
-static const int TEST_NBAN_IP		= 1;
-static const int TEST_NBAN_HOST		= 0;
+#include "../code/banflags.h"
 
 SCENARIO("finding bans by type", "[ban][repository]")
 {
@@ -25,7 +16,7 @@ SCENARIO("finding bans by type", "[ban][repository]")
 
 		WHEN("FindByType is called")
 		{
-			auto bans = repo.FindByType(TEST_NBAN_NEWBIE, TEST_NBAN_HOST);
+			auto bans = repo.FindByType(NBAN_NEWBIE, NBAN_HOST);
 
 			THEN("it issues a single parameterised query with the type bound, not interpolated")
 			{
@@ -57,7 +48,7 @@ SCENARIO("finding bans by type", "[ban][repository]")
 
 		WHEN("FindByType is called")
 		{
-			auto bans = repo.FindByType(TEST_NBAN_ALL, TEST_NBAN_IP);
+			auto bans = repo.FindByType(NBAN_ALL, NBAN_IP);
 
 			THEN("it returns nothing but still binds the requested type")
 			{
@@ -125,8 +116,8 @@ SCENARIO("adding a ban", "[ban][repository]")
 		ban.reason = "testing";
 		ban.date = "2026-07-11";
 		ban.duration = -1;
-		ban.ban_type = TEST_NBAN_NEWBIE;
-		ban.host_type = TEST_NBAN_IP;
+		ban.ban_type = NBAN_NEWBIE;
+		ban.host_type = NBAN_IP;
 
 		BanRepository repo(db);
 

--- a/tests/bitflag_tests.c
+++ b/tests/bitflag_tests.c
@@ -1,0 +1,276 @@
+#include <math.h>
+#include "catch.hpp"
+#include "../code/merc.h"
+#include "../code/stdlibs/bitvector.h"
+
+// Equivalence proofs for the bitflag operator rewrite.
+//
+// The pre-rewrite operators are reproduced below *verbatim*
+// renamed with a LEGACY_ prefix. They are copied as text on
+// purpose: asserting the new shift-based macros against a 
+// hand-written pow() expression would only prove that expression
+// equal to itself. Comparing against the actual retired macro body 
+// is what makes this a proof rather than a restatement.
+
+// array flags
+#define LEGACY_IS_SET(flag, bit)		((flag[(int)(bit/32)]) & ((long)pow(2,(bit % 32))))
+#define LEGACY_SET_BIT(var, bit)		((var[(int)bit/32]) |= ((long)pow(2,bit % 32)))
+#define LEGACY_REMOVE_BIT(var, bit)		((var[bit/32]) &= ~((long)pow(2,bit % 32)))
+
+// scalar flags
+#define LEGACY_IS_SET_OLD(flag, bit)	(flag & ((long)pow(2,bit)))
+#define LEGACY_SET_BIT_OLD(var, bit)	(var |= (long)pow(2,bit))
+#define LEGACY_REMOVE_BIT_OLD(var,bit)	(var &= ~((long)pow(2,bit)))
+
+// Word patterns exercised against every bit position. Exhaustive over *flag
+// values* is 2^128 for the array family, so the domain is (every bit) x (a set
+// of patterns chosen to cover both polarities, alternating neighbours, and the
+// isolated-bit case). Every bit position is covered totally; that is the axis
+// the rewrite could plausibly get wrong.
+static const long WORD_PATTERNS[] = {
+	0L,
+	~0L,
+	0x55555555L,
+	0xAAAAAAAAL,
+	0x00000001L,
+	0x80000000L,
+	0x0000FFFFL,
+	0xFFFF0000L,
+};
+
+static const int PATTERN_COUNT = sizeof(WORD_PATTERNS) / sizeof(WORD_PATTERNS[0]);
+
+// The array operators divide the bit by 32 and index, so bits 0..63 span both
+// words of a long[MAX_BITVECTOR]. The shift is always (bit % 32), i.e. 0..31,
+// where both (long)pow(2,n) and 1L << n are well defined.
+static const int ARRAY_BIT_MAX = 64;
+
+// The scalar operators shift by the absolute bit, so 63 would be a 1L << 63 on
+// a signed long, undefined in both the old and new spelling, and not a domain
+// the codebase uses (these overwhelmingly operate on obj->value[N], an int).
+// The proof therefore runs 0..62, which is total over every defined input.
+static const int SCALAR_BIT_MAX = 63;
+
+TEST_CASE("IS_SET matches the retired pow() macro for every bit", "[bitflag]")
+{
+	for (int bit = 0; bit < ARRAY_BIT_MAX; bit++)
+	{
+		for (int i = 0; i < PATTERN_COUNT; i++)
+		{
+			for (int j = 0; j < PATTERN_COUNT; j++)
+			{
+				long flag[MAX_BITVECTOR] = { WORD_PATTERNS[i], WORD_PATTERNS[j] };
+
+				INFO("bit=" << bit << " word0=" << flag[0] << " word1=" << flag[1]);
+				REQUIRE(!!IS_SET(flag, bit) == !!LEGACY_IS_SET(flag, bit));
+				REQUIRE(IS_SET(flag, bit) == LEGACY_IS_SET(flag, bit));
+			}
+		}
+	}
+}
+
+TEST_CASE("SET_BIT matches the retired pow() macro for every bit", "[bitflag]")
+{
+	for (int bit = 0; bit < ARRAY_BIT_MAX; bit++)
+	{
+		for (int i = 0; i < PATTERN_COUNT; i++)
+		{
+			for (int j = 0; j < PATTERN_COUNT; j++)
+			{
+				long fresh[MAX_BITVECTOR] = { WORD_PATTERNS[i], WORD_PATTERNS[j] };
+				long legacy[MAX_BITVECTOR] = { WORD_PATTERNS[i], WORD_PATTERNS[j] };
+
+				SET_BIT(fresh, bit);
+				LEGACY_SET_BIT(legacy, bit);
+
+				INFO("bit=" << bit << " word0=" << WORD_PATTERNS[i] << " word1=" << WORD_PATTERNS[j]);
+				REQUIRE(fresh[0] == legacy[0]);
+				REQUIRE(fresh[1] == legacy[1]);
+			}
+		}
+	}
+}
+
+TEST_CASE("REMOVE_BIT matches the retired pow() macro for every bit", "[bitflag]")
+{
+	for (int bit = 0; bit < ARRAY_BIT_MAX; bit++)
+	{
+		for (int i = 0; i < PATTERN_COUNT; i++)
+		{
+			for (int j = 0; j < PATTERN_COUNT; j++)
+			{
+				long fresh[MAX_BITVECTOR] = { WORD_PATTERNS[i], WORD_PATTERNS[j] };
+				long legacy[MAX_BITVECTOR] = { WORD_PATTERNS[i], WORD_PATTERNS[j] };
+
+				REMOVE_BIT(fresh, bit);
+				LEGACY_REMOVE_BIT(legacy, bit);
+
+				INFO("bit=" << bit << " word0=" << WORD_PATTERNS[i] << " word1=" << WORD_PATTERNS[j]);
+				REQUIRE(fresh[0] == legacy[0]);
+				REQUIRE(fresh[1] == legacy[1]);
+			}
+		}
+	}
+}
+
+TEST_CASE("IS_SET_OLD matches the retired pow() macro for every bit", "[bitflag]")
+{
+	for (int bit = 0; bit < SCALAR_BIT_MAX; bit++)
+	{
+		for (int i = 0; i < PATTERN_COUNT; i++)
+		{
+			long flag = WORD_PATTERNS[i];
+
+			INFO("bit=" << bit << " flag=" << flag);
+			REQUIRE(!!IS_SET_OLD(flag, bit) == !!LEGACY_IS_SET_OLD(flag, bit));
+			REQUIRE(IS_SET_OLD(flag, bit) == LEGACY_IS_SET_OLD(flag, bit));
+		}
+	}
+}
+
+TEST_CASE("SET_BIT_OLD matches the retired pow() macro for every bit", "[bitflag]")
+{
+	for (int bit = 0; bit < SCALAR_BIT_MAX; bit++)
+	{
+		for (int i = 0; i < PATTERN_COUNT; i++)
+		{
+			long fresh = WORD_PATTERNS[i];
+			long legacy = WORD_PATTERNS[i];
+
+			SET_BIT_OLD(fresh, bit);
+			LEGACY_SET_BIT_OLD(legacy, bit);
+
+			INFO("bit=" << bit << " flag=" << WORD_PATTERNS[i]);
+			REQUIRE(fresh == legacy);
+		}
+	}
+}
+
+TEST_CASE("REMOVE_BIT_OLD matches the retired pow() macro for every bit", "[bitflag]")
+{
+	for (int bit = 0; bit < SCALAR_BIT_MAX; bit++)
+	{
+		for (int i = 0; i < PATTERN_COUNT; i++)
+		{
+			long fresh = WORD_PATTERNS[i];
+			long legacy = WORD_PATTERNS[i];
+
+			REMOVE_BIT_OLD(fresh, bit);
+			LEGACY_REMOVE_BIT_OLD(legacy, bit);
+
+			INFO("bit=" << bit << " flag=" << WORD_PATTERNS[i]);
+			REQUIRE(fresh == legacy);
+		}
+	}
+}
+
+// TOGGLE_BIT / TOGGLE_BIT_OLD (merc.h:3264-3265) are defined in terms of the six
+// operators above, so they inherit the rewrite rather than being rewritten. They
+// are covered here because phase-02 §2 did not enumerate them and they are the
+// operators most exposed to the double-evaluation hazard: TOGGLE_BIT expands its
+// `bit` argument six times.
+TEST_CASE("TOGGLE_BIT flips exactly the requested bit", "[bitflag]")
+{
+	for (int bit = 0; bit < ARRAY_BIT_MAX; bit++)
+	{
+		for (int i = 0; i < PATTERN_COUNT; i++)
+		{
+			for (int j = 0; j < PATTERN_COUNT; j++)
+			{
+				long flag[MAX_BITVECTOR] = { WORD_PATTERNS[i], WORD_PATTERNS[j] };
+				bool wasSet = !!IS_SET(flag, bit);
+
+				TOGGLE_BIT(flag, bit);
+
+				INFO("bit=" << bit << " word0=" << WORD_PATTERNS[i] << " word1=" << WORD_PATTERNS[j]);
+				REQUIRE(!!IS_SET(flag, bit) == !wasSet);
+
+				// every other bit is untouched
+				long expected[MAX_BITVECTOR] = { WORD_PATTERNS[i], WORD_PATTERNS[j] };
+				expected[bit / 32] ^= (1L << (bit % 32));
+				REQUIRE(flag[0] == expected[0]);
+				REQUIRE(flag[1] == expected[1]);
+			}
+		}
+	}
+}
+
+TEST_CASE("TOGGLE_BIT_OLD flips exactly the requested bit", "[bitflag]")
+{
+	for (int bit = 0; bit < SCALAR_BIT_MAX; bit++)
+	{
+		for (int i = 0; i < PATTERN_COUNT; i++)
+		{
+			long flag = WORD_PATTERNS[i];
+			bool wasSet = !!IS_SET_OLD(flag, bit);
+
+			TOGGLE_BIT_OLD(flag, bit);
+
+			INFO("bit=" << bit << " flag=" << WORD_PATTERNS[i]);
+			REQUIRE(!!IS_SET_OLD(flag, bit) == !wasSet);
+			REQUIRE(flag == (WORD_PATTERNS[i] ^ (1L << bit)));
+		}
+	}
+}
+
+// The rewrite adds the parentheses the originals lacked entirely. Without them
+// an argument that is an expression rather than an identifier binds wrong:
+// IS_SET(f, a + b) expanded to f[(int)(a + b/32)] — b/32, not (a+b)/32.
+TEST_CASE("bitflag operators accept expression arguments", "[bitflag]")
+{
+	long flag[MAX_BITVECTOR] = { 0L, 0L };
+	int base = 30;
+	int offset = 3;
+
+	SET_BIT(flag, base + offset);
+	REQUIRE(flag[1] == 0x2L);				// bit 33 -> word 1, offset 1
+	REQUIRE(flag[0] == 0L);
+	REQUIRE(!!IS_SET(flag, base + offset));
+
+	REMOVE_BIT(flag, base + offset);
+	REQUIRE(flag[0] == 0L);
+	REQUIRE(flag[1] == 0L);
+
+	long scalar = 0L;
+	SET_BIT_OLD(scalar, base + offset);
+	REQUIRE(scalar == (1L << 33));
+	REQUIRE(!!IS_SET_OLD(scalar, base + offset));
+
+	REMOVE_BIT_OLD(scalar, base + offset);
+	REQUIRE(scalar == 0L);
+}
+
+// ARR(x) in stdlibs/bitvector.h had the same defect and the same fix.
+//
+// ARR expands a bare conditional, so it must be assigned out before Catch sees
+// it. REQUIRE(ARR(x) == n) hands the `<` to Catch's expression decomposition
+// and does not compile.
+TEST_CASE("ARR maps a bit to its word index", "[bitflag]")
+{
+	int word0 = ARR(0);
+	int word31 = ARR(31);
+	int word32 = ARR(32);
+	int word63 = ARR(63);
+
+	REQUIRE(word0 == 0);
+	REQUIRE(word31 == 0);
+	REQUIRE(word32 == 1);
+	REQUIRE(word63 == 1);
+}
+
+// The actual defect. ARR's body was an unparenthesized `x < 32 ? 0 : 1`, so any
+// use inside a larger expression re-associated: `1 + ARR(32)` expanded to
+// `1 + 32 < 32 ? 0 : 1`, i.e. `(33 < 32) ? 0 : 1` == 1, not 2.
+//
+// Note the argument side is *not* the hazard it looks like: `+`, `<<` and `>`
+// all bind at least as tightly as `<`, so ARR(a + b) happened to work. It is the
+// missing outer parentheses that bite, which is why this is the case that fails
+// against the pre-fix header.
+TEST_CASE("ARR binds correctly inside a larger expression", "[bitflag]")
+{
+	int embedded = 1 + ARR(32);
+	REQUIRE(embedded == 2);
+
+	int doubled = 2 * ARR(32);
+	REQUIRE(doubled == 2);
+}

--- a/tests/constant_folding_check.sh
+++ b/tests/constant_folding_check.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+#
+# Standing check that the bitflag operators do not drag a libm call
+# into every flag test.
+#
+# This is the one assertion a Catch2 test cannot make: it is about 
+# generated code, not values. It inspects a *real* object file from
+# a real build and asserts that no relocation against `pow` survives.
+#
+# From a planning-time measurement, that "GCC constant-folds pow(2, ACT_IS_NPC)
+# at *every* optimization level including -O0", and concluded that only ~60
+# runtime-variable sites paid a real call. Re-measuring while executing
+# Commit 1 showed that is FALSE for this codebase.
+#
+# Measured on code/handler.c (GCC 13, x86-64, the project's default Debug/-O0):
+#
+#     pre-rewrite  (pow macros):  308 pow relocations
+#     post-rewrite (shift macros):  0 pow relocations
+#
+# 308 is exactly handler.c's count of IS_SET/SET_BIT/REMOVE_BIT uses. Every one
+# emitted a libm call. Not ~60 sites tree-wide -- every site, in the default
+# build.
+#
+# Notes on measurement and the trap that can cause errors:
+#
+#   * In C, pow(2,n) is a GCC builtin and folds even at -O0. That is almost
+#     certainly what was compiled.
+#   * This codebase compiles every .c as C++17 (README §2 -- code/CMakeLists.txt
+#     forces LANGUAGE CXX). In C++, `pow(2, bit)` with two int arguments resolves
+#     to the std::pow<int,int> template in <cmath>, an ordinary function call
+#     that GCC does not fold at -O0. It folds only at -O1 and above, and even
+#     then only when the bit is a compile-time constant.
+#
+# A second trap, worth recording because it nearly reproduced the original error:
+# in an unlinked .o the call target is not yet resolved, so `objdump -d | grep
+# pow` shows `call <probe+0x27>` and reports a false negative. The relocations
+# are the truth. This script greps relocations for that reason.
+#
+# This pins the claim to *this* toolchain and *this* build type. A compiler
+# upgrade can invalidate it, and that is the point -- it should fail loudly
+# rather than leave the plan asserting something no longer true.
+#
+# It checks one representative translation unit, not all of them. handler.c is
+# chosen because it has the most flag operations of any file (308) and uses no
+# other libm function, so any pow relocation in it is necessarily from the flag
+# path. Files that legitimately call pow (bitvector.c, and anything using
+# spec.h's BV macro) are deliberately out of scope -- see phase-02 §6.
+#
+# Config:
+#   CF_OBJ    path to the object file to inspect (auto-detected otherwise)
+#   CF_SRC    source file the object was built from (default code/handler.c)
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+SRC="${CF_SRC:-$REPO_ROOT/code/handler.c}"
+OBJ_NAME="$(basename "$SRC").o"
+
+# --- locate the object file ----------------------------------------------------
+OBJ="${CF_OBJ:-}"
+if [[ -z "$OBJ" ]]; then
+	newest=""
+	while IFS= read -r cand; do
+		if [[ -z "$newest" ]] || [[ "$cand" -nt "$newest" ]]; then
+			newest="$cand"
+		fi
+	done < <(find "$REPO_ROOT" -name "$OBJ_NAME" -path '*RiftCore.dir*' 2>/dev/null)
+	OBJ="$newest"
+fi
+
+if [[ -z "$OBJ" || ! -f "$OBJ" ]]; then
+	echo "CF SKIP: no built $OBJ_NAME found. Build RiftCore first, or set CF_OBJ."
+	exit 77
+fi
+
+# --- staleness guard -----------------------------------------------------------
+# The auto-detect only searches under the repo, so an out-of-tree build dir is
+# invisible to it and a leftover object from an older build gets picked instead.
+# That is not hypothetical: it happened while writing this check, and it reported
+# a confident FAIL against an object built before the rewrite. The same mechanism
+# can just as easily report a false PASS, which is worse. So: refuse to answer
+# unless the object is demonstrably newer than the inputs that determine it.
+for input in "$SRC" "$REPO_ROOT/code/merc.h"; do
+	if [[ "$input" -nt "$OBJ" ]]; then
+		echo "CF FAIL: $(basename "$OBJ") is older than $(basename "$input") -- it is stale."
+		echo "  object: $OBJ"
+		echo "  input:  $input"
+		echo
+		echo "Rebuild RiftCore, or point CF_OBJ at the object from the build you mean"
+		echo "to check. An out-of-tree build directory is not auto-detected."
+		exit 1
+	fi
+done
+
+# --- sanity: the source must actually exercise the flag operators --------------
+ops="$(grep -cE '\b(IS_SET|SET_BIT|REMOVE_BIT|TOGGLE_BIT)(_OLD)?\b' "$SRC" || true)"
+if [[ "$ops" -eq 0 ]]; then
+	echo "CF FAIL: $SRC contains no flag operations, so this check proves nothing."
+	echo "Pick a different CF_SRC/CF_OBJ pair."
+	exit 1
+fi
+
+# --- sanity: the source must not use libm for anything else --------------------
+# Otherwise a pow relocation could not be attributed to the flag path.
+if grep -qE '\b(pow|sqrt|exp|log|sin|cos|tan)\s*\(' "$SRC"; then
+	echo "CF FAIL: $SRC calls a libm function directly, so a pow relocation could"
+	echo "not be attributed to the bitflag operators. Pick a different CF_SRC."
+	exit 1
+fi
+
+# --- the check -----------------------------------------------------------------
+# Relocations, not disassembly text: in an unlinked .o the call target is
+# unresolved, so grepping the disassembly gives a false negative.
+found="$(objdump -drC "$OBJ" | grep -cE 'R_X86_64_(PLT32|PC32)[[:space:]]+.*\bpow\b' || true)"
+
+echo "CF: $(basename "$SRC") -- $ops flag operations, $found pow relocation(s)"
+
+if [[ "$found" -ne 0 ]]; then
+	echo
+	echo "CF FAIL: the bitflag operators reference pow."
+	echo "----- offending relocations -----"
+	objdump -drC "$OBJ" | grep -E 'R_X86_64_(PLT32|PC32)[[:space:]]+.*\bpow\b' | sed -n '1,10p'
+	echo
+	echo "Re-read phase-02 §2 before reacting. This means either the flag path has"
+	echo "regressed onto libm, or the operators were reverted to the pow() spelling."
+	echo "Reference: pre-rewrite handler.c had 308 such relocations; post-rewrite, 0."
+	exit 1
+fi
+
+echo "CF PASS: no pow relocation from the bitflag operators"
+echo "         (pre-rewrite baseline for this file was 308 -- see header comment)"


### PR DESCRIPTION
This PR breaks apart `merc.h` most of the dense layer of defines to a separate enums header. This is so that we can eventually do away with the god header.

It also fixes a couple of correctness issues with our macros.