### PR TITLE
Automatic memory management refactor

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -5,8 +5,8 @@
             "includePath": [
                 "${workspaceFolder}/**",
                 "/usr/include/**",
-                "/usr/lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11",
-                "/usr/lib/gcc/x86_64-linux-gnu/11/include",
+                "/usr/lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13",
+                "/usr/lib/gcc/x86_64-linux-gnu/13/include",
                 "/usr/local/include"
             ],
 			"browse": {

--- a/code/act_comm.c
+++ b/code/act_comm.c
@@ -98,9 +98,9 @@ void do_delete(CHAR_DATA *ch, char *argument)
 			wiznet("$N turns $Mself into line noise.", ch, nullptr, 0, 0, 0);
 			ch->pause = 0;
 
-			while (ch->affected)
+			while (!ch->affected.empty())
 			{
-				affect_remove(ch, ch->affected);
+				affect_remove(ch, &ch->affected.front());
 			}
 
 			stop_fighting(ch, true);
@@ -1867,11 +1867,14 @@ void do_quit_new(CHAR_DATA *ch, char *argument, bool autoq)
 
 		if (is_affected(wch, gsn_empathy))
 		{
-			auto laf = wch->affected;
-			for (; laf != nullptr; laf = laf->next)
+			AFFECT_DATA *laf = nullptr;
+			for (auto &laf_elem : wch->affected)
 			{
-				if (laf->type == gsn_empathy)
+				if (laf_elem.type == gsn_empathy)
+				{
+					laf = &laf_elem;
 					break;
+				}
 			}
 
 			if (laf->owner == ch)

--- a/code/act_comm.c
+++ b/code/act_comm.c
@@ -2502,13 +2502,10 @@ void do_gtell(CHAR_DATA *ch, char *argument)
 
 SPEECH_DATA *find_speech(MOB_INDEX_DATA *mob, char *name)
 {
-	if (!mob->speech)
-		return nullptr;
-
-	for (auto speech = mob->speech; speech; speech = speech->next)
+	for (auto &speech : mob->speech)
 	{
-		if (!str_cmp(speech->name, name))
-			return speech;
+		if (!str_cmp(speech.name, name))
+			return &speech;
 	}
 
 	return nullptr;
@@ -2516,10 +2513,10 @@ SPEECH_DATA *find_speech(MOB_INDEX_DATA *mob, char *name)
 
 void execute_speech(CHAR_DATA *ch, CHAR_DATA *mob, SPEECH_DATA *speech)
 {
-	if (!speech || !speech->first_line || !mob || !mob->in_room)
+	if (!speech || speech->first_line.empty() || !mob || !mob->in_room)
 		return;
 
-	if (speech->first_line != speech->current_line)
+	if (speech->current_line != speech->first_line.begin())
 		return;
 
 	speech_handler(ch, mob, speech);
@@ -2527,16 +2524,16 @@ void execute_speech(CHAR_DATA *ch, CHAR_DATA *mob, SPEECH_DATA *speech)
 
 void speech_handler(CHAR_DATA *ch, CHAR_DATA *mob, SPEECH_DATA *speech)
 {
-	if (!speech || !speech->first_line || !mob || !mob->in_room)
+	if (!speech || speech->first_line.empty() || !mob || !mob->in_room)
 		return;
 
 	if (mob->position < POS_RESTING)
 		return;
 
 	auto line = speech->current_line;
-	if (line == nullptr)
+	if (line == speech->first_line.end())
 	{
-		speech->current_line = speech->first_line;
+		speech->current_line = speech->first_line.begin();
 		return;
 	}
 
@@ -2606,13 +2603,13 @@ void speech_handler(CHAR_DATA *ch, CHAR_DATA *mob, SPEECH_DATA *speech)
 		return;
 	}
 
-	if (!line->next)
+	if (std::next(line) == speech->first_line.end())
 	{
-		speech->current_line = speech->first_line;
+		speech->current_line = speech->first_line.begin();
 		return;
 	}
 
-	speech->current_line = line->next;
+	speech->current_line = std::next(line);
 
 	if (speech->current_line->delay <= 0)
 	{

--- a/code/act_comm.c
+++ b/code/act_comm.c
@@ -229,14 +229,16 @@ void do_replay(CHAR_DATA *ch, char *argument)
 		return;
 	}
 
-	if (!ch->pcdata->buffer->string || ch->pcdata->buffer->string[0] == '\0')
+	const char *replay = ch->pcdata->buffer->str();
+
+	if (!replay || replay[0] == '\0')
 	{
 		send_to_char("You have no tells to replay.\n\r", ch);
 		return;
 	}
 
-	page_to_char(buf_string(ch->pcdata->buffer), ch);
-	clear_buf(ch->pcdata->buffer);
+	page_to_char(ch->pcdata->buffer->str(), ch);
+	ch->pcdata->buffer->clear();
 }
 
 void do_cb(CHAR_DATA *ch, char *argument)
@@ -1223,7 +1225,7 @@ void do_tell(CHAR_DATA *ch, char *argument)
 		act("$N seems to have lost consciousness...try again later.", ch, nullptr, victim, TO_CHAR);
 		sprintf(buf, "%s tells you '%s'\n\r", pers(ch, victim), argument);
 		buf[0] = UPPER(buf[0]);
-		add_buf(victim->pcdata->buffer, buf);
+		victim->pcdata->buffer->add(buf);
 		return;
 	}
 
@@ -1309,7 +1311,7 @@ void do_reply(CHAR_DATA *ch, char *argument)
 		act("$N seems to have lost consciousness...try again later.", ch, nullptr, victim, TO_CHAR);
 		sprintf(buf, "%s tells you '%s'\n\r", pers(ch, victim), argument);
 		buf[0] = UPPER(buf[0]);
-		add_buf(victim->pcdata->buffer, buf);
+		victim->pcdata->buffer->add(buf);
 		return;
 	}
 

--- a/code/act_info.c
+++ b/code/act_info.c
@@ -187,13 +187,7 @@ char *format_obj_to_char(OBJ_DATA *obj, CHAR_DATA *ch, bool fShort)
 
 	if (is_affected_obj(obj, gsn_stash) && is_immortal(ch))
 	{
-		auto oaf = obj->affected;
-		for (; oaf != nullptr; oaf = oaf->next)
-		{
-			if (oaf->type == gsn_stash)
-				break;
-		}
-
+		OBJ_AFFECT_DATA *oaf = affect_find_obj(obj->affected, gsn_stash);
 		sprintf(buf, "(Stashed by %s) ", oaf->owner->name);
 	}
 

--- a/code/act_info.c
+++ b/code/act_info.c
@@ -1005,14 +1005,9 @@ bool check_blind(CHAR_DATA *ch)
 
 	if (is_affected_area(ch->in_room->area, gsn_whiteout) && is_outside(ch))
 	{
-		auto paf = ch->in_room->area->affected;
-		for (; paf != nullptr; paf = paf->next)
-		{
-			if (paf->type == gsn_whiteout)
-				break;
-		}
+		auto paf = affect_find_area(ch->in_room->area->affected, gsn_whiteout);
 
-		if (paf->owner != ch)
+		if (paf && paf->owner != ch)
 		{
 			send_to_char("You can't see a thing through the snow!\n\r", ch);
 			return false;

--- a/code/act_info.c
+++ b/code/act_info.c
@@ -378,9 +378,9 @@ void show_char_to_char_0(CHAR_DATA *victim, CHAR_DATA *ch)
 	if (is_affected_by(ch, AFF_DETECT_MAGIC))
 	{
 		auto spellaffs = 0;
-		for (auto af = victim->affected; af; af = af->next)
+		for (auto &af : victim->affected)
 		{
-			if (af->aftype == AFT_SPELL)
+			if (af.aftype == AFT_SPELL)
 				spellaffs++;
 		}
 
@@ -688,9 +688,9 @@ void show_char_to_char_1(CHAR_DATA *victim, CHAR_DATA *ch)
 	{
 		auto counter = 0;
 
-		for (auto paf = victim->affected; paf; paf = paf->next)
+		for (auto &paf : victim->affected)
 		{
-			if (paf->type == gsn_rotating_ward)
+			if (paf.type == gsn_rotating_ward)
 				counter++;
 		}
 
@@ -2701,7 +2701,7 @@ void do_score(CHAR_DATA *ch, char *argument)
 
 void do_affects(CHAR_DATA *ch, char *argument)
 {
-	if (ch->affected == nullptr || !(ch->affected->aftype != AFT_INVIS || ch->affected->next != nullptr))
+	if (ch->affected.empty() || !(ch->affected.front().aftype != AFT_INVIS || ch->affected.size() > 1))
 	{
 		send_to_char("You are not affected by anything.\n\r", ch);
 		return;
@@ -2711,9 +2711,9 @@ void do_affects(CHAR_DATA *ch, char *argument)
 
 	AFFECT_DATA *paf_last = nullptr;
 	char buf[MAX_STRING_LENGTH];
-	for (auto paf = ch->affected; paf != nullptr; paf = paf->next)
+	for (auto &paf : ch->affected)
 	{
-		if (paf->aftype == AFT_INVIS)
+		if (paf.aftype == AFT_INVIS)
 			continue;
 
 		for (auto i = 0; i < MAX_STRING_LENGTH; i++)
@@ -2722,7 +2722,7 @@ void do_affects(CHAR_DATA *ch, char *argument)
 		}
 
 		if (paf_last != nullptr
-			&& (paf->type == paf_last->type && ((paf->name == nullptr && paf_last->name == nullptr) || !str_cmp(paf->name, paf_last->name))))
+			&& (paf.type == paf_last->type && ((paf.name == nullptr && paf_last->name == nullptr) || !str_cmp(paf.name, paf_last->name))))
 		{
 			if (ch->level >= 20)
 				sprintf(buf, "                          ");
@@ -2731,37 +2731,37 @@ void do_affects(CHAR_DATA *ch, char *argument)
 		}
 		else
 		{
-			if (paf->aftype == AFT_SKILL)
-				sprintf(buf, "Skill  : %-17s", paf->name ? paf->name : skill_table[paf->type].name);
-			else if (paf->aftype == AFT_POWER)
-				sprintf(buf, "Power  : %-17s", paf->name ? paf->name : skill_table[paf->type].name);
-			else if (paf->aftype == AFT_MALADY)
-				sprintf(buf, "Malady : %-17s", paf->name ? paf->name : skill_table[paf->type].name);
-			else if (paf->aftype == AFT_COMMUNE)
-				sprintf(buf, "Commune: %-17s", paf->name ? paf->name : skill_table[paf->type].name);
-			else if (paf->aftype == AFT_RUNE)
-				sprintf(buf, "Rune   : %-17s", paf->name ? paf->name : skill_table[paf->type].name);
-			else if (paf->aftype == AFT_TIMER)
-				sprintf(buf, "Timer  : %-17s", paf->name ? paf->name : skill_table[paf->type].name);
-			else if (paf->aftype != AFT_INVIS)
-				sprintf(buf, "Spell  : %-17s", paf->name ? paf->name : skill_table[paf->type].name);
+			if (paf.aftype == AFT_SKILL)
+				sprintf(buf, "Skill  : %-17s", paf.name ? paf.name : skill_table[paf.type].name);
+			else if (paf.aftype == AFT_POWER)
+				sprintf(buf, "Power  : %-17s", paf.name ? paf.name : skill_table[paf.type].name);
+			else if (paf.aftype == AFT_MALADY)
+				sprintf(buf, "Malady : %-17s", paf.name ? paf.name : skill_table[paf.type].name);
+			else if (paf.aftype == AFT_COMMUNE)
+				sprintf(buf, "Commune: %-17s", paf.name ? paf.name : skill_table[paf.type].name);
+			else if (paf.aftype == AFT_RUNE)
+				sprintf(buf, "Rune   : %-17s", paf.name ? paf.name : skill_table[paf.type].name);
+			else if (paf.aftype == AFT_TIMER)
+				sprintf(buf, "Timer  : %-17s", paf.name ? paf.name : skill_table[paf.type].name);
+			else if (paf.aftype != AFT_INVIS)
+				sprintf(buf, "Spell  : %-17s", paf.name ? paf.name : skill_table[paf.type].name);
 		}
 
 		send_to_char(buf, ch);
 
 		if (ch->level >= 20)
 		{
-			auto showdur = paf->duration + 1;
+			auto showdur = paf.duration + 1;
 
 			auto buffer = fmt::format("| modifies {}{}{} ",
-					(paf->mod_name > -1) ? mod_names[paf->mod_name].name : affect_loc_name(paf->location),
-					(paf->mod_name > -1) ? "" : " by ",
-					(paf->mod_name > -1) ? "" : std::to_string(paf->modifier)); //TODO: change the rest of the sprintf calls to format
+					(paf.mod_name > -1) ? mod_names[paf.mod_name].name : affect_loc_name(paf.location),
+					(paf.mod_name > -1) ? "" : " by ",
+					(paf.mod_name > -1) ? "" : std::to_string(paf.modifier)); //TODO: change the rest of the sprintf calls to format
 
-			if (paf->aftype != AFT_INVIS)
+			if (paf.aftype != AFT_INVIS)
 				send_to_char(buffer.c_str(), ch);
 
-			if (paf->duration == -1)
+			if (paf.duration == -1)
 			{
 				buffer = "permanently";
 			}
@@ -2773,14 +2773,14 @@ void do_affects(CHAR_DATA *ch, char *argument)
 					(showdur == 1 || showdur == 2) ? "" : "s");
 			}
 
-			if (paf->aftype != AFT_INVIS)
+			if (paf.aftype != AFT_INVIS)
 				send_to_char(buffer.c_str(), ch);
 		}
 
-		if (paf->aftype != AFT_INVIS)
+		if (paf.aftype != AFT_INVIS)
 			send_to_char("\n\r", ch);
 
-		paf_last = paf;
+		paf_last = &paf;
 	}
 }
 

--- a/code/act_info.c
+++ b/code/act_info.c
@@ -239,7 +239,7 @@ void show_list_to_char(OBJ_DATA *list, CHAR_DATA *ch, bool fShort, bool fShowNot
 
 	ch->lines = 0;
 
-	auto output = new_buf();
+	BUFFER output;
 	auto prgpstrShow = (char **)talloc_struct((count * sizeof(char *)));
 	auto prgnShow = (int *)talloc_struct((count * sizeof(int)));
 	auto nShow = 0;
@@ -300,15 +300,15 @@ void show_list_to_char(OBJ_DATA *list, CHAR_DATA *ch, bool fShort, bool fShowNot
 			{
 				char buf[MAX_STRING_LENGTH];
 				sprintf(buf, "(%2d) ", prgnShow[iShow]);
-				add_buf(output, buf);
+				output.add(buf);
 			}
 			else
 			{
-				add_buf(output, "     ");
+				output.add("     ");
 			}
 		}
-		add_buf(output, prgpstrShow[iShow]);
-		add_buf(output, "\n\r");
+		output.add(prgpstrShow[iShow]);
+		output.add("\n\r");
 	}
 
 	if (fShowNothing && nShow == 0)
@@ -319,12 +319,11 @@ void show_list_to_char(OBJ_DATA *list, CHAR_DATA *ch, bool fShort, bool fShowNot
 		send_to_char("Nothing.\n\r", ch);
 	}
 
-	page_to_char(buf_string(output), ch);
+	page_to_char(output.str(), ch);
 
 	/*
 	 * Clean up.
 	 */
-	free_buf(output);
 	ch->lines = line;
 }
 
@@ -2894,7 +2893,7 @@ void do_oldhelp(CHAR_DATA *ch, char *argument)
 		strcat(argall, argone);
 	}
 
-	auto output = new_buf();
+	BUFFER output;
 	for (auto pHelp = help_first; pHelp != nullptr; pHelp = pHelp->next)
 	{
 		auto level = (pHelp->level < 0) ? -1 * pHelp->level - 1 : pHelp->level;
@@ -2909,21 +2908,21 @@ void do_oldhelp(CHAR_DATA *ch, char *argument)
 		{
 			/* add separator if found */
 			if (found)
-				add_buf(output, "\n\r============================================================\n\r\n\r");
+				output.add("\n\r============================================================\n\r\n\r");
 
 			if (pHelp->level >= 0 && str_cmp(argall, "imotd"))
 			{
-				add_buf(output, pHelp->keyword);
-				add_buf(output, "\n\r");
+				output.add(pHelp->keyword);
+				output.add("\n\r");
 			}
 
 			/*
 			 * Strip leading '.' to allow initial blanks.
 			 */
 			if (pHelp->text[0] == '.')
-				add_buf(output, pHelp->text + 1);
+				output.add(pHelp->text + 1);
 			else
-				add_buf(output, pHelp->text);
+				output.add(pHelp->text);
 
 			found = true;
 
@@ -2936,9 +2935,8 @@ void do_oldhelp(CHAR_DATA *ch, char *argument)
 	if (!found)
 		send_to_char("No help on that word.\n\r", ch);
 	else
-		page_to_char(buf_string(output), ch);
+		page_to_char(output.str(), ch);
 
-	free_buf(output);
 }
 
 /* whois command */
@@ -2955,7 +2953,7 @@ void do_whois(CHAR_DATA *ch, char *argument)
 
 	std::string buffer;
 
-	auto output = new_buf();
+	BUFFER output;
 	auto found = false;
 	for (auto d = descriptor_list; d != nullptr; d = d->next)
 	{
@@ -3052,7 +3050,7 @@ void do_whois(CHAR_DATA *ch, char *argument)
 					wch->true_name,
 					is_npc(wch) ? "" : wch->pcdata->title,
 					is_npc(wch) ? "" : wch->pcdata->extitle ? wch->pcdata->extitle : "");
-				add_buf(output, buffer.data());
+				output.add(buffer.data());
 			}
 			else if (get_trust(wch) >= 52 && !is_immortal(ch))
 			{
@@ -3074,7 +3072,7 @@ void do_whois(CHAR_DATA *ch, char *argument)
 					is_npc(wch) ? "" : wch->pcdata->title,
 					is_npc(wch) ? "" : (wch->pcdata->extitle) ? wch->pcdata->extitle : ""); //TODO: change the rest of the sprintf calls to format
 
-				add_buf(output, buffer.data());
+				output.add(buffer.data());
 			}
 			else
 			{
@@ -3103,7 +3101,7 @@ void do_whois(CHAR_DATA *ch, char *argument)
 					wch->name,
 					is_npc(wch) ? "" : wch->pcdata->title,
 					is_npc(wch) ? "" : (wch->pcdata->extitle) ? wch->pcdata->extitle : "");
-				add_buf(output, buffer.data());
+				output.add(buffer.data());
 			}
 		}
 	}
@@ -3114,8 +3112,7 @@ void do_whois(CHAR_DATA *ch, char *argument)
 		return;
 	}
 
-	page_to_char(buf_string(output), ch);
-	free_buf(output);
+	page_to_char(output.str(), ch);
 }
 
 /*
@@ -3304,7 +3301,7 @@ void do_who(CHAR_DATA *ch, char *argument)
 	buf[0] = '\0';
 
 	auto nMatch = 0;
-	auto output = new_buf();
+	BUFFER output;
 	for (auto d = descriptor_list; d != nullptr; d = d->next)
 	{
 		/*
@@ -3438,7 +3435,7 @@ void do_who(CHAR_DATA *ch, char *argument)
 				wch->true_name,
 				is_npc(wch) ? "" : wch->pcdata->title,
 				is_npc(wch) ? "" : wch->pcdata->extitle ? wch->pcdata->extitle : "");
-			add_buf(output, buffer.data());
+			output.add(buffer.data());
 		}
 		else if (get_trust(wch) >= 52 && !is_immortal(ch))
 		{
@@ -3463,7 +3460,7 @@ void do_who(CHAR_DATA *ch, char *argument)
 				wch->true_name,
 				is_npc(wch) ? "" : wch->pcdata->title,
 				is_npc(wch) ? "" : (wch->pcdata->extitle) ? wch->pcdata->extitle : ""); //TODO: change the rest of the sprintf calls to format
-			add_buf(output, buffer.data());
+			output.add(buffer.data());
 		}
 		else
 		{
@@ -3495,14 +3492,13 @@ void do_who(CHAR_DATA *ch, char *argument)
 				wch->true_name,
 				is_npc(wch) ? "" : wch->pcdata->title,
 				is_npc(wch) ? "" : wch->pcdata->extitle ? wch->pcdata->extitle : "");
-			add_buf(output, buffer.data());
+			output.add(buffer.data());
 		}
 	}
 
 	sprintf(buf2, "\n\rPlayers found: %d\n\r", nMatch);
-	add_buf(output, buf2);
-	page_to_char(buf_string(output), ch);
-	free_buf(output);
+	output.add(buf2);
+	page_to_char(output.str(), ch);
 }
 
 void do_count(CHAR_DATA *ch, char *argument)
@@ -4104,19 +4100,18 @@ void do_description(CHAR_DATA *ch, char *argument)
 	else if (!str_cmp(arg1, "+"))
 	{
 		smash_tilde(argument);
-		auto buffer = new_buf();
+		BUFFER buffer;
 
 		if (ch->description)
-			add_buf(buffer, ch->description);
+			buffer.add(ch->description);
 
-		add_buf(buffer, argument);
-		add_buf(buffer, "\n\r");
+		buffer.add(argument);
+		buffer.add("\n\r");
 
 		if (ch->description)
 			free_pstring(ch->description);
 
-		ch->description = palloc_string(buf_string(buffer));
-		free_buf(buffer);
+		ch->description = palloc_string(buffer.str());
 
 		send_to_char("Line added.\n\r", ch);
 		return;
@@ -5375,10 +5370,9 @@ void do_role(CHAR_DATA *ch, char *argument)
 				return;
 			}
 
-			auto output = new_buf();
-			add_buf(output, victim->pcdata->role);
-			page_to_char(buf_string(output), ch);
-			free_buf(output);
+			BUFFER output;
+			output.add(victim->pcdata->role);
+			page_to_char(output.str(), ch);
 			return;
 		}
 
@@ -5521,10 +5515,9 @@ void show_temp_role(CHAR_DATA *ch)
 	}
 	else
 	{
-		auto output = new_buf();
-		add_buf(output, ch->pcdata->temp_role);
-		page_to_char(buf_string(output), ch);
-		free_buf(output);
+		BUFFER output;
+		output.add(ch->pcdata->temp_role);
+		page_to_char(output.str(), ch);
 	}
 }
 
@@ -5538,9 +5531,8 @@ void show_role(CHAR_DATA *ch)
 	}
 	else
 	{
-		auto output = new_buf();
-		add_buf(output, ch->pcdata->role);
-		page_to_char(buf_string(output), ch);
-		free_buf(output);
+		BUFFER output;
+		output.add(ch->pcdata->role);
+		page_to_char(output.str(), ch);
 	}
 }

--- a/code/act_info.c
+++ b/code/act_info.c
@@ -5116,9 +5116,9 @@ void do_lore(CHAR_DATA *ch, char *argument) /* Lore by Detlef */
 				break;
 		}
 
-		for (auto app = obj->apply; app; app = app->next)
+		for (const auto &app : obj->apply)
 		{
-			sprintf(buf, "It affects your %s by %d.\n\r", affect_loc_name(app->location), app->modifier);
+			sprintf(buf, "It affects your %s by %d.\n\r", affect_loc_name(app.location), app.modifier);
 			send_to_char(buf, ch);
 		}
 

--- a/code/act_info.c
+++ b/code/act_info.c
@@ -1857,10 +1857,10 @@ void do_look(CHAR_DATA *ch, char *argument)
 
 		if (is_affected_room(ch->in_room, gsn_riptide))
 		{
-			for (auto raf = ch->in_room->affected; raf != nullptr; raf = raf->next)
+			for (auto &raf : ch->in_room->affected)
 			{
-				if (raf->type == gsn_riptide && raf->owner == ch && raf->location == APPLY_ROOM_NONE &&
-					raf->modifier == 1)
+				if (raf.type == gsn_riptide && raf.owner == ch && raf.location == APPLY_ROOM_NONE &&
+					raf.modifier == 1)
 				{
 					sprintf(buf, "%sThe calm surface of the water belies the deadly riptide churning beneath!%s\n\r",
 						get_char_color(ch, "cyan"),
@@ -1869,8 +1869,8 @@ void do_look(CHAR_DATA *ch, char *argument)
 					send_to_char(buf, ch);
 					break;
 				}
-				else if (raf->type == gsn_riptide && raf->owner == ch && raf->location == APPLY_ROOM_NONE &&
-						 raf->modifier == 2)
+				else if (raf.type == gsn_riptide && raf.owner == ch && raf.location == APPLY_ROOM_NONE &&
+						 raf.modifier == 2)
 				{
 					sprintf(buf, "%sThe waters swirl menacingly, ready to receive the riptide's prey.%s\n\r",
 						get_char_color(ch, "cyan"),

--- a/code/act_info.c
+++ b/code/act_info.c
@@ -785,7 +785,9 @@ void show_char_to_char_1(CHAR_DATA *victim, CHAR_DATA *ch)
 		auto placeholder = victim->pcdata->trophy;
 
 		act("\n\r$p catches your eye, meriting closer examination.", ch, belt, 0, TO_CHAR);
-		send_to_char(belt->extra_descr->description, ch);
+
+		if (!belt->extra_descr.empty())
+			send_to_char(belt->extra_descr.front().description, ch);
 		send_to_char("\n\rAttached to the belt are:\n\r", ch);
 
 		for (auto i = 0; i < MAX_STRING_LENGTH; i++)

--- a/code/act_info.c
+++ b/code/act_info.c
@@ -780,10 +780,8 @@ void show_char_to_char_1(CHAR_DATA *victim, CHAR_DATA *ch)
 		&& victim->cabal == CABAL_HORDE
 		&& belt != nullptr
 		&& belt->pIndexData->vnum == OBJ_VNUM_TROPHY_BELT
-		&& victim->pcdata->trophy && belt->value[4] >= 1)
+		&& !victim->pcdata->trophy.empty() && belt->value[4] >= 1)
 	{
-		auto placeholder = victim->pcdata->trophy;
-
 		act("\n\r$p catches your eye, meriting closer examination.", ch, belt, 0, TO_CHAR);
 
 		if (!belt->extra_descr.empty())
@@ -796,12 +794,14 @@ void show_char_to_char_1(CHAR_DATA *victim, CHAR_DATA *ch)
 			buf3[i] = '\0';
 		}
 
+		auto it = victim->pcdata->trophy.begin();
+
 		for (auto counter = 1; counter <= belt->value[4]; counter++)
 		{
 			sprintf(buf2, "%s%s%c scalp of %s",
 				counter > 1 ? ", " : "",
 				counter % 4 == 0 ? "\n\r" : "",
-				counter > 1 ? 'a' : 'A', victim->pcdata->trophy->victname);
+				counter > 1 ? 'a' : 'A', it->victname);
 
 			strcat(buf3, buf2);
 
@@ -813,10 +813,10 @@ void show_char_to_char_1(CHAR_DATA *victim, CHAR_DATA *ch)
 			if (counter >= belt->value[4])
 				break;
 
-			if (!victim->pcdata->trophy->next)
+			if (std::next(it) == victim->pcdata->trophy.end())
 				break;
 
-			victim->pcdata->trophy = victim->pcdata->trophy->next;
+			++it;
 		}
 
 		strcat(buf3, ".\n\r");
@@ -824,7 +824,6 @@ void show_char_to_char_1(CHAR_DATA *victim, CHAR_DATA *ch)
 		send_to_char(buf3, ch);
 
 		buf3[0] = '\0';
-		victim->pcdata->trophy = placeholder;
 	}
 
 	if (victim != ch

--- a/code/act_info.c
+++ b/code/act_info.c
@@ -1894,13 +1894,10 @@ void do_look(CHAR_DATA *ch, char *argument)
 
 			for (i = 0; i < MAX_TRACKS; i++)
 			{
-				if (!ch->in_room->tracks[i])
-					break;
-
-				if (ch->in_room->tracks[i]->prey != af->owner)
+				if (ch->in_room->tracks[i].prey != af->owner)
 					continue;
 
-				direction = (char *)flag_name_lookup(ch->in_room->tracks[i]->direction, direction_table);
+				direction = (char *)flag_name_lookup(ch->in_room->tracks[i].direction, direction_table);
 
 				sprintf(buf, "%sThrough the veil of your rage, you sense %s's tracks leading %s.%s\n\r",
 					get_char_color(ch, "lightred"),
@@ -1916,22 +1913,19 @@ void do_look(CHAR_DATA *ch, char *argument)
 		{
 			for (i = 0; i <= 2; i++)
 			{
-				if (!ch->in_room->tracks[i])
+				if (!ch->in_room->tracks[i].prey)
 					continue;
 
-				if (!ch->in_room->tracks[i]->prey)
+				if (ch->in_room->tracks[i].flying)
 					continue;
 
-				if (ch->in_room->tracks[i]->flying)
-					continue;
-
-				direction = flag_name_lookup(ch->in_room->tracks[i]->direction, direction_table);
+				direction = flag_name_lookup(ch->in_room->tracks[i].direction, direction_table);
 
 				sprintf(buf, "%sYou see %s footprints leading %s through the snow.%s\n\r",
 					get_char_color(ch, "white"),
-					(ch->in_room->tracks[i]->prey->race == 4)
+					(ch->in_room->tracks[i].prey->race == 4)
 						? "elven"
-						: pc_race_table[ch->in_room->tracks[i]->prey->race].race_time,
+						: pc_race_table[ch->in_room->tracks[i].prey->race].race_time,
 					direction,
 					END_COLOR(ch));
 					

--- a/code/act_move.c
+++ b/code/act_move.c
@@ -174,12 +174,7 @@ void move_char(CHAR_DATA *ch, int door, bool automatic, bool fcharm)
 
 	if (is_affected_room(ch->in_room, gsn_smokescreen))
 	{
-		auto raf = ch->in_room->affected;
-		for (; raf != nullptr; raf = raf->next)
-		{
-			if (raf->type == gsn_smokescreen)
-				break;
-		}
+		auto raf = affect_find_room(ch->in_room->affected, gsn_smokescreen);
 
 		if (raf != nullptr)
 		{
@@ -680,18 +675,24 @@ void move_char(CHAR_DATA *ch, int door, bool automatic, bool fcharm)
 
 	if (is_affected_room(in_room, gsn_tripwire) && is_affected_room(to_room, gsn_tripwire))
 	{
-		auto raf = in_room->affected;
-		for (; raf != nullptr; raf = raf->next)
+		ROOM_AFFECT_DATA *raf = nullptr;
+		for (auto &r : in_room->affected)
 		{
-			if (raf->modifier == door && raf->type == gsn_tripwire)
+			if (r.modifier == door && r.type == gsn_tripwire)
+			{
+				raf = &r;
 				break;
+			}
 		}
 
-		auto raf_two = to_room->affected;
-		for (; raf_two != nullptr; raf_two = raf_two->next)
+		ROOM_AFFECT_DATA *raf_two = nullptr;
+		for (auto &r : to_room->affected)
 		{
-			if (raf_two->modifier == reverse_d(door) && raf->type == gsn_tripwire)
+			if (r.modifier == reverse_d(door) && raf->type == gsn_tripwire)
+			{
+				raf_two = &r;
 				break;
+			}
 		}
 
 		if (is_affected_by(ch, AFF_FLYING))
@@ -722,22 +723,22 @@ void move_char(CHAR_DATA *ch, int door, bool automatic, bool fcharm)
 
 	if (is_affected_room(to_room, gsn_riptide))
 	{
-		for (auto raf = to_room->affected; raf != nullptr; raf = raf->next)
+		for (auto &raf : to_room->affected)
 		{
-			if (raf->type == gsn_riptide && raf->location == APPLY_ROOM_NONE && raf->modifier == 1)
+			if (raf.type == gsn_riptide && raf.location == APPLY_ROOM_NONE && raf.modifier == 1)
 			{
-				if (is_safe_new(raf->owner, ch, false) || raf->owner == ch)
+				if (is_safe_new(raf.owner, ch, false) || raf.owner == ch)
 					break;
 
-				ROOM_INDEX_DATA *riptideroom;
+				ROOM_INDEX_DATA *riptideroom = nullptr;
 				for (auto room = top_affected_room; room; room = room->aff_next)
 				{
 					if (is_affected_room(room, gsn_riptide))
 					{
-						for (auto raf_two = room->affected; raf_two != nullptr; raf_two = raf_two->next)
+						for (auto &raf_two : room->affected)
 						{
-							if (raf_two->type == gsn_riptide && raf_two->owner == raf->owner &&
-								raf_two->location == APPLY_ROOM_NONE && raf_two->modifier == 2)
+							if (raf_two.type == gsn_riptide && raf_two.owner == raf.owner &&
+								raf_two.location == APPLY_ROOM_NONE && raf_two.modifier == 2)
 								riptideroom = room;
 						}
 					}
@@ -768,12 +769,7 @@ void move_char(CHAR_DATA *ch, int door, bool automatic, bool fcharm)
 
 	while (is_affected_room(to_room, gsn_frost_growth))
 	{
-		auto raf = to_room->affected;
-		for (; raf != nullptr; raf = raf->next)
-		{
-			if (raf->type == gsn_frost_growth)
-				break;
-		}
+		auto raf = affect_find_room(to_room->affected, gsn_frost_growth);
 
 		if (is_affected_by(ch, AFF_FLYING))
 			break;
@@ -809,12 +805,7 @@ void move_char(CHAR_DATA *ch, int door, bool automatic, bool fcharm)
 		if (is_npc(ch))
 			break;
 
-		auto raf = to_room->affected;
-		for (; raf != nullptr; raf = raf->next)
-		{
-			if (raf->type == gsn_quicksand)
-				break;
-		}
+		auto raf = affect_find_room(to_room->affected, gsn_quicksand);
 
 		if (is_safe_new(raf->owner, ch, false) || is_same_group(raf->owner, ch) || is_same_cabal(raf->owner, ch))
 			break;
@@ -851,12 +842,7 @@ void move_char(CHAR_DATA *ch, int door, bool automatic, bool fcharm)
 
 	while (is_affected_room(to_room, gsn_stalactites))
 	{
-		auto raf = to_room->affected;
-		for (; raf != nullptr; raf = raf->next)
-		{
-			if (raf->type == gsn_stalactites)
-				break;
-		}
+		auto raf = affect_find_room(to_room->affected, gsn_stalactites);
 
 		if (is_safe_new(raf->owner, ch, false) || is_same_group(raf->owner, ch) || is_same_cabal(raf->owner, ch))
 			break;
@@ -894,12 +880,7 @@ void move_char(CHAR_DATA *ch, int door, bool automatic, bool fcharm)
 
 	if (is_affected_room(to_room, gsn_caustic_vapor))
 	{
-		auto raf = to_room->affected;
-		for (; raf != nullptr; raf = raf->next)
-		{
-			if (raf->type == gsn_caustic_vapor)
-				break;
-		}
+		auto raf = affect_find_room(to_room->affected, gsn_caustic_vapor);
 
 		if (is_immortal(ch))
 			return;

--- a/code/act_move.c
+++ b/code/act_move.c
@@ -905,10 +905,14 @@ void move_char(CHAR_DATA *ch, int door, bool automatic, bool fcharm)
 				new_affect_to_char(ch, &cvaf);
 			}
 
-			for (auto paf = ch->affected; paf != nullptr; paf = paf->next)
+			AFFECT_DATA *paf = nullptr;
+			for (auto &paf_elem : ch->affected)
 			{
-				if (paf->type == gsn_noxious_fumes)
+				if (paf_elem.type == gsn_noxious_fumes)
+				{
+					paf = &paf_elem;
 					break;
+				}
 			}
 
 			paf->modifier = URANGE(0, paf->modifier, 5);
@@ -1237,19 +1241,21 @@ void trap_execute(CHAR_DATA *victim, ROOM_INDEX_DATA *room, TRAP_DATA *trap)
 
 			send_to_char("Your blood burns as a deadly venom seeps into your body!\n\r", victim);
 
-			AFFECT_DATA af;
-			init_affect(&af);
-			af.where = TO_AFFECTS;
-			af.aftype = AFT_MALADY;
-			af.type = gsn_poison;
-			af.level = trap->quality * 7;
-			af.location = APPLY_STR;
-			af.modifier = -5;
-			af.duration = trap->quality * 2;
-			af.owner = victim;
-			SET_BIT(af.bitvector, AFF_POISON);
-			af.tick_fun = poison_tick;
-			affect_to_char(victim, &af);
+			{
+				AFFECT_DATA af;
+				init_affect(&af);
+				af.where = TO_AFFECTS;
+				af.aftype = AFT_MALADY;
+				af.type = gsn_poison;
+				af.level = trap->quality * 7;
+				af.location = APPLY_STR;
+				af.modifier = -5;
+				af.duration = trap->quality * 2;
+				af.owner = victim;
+				SET_BIT(af.bitvector, AFF_POISON);
+				af.tick_fun = poison_tick;
+				affect_to_char(victim, &af);
+			}
 			break;
 		case TRAP_FIREBALL:
 			for (auto vch = room->people; vch; vch = vch->next_in_room)

--- a/code/act_move.c
+++ b/code/act_move.c
@@ -1103,33 +1103,25 @@ void move_char(CHAR_DATA *ch, int door, bool automatic, bool fcharm)
 	if (IS_SET(ch->progtypes, MPROG_ENTRY))
 		ch->pIndexData->mprogs->entry_prog(ch);
 
-	if (!is_npc(ch) && to_room->tracks[0] != nullptr)
+	if (!is_npc(ch))
 	{
 		auto i = 0;
 		for (; i < MAX_TRACKS; i++)
 		{
-			if (to_room->tracks[i]->prey == ch)
+			if (to_room->tracks[i].prey == ch)
 				break;
 		}
 
 		if (i == MAX_TRACKS)
 			i--;
 
-		if (to_room->tracks[i]->prey == ch)
+		if (to_room->tracks[i].prey == ch)
 		{
 			for (; i < MAX_TRACKS - 1; i++)
-			{
-				to_room->tracks[i]->prey = to_room->tracks[i + 1]->prey;
-				to_room->tracks[i]->time = to_room->tracks[i + 1]->time;
-				to_room->tracks[i]->direction = to_room->tracks[i + 1]->direction;
-				to_room->tracks[i]->flying = to_room->tracks[i + 1]->flying;
-				to_room->tracks[i]->sneaking = to_room->tracks[i + 1]->sneaking;
-				to_room->tracks[i]->bleeding = to_room->tracks[i + 1]->bleeding;
-				to_room->tracks[i]->legs = to_room->tracks[i + 1]->legs;
-			}
+				to_room->tracks[i] = to_room->tracks[i + 1];
 
-			to_room->tracks[MAX_TRACKS - 1]->prey = nullptr;
-			to_room->tracks[MAX_TRACKS - 1]->direction = -1;
+			to_room->tracks[MAX_TRACKS - 1].prey = nullptr;
+			to_room->tracks[MAX_TRACKS - 1].direction = -1;
 		}
 	}
 
@@ -3769,7 +3761,7 @@ void track_char(CHAR_DATA *ch, CHAR_DATA *mob)
 	auto found = false;
 	for (; i < MAX_TRACKS; i++)
 	{
-		if (mob->in_room->tracks[i] && mob->in_room->tracks[i]->prey == ch)
+		if (mob->in_room->tracks[i].prey == ch)
 		{
 			found = true;
 			break;
@@ -3779,10 +3771,10 @@ void track_char(CHAR_DATA *ch, CHAR_DATA *mob)
 	if (!found)
 		return;
 
-	if (mob->in_room->tracks[i]->prey != ch)
+	if (mob->in_room->tracks[i].prey != ch)
 		return;
 
-	auto track_dir = mob->in_room->tracks[i]->direction;
+	auto track_dir = mob->in_room->tracks[i].direction;
 
 	if (is_affected_by(mob, AFF_CHARM))
 		return;
@@ -4513,41 +4505,30 @@ void add_tracks(ROOM_INDEX_DATA *room, CHAR_DATA *ch, int direction)
 	if (is_ground(room) && is_affected(ch, gsn_pass_without_trace))
 		return;
 
-	if (room->tracks[0] == nullptr)
-		return;
-
-	if (room->tracks[0]->prey != nullptr)
+	if (room->tracks[0].prey != nullptr)
 	{
 		for (auto i = MAX_TRACKS - 1; i > 0; i--)
-		{
-			room->tracks[i]->prey = room->tracks[i - 1]->prey;
-			room->tracks[i]->time = room->tracks[i - 1]->time;
-			room->tracks[i]->direction = room->tracks[i - 1]->direction;
-			room->tracks[i]->flying = room->tracks[i - 1]->flying;
-			room->tracks[i]->sneaking = room->tracks[i - 1]->sneaking;
-			room->tracks[i]->bleeding = room->tracks[i - 1]->bleeding;
-			room->tracks[i]->legs = room->tracks[i - 1]->legs;
-		}
+			room->tracks[i] = room->tracks[i - 1];
 	}
 
-	room->tracks[0]->prey = ch;
-	room->tracks[0]->time = time_info;
-	room->tracks[0]->direction = direction;
-	room->tracks[0]->flying = is_affected_by(ch, AFF_FLYING);
-	room->tracks[0]->sneaking = is_affected_by(ch, AFF_SNEAK);
-	room->tracks[0]->bleeding = is_affected(ch, gsn_bleeding);
-	room->tracks[0]->legs = ch->legs;
+	room->tracks[0].prey = ch;
+	room->tracks[0].time = time_info;
+	room->tracks[0].direction = direction;
+	room->tracks[0].flying = is_affected_by(ch, AFF_FLYING);
+	room->tracks[0].sneaking = is_affected_by(ch, AFF_SNEAK);
+	room->tracks[0].bleeding = is_affected(ch, gsn_bleeding);
+	room->tracks[0].legs = ch->legs;
 }
 
 void clear_tracks(ROOM_INDEX_DATA *room)
 {
 	for (auto i = 0; i < MAX_TRACKS - 1; i++)
 	{
-		room->tracks[i]->prey = nullptr;
-		room->tracks[i]->direction = -1;
-		room->tracks[i]->flying= false;
-		room->tracks[i]->sneaking= false;
-		room->tracks[i]->bleeding= false;
-		room->tracks[i]->legs = -1;
+		room->tracks[i].prey = nullptr;
+		room->tracks[i].direction = -1;
+		room->tracks[i].flying= false;
+		room->tracks[i].sneaking= false;
+		room->tracks[i].bleeding= false;
+		room->tracks[i].legs = -1;
 	}
 }

--- a/code/act_obj.c
+++ b/code/act_obj.c
@@ -75,7 +75,6 @@
 bool check_arms(CHAR_DATA *ch, OBJ_DATA *obj)
 {
 	char buf[MSL];
-	OBJ_AFFECT_DATA *paf = nullptr;
 
 	if (is_affected_obj(obj, gsn_arms_of_light)
 		|| is_affected_obj(obj, gsn_arms_of_wrath)
@@ -83,13 +82,13 @@ bool check_arms(CHAR_DATA *ch, OBJ_DATA *obj)
 		|| is_affected_obj(obj, gsn_arms_of_judgement))
 	{
 
-		for (paf = obj->affected; paf != nullptr; paf = paf->next)
+		for (auto &paf : obj->affected)
 		{
-			if ((paf->type == gsn_arms_of_light
-					|| paf->type == gsn_arms_of_wrath
-					|| paf->type == gsn_arms_of_purity
-					|| paf->type == gsn_arms_of_judgement)
-				&& paf->owner != ch)
+			if ((paf.type == gsn_arms_of_light
+					|| paf.type == gsn_arms_of_wrath
+					|| paf.type == gsn_arms_of_purity
+					|| paf.type == gsn_arms_of_judgement)
+				&& paf.owner != ch)
 			{
 				act("$p shocks you, falling from your numb hands.", ch, obj, 0, TO_CHAR);
 				act("$n drops $p.", ch, obj, 0, TO_ROOM);

--- a/code/act_obj.c
+++ b/code/act_obj.c
@@ -1971,7 +1971,6 @@ void wear_obj(CHAR_DATA *ch, OBJ_DATA *obj, bool fReplace)
 	OBJ_DATA *weapon;
 	OBJ_DATA *oldobj;
 	int sn, skill;
-	OBJ_AFFECT_DATA *paf;
 
 	if (can_wear(obj, ITEM_WEAR_COSMETIC))
 	{

--- a/code/act_wiz.c
+++ b/code/act_wiz.c
@@ -1798,22 +1798,22 @@ void do_rstat(CHAR_DATA *ch, char *argument)
 	send_to_char("Characters who have passed through:\n\r", ch);
 	for (i = 0; i < MAX_TRACKS; i++)
 	{
-		if (location->tracks[i] && location->tracks[i]->prey)
+		if (location->tracks[i].prey)
 		{
-			time = (time_info.hour >= location->tracks[i]->time.hour)
-					   ? (time_info.hour - location->tracks[i]->time.hour)
-					   : (24 + time_info.hour - location->tracks[i]->time.hour) +
-								 (time_info.day >= location->tracks[i]->time.day)
-							 ? 24 * (time_info.day - location->tracks[i]->time.day)
-							 : 24 * (30 + time_info.day - location->tracks[i]->time.day) +
-									   (time_info.month >= location->tracks[i]->time.month)
-								   ? 24 * 30 * (time_info.month - location->tracks[i]->time.month)
-								   : 24 * 30 * (12 + time_info.month - location->tracks[i]->time.month) +
-										 24 * 30 * 12 * (time_info.year - location->tracks[i]->time.year);
+			time = (time_info.hour >= location->tracks[i].time.hour)
+					   ? (time_info.hour - location->tracks[i].time.hour)
+					   : (24 + time_info.hour - location->tracks[i].time.hour) +
+								 (time_info.day >= location->tracks[i].time.day)
+							 ? 24 * (time_info.day - location->tracks[i].time.day)
+							 : 24 * (30 + time_info.day - location->tracks[i].time.day) +
+									   (time_info.month >= location->tracks[i].time.month)
+								   ? 24 * 30 * (time_info.month - location->tracks[i].time.month)
+								   : 24 * 30 * (12 + time_info.month - location->tracks[i].time.month) +
+										 24 * 30 * 12 * (time_info.year - location->tracks[i].time.year);
 
-			direction = flag_name_lookup(location->tracks[i]->direction, direction_table);
+			direction = flag_name_lookup(location->tracks[i].direction, direction_table);
 
-			sprintf(buf, "%s exited to the %s %d hours ago.\n\r", location->tracks[i]->prey->name, direction, time);
+			sprintf(buf, "%s exited to the %s %d hours ago.\n\r", location->tracks[i].prey->name, direction, time);
 			send_to_char(buf, ch);
 
 			counter++;

--- a/code/act_wiz.c
+++ b/code/act_wiz.c
@@ -1829,7 +1829,6 @@ void do_rstat(CHAR_DATA *ch, char *argument)
 void do_ostat(CHAR_DATA *ch, char *argument)
 {
 	char buf[MAX_STRING_LENGTH], arg[MAX_INPUT_LENGTH], buf2[MSL];
-	OBJ_AFFECT_DATA *paf;
 	AFFECT_DATA *paf2;
 	OBJ_DATA *obj;
 
@@ -2296,35 +2295,35 @@ void do_ostat(CHAR_DATA *ch, char *argument)
 		}
 	}
 
-	for (paf = obj->affected; paf != nullptr; paf = paf->next)
+	for (auto &paf : obj->affected)
 	{
-		if (paf->aftype == AFT_SKILL)
+		if (paf.aftype == AFT_SKILL)
 			sprintf(buf2, "Skill");
-		else if (paf->aftype == AFT_POWER)
+		else if (paf.aftype == AFT_POWER)
 			sprintf(buf2, "Power");
-		else if (paf->aftype == AFT_COMMUNE)
+		else if (paf.aftype == AFT_COMMUNE)
 			sprintf(buf2, "Commune");
-		else if (paf->aftype == AFT_RUNE)
+		else if (paf.aftype == AFT_RUNE)
 			sprintf(buf2, "Rune");
 		else
 			sprintf(buf2, "Spell");
 
 		auto buffer = fmt::sprintf(buf, "%s: '%s' modifies %s by %d for %d%s hours with %s-bits %s, owner %s, level %d.\n\r",
 			buf2,
-			skill_table[(int)paf->type].name,
-			(paf->where == TO_OBJ_AFFECTS)
-				? str_cmp(oaffect_loc_name(paf->location), "none")
-					? oaffect_loc_name(paf->location)
-					: (paf->where == TO_OBJ_APPLY)
-						? affect_loc_name(paf->location)
-						: apply_locations[paf->location].name
+			skill_table[(int)paf.type].name,
+			(paf.where == TO_OBJ_AFFECTS)
+				? str_cmp(oaffect_loc_name(paf.location), "none")
+					? oaffect_loc_name(paf.location)
+					: (paf.where == TO_OBJ_APPLY)
+						? affect_loc_name(paf.location)
+						: apply_locations[paf.location].name
 				: "none",
-			paf->modifier,
-			(paf->duration == -1) ? -1 : (paf->duration / 2) + 1,
-			(paf->duration == 0) ? "" : (paf->duration == -1) ? "" : ".5",
-			(paf->where == TO_OBJ_AFFECTS) ? "aff" : (paf->where == TO_OBJ_APPLY) ? "apply" : "?",
-			oaffect_bit_name(paf->bitvector),
-			(paf->owner) ? paf->owner->name : "none", paf->level);
+			paf.modifier,
+			(paf.duration == -1) ? -1 : (paf.duration / 2) + 1,
+			(paf.duration == 0) ? "" : (paf.duration == -1) ? "" : ".5",
+			(paf.where == TO_OBJ_AFFECTS) ? "aff" : (paf.where == TO_OBJ_APPLY) ? "apply" : "?",
+			oaffect_bit_name(paf.bitvector),
+			(paf.owner) ? paf.owner->name : "none", paf.level);
 		send_to_char(buffer.c_str(), ch);
 	}
 }
@@ -7255,7 +7254,6 @@ void do_aastrip(CHAR_DATA *ch, char *argument)
 void do_oastrip(CHAR_DATA *ch, char *argument)
 {
 	OBJ_DATA *obj;
-	OBJ_AFFECT_DATA *af, *af_next;
 	char arg[MSL];
 
 	one_argument(argument, arg);
@@ -7276,14 +7274,14 @@ void do_oastrip(CHAR_DATA *ch, char *argument)
 		return;
 	}
 
-	for (af = obj->affected; af != nullptr; af = af_next)
+	for (auto it = obj->affected.begin(); it != obj->affected.end(); )
 	{
-		af_next = af->next;
+		auto next = std::next(it);
 
-		if (IS_SET(af->bitvector, AFF_PERMANENT))
-			continue;
+		if (!IS_SET(it->bitvector, AFF_PERMANENT))
+			affect_remove_obj(obj, &*it, true);
 
-		affect_remove_obj(obj, af, true);
+		it = next;
 	}
 
 	act("All affects stripped from $p.", ch, obj, 0, TO_CHAR);

--- a/code/act_wiz.c
+++ b/code/act_wiz.c
@@ -2334,7 +2334,6 @@ void do_astat(CHAR_DATA *ch, char *argument)
 	char buf[MSL];
 	int count = 0;
 	AREA_DATA *area, *pArea;
-	AREA_AFFECT_DATA *paf;
 
 	area = ch->in_room->area;
 
@@ -2468,31 +2467,31 @@ void do_astat(CHAR_DATA *ch, char *argument)
 	else
 		send_to_char(".\n\r", ch);
 
-	if (area->affected)
+	if (!area->affected.empty())
 	{
 		send_to_char("The area is affected by:\n\r", ch);
 
-		for (paf = area->affected; paf; paf = paf->next)
+		for (auto &paf : area->affected)
 		{
-			if (paf->aftype == AFT_SKILL)
-				sprintf(buf, "Skill: '%s' ", skill_table[paf->type].name);
-			else if (paf->aftype == AFT_POWER)
-				sprintf(buf, "Power: '%s' ", skill_table[paf->type].name);
-			else if (paf->aftype == AFT_COMMUNE)
-				sprintf(buf, "Commune: '%s' ", skill_table[paf->type].name);
+			if (paf.aftype == AFT_SKILL)
+				sprintf(buf, "Skill: '%s' ", skill_table[paf.type].name);
+			else if (paf.aftype == AFT_POWER)
+				sprintf(buf, "Power: '%s' ", skill_table[paf.type].name);
+			else if (paf.aftype == AFT_COMMUNE)
+				sprintf(buf, "Commune: '%s' ", skill_table[paf.type].name);
 			else
-				sprintf(buf, "Spell: '%s' ", skill_table[paf->type].name);
+				sprintf(buf, "Spell: '%s' ", skill_table[paf.type].name);
 
 			send_to_char(buf, ch);
 
 			sprintf(buf, "modifies %s by %d for %d hours with %s-bits %s, owner %s, level %d.\n\r",
-				aaffect_loc_name(paf->location),
-				paf->modifier,
-				(paf->duration == -1) ? paf->duration : paf->duration / 2,
+				aaffect_loc_name(paf.location),
+				paf.modifier,
+				(paf.duration == -1) ? paf.duration : paf.duration / 2,
 				"flag",
 				"nullptr",
-				paf->owner != nullptr ? paf->owner->name : "none",
-				paf->level);
+				paf.owner != nullptr ? paf.owner->name : "none",
+				paf.level);
 			send_to_char(buf, ch);
 		}
 	}
@@ -7242,13 +7241,13 @@ void do_rastrip(CHAR_DATA *ch, char *argument)
 
 void do_aastrip(CHAR_DATA *ch, char *argument)
 {
-	AREA_AFFECT_DATA *af, *af_next;
 	AREA_DATA *area = ch->in_room->area;
 
-	for (af = area->affected; af; af = af_next)
+	for (auto it = area->affected.begin(); it != area->affected.end(); )
 	{
-		af_next = af->next;
-		affect_remove_area(area, af);
+		auto next = std::next(it);
+		affect_remove_area(area, &*it);
+		it = next;
 	}
 
 	act("All affects stripped from '$t'.", ch, area->name, 0, TO_CHAR);

--- a/code/act_wiz.c
+++ b/code/act_wiz.c
@@ -3699,7 +3699,10 @@ void do_switch(CHAR_DATA *ch, char *argument)
 	ch->desc->character = victim;
 	ch->desc->original = ch;
 	victim->desc = ch->desc;
-	victim->pcdata = ch->pcdata;
+	// The possessed mob borrows the immortal's pcdata (it's an NPC, so its own
+	// pcdata is null). Ownership stays with the original body; do_return calls
+	// release() so this borrow is never freed through the mob.
+	victim->pcdata.reset(ch->pcdata.get());
 	ch->desc = nullptr;
 	/* change communications to match */
 	/*
@@ -3738,7 +3741,7 @@ void do_return(CHAR_DATA *ch, char *argument)
 
 	wiznet(buf, ch->desc->original, 0, WIZ_SWITCHES, WIZ_SECURE, get_trust(ch));
 
-	ch->pcdata = nullptr;
+	ch->pcdata.release();		// relinquish the borrowed pcdata WITHOUT freeing it
 	ch->desc->character = ch->desc->original;
 	ch->desc->original = nullptr;
 	ch->desc->character->desc = ch->desc;

--- a/code/act_wiz.c
+++ b/code/act_wiz.c
@@ -3225,7 +3225,7 @@ void do_ofind(CHAR_DATA *ch, char *argument)
 void do_owhere(CHAR_DATA *ch, char *argument)
 {
 	char buf[MAX_INPUT_LENGTH];
-	BUFFER *buffer;
+	BUFFER buffer;
 	OBJ_DATA *obj;
 	OBJ_DATA *in_obj;
 	bool found;
@@ -3234,8 +3234,6 @@ void do_owhere(CHAR_DATA *ch, char *argument)
 	found = false;
 	number = 0;
 	max_found = 200;
-
-	buffer = new_buf();
 
 	if (argument[0] == '\0')
 	{
@@ -3277,7 +3275,7 @@ void do_owhere(CHAR_DATA *ch, char *argument)
 		found = true;
 
 		buf[0] = UPPER(buf[0]);
-		add_buf(buffer, buf);
+		buffer.add(buf);
 
 		if (number >= max_found)
 			break;
@@ -3286,15 +3284,13 @@ void do_owhere(CHAR_DATA *ch, char *argument)
 	if (!found)
 		send_to_char("Nothing like that in heaven or earth.\n\r", ch);
 	else
-		page_to_char(buf_string(buffer), ch);
-
-	free_buf(buffer);
+		page_to_char(buffer.str(), ch);
 }
 
 void do_mwhere(CHAR_DATA *ch, char *argument)
 {
 	char buf[MAX_STRING_LENGTH];
-	BUFFER *buffer;
+	BUFFER buffer;
 	CHAR_DATA *victim;
 	bool found;
 	int count = 0;
@@ -3305,7 +3301,6 @@ void do_mwhere(CHAR_DATA *ch, char *argument)
 
 		/* show characters logged */
 
-		buffer = new_buf();
 		for (d = descriptor_list; d != nullptr; d = d->next)
 		{
 			if (d->character != nullptr
@@ -3335,17 +3330,15 @@ void do_mwhere(CHAR_DATA *ch, char *argument)
 						victim->in_room->vnum);
 				}
 
-				add_buf(buffer, buf);
+				buffer.add(buf);
 			}
 		}
 
-		page_to_char(buf_string(buffer), ch);
-		free_buf(buffer);
+		page_to_char(buffer.str(), ch);
 		return;
 	}
 
 	found = false;
-	buffer = new_buf();
 
 	for (victim = char_list; victim != nullptr; victim = victim->next)
 	{
@@ -3360,16 +3353,14 @@ void do_mwhere(CHAR_DATA *ch, char *argument)
 				is_npc(victim) ? victim->short_descr : victim->name,
 				victim->in_room->vnum,
 				get_room_name(victim->in_room));
-			add_buf(buffer, buf);
+			buffer.add(buf);
 		}
 	}
 
 	if (!found)
 		act("You didn't find any $T.", ch, nullptr, argument, TO_CHAR);
 	else
-		page_to_char(buf_string(buffer), ch);
-
-	free_buf(buffer);
+		page_to_char(buffer.str(), ch);
 }
 
 void do_reboo(CHAR_DATA *ch, char *argument)
@@ -7018,9 +7009,8 @@ void add_history(CHAR_DATA *ch, CHAR_DATA *victim, char *string)
 
 void show_temp_history(CHAR_DATA *ch, CHAR_DATA *victim)
 {
-	BUFFER *output;
+	BUFFER output;
 
-	output = new_buf();
 	send_to_char(victim->name, ch);
 	send_to_char("'s temporary history buffer:\n\r", ch);
 
@@ -7030,17 +7020,14 @@ void show_temp_history(CHAR_DATA *ch, CHAR_DATA *victim)
 	}
 	else
 	{
-		add_buf(output, victim->pcdata->temp_history_buffer);
-		page_to_char(buf_string(output), ch);
-		free_buf(output);
+		output.add(victim->pcdata->temp_history_buffer);
+		page_to_char(output.str(), ch);
 	}
 }
 
 void show_history(CHAR_DATA *ch, CHAR_DATA *victim)
 {
-	BUFFER *output;
-
-	output = new_buf();
+	BUFFER output;
 
 	send_to_char(victim->name, ch);
 	send_to_char("'s player history:\n\r", ch);
@@ -7051,9 +7038,8 @@ void show_history(CHAR_DATA *ch, CHAR_DATA *victim)
 	}
 	else
 	{
-		add_buf(output, victim->pcdata->history_buffer);
-		page_to_char(buf_string(output), ch);
-		free_buf(output);
+		output.add(victim->pcdata->history_buffer);
+		page_to_char(output.str(), ch);
 	}
 }
 
@@ -7455,9 +7441,7 @@ void do_gsnlist(CHAR_DATA *ch, char *argument)
 {
 	int sn, col = 0;
 	char buf[MSL];
-	BUFFER *output;
-
-	output = new_buf();
+	BUFFER output;
 
 	for (sn = 0; sn < MAX_SKILL; sn++)
 	{
@@ -7465,14 +7449,13 @@ void do_gsnlist(CHAR_DATA *ch, char *argument)
 			continue;
 
 		sprintf(buf, "%-18s %3d  ", skill_table[sn].name, sn);
-		add_buf(output, buf);
+		output.add(buf);
 
 		if (++col % 3 == 0)
-			add_buf(output, "\n\r");
+			output.add("\n\r");
 	}
 
-	page_to_char(buf_string(output), ch);
-	free_buf(output);
+	page_to_char(output.str(), ch);
 }
 
 void do_ccl(CHAR_DATA *ch, char *argument)

--- a/code/act_wiz.c
+++ b/code/act_wiz.c
@@ -1830,7 +1830,6 @@ void do_ostat(CHAR_DATA *ch, char *argument)
 {
 	char buf[MAX_STRING_LENGTH], arg[MAX_INPUT_LENGTH], buf2[MSL];
 	OBJ_AFFECT_DATA *paf;
-	OBJ_APPLY_DATA *app;
 	AFFECT_DATA *paf2;
 	OBJ_DATA *obj;
 
@@ -2258,9 +2257,9 @@ void do_ostat(CHAR_DATA *ch, char *argument)
 		send_to_char(buf, ch);
 	}
 
-	for (app = obj->apply; app; app = app->next)
+	for (const auto &app : obj->apply)
 	{
-		sprintf(buf, "Modifies %s by %d.\n\r", affect_loc_name(app->location), app->modifier);
+		sprintf(buf, "Modifies %s by %d.\n\r", affect_loc_name(app.location), app.modifier);
 		send_to_char(buf, ch);
 	}
 
@@ -6529,7 +6528,6 @@ void do_addapply(CHAR_DATA *ch, char *argument)
 {
 	OBJ_DATA *obj;
 	AFFECT_DATA *paf, *paf_next, af;
-	OBJ_APPLY_DATA *app, *app_next;
 	char arg1[MAX_INPUT_LENGTH];
 	char arg2[MAX_INPUT_LENGTH];
 	char arg3[MAX_INPUT_LENGTH];
@@ -6571,12 +6569,7 @@ void do_addapply(CHAR_DATA *ch, char *argument)
 
 		obj->charaffs = nullptr;
 
-		for (app = obj->apply; app; app = app_next)
-		{
-			app_next = app->next;
-		}
-
-		obj->apply = nullptr;
+		obj->apply.clear();
 
 		act("All affects removed from $p.", ch, obj, 0, TO_CHAR);
 		return;
@@ -6619,22 +6612,18 @@ void do_addapply(CHAR_DATA *ch, char *argument)
 
 	if (location != APPLY_SPELL_AFFECT)
 	{
-		app = new_apply_data();
-		app->location = location;
-
-		if (is_number(arg3))
-		{
-			modifier = atoi(arg3);
-		}
-		else
+		if (!is_number(arg3))
 		{
 			send_to_char("Applies require a numerical value.\n\r", ch);
 			return;
 		}
 
-		app->modifier = modifier;
-		app->next = obj->apply;
-		obj->apply = app;
+		modifier = atoi(arg3);
+
+		OBJ_APPLY_DATA app;
+		app.location = location;
+		app.modifier = modifier;
+		obj->apply.push_front(app);
 	}
 	else
 	{

--- a/code/act_wiz.c
+++ b/code/act_wiz.c
@@ -1726,17 +1726,18 @@ void do_rstat(CHAR_DATA *ch, char *argument)
 	sprintf(buf, "Description:\n\r%s", location->description);
 	send_to_char(buf, ch);
 
-	if (location->extra_descr != nullptr)
+	if (!location->extra_descr.empty())
 	{
-		EXTRA_DESCR_DATA *ed;
-
 		send_to_char("Extra description keywords: '", ch);
 
-		for (ed = location->extra_descr; ed; ed = ed->next)
+		bool first = true;
+		for (const auto &ed : location->extra_descr)
 		{
-			send_to_char(ed->keyword, ch);
-			if (ed->next != nullptr)
+			if (!first)
 				send_to_char(" ", ch);
+
+			send_to_char(ed.keyword, ch);
+			first = false;
 		}
 
 		send_to_char("'.\n\r", ch);
@@ -2073,26 +2074,25 @@ void do_ostat(CHAR_DATA *ch, char *argument)
 		send_to_char(buf, ch);
 	}
 
-	if (obj->extra_descr != nullptr || obj->pIndexData->extra_descr != nullptr)
+	if (!obj->extra_descr.empty() || !obj->pIndexData->extra_descr.empty())
 	{
-		EXTRA_DESCR_DATA *ed, *ed2;
 		bool duplicate = false; /* Don't duplicate extradescs. */
 
 		send_to_char("Extra description keywords: '", ch);
 
-		for (ed = obj->extra_descr; ed != nullptr; ed = ed->next)
+		for (auto ed = obj->extra_descr.begin(); ed != obj->extra_descr.end(); ++ed)
 		{
 			send_to_char(ed->keyword, ch);
 
-			if (ed->next != nullptr)
+			if (std::next(ed) != obj->extra_descr.end())
 				send_to_char(" ", ch);
 		}
 
-		for (ed = obj->pIndexData->extra_descr; ed != nullptr; ed = ed->next)
+		for (auto ed = obj->pIndexData->extra_descr.begin(); ed != obj->pIndexData->extra_descr.end(); ++ed)
 		{
-			for (ed2 = obj->extra_descr; ed2; ed2 = ed2->next)
+			for (const auto &ed2 : obj->extra_descr)
 			{
-				if (!str_cmp(ed->keyword, ed2->keyword))
+				if (!str_cmp(ed->keyword, ed2.keyword))
 					duplicate = true;
 			}
 
@@ -2101,7 +2101,7 @@ void do_ostat(CHAR_DATA *ch, char *argument)
 
 			send_to_char(ed->keyword, ch);
 
-			if (ed->next != nullptr)
+			if (std::next(ed) != obj->pIndexData->extra_descr.end())
 				send_to_char(" ", ch);
 		}
 
@@ -5600,8 +5600,6 @@ void do_string(CHAR_DATA *ch, char *argument)
 
 		if (!str_prefix(arg2, "ed") || !str_prefix(arg2, "extended"))
 		{
-			EXTRA_DESCR_DATA *ed;
-
 			argument = one_argument(argument, arg3);
 
 			if (argument == nullptr)
@@ -5612,12 +5610,11 @@ void do_string(CHAR_DATA *ch, char *argument)
 
 			strcat(argument, "\n\r");
 
-			ed = new_extra_descr();
+			EXTRA_DESCR_DATA ed;
 
-			ed->keyword = palloc_string(arg3);
-			ed->description = palloc_string(argument);
-			ed->next = obj->extra_descr;
-			obj->extra_descr = ed;
+			ed.keyword = palloc_string(arg3);
+			ed.description = palloc_string(argument);
+			obj->extra_descr.push_front(std::move(ed));
 			return;
 		}
 	}

--- a/code/act_wiz.c
+++ b/code/act_wiz.c
@@ -7140,44 +7140,43 @@ void do_empower(CHAR_DATA *ch, char *argument)
 
 void do_raffects(CHAR_DATA *ch, char *argument)
 {
-	ROOM_AFFECT_DATA *paf;
 	RUNE_DATA *rune;
 	char buf[MAX_STRING_LENGTH];
 	bool found = false;
 	int i = 0;
 
-	if (ch->in_room->affected != nullptr)
+	if (!ch->in_room->affected.empty())
 	{
 		found = true;
 		send_to_char("The room is affected by:\n\r", ch);
 
-		for (paf = ch->in_room->affected; paf != nullptr; paf = paf->next)
+		for (auto &paf : ch->in_room->affected)
 		{
-			if (paf->aftype == AFT_SPELL)
-				sprintf(buf, "Spell: '%s' ", skill_table[paf->type].name);
+			if (paf.aftype == AFT_SPELL)
+				sprintf(buf, "Spell: '%s' ", skill_table[paf.type].name);
 
-			if (paf->aftype == AFT_SKILL)
-				sprintf(buf, "Skill: '%s' ", skill_table[paf->type].name);
+			if (paf.aftype == AFT_SKILL)
+				sprintf(buf, "Skill: '%s' ", skill_table[paf.type].name);
 
-			if (paf->aftype == AFT_POWER)
-				sprintf(buf, "Power: '%s' ", skill_table[paf->type].name);
+			if (paf.aftype == AFT_POWER)
+				sprintf(buf, "Power: '%s' ", skill_table[paf.type].name);
 
-			if (paf->aftype == AFT_COMMUNE)
-				sprintf(buf, "Commune: '%s' ", skill_table[paf->type].name);
+			if (paf.aftype == AFT_COMMUNE)
+				sprintf(buf, "Commune: '%s' ", skill_table[paf.type].name);
 
-			if (paf->aftype != AFT_SPELL && paf->aftype != AFT_SKILL && paf->aftype != AFT_POWER &&
-				paf->aftype != AFT_MALADY && paf->aftype != AFT_COMMUNE)
-				sprintf(buf, "Spell: '%s' ", skill_table[paf->type].name);
+			if (paf.aftype != AFT_SPELL && paf.aftype != AFT_SKILL && paf.aftype != AFT_POWER &&
+				paf.aftype != AFT_MALADY && paf.aftype != AFT_COMMUNE)
+				sprintf(buf, "Spell: '%s' ", skill_table[paf.type].name);
 			send_to_char(buf, ch);
 
 			sprintf(buf, "modifies %s by %d for %d hours with %s-bits %s, owner %s, level %d.\n\r",
-				raffect_loc_name(paf->location),
-				paf->modifier,
-				paf->duration / 2,
-				paf->where == TO_ROOM_FLAGS ? "flag" : paf->where == TO_ROOM_CONST ? "const" : "aff",
+				raffect_loc_name(paf.location),
+				paf.modifier,
+				paf.duration / 2,
+				paf.where == TO_ROOM_FLAGS ? "flag" : paf.where == TO_ROOM_CONST ? "const" : "aff",
 				"nullptr",
-				paf->owner != nullptr ? paf->owner->name : "none",
-				paf->level);
+				paf.owner != nullptr ? paf.owner->name : "none",
+				paf.level);
 			send_to_char(buf, ch);
 		}
 	}
@@ -7218,7 +7217,6 @@ void do_raffects(CHAR_DATA *ch, char *argument)
 
 void do_rastrip(CHAR_DATA *ch, char *argument)
 {
-	ROOM_AFFECT_DATA *af, *af_next;
 	ROOM_INDEX_DATA *location = nullptr;
 
 	if (argument[0] == '\0')
@@ -7230,10 +7228,11 @@ void do_rastrip(CHAR_DATA *ch, char *argument)
 		return;
 	}
 
-	for (af = location->affected; af != nullptr; af = af_next)
+	for (auto it = location->affected.begin(); it != location->affected.end(); )
 	{
-		af_next = af->next;
-		affect_remove_room(location, af);
+		auto next = std::next(it);
+		affect_remove_room(location, &*it);
+		it = next;
 	}
 
 	act("All affects stripped from '$t'.", ch, location->name, 0, TO_CHAR);

--- a/code/act_wiz.c
+++ b/code/act_wiz.c
@@ -1829,7 +1829,6 @@ void do_rstat(CHAR_DATA *ch, char *argument)
 void do_ostat(CHAR_DATA *ch, char *argument)
 {
 	char buf[MAX_STRING_LENGTH], arg[MAX_INPUT_LENGTH], buf2[MSL];
-	AFFECT_DATA *paf2;
 	OBJ_DATA *obj;
 
 	one_argument(argument, arg);
@@ -2286,11 +2285,11 @@ void do_ostat(CHAR_DATA *ch, char *argument)
 		send_to_char(buf, ch);
 	}
 
-	for (paf2 = obj->charaffs; paf2; paf2 = paf2->next)
+	for (auto &paf2 : obj->charaffs)
 	{
-		if (paf2->bitvector)
+		if (paf2.bitvector)
 		{
-			sprintf(buf, "Imbues wearer with %s.\n\r", affect_bit_name(paf2->bitvector));
+			sprintf(buf, "Imbues wearer with %s.\n\r", affect_bit_name(paf2.bitvector));
 			send_to_char(buf, ch);
 		}
 	}
@@ -2507,7 +2506,6 @@ void do_mstat(CHAR_DATA *ch, char *argument)
 	char buf2[MAX_STRING_LENGTH];
 	char cred[MSL], tbuf[MSL];
 	char arg[MAX_INPUT_LENGTH];
-	AFFECT_DATA *paf;
 	CHAR_DATA *victim;
 	ROOM_INDEX_DATA *barred;
 	int i, x;
@@ -3027,43 +3025,43 @@ void do_mstat(CHAR_DATA *ch, char *argument)
 		send_to_char(buf, ch);
 	}
 
-	for (paf = victim->affected; paf != nullptr; paf = paf->next)
+	for (auto &paf : victim->affected)
 	{
-		if (paf->aftype == AFT_SPELL)
+		if (paf.aftype == AFT_SPELL)
 			sprintf(buf2, "Spell");
-		else if (paf->aftype == AFT_SKILL)
+		else if (paf.aftype == AFT_SKILL)
 			sprintf(buf2, "Skill");
-		else if (paf->aftype == AFT_POWER)
+		else if (paf.aftype == AFT_POWER)
 			sprintf(buf2, "Power");
-		else if (paf->aftype == AFT_MALADY)
+		else if (paf.aftype == AFT_MALADY)
 			sprintf(buf2, "Malady");
-		else if (paf->aftype == AFT_COMMUNE)
+		else if (paf.aftype == AFT_COMMUNE)
 			sprintf(buf2, "Commune");
-		else if (paf->aftype == AFT_INVIS)
+		else if (paf.aftype == AFT_INVIS)
 			sprintf(buf2, "Hidden Affect");
-		else if (paf->aftype == AFT_RUNE)
+		else if (paf.aftype == AFT_RUNE)
 			sprintf(buf2, "Rune");
-		else if (paf->aftype == AFT_TIMER)
+		else if (paf.aftype == AFT_TIMER)
 			sprintf(buf2, "Timer");
 		else
 			sprintf(buf2, "Spell");
 
 		buffer = fmt::sprintf("%s: '%s' %s%s%smodifies %s by %d for %d%s hours with %s-bits %s, owner %s, level %d.\n\r",
 			buf2,
-			skill_table[(int)paf->type].name,
-			paf->name ? "(" : "", paf->name ? paf->name : "",
-			paf->name ? ") " : "",
-			str_cmp(affect_loc_name(paf->location), "none")
-				? affect_loc_name(paf->location)
-				: apply_locations[paf->location].name,
-			paf->modifier,
-			(paf->duration == -1) ? -1 : (paf->duration / 2) + 1,
-			(paf->duration % 2 == 0) ? "" : (paf->duration == -1) ? "" : ".5",
-			paf->where == TO_IMMUNE ? "imm" : paf->where == TO_RESIST ? "res" : paf->where == TO_VULN ? "vuln" : "aff",
-			paf->where == TO_IMMUNE || paf->where == TO_RESIST || paf->where == TO_VULN
-				? imm_bit_name(paf->bitvector)
-				: affect_bit_name(paf->bitvector),
-			paf->owner != nullptr ? paf->owner->true_name : "none", paf->level);
+			skill_table[(int)paf.type].name,
+			paf.name ? "(" : "", paf.name ? paf.name : "",
+			paf.name ? ") " : "",
+			str_cmp(affect_loc_name(paf.location), "none")
+				? affect_loc_name(paf.location)
+				: apply_locations[paf.location].name,
+			paf.modifier,
+			(paf.duration == -1) ? -1 : (paf.duration / 2) + 1,
+			(paf.duration % 2 == 0) ? "" : (paf.duration == -1) ? "" : ".5",
+			paf.where == TO_IMMUNE ? "imm" : paf.where == TO_RESIST ? "res" : paf.where == TO_VULN ? "vuln" : "aff",
+			paf.where == TO_IMMUNE || paf.where == TO_RESIST || paf.where == TO_VULN
+				? imm_bit_name(paf.bitvector)
+				: affect_bit_name(paf.bitvector),
+			paf.owner != nullptr ? paf.owner->true_name : "none", paf.level);
 		send_to_char(buffer.c_str(), ch);
 	}
 
@@ -6288,7 +6286,6 @@ void do_prefix(CHAR_DATA *ch, char *argument)
 void do_astrip(CHAR_DATA *ch, char *argument)
 {
 	CHAR_DATA *victim;
-	AFFECT_DATA *af, *af_next;
 	char arg[MAX_STRING_LENGTH];
 
 	one_argument(argument, arg);
@@ -6304,14 +6301,14 @@ void do_astrip(CHAR_DATA *ch, char *argument)
 		return;
 	}
 
-	for (af = victim->affected; af != nullptr; af = af_next)
+	for (auto it = victim->affected.begin(); it != victim->affected.end(); )
 	{
-		af_next = af->next;
+		auto next = std::next(it);
 
-		if (IS_SET(af->bitvector, AFF_PERMANENT))
-			continue;
+		if (!IS_SET(it->bitvector, AFF_PERMANENT))
+			affect_remove(victim, &*it);
 
-		affect_remove(victim, af);
+		it = next;
 	}
 
 	if (victim != ch)
@@ -6525,7 +6522,7 @@ void do_max_limits(CHAR_DATA *ch, char *argument)
 void do_addapply(CHAR_DATA *ch, char *argument)
 {
 	OBJ_DATA *obj;
-	AFFECT_DATA *paf, *paf_next, af;
+	AFFECT_DATA af;
 	char arg1[MAX_INPUT_LENGTH];
 	char arg2[MAX_INPUT_LENGTH];
 	char arg3[MAX_INPUT_LENGTH];
@@ -6559,13 +6556,7 @@ void do_addapply(CHAR_DATA *ch, char *argument)
 
 	if (!str_prefix(arg2, "clear"))
 	{
-		for (paf = obj->charaffs; paf; paf = paf_next)
-		{
-			paf_next = paf->next;
-			free_affect(paf);
-		}
-
-		obj->charaffs = nullptr;
+		obj->charaffs.clear();
 
 		obj->apply.clear();
 

--- a/code/ban.c
+++ b/code/ban.c
@@ -84,7 +84,7 @@ void do_ban(CHAR_DATA *ch, char *argument)
 
 	char buf[MSL];
 	char arg1[MSL], arg2[MSL], arg3[MSL], arg4[MSL], date[MSL];
-	BUFFER *buffer;
+	BUFFER buffer;
 	int ban_type = 0, host_type = 0, duration = 0;
 
 	argument = one_argument(argument, arg1);
@@ -99,10 +99,9 @@ void do_ban(CHAR_DATA *ch, char *argument)
 
 		if (!banList.empty())
 		{
-			buffer = new_buf();
 
 			sprintf(buf, "%-25s\t%-10s\t%-10s\t%-10s\t%-10s\t%-10s\n\r", "Site", "By", "Type", "Date", "Duration", "Reason");
-			add_buf(buffer, buf);
+			buffer.add(buf);
 
 			for (const auto &ban : banList)
 			{
@@ -114,11 +113,10 @@ void do_ban(CHAR_DATA *ch, char *argument)
 					ban.duration,
 					ban.reason.c_str());
 
-				add_buf(buffer, buf);
+				buffer.add(buf);
 			}
 
-			page_to_char(buf_string(buffer), ch);
-			free_buf(buffer);
+			page_to_char(buffer.str(), ch);
 		}
 		else
 		{

--- a/code/characterClasses/ap.c
+++ b/code/characterClasses/ap.c
@@ -814,7 +814,6 @@ void living_blade_pulse(OBJ_DATA *obj, OBJ_AFFECT_DATA *af)
 {
 	char buf[MSL];
 	CHAR_DATA *ch;
-	OBJ_AFFECT_DATA *af2;
 
 	if ((ch = obj->carried_by) == nullptr)
 		return;
@@ -876,22 +875,22 @@ void living_blade_pulse(OBJ_DATA *obj, OBJ_AFFECT_DATA *af)
 
 	if (!ch->fighting && number_percent() <= 33)
 	{
-		af2 = new_affect_obj();
-		af2->where = af->where;
-		af2->aftype = af->aftype;
-		af2->type = af->type;
-		af2->owner = af->owner;
-		af2->level = af->level;
-		af2->location = af->location;
-		af2->modifier = af->modifier;
-		af2->duration = af->duration;
-		af2->end_fun = af->end_fun;
-		af2->pulse_fun = af->pulse_fun;
+		OBJ_AFFECT_DATA af2;
+		af2.where = af->where;
+		af2.aftype = af->aftype;
+		af2.type = af->type;
+		af2.owner = af->owner;
+		af2.level = af->level;
+		af2.location = af->location;
+		af2.modifier = af->modifier;
+		af2.duration = af->duration;
+		af2.end_fun = af->end_fun;
+		af2.pulse_fun = af->pulse_fun;
 		affect_remove_obj(obj, af, false);
 
-		af2->modifier--;
-		af2->modifier = std::max(0, (int)af2->modifier);
-		affect_to_obj(obj, af2);
+		af2.modifier--;
+		af2.modifier = std::max(0, (int)af2.modifier);
+		affect_to_obj(obj, &af2);
 
 		return;
 	}
@@ -906,37 +905,37 @@ void living_blade_pulse(OBJ_DATA *obj, OBJ_AFFECT_DATA *af)
 	if (is_npc(ch->fighting) && number_percent() > 5)
 		return;
 
-	af2 = new_affect_obj();
-	af2->where = af->where;
-	af2->aftype = af->aftype;
-	af2->type = af->type;
-	af2->owner = af->owner;
-	af2->level = af->level;
-	af2->location = af->location;
-	af2->modifier = af->modifier;
-	af2->duration = af->duration;
-	af2->end_fun = af->end_fun;
-	af2->pulse_fun = af->pulse_fun;
+	OBJ_AFFECT_DATA af2;
+	af2.where = af->where;
+	af2.aftype = af->aftype;
+	af2.type = af->type;
+	af2.owner = af->owner;
+	af2.level = af->level;
+	af2.location = af->location;
+	af2.modifier = af->modifier;
+	af2.duration = af->duration;
+	af2.end_fun = af->end_fun;
+	af2.pulse_fun = af->pulse_fun;
 	affect_remove_obj(obj, af, false);
 
-	if (is_npc(ch->fighting) && af2->modifier <= 15)
+	if (is_npc(ch->fighting) && af2.modifier <= 15)
 	{
-		af2->modifier++;
-		af2->modifier = std::min((int)af2->modifier, 15);
+		af2.modifier++;
+		af2.modifier = std::min((int)af2.modifier, 15);
 	}
 	else if (is_npc(ch->fighting))
 	{
-		af2->modifier -= 2;
+		af2.modifier -= 2;
 	}
 	else
 	{
-		af2->modifier++;
-		af2->modifier = std::min((int)af2->modifier, 50);
+		af2.modifier++;
+		af2.modifier = std::min((int)af2.modifier, 50);
 	}
 
-	affect_to_obj(obj, af2);
+	affect_to_obj(obj, &af2);
 
-	if (number_percent() < 10 && af2->location == APPLY_DAMROLL)
+	if (number_percent() < 10 && af2.location == APPLY_DAMROLL)
 	{
 		switch (number_range(1, 3))
 		{

--- a/code/characterClasses/chrono.c
+++ b/code/characterClasses/chrono.c
@@ -51,7 +51,9 @@ void spell_stasis_wall(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 	}
 
 	// allocate temporary rune, it'll be discarded after apply_rune anyway
-	rune = (RUNE_DATA *)talloc_struct(sizeof(rune));
+	// (sizeof(*rune), not sizeof(rune): the latter is the pointer's 8 bytes, which
+	// left every field write below running off the end of the allocation)
+	rune = (RUNE_DATA *)talloc_struct(sizeof(*rune));
 
 	// if it's not RUNE_DOOR then it's been casted, not runed, so it's immediate
 	if (target != RUNE_DOOR)

--- a/code/characterClasses/healer.c
+++ b/code/characterClasses/healer.c
@@ -66,16 +66,16 @@ void spell_healing_sleep(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 
 void healing_sleep_end(CHAR_DATA *ch, AFFECT_DATA *af)
 {
-	AFFECT_DATA *laf;
-
 	if (is_awake(ch))
 		return;
 
-	for (laf = ch->affected; laf != nullptr; laf = laf->next)
-	{
-		if (laf->type > 5 && skill_table[laf->type].dispel & CAN_CLEANSE)
-			affect_strip(ch, laf->type);
-	}
+	std::vector<int> cleanse_types;
+	for (auto &laf : ch->affected)
+		if (laf.type > 5 && skill_table[laf.type].dispel & CAN_CLEANSE)
+			cleanse_types.push_back(laf.type);
+
+	for (int cleanse_type : cleanse_types)
+		affect_strip(ch, cleanse_type);
 
 	ch->position = POS_STANDING;
 	ch->hit = ch->max_hit;

--- a/code/characterClasses/paladin.c
+++ b/code/characterClasses/paladin.c
@@ -1283,7 +1283,6 @@ void ispirit_end(CHAR_DATA *ch, AFFECT_DATA *af)
 
 void spell_altruism(int level, int sn, CHAR_DATA *ch, void *vo, int target)
 {
-	AFFECT_DATA *from_af, *faf_next, to_af;
 	CHAR_DATA *vict = (CHAR_DATA *)vo;
 
 	if (ch == vict)
@@ -1292,36 +1291,40 @@ void spell_altruism(int level, int sn, CHAR_DATA *ch, void *vo, int target)
 		return;
 	}
 
-	for (from_af = vict->affected; from_af != nullptr; from_af = faf_next)
+	for (auto it = vict->affected.begin(); it != vict->affected.end(); )
 	{
-		faf_next = from_af->next;
+		auto next = std::next(it);
 
-		if (skill_table[from_af->type].dispel & CAN_CLEANSE)
+		if (skill_table[it->type].dispel & CAN_CLEANSE)
 		{
+			AFFECT_DATA to_af;
 			init_affect(&to_af);
-			to_af.owner = from_af->owner;
+			to_af.owner = it->owner;
 
-			if (from_af->name != nullptr)
-				to_af.name = talloc_string(from_af->name);
+			// palloc (not talloc): the affect owns this string and frees it
+			// with free_pstring; a temp-pool string would be freed wrong.
+			if (it->name != nullptr)
+				to_af.name = palloc_string(it->name);
 
-			to_af.valid = from_af->valid;
-			to_af.where = from_af->where;
-			to_af.type = from_af->type;
-			to_af.level = from_af->level;
-			to_af.duration = from_af->duration;
-			to_af.location = from_af->location;
-			to_af.modifier = from_af->modifier;
+			to_af.where = it->where;
+			to_af.type = it->type;
+			to_af.level = it->level;
+			to_af.duration = it->duration;
+			to_af.location = it->location;
+			to_af.modifier = it->modifier;
 
-			copy_vector(to_af.bitvector, from_af->bitvector);
+			copy_vector(to_af.bitvector, it->bitvector);
 
-			to_af.aftype = from_af->aftype;
-			to_af.tick_fun = from_af->tick_fun;
-			to_af.pulse_fun = from_af->pulse_fun;
-			to_af.end_fun = from_af->end_fun;
-			to_af.init_duration = from_af->init_duration;
+			to_af.aftype = it->aftype;
+			to_af.tick_fun = it->tick_fun;
+			to_af.pulse_fun = it->pulse_fun;
+			to_af.end_fun = it->end_fun;
+			to_af.init_duration = it->init_duration;
 			affect_to_char(ch, &to_af);
-			affect_remove(vict, from_af);
+			affect_remove(vict, &*it);
 		}
+
+		it = next;
 	}
 
 	act("You absorb all of $N's maledictions.", ch, 0, vict, TO_CHAR);

--- a/code/characterClasses/sorcerer.c
+++ b/code/characterClasses/sorcerer.c
@@ -2316,11 +2316,7 @@ void spell_flood(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 
 		if (is_affected_room(ch->in_room, sn))
 		{
-			for (oaf = ch->in_room->affected; oaf != nullptr; oaf = oaf->next)
-			{
-				if (oaf->type == sn)
-					break;
-			}
+			oaf = affect_find_room(ch->in_room->affected, sn);
 
 			duration = std::max(oaf->duration - 1, 0);
 		}
@@ -2535,14 +2531,14 @@ void spell_riptide(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 	{
 		if (is_affected_room(room, sn))
 		{
-			for (raf = room->affected; raf != nullptr; raf = raf->next)
+			for (auto &raf : room->affected)
 			{
-				if (raf->type == sn && raf->owner == ch && raf->location == APPLY_ROOM_NONE && raf->modifier == 1)
+				if (raf.type == sn && raf.owner == ch && raf.location == APPLY_ROOM_NONE && raf.modifier == 1)
 				{
 					first_room = room;
-					fraf = raf;
+					fraf = &raf;
 				}
-				else if (raf->type == sn && raf->owner == ch && raf->location == APPLY_ROOM_NONE && raf->modifier == 2)
+				else if (raf.type == sn && raf.owner == ch && raf.location == APPLY_ROOM_NONE && raf.modifier == 2)
 				{
 					second_room = room;
 				}
@@ -5477,11 +5473,17 @@ void spell_pure_air(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 			}
 		}
 
-		for (raf = ch->in_room->affected; raf != nullptr; raf = raf->next)
+		// Snapshot the types to purify before stripping: affect_strip_room
+		// erases matching elements, which would invalidate a live iterator.
+		std::vector<int> purify_types;
+		for (auto &raf : ch->in_room->affected)
 		{
-			if (skill_table[raf->type].dispel & CAN_PURIFY)
-				affect_strip_room(ch->in_room, raf->type);
+			if (skill_table[raf.type].dispel & CAN_PURIFY)
+				purify_types.push_back(raf.type);
 		}
+
+		for (auto purify_type : purify_types)
+			affect_strip_room(ch->in_room, purify_type);
 
 		if (cleansed)
 			act("The air around $n is purified.", vch, 0, 0, TO_ROOM);

--- a/code/characterClasses/sorcerer.c
+++ b/code/characterClasses/sorcerer.c
@@ -713,11 +713,7 @@ void un_ultradiffusion(CHAR_DATA *ch, char *argument)
 	if (!is_affected(ch, gsn_ultradiffusion))
 		return;
 
-	for (paf = ch->affected; paf != nullptr; paf = paf->next)
-	{
-		if (paf->type == gsn_ultradiffusion)
-			break;
-	}
+	paf = affect_find(ch->affected, gsn_ultradiffusion);
 
 	if (paf->duration == 0)
 	{
@@ -730,7 +726,7 @@ void un_ultradiffusion(CHAR_DATA *ch, char *argument)
 
 void ultradiffusion_end(CHAR_DATA *ch, AFFECT_DATA *af)
 {
-	AFFECT_DATA paf, *rpaf;
+	AFFECT_DATA paf;
 	int modifier = 0;
 
 	if (af->duration == -1)
@@ -748,10 +744,10 @@ void ultradiffusion_end(CHAR_DATA *ch, AFFECT_DATA *af)
 		act("$n attempts to recollect the molecules of $s body as $e becomes visible.", ch, nullptr, nullptr, TO_ROOM);
 	}
 
-	for (rpaf = ch->affected; rpaf; rpaf = rpaf->next)
+	for (auto &rpaf : ch->affected)
 	{
-		if (rpaf->type == gsn_ultradiffusion && rpaf->end_fun)
-			rpaf->end_fun = nullptr;
+		if (rpaf.type == gsn_ultradiffusion && rpaf.end_fun)
+			rpaf.end_fun = nullptr;
 	}
 
 	switch (af->duration)
@@ -1319,10 +1315,10 @@ void spell_diuretic(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 
 	if (af)
 	{
-		for (af = victim->affected; af != nullptr; af = af->next)
+		for (auto &af : victim->affected)
 		{
-			if (af->type == gsn_bleeding && af->level < 150)
-				af->level = (int)((float)af->level * 1.33);
+			if (af.type == gsn_bleeding && af.level < 150)
+				af.level = (int)((float)af.level * 1.33);
 		}
 
 		send_to_char("The flow of blood from your wounds intensifies.\n\r", victim);
@@ -3707,7 +3703,7 @@ void spell_freezemetal(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 void spell_frostbite(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 {
 	CHAR_DATA *victim = (CHAR_DATA *)vo;
-	AFFECT_DATA af, *paf;
+	AFFECT_DATA af;
 
 	if (saves_spell(level, victim, DAM_COLD))
 	{
@@ -3727,10 +3723,14 @@ void spell_frostbite(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 		act_new("Your arm goes limp as $n draws heat from it.", ch, 0, victim, TO_VICT, POS_SLEEPING);
 		act("$N's arm goes limp as $n draws heat from it.", ch, 0, victim, TO_NOTVICT);
 
-		for (paf = victim->affected; paf != nullptr; paf = paf->next)
+		for (auto it = victim->affected.begin(); it != victim->affected.end(); )
 		{
-			if (paf->type == sn && paf->location == APPLY_STR)
-				affect_remove(victim, paf);
+			auto next = std::next(it);
+
+			if (it->type == sn && it->location == APPLY_STR)
+				affect_remove(victim, &*it);
+
+			it = next;
 		}
 
 		init_affect(&af);
@@ -3772,10 +3772,14 @@ void spell_frostbite(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 		act_new("Your leg goes limp as $n draws heat from it.", ch, 0, victim, TO_VICT, POS_SLEEPING);
 		act("$N's leg goes limp as $n draws heat from it.", ch, 0, victim, TO_NOTVICT);
 
-		for (paf = victim->affected; paf != nullptr; paf = paf->next)
+		for (auto it = victim->affected.begin(); it != victim->affected.end(); )
 		{
-			if (paf->type == sn && paf->location == APPLY_DEX)
-				affect_remove(victim, paf);
+			auto next = std::next(it);
+
+			if (it->type == sn && it->location == APPLY_DEX)
+				affect_remove(victim, &*it);
+
+			it = next;
 		}
 
 		init_affect(&af);
@@ -5443,7 +5447,6 @@ void spell_pure_air(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 {
 	CHAR_DATA *vch;
 	bool cleansed;
-	AFFECT_DATA *laf;
 	ROOM_AFFECT_DATA *raf;
 
 	if (ch->in_room->sector_type && ch->in_room->sector_type == SECT_UNDERWATER)
@@ -5464,13 +5467,19 @@ void spell_pure_air(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 	{
 		cleansed = false;
 
-		for (laf = ch->affected; laf != nullptr; laf = laf->next)
+		// Snapshot the caster's purifiable types before stripping: when vch is
+		// the caster, affect_strip erases from the same list being read.
+		std::vector<int> purify_char_types;
+		for (auto &laf : ch->affected)
 		{
-			if (skill_table[laf->type].dispel & CAN_PURIFY)
-			{
-				affect_strip(vch, laf->type);
-				cleansed = true;
-			}
+			if (skill_table[laf.type].dispel & CAN_PURIFY)
+				purify_char_types.push_back(laf.type);
+		}
+
+		for (auto purify_char_type : purify_char_types)
+		{
+			affect_strip(vch, purify_char_type);
+			cleansed = true;
 		}
 
 		// Snapshot the types to purify before stripping: affect_strip_room
@@ -7858,7 +7867,7 @@ void spell_detonation(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 void spell_rotating_ward(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 {
 	OBJ_AFFECT_DATA *oaf;
-	AFFECT_DATA *paf, af;
+	AFFECT_DATA af;
 	OBJ_DATA *obj;
 	int charges;
 	bool affected = false;
@@ -7884,9 +7893,9 @@ void spell_rotating_ward(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 
 	if (is_affected(ch, gsn_rotating_ward))
 	{
-		for (paf = ch->affected; paf; paf = paf->next)
+		for (auto &paf : ch->affected)
 		{
-			if (paf->type == gsn_rotating_ward)
+			if (paf.type == gsn_rotating_ward)
 				count++;
 		}
 

--- a/code/characterClasses/sorcerer.c
+++ b/code/characterClasses/sorcerer.c
@@ -6161,47 +6161,49 @@ void spell_fortify_weapon(int sn, int level, CHAR_DATA *ch, void *vo, int target
 
 	if (hitbonus)
 	{
-		for (hitapp = weapon->apply; hitapp; hitapp = hitapp->next)
+		for (auto &a : weapon->apply)
 		{
-			if (hitapp->location == APPLY_HITROLL && hitapp->type == sn)
+			if (a.location == APPLY_HITROLL && a.type == sn)
 			{
 				hitfound = true;
-				oldhit = hitapp->modifier;
+				oldhit = a.modifier;
+				hitapp = &a;
 				break;
 			}
 		}
 
 		if (!hitfound)
 		{
-			hitapp = new_apply_data();
+			// std::list keeps this element pointer valid across the dambonus
+			// prepend below, where hitapp->modifier is still dereferenced.
+			weapon->apply.push_front(OBJ_APPLY_DATA{});
+			hitapp = &weapon->apply.front();
 			hitapp->type = sn;
 			hitapp->location = APPLY_HITROLL;
 			hitapp->modifier = 0;
-			hitapp->next = weapon->apply;
-			weapon->apply = hitapp;
 		}
 	}
 
 	if (dambonus)
 	{
-		for (damapp = weapon->apply; damapp; damapp = damapp->next)
+		for (auto &a : weapon->apply)
 		{
-			if (damapp->location == APPLY_DAMROLL && damapp->type == sn)
+			if (a.location == APPLY_DAMROLL && a.type == sn)
 			{
 				damfound = true;
-				olddam = damapp->modifier;
+				olddam = a.modifier;
+				damapp = &a;
 				break;
 			}
 		}
 
 		if (!damfound)
 		{
-			damapp = new_apply_data();
+			weapon->apply.push_front(OBJ_APPLY_DATA{});
+			damapp = &weapon->apply.front();
 			damapp->type = sn;
 			damapp->location = APPLY_DAMROLL;
 			damapp->modifier = 0;
-			damapp->next = weapon->apply;
-			weapon->apply = damapp;
 		}
 	}
 

--- a/code/characterClasses/thief.c
+++ b/code/characterClasses/thief.c
@@ -1581,7 +1581,6 @@ void do_undisguise(CHAR_DATA *ch, char *argument)
 void do_search(CHAR_DATA *ch, char *argument)
 {
 	OBJ_DATA *obj = nullptr;
-	OBJ_AFFECT_DATA *oaf;
 	int chance;
 
 	act("You intently scrutinize your surroundings...", ch, 0, 0, TO_CHAR);
@@ -1593,17 +1592,17 @@ void do_search(CHAR_DATA *ch, char *argument)
 	{
 		if (is_affected_obj(obj, gsn_stash))
 		{
-			for (oaf = obj->affected; oaf != nullptr; oaf = oaf->next)
+			for (auto &oaf : obj->affected)
 			{
-				if (oaf->type == gsn_stash)
+				if (oaf.type == gsn_stash)
 					break;
 
-				chance += (ch->level - oaf->level);
+				chance += (ch->level - oaf.level);
 
 				if (ch->Class()->GetIndex() == CLASS_THIEF)
 					chance += (ch->level / 2);
 
-				if (oaf->owner != ch && (number_percent() < chance))
+				if (oaf.owner != ch && (number_percent() < chance))
 				{
 					affect_strip_obj(obj, gsn_stash);
 					act("You stumble across $p which seemed to be hidden from your eye.", ch, obj, 0, TO_CHAR);

--- a/code/characterClasses/thief.c
+++ b/code/characterClasses/thief.c
@@ -1993,15 +1993,18 @@ void thief_yell(CHAR_DATA *ch, CHAR_DATA *victim)
 
 AFFECT_DATA *check_bind(CHAR_DATA *ch, char *type)
 {
-	AFFECT_DATA *af;
+	AFFECT_DATA *af = nullptr;
 
-	for (af = ch->affected; af != nullptr; af = af->next)
+	for (auto &af_elem : ch->affected)
 	{
-		if (af->type == gsn_bind && !str_infix(type, af->name))
-			return af;
+		if (af_elem.type == gsn_bind && !str_infix(type, af_elem.name))
+		{
+			af = &af_elem;
+			break;
+		}
 	}
 
-	return nullptr;
+	return af;
 }
 
 void do_bind(CHAR_DATA *ch, char *argument)

--- a/code/characterClasses/warrior.c
+++ b/code/characterClasses/warrior.c
@@ -1245,14 +1245,13 @@ void do_bleed(CHAR_DATA *ch, char *argument)
 
 int check_posture(CHAR_DATA *ch)
 {
-	AFFECT_DATA *paf;
 	int modifier = POSTURE_NONE;
 
-	for (paf = ch->affected; paf != nullptr; paf = paf->next)
+	for (auto &paf : ch->affected)
 	{
-		if (paf->type == gsn_posture)
+		if (paf.type == gsn_posture)
 		{
-			modifier = paf->modifier;
+			modifier = paf.modifier;
 			break;
 		}
 	}
@@ -3328,13 +3327,13 @@ void check_batter(CHAR_DATA *ch)
 
 bool check_entwine(CHAR_DATA *ch, int type)
 {
-	for (AFFECT_DATA *af = ch->affected; af != nullptr; af = af->next)
+	for (auto &af : ch->affected)
 	{
-		if (type == 0 && af->type == gsn_entwine && af->modifier == 0)
+		if (type == 0 && af.type == gsn_entwine && af.modifier == 0)
 			return true;
-		else if (type == 1 && af->type == gsn_entwine && af->modifier == 1)
+		else if (type == 1 && af.type == gsn_entwine && af.modifier == 1)
 			return true;
-		else if (type == 2 && af->type == gsn_entwine && af->location == APPLY_DEX)
+		else if (type == 2 && af.type == gsn_entwine && af.location == APPLY_DEX)
 			return true;
 	}
 
@@ -3544,24 +3543,38 @@ void do_uncoil(CHAR_DATA *ch, char *argument)
 		return;
 	}
 
-	for (af = ch->affected; af != nullptr; af = af->next)
+	af = nullptr;
+	for (auto &af_elem : ch->affected)
 	{
-		if (type == 0 && af->type == gsn_entwine && af->modifier == 0)
+		if (type == 0 && af_elem.type == gsn_entwine && af_elem.modifier == 0)
+		{
+			af = &af_elem;
 			break;
-		else if (type == 1 && af->type == gsn_entwine && af->modifier == 1)
+		}
+		else if (type == 1 && af_elem.type == gsn_entwine && af_elem.modifier == 1)
+		{
+			af = &af_elem;
 			break;
-		else if (type == 2 && af->type == gsn_entwine && af->location == APPLY_DEX)
+		}
+		else if (type == 2 && af_elem.type == gsn_entwine && af_elem.location == APPLY_DEX)
+		{
+			af = &af_elem;
 			break;
+		}
 	}
 
 	guy = af->owner;
 
 	if (guy != nullptr)
 	{
-		for (af2 = guy->affected; af2 != nullptr; af2 = af2->next)
+		af2 = nullptr;
+		for (auto &af2_elem : guy->affected)
 		{
-			if (af2->type == gsn_entwine && af2->owner == ch)
+			if (af2_elem.type == gsn_entwine && af2_elem.owner == ch)
+			{
+				af2 = &af2_elem;
 				break;
+			}
 		}
 	}
 
@@ -3646,18 +3659,26 @@ void do_pull(CHAR_DATA *ch, char *argument)
 
 	if (check_entwine(ch, 0))
 	{
-		for (af = ch->affected; af != nullptr; af = af->next)
+		af = nullptr;
+		for (auto &af_elem : ch->affected)
 		{
-			if (af->type == gsn_entwine && af->modifier == 0)
+			if (af_elem.type == gsn_entwine && af_elem.modifier == 0)
+			{
+				af = &af_elem;
 				break;
+			}
 		}
 
 		guy = af->owner;
 
-		for (af2 = guy->affected; af2 != nullptr; af2 = af2->next)
+		af2 = nullptr;
+		for (auto &af2_elem : guy->affected)
 		{
-			if (af2->type == gsn_entwine && af2->owner == ch)
+			if (af2_elem.type == gsn_entwine && af2_elem.owner == ch)
+			{
+				af2 = &af2_elem;
 				break;
+			}
 		}
 
 		WAIT_STATE(ch, PULSE_VIOLENCE * 2);
@@ -4969,26 +4990,26 @@ bool check_leadership_save(CHAR_DATA *ch, int skill)
 
 void check_leadership_affect(CHAR_DATA *ch)
 {
-	AFFECT_DATA *af, *af_next;
-
-	for (af = ch->affected; af != nullptr; af = af_next)
+	for (auto it = ch->affected.begin(); it != ch->affected.end(); )
 	{
-		af_next = af->next;
-		if (af->type == gsn_leadership)
-			affect_remove(ch, af);
+		auto next = std::next(it);
+
+		if (it->type == gsn_leadership)
+			affect_remove(ch, &*it);
+
+		it = next;
 	}
 }
 
 int check_outflank(CHAR_DATA *ch)
 {
-	AFFECT_DATA *paf;
 	int modifier = -1;
 
-	for (paf = ch->affected; paf != nullptr; paf = paf->next)
+	for (auto &paf : ch->affected)
 	{
-		if (paf->type == gsn_outflank)
+		if (paf.type == gsn_outflank)
 		{
-			modifier = paf->modifier;
+			modifier = paf.modifier;
 			break;
 		}
 	}

--- a/code/characterClasses/zealot.c
+++ b/code/characterClasses/zealot.c
@@ -56,10 +56,14 @@ int get_bv_stage(CHAR_DATA *ch)
 	if (!is_affected(ch, gsn_burning_vision) /*|| is_immortal(ch)*/)
 		return -1;
 
-	for (af = ch->affected; af != nullptr; af = af->next)
+	af = nullptr;
+	for (auto &af_elem : ch->affected)
 	{
-		if (af->type == gsn_burning_vision)
+		if (af_elem.type == gsn_burning_vision)
+		{
+			af = &af_elem;
 			break;
+		}
 	}
 
 	return ((20 - af->duration) / af->modifier);
@@ -73,10 +77,14 @@ void spell_burning_vision(int sn, int level, CHAR_DATA *ch, void *vo, int target
 
 	if (is_affected(victim, gsn_burning_vision))
 	{
-		for (maf = victim->affected; maf != nullptr; maf = maf->next)
+		maf = nullptr;
+		for (auto &maf_elem : victim->affected)
 		{
-			if (maf->type == gsn_burning_vision)
+			if (maf_elem.type == gsn_burning_vision)
+			{
+				maf = &maf_elem;
 				break;
+			}
 		}
 
 		mod = maf->modifier;
@@ -126,10 +134,14 @@ void burning_vision_tick(CHAR_DATA *ch, AFFECT_DATA *af)
 		act("You are blinded!", ch, 0, 0, TO_CHAR);
 		act("$n appears to be blinded.", ch, 0, 0, TO_ROOM);
 
-		for (caf = ch->affected; caf != nullptr; caf = caf->next)
+		caf = nullptr;
+		for (auto &caf_elem : ch->affected)
 		{
-			if (caf->type == gsn_burning_vision)
+			if (caf_elem.type == gsn_burning_vision)
+			{
+				caf = &caf_elem;
 				break;
+			}
 		}
 
 		SET_BIT(caf->bitvector, AFF_BLIND);

--- a/code/comm.c
+++ b/code/comm.c
@@ -751,16 +751,18 @@ void read_from_buffer(DESCRIPTOR_DATA *d)
 
 const char *get_battle_condition(CHAR_DATA *victim, int percent)
 {
-	AFFECT_DATA *b_af = nullptr;
 
 	if (is_affected(victim, gsn_bluff))
 	{
 		AFFECT_DATA *b_af = nullptr;
 
-		for (b_af = victim->affected; b_af != nullptr; b_af = b_af->next)
+		for (auto &b_af_elem : victim->affected)
 		{
-			if (b_af->type == gsn_bluff)
+			if (b_af_elem.type == gsn_bluff)
+			{
+				b_af = &b_af_elem;
 				break;
+			}
 		}
 
 		percent *= (b_af->modifier * 3);

--- a/code/db.c
+++ b/code/db.c
@@ -3971,7 +3971,6 @@ void load_rooms(FILE *fp)
 {
 	ROOM_INDEX_DATA *pRoomIndex;
 	char error_v[MAX_STRING_LENGTH];
-	int i;
 
 	if (area_last == nullptr)
 		bugout("Load_resets: no #AREA seen yet.");
@@ -4021,11 +4020,6 @@ void load_rooms(FILE *fp)
 		pRoomIndex->trap = nullptr;
 		pRoomIndex->affected = nullptr;
 		zero_vector(pRoomIndex->room_flags);
-
-		for (i = 0; i < MAX_TRACKS; i++)
-		{
-			pRoomIndex->tracks[i] = new_track_data();
-		}
 
 		pRoomIndex->area = area_last;
 		pRoomIndex->vnum = vnum;

--- a/code/db.c
+++ b/code/db.c
@@ -2367,7 +2367,6 @@ OBJ_DATA *create_object(OBJ_INDEX_DATA *pObjIndex, int level)
 void clone_object(OBJ_DATA *parent, OBJ_DATA *clone)
 {
 	int i;
-	OBJ_AFFECT_DATA *paf;
 
 	if (parent == nullptr || clone == nullptr)
 		return;
@@ -2405,10 +2404,8 @@ void clone_object(OBJ_DATA *parent, OBJ_DATA *clone)
 
 	/* affects */
 
-	for (paf = parent->affected; paf != nullptr; paf = paf->next)
-	{
-		affect_to_obj(clone, paf);
-	}
+	for (auto &paf : parent->affected)
+		affect_to_obj(clone, &paf);
 
 	/* extended desc — prepend each (reverses order), matching the old intrusive list */
 	for (const auto &ed : parent->extra_descr)
@@ -3204,7 +3201,6 @@ void do_dump(CHAR_DATA *ch, char *argument)
 	EXIT_DATA *exit;
 	DESCRIPTOR_DATA *d;
 	AFFECT_DATA *af;
-	OBJ_AFFECT_DATA *oaf;
 	FILE *fp;
 	int vnum, nMatch = 0;
 
@@ -3300,10 +3296,7 @@ void do_dump(CHAR_DATA *ch, char *argument)
 	{
 		count++;
 
-		for (oaf = obj->affected; oaf != nullptr; oaf = oaf->next)
-		{
-			aff_count++;
-		}
+		aff_count += obj->affected.size();
 	}
 
 	for (obj = obj_free; obj != nullptr; obj = obj->next)

--- a/code/db.c
+++ b/code/db.c
@@ -2216,7 +2216,7 @@ OBJ_DATA *create_object(OBJ_INDEX_DATA *pObjIndex, int level)
 
 	copy_vector(obj->extra_flags, pObjIndex->extra_flags);
 
-	obj->apply = pObjIndex->apply;
+	obj->apply = pObjIndex->apply;		// deep-copies the prototype's applies (was a shared pointer)
 	obj->charaffs = pObjIndex->charaffs;
 
 	copy_vector(obj->wear_flags, pObjIndex->wear_flags);
@@ -2379,7 +2379,7 @@ void clone_object(OBJ_DATA *parent, OBJ_DATA *clone)
 
 	copy_vector(clone->extra_flags, parent->extra_flags);
 
-	clone->apply = parent->apply;
+	clone->apply = parent->apply;		// deep-copies the applies (was a shared pointer)
 
 	copy_vector(clone->wear_flags, parent->wear_flags);
 	copy_vector(clone->imm_flags, parent->imm_flags);

--- a/code/db.c
+++ b/code/db.c
@@ -716,7 +716,7 @@ void load_area(FILE *fp)
 	zero_vector(pArea->area_flags);
 	SET_BIT(pArea->area_flags, AREA_LOADING); /* OLC */
 	pArea->vnum = top_area;					  /* OLC */
-	pArea->affected = nullptr;
+	pArea->affected.clear();
 	pArea->name = fread_string(fp);
 	pArea->credits = fread_string(fp);
 	pArea->low_range = fread_number(fp);
@@ -1336,7 +1336,6 @@ void find_adjacents(void)
 void area_update(void)
 {
 	AREA_DATA *pArea;
-	AREA_AFFECT_DATA *paf, *paf_next;
 	char buf[MAX_STRING_LENGTH];
 
 	for (pArea = area_first; pArea != nullptr; pArea = pArea->next)
@@ -1344,22 +1343,24 @@ void area_update(void)
 		if (IS_SET(pArea->progtypes, APROG_TICK))
 			(pArea->aprogs->tick_prog)(pArea);
 
-		for (paf = pArea->affected; paf; paf = paf_next)
+		for (auto it = pArea->affected.begin(); it != pArea->affected.end(); )
 		{
-			paf_next = paf->next;
+			auto next = std::next(it);
 
-			if (paf->duration > 0)
+			if (it->duration > 0)
 			{
-				if (paf->tick_fun)
-					(*paf->tick_fun)(pArea, paf);
+				if (it->tick_fun)
+					(*it->tick_fun)(pArea, &*it);
 
-				paf->duration--;
+				it->duration--;
 			}
-			else if (paf->duration < 0);
+			else if (it->duration < 0);
 			else
 			{
-				affect_remove_area(pArea, paf);
+				affect_remove_area(pArea, &*it);
 			}
+
+			it = next;
 		}
 
 		if (pArea->nplayer == 0)

--- a/code/db.c
+++ b/code/db.c
@@ -2182,7 +2182,6 @@ void clone_mobile(CHAR_DATA *parent, CHAR_DATA *clone)
 OBJ_DATA *create_object(OBJ_INDEX_DATA *pObjIndex, int level)
 {
 	AFFECT_DATA *paf;
-	EXTRA_DESCR_DATA *ed;
 	OBJ_DATA *obj;
 	int i;
 
@@ -2236,14 +2235,8 @@ OBJ_DATA *create_object(OBJ_INDEX_DATA *pObjIndex, int level)
 	/* Morg - Valgrind Fix */
 	obj->contains = nullptr;
 
-	if (pObjIndex->extra_descr)
-	{
-		ed = new_extra_descr();
-		ed->description = palloc_string(pObjIndex->extra_descr->description);
-		ed->keyword = palloc_string(pObjIndex->extra_descr->keyword);
-		ed->next = obj->extra_descr;
-		obj->extra_descr = ed;
-	}
+	if (!pObjIndex->extra_descr.empty())
+		obj->extra_descr.push_back(pObjIndex->extra_descr.front());
 
 	if (level == -1 || pObjIndex->new_format)
 		obj->cost = pObjIndex->cost;
@@ -2374,7 +2367,6 @@ void clone_object(OBJ_DATA *parent, OBJ_DATA *clone)
 {
 	int i;
 	OBJ_AFFECT_DATA *paf;
-	EXTRA_DESCR_DATA *ed, *ed_new;
 
 	if (parent == nullptr || clone == nullptr)
 		return;
@@ -2417,15 +2409,9 @@ void clone_object(OBJ_DATA *parent, OBJ_DATA *clone)
 		affect_to_obj(clone, paf);
 	}
 
-	/* extended desc */
-	for (ed = parent->extra_descr; ed != nullptr; ed = ed->next)
-	{
-		ed_new = new_extra_descr();
-		ed_new->keyword = palloc_string(ed->keyword);
-		ed_new->description = palloc_string(ed->description);
-		ed_new->next = clone->extra_descr;
-		clone->extra_descr = ed_new;
-	}
+	/* extended desc — prepend each (reverses order), matching the old intrusive list */
+	for (const auto &ed : parent->extra_descr)
+		clone->extra_descr.insert(clone->extra_descr.begin(), ed);
 }
 
 /*
@@ -2472,12 +2458,12 @@ void clear_char(CHAR_DATA *ch)
 /*
  * Get an extra description from a list.
  */
-char *get_extra_descr(const char *name, EXTRA_DESCR_DATA *ed)
+char *get_extra_descr(const char *name, const std::list<EXTRA_DESCR_DATA> &eds)
 {
-	for (; ed != nullptr; ed = ed->next)
+	for (const auto &ed : eds)
 	{
-		if (is_name((char *)name, ed->keyword))
-			return ed->description;
+		if (is_name((char *)name, ed.keyword))
+			return ed.description;
 	}
 
 	return nullptr;
@@ -4028,7 +4014,7 @@ void load_rooms(FILE *fp)
 		pRoomIndex->move_progs= false;
 		pRoomIndex->people = nullptr;
 		pRoomIndex->contents = nullptr;
-		pRoomIndex->extra_descr = nullptr;
+		pRoomIndex->extra_descr.clear();
 		pRoomIndex->alt_description = nullptr;
 		pRoomIndex->alt_description_cond = 0;
 		pRoomIndex->alt_name = nullptr;
@@ -4126,13 +4112,11 @@ void load_rooms(FILE *fp)
 			}
 			else if (letter == 'E')
 			{
-				EXTRA_DESCR_DATA *ed;
+				EXTRA_DESCR_DATA ed;
 
-				ed = new EXTRA_DESCR_DATA;
-				ed->keyword = fread_string(fp);
-				ed->description = fread_string(fp);
-				ed->next = pRoomIndex->extra_descr;
-				pRoomIndex->extra_descr = ed;
+				ed.keyword = fread_string(fp);
+				ed.description = fread_string(fp);
+				pRoomIndex->extra_descr.insert(pRoomIndex->extra_descr.begin(), std::move(ed));
 				top_ed++;
 			}
 			else if (letter == 'T')

--- a/code/db.c
+++ b/code/db.c
@@ -2092,7 +2092,6 @@ CHAR_DATA *create_mobile(MOB_INDEX_DATA *pMobIndex)
 void clone_mobile(CHAR_DATA *parent, CHAR_DATA *clone)
 {
 	int i;
-	AFFECT_DATA *paf;
 
 	if (parent == nullptr || clone == nullptr || !is_npc(parent))
 		return;
@@ -2171,10 +2170,8 @@ void clone_mobile(CHAR_DATA *parent, CHAR_DATA *clone)
 	}
 
 	/* now add the affects */
-	for (paf = parent->affected; paf != nullptr; paf = paf->next)
-	{
-		affect_to_char(clone, paf);
-	}
+	for (auto &paf : parent->affected)
+		affect_to_char(clone, &paf);
 }
 
 /*
@@ -2182,7 +2179,6 @@ void clone_mobile(CHAR_DATA *parent, CHAR_DATA *clone)
  */
 OBJ_DATA *create_object(OBJ_INDEX_DATA *pObjIndex, int level)
 {
-	AFFECT_DATA *paf;
 	OBJ_DATA *obj;
 	int i;
 
@@ -2218,7 +2214,7 @@ OBJ_DATA *create_object(OBJ_INDEX_DATA *pObjIndex, int level)
 	copy_vector(obj->extra_flags, pObjIndex->extra_flags);
 
 	obj->apply = pObjIndex->apply;		// deep-copies the prototype's applies (was a shared pointer)
-	obj->charaffs = pObjIndex->charaffs;
+	obj->charaffs = pObjIndex->charaffs;	// deep-copies the prototype's charaffs (was a shared pointer)
 
 	copy_vector(obj->wear_flags, pObjIndex->wear_flags);
 	copy_vector(obj->imm_flags, pObjIndex->imm_flags);
@@ -2337,20 +2333,20 @@ OBJ_DATA *create_object(OBJ_INDEX_DATA *pObjIndex, int level)
 			break;
 	}
 
-	for (paf = pObjIndex->affected; paf != nullptr; paf = paf->next)
+	for (auto &paf : pObjIndex->affected)
 	{
-		if (paf->location == APPLY_SPELL_AFFECT)
+		if (paf.location == APPLY_SPELL_AFFECT)
 		{
 			OBJ_AFFECT_DATA oaf;
 
 			init_affect_obj(&oaf);
-			oaf.where = paf->where;
-			oaf.type = paf->type;
-			oaf.level = paf->level;
-			oaf.duration = paf->duration;
-			oaf.location = paf->location;
-			oaf.modifier = paf->modifier;
-			copy_vector(oaf.bitvector, paf->bitvector);
+			oaf.where = paf.where;
+			oaf.type = paf.type;
+			oaf.level = paf.level;
+			oaf.duration = paf.duration;
+			oaf.location = paf.location;
+			oaf.modifier = paf.modifier;
+			copy_vector(oaf.bitvector, paf.bitvector);
 			affect_to_obj(obj, &oaf);
 		}
 	}
@@ -3200,7 +3196,6 @@ void do_dump(CHAR_DATA *ch, char *argument)
 	ROOM_INDEX_DATA *room;
 	EXIT_DATA *exit;
 	DESCRIPTOR_DATA *d;
-	AFFECT_DATA *af;
 	FILE *fp;
 	int vnum, nMatch = 0;
 
@@ -3231,10 +3226,7 @@ void do_dump(CHAR_DATA *ch, char *argument)
 		if (fch->pcdata != nullptr)
 			num_pcs++;
 
-		for (af = fch->affected; af != nullptr; af = af->next)
-		{
-			aff_count++;
-		}
+		aff_count += fch->affected.size();
 	}
 
 	for (fch = char_free; fch != nullptr; fch = fch->next)
@@ -3277,10 +3269,7 @@ void do_dump(CHAR_DATA *ch, char *argument)
 
 		if (pObjIndex != nullptr)
 		{
-			for (af = pObjIndex->affected; af != nullptr; af = af->next)
-			{
-				aff_count++;
-			}
+			aff_count += pObjIndex->affected.size();
 
 			nMatch++;
 		}
@@ -3306,14 +3295,10 @@ void do_dump(CHAR_DATA *ch, char *argument)
 
 	fprintf(fp, "Objs	%4d (%8lu bytes), %2d free (%lu bytes)\n", count, count * (sizeof(*obj)), count2, count2 * (sizeof(*obj)));
 
-	/* affects */
+	/* affects — no free list any more (affects are owned by value) */
 	count = 0;
-	for (af = affect_free; af != nullptr; af = af->next)
-	{
-		count++;
-	}
 
-	fprintf(fp, "Affects	%4d (%8lu bytes), %2d free (%lu bytes)\n", aff_count, aff_count * (sizeof(*af)), count, count * (sizeof(*af)));
+	fprintf(fp, "Affects	%4d (%8lu bytes), %2d free (%lu bytes)\n", aff_count, aff_count * (sizeof(AFFECT_DATA)), count, count * (sizeof(AFFECT_DATA)));
 
 	/* rooms */
 	fprintf(fp, "Rooms	%4d (%8lu bytes)\n", top_room, top_room * (sizeof(*room)));

--- a/code/db.c
+++ b/code/db.c
@@ -2413,10 +2413,9 @@ void clone_object(OBJ_DATA *parent, OBJ_DATA *clone)
  */
 void clear_char(CHAR_DATA *ch)
 {
-	static CHAR_DATA ch_zero;
 	int i;
 
-	*ch = ch_zero;
+	*ch = CHAR_DATA();
 	ch->name = &str_empty[0];
 	ch->short_descr = &str_empty[0];
 	ch->long_descr = &str_empty[0];
@@ -3190,7 +3189,6 @@ void do_dump(CHAR_DATA *ch, char *argument)
 	int count, count2, num_pcs, aff_count;
 	CHAR_DATA *fch;
 	MOB_INDEX_DATA *pMobIndex;
-	PC_DATA *pc;
 	OBJ_DATA *obj;
 	OBJ_INDEX_DATA *pObjIndex;
 	ROOM_INDEX_DATA *room;
@@ -3236,15 +3234,10 @@ void do_dump(CHAR_DATA *ch, char *argument)
 
 	fprintf(fp, "Mobs	%4d (%8lu bytes), %2d free (%lu bytes)\n", count, count * (sizeof(*fch)), count2, count2 * (sizeof(*fch)));
 
-	/* pcdata */
+	/* pcdata — no free list any more (pcdata is owned by unique_ptr) */
 	count = 0;
 
-	for (pc = pcdata_free; pc != nullptr; pc = pc->next)
-	{
-		count++;
-	}
-
-	fprintf(fp, "Pcdata	%4d (%8lu bytes), %2d free (%lu bytes)\n", num_pcs, num_pcs * (sizeof(*pc)), count, count * (sizeof(*pc)));
+	fprintf(fp, "Pcdata	%4d (%8lu bytes), %2d free (%lu bytes)\n", num_pcs, num_pcs * (sizeof(PC_DATA)), count, count * (sizeof(PC_DATA)));
 
 	/* descriptors */
 	count = 0;

--- a/code/db.c
+++ b/code/db.c
@@ -4019,7 +4019,7 @@ void load_rooms(FILE *fp)
 		pRoomIndex->alt_description_cond = 0;
 		pRoomIndex->alt_name = nullptr;
 		pRoomIndex->trap = nullptr;
-		pRoomIndex->affected = nullptr;
+		pRoomIndex->affected.clear();
 		zero_vector(pRoomIndex->room_flags);
 
 		pRoomIndex->area = area_last;

--- a/code/db.h
+++ b/code/db.h
@@ -35,10 +35,13 @@
 #define DB_H
 
 #include <cstddef>
+#include <list>
 #include <time.h>
 #include <stdio.h>
 #include <stdlib.h>		// srandom
 #include <unistd.h>		// getpid -- replaces the OLD_RAND hand declarations
+
+#include "entity/extra_descr.h"		// get_extra_descr takes a std::list<EXTRA_DESCR_DATA>&
 
 #include "entity/fwd.h"
 #include "entity/limits.h"
@@ -677,7 +680,7 @@ void clone_mobile (CHAR_DATA *parent, CHAR_DATA *clone);
 OBJ_DATA *create_object (OBJ_INDEX_DATA *pObjIndex, int level);
 void clone_object (OBJ_DATA *parent, OBJ_DATA *clone);
 void clear_char(CHAR_DATA *ch);
-char *get_extra_descr (const char *name, EXTRA_DESCR_DATA *ed);
+char *get_extra_descr (const char *name, const std::list<EXTRA_DESCR_DATA> &eds);
 MOB_INDEX_DATA *get_mob_index (int vnum);
 OBJ_INDEX_DATA *get_obj_index(int vnum);
 ROOM_INDEX_DATA *get_room_index (int vnum);

--- a/code/db2.c
+++ b/code/db2.c
@@ -1046,14 +1046,14 @@ void load_objs(FILE *fp)
 		zero_vector(pObjIndex->vuln_flags);
 		pObjIndex->start_timer = -1;
 		pObjIndex->notes = nullptr;
-		pObjIndex->charaffs = nullptr;
+		pObjIndex->charaffs.clear();
 		pObjIndex->apply.clear();
 		pObjIndex->wear_echo[0] = nullptr;
 		pObjIndex->remove_echo[0] = nullptr;
 		pObjIndex->wear_echo[1] = nullptr;
 		pObjIndex->remove_echo[1] = nullptr;
 		pObjIndex->wear_loc_name = nullptr;
-		pObjIndex->affected = nullptr;
+		pObjIndex->affected.clear();
 		pObjIndex->spec_prog.trapvector = 0;
 		pObjIndex->cabal = 0;
 		pObjIndex->verb = nullptr;

--- a/code/db2.c
+++ b/code/db2.c
@@ -1073,7 +1073,7 @@ void load_objs(FILE *fp)
 		pObjIndex->start_timer = -1;
 		pObjIndex->notes = nullptr;
 		pObjIndex->charaffs = nullptr;
-		pObjIndex->apply = nullptr;
+		pObjIndex->apply.clear();
 		pObjIndex->wear_echo[0] = nullptr;
 		pObjIndex->remove_echo[0] = nullptr;
 		pObjIndex->wear_echo[1] = nullptr;
@@ -1180,18 +1180,16 @@ void load_objs(FILE *fp)
 
 			if (letter == 'A')
 			{
-				OBJ_APPLY_DATA *apply;
+				OBJ_APPLY_DATA apply;
 				// read in PPLY and discard it
 				discard = fread_word(fp);
-				apply = new_apply_data();
-				apply->location = display_lookup(fread_word(fp), apply_locations);
+				apply.location = display_lookup(fread_word(fp), apply_locations);
 
-				if (apply->location == -1)
+				if (apply.location == -1)
 					bugout("Invalid affect apply location.");
 
-				apply->modifier = fread_number(fp);
-				apply->next = pObjIndex->apply;
-				pObjIndex->apply = apply;
+				apply.modifier = fread_number(fp);
+				pObjIndex->apply.insert(pObjIndex->apply.begin(), apply);
 			}
 			else if (letter == 'C') /* Cabal */
 			{

--- a/code/db2.c
+++ b/code/db2.c
@@ -411,8 +411,6 @@ void load_mobs(FILE *fp)
 	MOB_INDEX_DATA *pMobIndex;
 	int i = 0, pos = 0;
 	char *aword, *bword, *temp_wealth;
-	SPEECH_DATA *speech;
-	LINE_DATA *line;
 	char bugtext[250];
 	short wealth;
 
@@ -628,44 +626,20 @@ void load_mobs(FILE *fp)
 			{
 				char *word;
 
-				speech = new_speech_data();
-				speech->mob = pMobIndex;
+				SPEECH_DATA *speech = &pMobIndex->speech.emplace_back();
 				speech->name = palloc_string(bword);
-
-				if (!pMobIndex->speech)
-				{
-					pMobIndex->speech = speech;
-				}
-				else
-				{
-					SPEECH_DATA *sptr;
-
-					for (sptr = pMobIndex->speech; sptr->next; sptr = sptr->next);
-
-					sptr->next = speech;
-					speech->prev = sptr;
-				}
 
 				for (;;)
 				{
 					word = fread_word(fp);
 					if (!str_cmp(word, "LINE"))
 					{
-						line = new_line_data();
-						line->speech = speech;
-						if (!speech->first_line)
-						{
-							line->number = 0;
-							speech->first_line = line;
-							speech->current_line = line;
-						}
-						else
-						{
-							line->number = speech->current_line->number + 1;
-							speech->current_line->next = line;
-							line->prev = speech->current_line;
-							speech->current_line = line;
-						}
+						int number = speech->first_line.empty()
+							? 0
+							: speech->first_line.back().number + 1;
+
+						LINE_DATA *line = &speech->first_line.emplace_back();
+						line->number = number;
 
 						line->delay = fread_number(fp);
 						line->type = pos = flag_lookup(fread_word(fp), speech_table);
@@ -678,7 +652,7 @@ void load_mobs(FILE *fp)
 					}
 					else if (!str_cmp(word, "END"))
 					{
-						speech->current_line = speech->first_line;
+						speech->current_line = speech->first_line.begin();
 						break;
 					}
 					else

--- a/code/db2.c
+++ b/code/db2.c
@@ -1052,7 +1052,7 @@ void load_objs(FILE *fp)
 		newobjs++;
 		pObjIndex->limcount = 0;
 		pObjIndex->limtotal = 0;
-		pObjIndex->extra_descr = nullptr;
+		pObjIndex->extra_descr.clear();
 
 		pObjIndex->name = fread_string(fp);
 		pObjIndex->short_descr = fread_string(fp);
@@ -1277,13 +1277,11 @@ void load_objs(FILE *fp)
 
 			else if (letter == 'E')
 			{
-				EXTRA_DESCR_DATA *ed;
+				EXTRA_DESCR_DATA ed;
 
-				ed = new_extra_descr();
-				ed->keyword = fread_string(fp);
-				ed->description = fread_string(fp);
-				ed->next = pObjIndex->extra_descr;
-				pObjIndex->extra_descr = ed;
+				ed.keyword = fread_string(fp);
+				ed.description = fread_string(fp);
+				pObjIndex->extra_descr.insert(pObjIndex->extra_descr.begin(), std::move(ed));
 				top_ed++;
 			}
 			else if (letter == 'I')

--- a/code/devextra.c
+++ b/code/devextra.c
@@ -1866,7 +1866,6 @@ void do_assess_old(CHAR_DATA *ch, char *argument)
 	char arg[MAX_INPUT_LENGTH];
 	CHAR_DATA *victim;
 	char buf[MAX_STRING_LENGTH];
-	AFFECT_DATA *paf;
 
 	one_argument(argument, arg);
 
@@ -1911,7 +1910,7 @@ void do_assess_old(CHAR_DATA *ch, char *argument)
 		return;
 	}
 
-	if (victim->affected == nullptr)
+	if (victim->affected.empty())
 	{
 		send_to_char("You are unable to find any signs of affliction.\n\r", ch);
 		check_improve(ch, skill_lookup("assess"), true, 1);
@@ -1922,35 +1921,35 @@ void do_assess_old(CHAR_DATA *ch, char *argument)
 		return;
 	}
 
-	for (paf = victim->affected; paf != nullptr; paf = paf->next)
+	for (auto &paf : victim->affected)
 	{
 		buf[0] = '\0';
 
 		if (skill < 91);
-			sprintf(buf, "%s seems to be affected by %s.\n\r", is_npc(victim) ? victim->short_descr : victim->name, skill_table[paf->type].name);
+			sprintf(buf, "%s seems to be affected by %s.\n\r", is_npc(victim) ? victim->short_descr : victim->name, skill_table[paf.type].name);
 
 		if (skill >= 91);
 		{
 			fuzzy = number_range(0, 2);
 			// Let's fuz up the duration a bit if it's not permanent.
-			if (paf->duration > -1)
+			if (paf.duration > -1)
 			{
 				if (number_range(0, 1) == 0)
-					showdur = paf->duration + fuzzy;
+					showdur = paf.duration + fuzzy;
 				else
-					showdur = paf->duration - fuzzy;
+					showdur = paf.duration - fuzzy;
 
 				sprintf(buf, "%s seems to be affected by %s for about %d hours.\n\r",
 					is_npc(victim) ? victim->short_descr : victim->name,
-					skill_table[paf->type].name,
+					skill_table[paf.type].name,
 					showdur);
 			}
 
-			if (paf->duration == -1)
+			if (paf.duration == -1)
 			{
 				sprintf(buf, "%s seems to be affected by %s permanently.\n\r",
 					is_npc(victim) ? victim->short_descr : victim->name,
-					skill_table[paf->type].name);
+					skill_table[paf.type].name);
 			}
 		}
 
@@ -2169,10 +2168,14 @@ void do_commune(CHAR_DATA *ch, char *argument)
 
 	if (is_affected(ch, gsn_severed))
 	{
-		for (paf = ch->affected; paf != nullptr; paf = paf->next)
+		paf = nullptr;
+		for (auto &paf_elem : ch->affected)
 		{
-			if (paf->type == gsn_severed)
+			if (paf_elem.type == gsn_severed)
+			{
+				paf = &paf_elem;
 				break;
+			}
 		}
 
 		if (paf)

--- a/code/devextra.c
+++ b/code/devextra.c
@@ -435,7 +435,7 @@ void do_offer(CHAR_DATA *ch, char *argument)
 
 void do_sitetrack(CHAR_DATA *ch, char *argument)
 {
-	BUFFER *buffer;
+	BUFFER buffer;
 	char buf[MSL], arg1[MSL], arg2[MSL], query[MSL];
 	int results = 0;
 
@@ -447,27 +447,25 @@ void do_sitetrack(CHAR_DATA *ch, char *argument)
 	if (!strcmp(argument, ""))
 	{
 		auto comments = SiteCommentRepository(RS.DbRift);
-		buffer = new_buf();
 
-		add_buf(buffer, "ID #     Site                       Denials    Comments\n\r");
+		buffer.add("ID #     Site                       Denials    Comments\n\r");
 
 		for (const auto &site : sites.FindAll())
 		{
 			sprintf(buf, "%4d     %-26s %-10d %d\n\r",
 				site.site_id, site.site_name.c_str(), site.denials,
 				comments.CountBySite(site.site_id));
-			add_buf(buffer, buf);
+			buffer.add(buf);
 		}
 
-		add_buf(buffer, "Use sitetrack <id> to view more details.\n\r");
-		add_buf(buffer, "Use sitetrack comment <id> to enter a comment on the given site.\n\r");
-		add_buf(buffer, "Use sitetrack add <site IP, i.e. aol.com>.  Use numeric IP ONLY if it's unresolvable.\n\r");
+		buffer.add("Use sitetrack <id> to view more details.\n\r");
+		buffer.add("Use sitetrack comment <id> to enter a comment on the given site.\n\r");
+		buffer.add("Use sitetrack add <site IP, i.e. aol.com>.  Use numeric IP ONLY if it's unresolvable.\n\r");
 
 		if (get_trust(ch) >= 58)
-			add_buf(buffer, "Use sitetrack delcomment <comment id> to delete a comment, and sitetrack delsite <site id> to delete a site.\n\r");
+			buffer.add("Use sitetrack delcomment <comment id> to delete a comment, and sitetrack delsite <site id> to delete a site.\n\r");
 
-		page_to_char(buf_string(buffer), ch);
-		free_buf(buffer);
+		page_to_char(buffer.str(), ch);
 		return;
 	}
 
@@ -534,7 +532,6 @@ void do_sitetrack(CHAR_DATA *ch, char *argument)
 		}
 
 		const auto &site = found.front();
-		buffer = new_buf();
 
 		sprintf(buf, "Viewing %s (id %d).\n\r", site.site_name.c_str(), site.site_id);
 		send_to_char(buf, ch);
@@ -553,15 +550,15 @@ void do_sitetrack(CHAR_DATA *ch, char *argument)
 			sprintf(buf, "Added by %s on %s (CID #%d):\n\r%s",
 				comment.comment_name.c_str(), comment.comment_date.c_str(),
 				comment.comment_id, comment.comment.c_str());
-			add_buf(buffer, buf);
+			buffer.add(buf);
 		}
 
 		if (buf[0] == '\r')
-			add_buf(buffer, "(No comments)\n\r");
+			buffer.add("(No comments)\n\r");
 
 		if (get_trust(ch) >= 56)
 		{
-			add_buf(buffer, "Players from site:\n\r");
+			buffer.add("Players from site:\n\r");
 
 			auto logins = LoginRepository(RS.DbRift);
 			auto siteNames = logins.FindDistinctNamesBySite(site.site_name);
@@ -583,11 +580,10 @@ void do_sitetrack(CHAR_DATA *ch, char *argument)
 			if (!results)
 				sprintf(buf, "(No players)\n\r");
 
-			add_buf(buffer, buf);
+			buffer.add(buf);
 		}
 
-		page_to_char(buf_string(buffer), ch);
-		free_buf(buffer);
+		page_to_char(buffer.str(), ch);
 	}
 }
 
@@ -990,7 +986,7 @@ void do_pktrack(CHAR_DATA *ch, char *argument)
 		return;
 	}
 
-	BUFFER *buffer = new_buf();
+	BUFFER buffer;
 	for (auto &pklog : results)
 	{
 		sprintf(buf, "%3d) %s(%s) killed %s(%s) at %s on %s\n\r",
@@ -1002,11 +998,10 @@ void do_pktrack(CHAR_DATA *ch, char *argument)
 			pklog.room.c_str(),
 			pklog.date.c_str());
 
-		add_buf(buffer, buf);
+		buffer.add(buf);
 	}
 
-	page_to_char(buf_string(buffer), ch);
-	free_buf(buffer);
+	page_to_char(buffer.str(), ch);
 }
 
 bool trusts(CHAR_DATA *ch, CHAR_DATA *victim)
@@ -1608,10 +1603,8 @@ void do_rchanges(CHAR_DATA *ch, char *argument)
 	char writestring[MAX_STRING_LENGTH];
 	FILE *fpChar;
 	long size = 0;
-	BUFFER *output;
+	BUFFER output;
 	int numMatches=0, numEntries = 25;
-
-	output = new_buf();
 
 	one_argument(argument,arg1);
 	if(is_number(arg1))
@@ -1667,11 +1660,10 @@ void do_rchanges(CHAR_DATA *ch, char *argument)
 		if(size>=MAX_BUF || (numMatches-loop)==numEntries)
 				break;
 
-		add_buf(output,nlist);
+		output.add(nlist);
 	}
 
-	page_to_char(buf_string(output),ch);
-	free_buf(output);
+	page_to_char(output.str(),ch);
 	fclose(fpChar);
 */
 }
@@ -1804,7 +1796,7 @@ char *flags_to_string(CHAR_DATA *ch, const struct flag_type *showflags, int flag
 
 void do_ltrack(CHAR_DATA *ch, char *argument)
 {
-	BUFFER *buffer;
+	BUFFER buffer;
 	char arg1[MSL], arg2[MSL], buf[MSL];
 	int type = -1, show = -1, i = 0;
 
@@ -1847,8 +1839,6 @@ void do_ltrack(CHAR_DATA *ch, char *argument)
 		return;
 	}
 
-	buffer = new_buf();
-
 	for (const auto &login : results)
 	{
 		i++;
@@ -1867,11 +1857,10 @@ void do_ltrack(CHAR_DATA *ch, char *argument)
 			rowType == 2 ? " played, " : "",
 			login.obj,
 			login.lobj);
-		add_buf(buffer, buf);
+		buffer.add(buf);
 	}
 
-	page_to_char(buf_string(buffer), ch);
-	free_buf(buffer);
+	page_to_char(buffer.str(), ch);
 	return;
 }
 
@@ -1981,7 +1970,7 @@ void do_assess_old(CHAR_DATA *ch, char *argument)
 
 void do_supps(CHAR_DATA *ch, char *argument)
 {
-	BUFFER *buffer;
+	BUFFER buffer;
 	char arg[MAX_INPUT_LENGTH];
 	char spell_list[LEVEL_HERO + 1][MAX_STRING_LENGTH];
 	char spell_columns[LEVEL_HERO + 1];
@@ -2105,17 +2094,14 @@ void do_supps(CHAR_DATA *ch, char *argument)
 		return;
 	}
 
-	buffer = new_buf();
-
 	for (level = 0; level < LEVEL_HERO + 1; level++)
 	{
 		if (spell_list[level][0] != '\0')
-			add_buf(buffer, spell_list[level]);
+			buffer.add(spell_list[level]);
 	}
 
-	add_buf(buffer, "\n\r");
-	page_to_char(buf_string(buffer), ch);
-	free_buf(buffer);
+	buffer.add("\n\r");
+	page_to_char(buffer.str(), ch);
 }
 
 void do_commune(CHAR_DATA *ch, char *argument)

--- a/code/devextra.c
+++ b/code/devextra.c
@@ -1253,11 +1253,7 @@ void WAIT_STATE(CHAR_DATA *ch, int npulse)
 
 	if (ch->in_room && is_affected_room(ch->in_room, gsn_gravity_well))
 	{
-		for (raf = ch->in_room->affected; raf != nullptr; raf = raf->next)
-		{
-			if (raf->type == gsn_gravity_well)
-				break;
-		}
+		raf = affect_find_room(ch->in_room->affected, gsn_gravity_well);
 
 		if (ch == raf->owner)
 			wait += PULSE_VIOLENCE;

--- a/code/dioextra.c
+++ b/code/dioextra.c
@@ -554,7 +554,7 @@ void do_ccb(CHAR_DATA *ch, char *argument)
 
 void do_powers(CHAR_DATA *ch, char *argument)
 {
-	BUFFER *buffer;
+	BUFFER buffer;
 	char arg[MAX_INPUT_LENGTH];
 	char skill_list[LEVEL_HERO + 1][MAX_STRING_LENGTH];
 	char skill_columns[LEVEL_HERO + 1];
@@ -671,19 +671,16 @@ void do_powers(CHAR_DATA *ch, char *argument)
 		return;
 	}
 
-	buffer = new_buf();
-
 	for (level = 0; level < LEVEL_HERO + 1; level++)
 	{
 		if (skill_list[level][0] != '\0')
 		{
-			add_buf(buffer, skill_list[level]);
+			buffer.add(skill_list[level]);
 		}
 	}
 
-	add_buf(buffer, "\n\r");
-	page_to_char(buf_string(buffer), ch);
-	free_buf(buffer);
+	buffer.add("\n\r");
+	page_to_char(buffer.str(), ch);
 }
 
 bool check_shroud_of_light(CHAR_DATA *ch, CHAR_DATA *victim)
@@ -1019,7 +1016,7 @@ void do_finger(CHAR_DATA *ch, char *argument)
 	long sect_time[SECT_MAX];
 	short quests[MAX_QUESTS];
 	char questtext[MSL];
-	BUFFER *output;
+	BUFFER output;
 	long act[MAX_BITVECTOR];
 	long sectval[SECT_MAX], comm = 0;
 	float perc[SECT_MAX];
@@ -1244,7 +1241,6 @@ void do_finger(CHAR_DATA *ch, char *argument)
 
 	if (arg2[0] != '\0' && !str_prefix(arg2, "history"))
 	{
-		output = new_buf();
 		if (level >= ch->level)
 		{
 			send_to_char("Player is too high to access their history.\n\r", ch);
@@ -1260,9 +1256,8 @@ void do_finger(CHAR_DATA *ch, char *argument)
 		}
 		else
 		{
-			add_buf(output, history);
-			page_to_char(buf_string(output), ch);
-			free_buf(output);
+			output.add(history);
+			page_to_char(output.str(), ch);
 		}
 	}
 	else if (arg2[0] != '\0' && !str_prefix(arg2, "equipment"))
@@ -1323,10 +1318,8 @@ void do_finger(CHAR_DATA *ch, char *argument)
 		}
 		else
 		{
-			output = new_buf();
-			add_buf(output, tbuf);
-			page_to_char(buf_string(output), ch);
-			free_buf(output);
+			output.add(tbuf);
+			page_to_char(output.str(), ch);
 			return;
 		}
 	}
@@ -1437,7 +1430,7 @@ void do_ctrack(CHAR_DATA *ch, char *argument)
 {
 	char arg[MAX_STRING_LENGTH];
 	int numMatches = 0;
-	BUFFER *output;
+	BUFFER output;
 
 	one_argument(argument, arg);
 
@@ -1454,8 +1447,6 @@ void do_ctrack(CHAR_DATA *ch, char *argument)
 		send_to_char("No such cabal exists.\n\r", ch);
 		return;
 	}
-
-	output = new_buf();
 
 	std::string buffer;
 	auto dir = CDirectory(RIFT_PLAYER_DIR);
@@ -1480,7 +1471,7 @@ void do_ctrack(CHAR_DATA *ch, char *argument)
 
 		numMatches++;
 		buffer = fmt::sprintf("%3d) %s: %s\n\r", numMatches, name.c_str(), login ? login : "(none)");
-		add_buf(output, buffer.data());
+		output.add(buffer.data());
 	}
 
 	if (!numMatches)
@@ -1492,10 +1483,9 @@ void do_ctrack(CHAR_DATA *ch, char *argument)
 	{
 		buffer = fmt::format("{} players found in {}:\n\r", numMatches, arg);
 		send_to_char(buffer.c_str(), ch);
-		page_to_char(buf_string(output), ch);
+		page_to_char(output.str(), ch);
 	}
 
-	free_buf(output);
 }
 
 // Scans a player file returning its LogonTime string (or nullptr

--- a/code/dioextra.c
+++ b/code/dioextra.c
@@ -285,7 +285,6 @@ void do_affrem(CHAR_DATA *ch, char *argument)
 	char buf[MAX_STRING_LENGTH];
 	CHAR_DATA *victim;
 	int sn;
-	AFFECT_DATA *af, *af_next;
 	bool remove = true;
 	argument = one_argument(argument, arg1);
 	argument = one_argument(argument, arg2);
@@ -321,19 +320,22 @@ void do_affrem(CHAR_DATA *ch, char *argument)
 		return;
 	}
 
-	for (af = victim->affected; af != nullptr; af = af_next)
+	for (auto it = victim->affected.begin(); it != victim->affected.end(); )
 	{
-		af_next = af->next;
+		auto next = std::next(it);
 
-		if (IS_SET(af->bitvector, AFF_PERMANENT) && get_trust(ch) < MAX_LEVEL && af->type == sn)
+		if (IS_SET(it->bitvector, AFF_PERMANENT) && get_trust(ch) < MAX_LEVEL && it->type == sn)
 		{
 			send_to_char("You cannot remove a permanent affect.\n\r", ch);
 			remove = false;
+			it = next;
 			continue;
 		}
 
-		if (af->type == sn)
-			affect_remove(victim, af);
+		if (it->type == sn)
+			affect_remove(victim, &*it);
+
+		it = next;
 	}
 
 	if (skill_table[sn].msg_off && remove)

--- a/code/effects.c
+++ b/code/effects.c
@@ -138,18 +138,17 @@ void acid_effect(void *vo, int level, int dam, int target)
 
 		if (obj->item_type == ITEM_ARMOR) /* etch it */
 		{
-			OBJ_AFFECT_DATA *paf;
 			bool af_found = false;
 			int i;
 
-			for (paf = obj->affected; paf != nullptr; paf = paf->next)
+			for (auto &paf : obj->affected)
 			{
-				if (paf->location == APPLY_AC)
+				if (paf.location == APPLY_AC)
 				{
 					af_found = true;
-					paf->type = -1;
-					paf->modifier += 1;
-					paf->level = std::max((int)paf->level, level);
+					paf.type = -1;
+					paf.modifier += 1;
+					paf.level = std::max((int)paf.level, level);
 					break;
 				}
 			}
@@ -157,15 +156,14 @@ void acid_effect(void *vo, int level, int dam, int target)
 			/* needs a new affect */
 			if (!af_found)
 			{
-				paf = new_affect_obj();
+				OBJ_AFFECT_DATA paf;
 
-				paf->type = -1;
-				paf->level = level;
-				paf->duration = -1;
-				paf->location = APPLY_AC;
-				paf->modifier = 1;
-				paf->next = obj->affected;
-				obj->affected = paf;
+				paf.type = -1;
+				paf.level = level;
+				paf.duration = -1;
+				paf.location = APPLY_AC;
+				paf.modifier = 1;
+				obj->affected.push_front(paf);
 			}
 
 			if (obj->carried_by != nullptr && obj->wear_loc != WEAR_NONE)

--- a/code/entity/affect_data.h
+++ b/code/entity/affect_data.h
@@ -92,13 +92,14 @@ struct obj_affect_data
 	OAFF_FUN *end_fun;
 };
 
+// A stat apply on an object. Plain value type; parents own these by value in a
+// std::list<OBJ_APPLY_DATA> (list, not vector: spell_enchant_weapon holds element
+// pointers across a second prepend, so nodes must not move).
 struct obj_apply_data
 {
-	bool valid;
-	short location;
-	short modifier;
-	short type;						// For gsns, if relevant.
-	OBJ_APPLY_DATA *next;
+	short location = 0;
+	short modifier = 0;
+	short type = 0;						// For gsns, if relevant.
 };
 
 #endif /* ENTITY_AFFECT_DATA_H */

--- a/code/entity/affect_data.h
+++ b/code/entity/affect_data.h
@@ -76,22 +76,23 @@ struct area_affect_data
 	AAFF_FUN *end_fun = nullptr;
 };
 
+// An object affect. Plain value type; an object owns these by value in a
+// std::list<OBJ_AFFECT_DATA> (obj->affected). `owner` is a non-owning
+// CHAR_DATA back-reference and stays a raw pointer.
 struct obj_affect_data
 {
-	OBJ_AFFECT_DATA *next;
-	CHAR_DATA *owner;
-	bool valid;
-	short where;
-	short type;
-	short level;
-	short duration;
-	short location;
-	short modifier;
-	long bitvector[MAX_BITVECTOR];
-	int aftype;
-	OAFF_FUN *pulse_fun;
-	OAFF_FUN *tick_fun;
-	OAFF_FUN *end_fun;
+	CHAR_DATA *owner = nullptr;
+	short where = 0;
+	short type = 0;
+	short level = 0;
+	short duration = 0;
+	short location = 0;
+	short modifier = 0;
+	long bitvector[MAX_BITVECTOR] = {};
+	int aftype = 0;
+	OAFF_FUN *pulse_fun = nullptr;
+	OAFF_FUN *tick_fun = nullptr;
+	OAFF_FUN *end_fun = nullptr;
 };
 
 // A stat apply on an object. Plain value type; parents own these by value in a

--- a/code/entity/affect_data.h
+++ b/code/entity/affect_data.h
@@ -56,22 +56,23 @@ struct room_affect_data
 // An area affect.
 //
 
+// An area affect. Plain value type; an area owns these by value in a
+// std::list<AREA_AFFECT_DATA> (area->affected). `owner` is a non-owning
+// CHAR_DATA back-reference and stays a raw pointer.
 struct area_affect_data
 {
-	AREA_AFFECT_DATA *next;
-	CHAR_DATA *owner;
-	bool valid;
-	short where;
-	short type;
-	short level;
-	short duration;
-	short location;
-	short modifier;
-	long bitvector[MAX_BITVECTOR];
-	int aftype;
-	AAFF_FUN *pulse_fun;
-	AAFF_FUN *tick_fun;
-	AAFF_FUN *end_fun;
+	CHAR_DATA *owner = nullptr;
+	short where = 0;
+	short type = 0;
+	short level = 0;
+	short duration = 0;
+	short location = 0;
+	short modifier = 0;
+	long bitvector[MAX_BITVECTOR] = {};
+	int aftype = 0;
+	AAFF_FUN *pulse_fun = nullptr;
+	AAFF_FUN *tick_fun = nullptr;
+	AAFF_FUN *end_fun = nullptr;
 };
 
 struct obj_affect_data

--- a/code/entity/affect_data.h
+++ b/code/entity/affect_data.h
@@ -8,26 +8,39 @@
 // An affect.
 //
 
+// A character affect. Owns its `name` string (palloc_string / free_pstring) →
+// rule-of-5 (bodies in recycle.c). Parents hold these by value in a
+// std::list<AFFECT_DATA> (ch->affected, obj->charaffs, and the two Tier-0
+// prototype lists obj_index->affected / obj_index->charaffs). `owner` is a
+// non-owning CHAR_DATA back-reference and stays a raw pointer (scrubbed on
+// extract_char). std::list, not vector: callers cache an element pointer
+// returned by affect_find across later list mutations.
 struct affect_data
 {
-	AFFECT_DATA *next;
-	CHAR_DATA *owner;
-	char *name;
-	bool valid;
-	short where;
-	short type;
-	short level;
-	short duration;
-	short location;
-	short modifier;
-	short mod_name;
-	long bitvector[MAX_BITVECTOR];
-	int aftype;
-	AFF_FUN *tick_fun;		// goes off every tick that char is affected
-	AFF_FUN *pulse_fun;
-	AFF_FUN *end_fun;		// when the affect wears off this is called
-	short init_duration;
-	AFF_FUN *beat_fun;		// goes off every beat
+	CHAR_DATA *owner = nullptr;
+	char *name = nullptr;
+	short where = 0;
+	short type = 0;
+	short level = 0;
+	short duration = 0;
+	short location = 0;
+	short modifier = 0;
+	short mod_name = 0;
+	long bitvector[MAX_BITVECTOR] = {};
+	int aftype = 0;
+	AFF_FUN *tick_fun = nullptr;	// goes off every tick that char is affected
+	AFF_FUN *pulse_fun = nullptr;
+	AFF_FUN *end_fun = nullptr;		// when the affect wears off this is called
+	short init_duration = 0;
+	AFF_FUN *beat_fun = nullptr;	// goes off every beat
+
+	affect_data() = default;
+	~affect_data();
+
+	affect_data(const affect_data &other);
+	affect_data &operator=(const affect_data &other);
+	affect_data(affect_data &&other) noexcept;
+	affect_data &operator=(affect_data &&other) noexcept;
 };
 
 //

--- a/code/entity/affect_data.h
+++ b/code/entity/affect_data.h
@@ -34,22 +34,23 @@ struct affect_data
 // A room affect.
 //
 
+// A room affect. Plain value type; a room owns these by value in a
+// std::list<ROOM_AFFECT_DATA> (room->affected). `owner` is a non-owning
+// CHAR_DATA back-reference and stays a raw pointer.
 struct room_affect_data
 {
-	ROOM_AFFECT_DATA *next;
-	CHAR_DATA *owner;
-	bool valid;
-	short where;
-	short type;
-	short level;
-	short duration;
-	short location;
-	short modifier;
-	long bitvector[MAX_BITVECTOR];
-	int aftype;
-	RAFF_FUN *pulse_fun;
-	RAFF_FUN *tick_fun;	// goes off every tick
-	RAFF_FUN *end_fun;	// when the affect wears off this is called
+	CHAR_DATA *owner = nullptr;
+	short where = 0;
+	short type = 0;
+	short level = 0;
+	short duration = 0;
+	short location = 0;
+	short modifier = 0;
+	long bitvector[MAX_BITVECTOR] = {};
+	int aftype = 0;
+	RAFF_FUN *pulse_fun = nullptr;
+	RAFF_FUN *tick_fun = nullptr;	// goes off every tick
+	RAFF_FUN *end_fun = nullptr;	// when the affect wears off this is called
 };
 
 //

--- a/code/entity/area_data.h
+++ b/code/entity/area_data.h
@@ -1,8 +1,11 @@
 #ifndef ENTITY_AREA_DATA_H
 #define ENTITY_AREA_DATA_H
 
+#include <list>
+
 #include "fwd.h"
 #include "limits.h"
+#include "affect_data.h"					// AREA_AFFECT_DATA held by value in area->affected
 
 //
 // Area definition.
@@ -29,7 +32,7 @@ struct area_data
 	long area_flags[MAX_BITVECTOR];
 	bool empty;
 	long affected_by[MAX_BITVECTOR];
-	AREA_AFFECT_DATA *affected;
+	std::list<AREA_AFFECT_DATA> affected;
 	AREA_DATA *adjacent[MAX_ADJACENT];
 	short climate;
 	short sky;

--- a/code/entity/char_data.h
+++ b/code/entity/char_data.h
@@ -11,6 +11,7 @@
 #include "mob_index_data.h"				// Class() falls back through pIndexData
 #include "pc_data.h"					// Profs() reaches into pcdata
 #include "mem_data.h"					// MEM_DATA held by value in ch->memory
+#include "affect_data.h"				// AFFECT_DATA held by value in ch->affected
 
 //
 // One character (PC or NPC).
@@ -39,7 +40,7 @@ public:
 	GAME_FUN *game_fun;
 	MOB_INDEX_DATA *pIndexData;
 	DESCRIPTOR_DATA *desc;
-	AFFECT_DATA *affected;
+	std::list<AFFECT_DATA> affected;
 	NOTE_DATA *pnote;
 	OBJ_DATA *carrying;
 	OBJ_DATA *on;

--- a/code/entity/char_data.h
+++ b/code/entity/char_data.h
@@ -2,6 +2,7 @@
 #define ENTITY_CHAR_DATA_H
 
 #include <time.h>
+#include <list>
 
 #include "fwd.h"
 #include "limits.h"
@@ -9,6 +10,7 @@
 #include "../characterClasses/class.h"	// CClass, used by the inline accessors
 #include "mob_index_data.h"				// Class() falls back through pIndexData
 #include "pc_data.h"					// Profs() reaches into pcdata
+#include "mem_data.h"					// MEM_DATA held by value in ch->memory
 
 //
 // One character (PC or NPC).
@@ -33,7 +35,7 @@ public:
 	char * last_fight_name;
 	CHAR_DATA *hunting;
 	CHAR_DATA *defending;
-	MEM_DATA *memory;
+	std::list<MEM_DATA> memory;
 	GAME_FUN *game_fun;
 	MOB_INDEX_DATA *pIndexData;
 	DESCRIPTOR_DATA *desc;

--- a/code/entity/char_data.h
+++ b/code/entity/char_data.h
@@ -11,6 +11,7 @@
 #include "../characterClasses/class.h"	// CClass, used by the inline accessors
 #include "mob_index_data.h"				// Class() falls back through pIndexData
 #include "pc_data.h"					// Profs() reaches into pcdata
+#include "gen_data.h"					// GEN_DATA held by unique_ptr in ch->gen_data
 #include "mem_data.h"					// MEM_DATA held by value in ch->memory
 #include "affect_data.h"				// AFFECT_DATA held by value in ch->affected
 
@@ -49,7 +50,7 @@ public:
 	ROOM_INDEX_DATA *was_in_room;
 	AREA_DATA *zone;
 	std::unique_ptr<PC_DATA> pcdata;
-	GEN_DATA *gen_data;
+	std::unique_ptr<GEN_DATA> gen_data;
 	PATHFIND_DATA *path;	// For smart pathfinding/tracking.  Mob only.
 	PATHFIND_DATA *best;	// Stores best direction thus far.  Mob only.
 	bool valid;

--- a/code/entity/char_data.h
+++ b/code/entity/char_data.h
@@ -3,6 +3,7 @@
 
 #include <time.h>
 #include <list>
+#include <memory>
 
 #include "fwd.h"
 #include "limits.h"
@@ -47,7 +48,7 @@ public:
 	ROOM_INDEX_DATA *in_room;
 	ROOM_INDEX_DATA *was_in_room;
 	AREA_DATA *zone;
-	PC_DATA *pcdata;
+	std::unique_ptr<PC_DATA> pcdata;
 	GEN_DATA *gen_data;
 	PATHFIND_DATA *path;	// For smart pathfinding/tracking.  Mob only.
 	PATHFIND_DATA *best;	// Stores best direction thus far.  Mob only.

--- a/code/entity/extra_descr.h
+++ b/code/entity/extra_descr.h
@@ -6,13 +6,27 @@
 //
 // Extra description data for a room or object.
 //
-
+// Owns its two strings (palloc_string / free_pstring). Parents hold these by
+// value in a std::list<EXTRA_DESCR_DATA>. std::list (not vector) is deliberate:
+// OLC's `ed add`/`ed edit` hand string_append() a `char**` INTO an element
+// (&ed->description) that must stay valid across a deferred string-editing
+// session, and a vector realloc (e.g. a concurrent `ed add` on the same room)
+// would dangle it. list keeps node/reference stability, exactly as the intrusive
+// list it replaces did (dbsession.h precedent). The rule-of-5 below keeps copies
+// deep and moves cheap; bodies live in recycle.c by the memory helpers they call.
+//
 struct extra_descr_data
 {
-	EXTRA_DESCR_DATA *next;				// Next in list
-	bool valid;
-	char *keyword;						// Keyword in look/examine
-	char *description;					// What to see
+	char *keyword = nullptr;			// Keyword in look/examine
+	char *description = nullptr;		// What to see
+
+	extra_descr_data() = default;
+	~extra_descr_data();
+
+	extra_descr_data(const extra_descr_data &other);
+	extra_descr_data &operator=(const extra_descr_data &other);
+	extra_descr_data(extra_descr_data &&other) noexcept;
+	extra_descr_data &operator=(extra_descr_data &&other) noexcept;
 };
 
 #endif /* ENTITY_EXTRA_DESCR_H */

--- a/code/entity/fwd.h
+++ b/code/entity/fwd.h
@@ -15,7 +15,7 @@
 
 struct	affect_data;		typedef struct	affect_data			AFFECT_DATA;
 struct	area_data;			typedef struct	area_data			AREA_DATA;
-struct	buf_type;			typedef struct	buf_type			BUFFER;
+class	buf_type;			typedef class	buf_type			BUFFER;
 class	char_data;			typedef class	char_data			CHAR_DATA;
 struct	descriptor_data;	typedef struct	descriptor_data		DESCRIPTOR_DATA;
 struct	exit_data;			typedef struct	exit_data			EXIT_DATA;

--- a/code/entity/fwd.h
+++ b/code/entity/fwd.h
@@ -46,7 +46,6 @@ struct	room_affect_data;	typedef struct	room_affect_data	ROOM_AFFECT_DATA;
 struct	area_affect_data;	typedef struct	area_affect_data	AREA_AFFECT_DATA;
 struct	obj_affect_data;	typedef struct	obj_affect_data		OBJ_AFFECT_DATA;
 struct	obj_apply_data;		typedef struct	obj_apply_data		OBJ_APPLY_DATA;
-struct	queue_data;			typedef struct	queue_data			QUEUE_DATA;
 struct	rune_data;			typedef struct	rune_data			RUNE_DATA;
 struct	trophy_data;		typedef struct	trophy_data			TROPHY_DATA;
 struct	track_data;			typedef struct	track_data			TRACK_DATA;

--- a/code/entity/gen_data.h
+++ b/code/entity/gen_data.h
@@ -1,0 +1,26 @@
+#ifndef ENTITY_GEN_DATA_H
+#define ENTITY_GEN_DATA_H
+
+#include "fwd.h"
+#include "limits.h"
+
+//
+// Scratch state for the character-generation skill/group picker: which skills
+// and groups have been chosen so far, and what they have cost in points.
+//
+// A character owns at most one of these (ch->gen_data), and only while it is
+// being generated -- hence a nullable unique_ptr on the char rather than an
+// inline member. The two arrays are roughly 850 bytes that a fully generated
+// character has no use for.
+//
+// The picker that drives this (parse_gen_groups, skills.c) is commented out
+// today; the type is kept for it.
+//
+struct gen_data
+{
+	bool skill_chosen[MAX_SKILL] = {};
+	bool group_chosen[MAX_GROUP] = {};
+	int points_chosen = 0;
+};
+
+#endif /* ENTITY_GEN_DATA_H */

--- a/code/entity/line_data.h
+++ b/code/entity/line_data.h
@@ -1,0 +1,33 @@
+#ifndef ENTITY_LINE_DATA_H
+#define ENTITY_LINE_DATA_H
+
+#include "fwd.h"
+
+//
+// One line of a mob speech: what to say (text), how (type), after how long
+// (delay), and its ordering number. Owns its `text` string. A speech holds
+// these by value in a std::list<LINE_DATA> (speech->first_line).
+//
+// Immovable/uncopyable: the lists that hold these only ever emplace, erase,
+// iterate, and sort (all of which relink nodes rather than copy/move the
+// elements), so a plain owning dtor is all that's needed -- no rule-of-5.
+// Keeping it immovable also guarantees element addresses are stable, which the
+// runtime speech cursor (an iterator into first_line) relies on.
+//
+struct line_data
+{
+	int number = -1;					// Ordering index within the speech.
+	int delay = -1;						// Ticks to wait before this line.
+	short type = -1;					// SPEECH_SAY / TELL / ... (speech_table).
+	char *text = nullptr;				// What to say (owned).
+
+	line_data() = default;
+	~line_data();
+
+	line_data(const line_data &) = delete;
+	line_data &operator=(const line_data &) = delete;
+	line_data(line_data &&) = delete;
+	line_data &operator=(line_data &&) = delete;
+};
+
+#endif /* ENTITY_LINE_DATA_H */

--- a/code/entity/mem_data.h
+++ b/code/entity/mem_data.h
@@ -1,0 +1,27 @@
+#ifndef ENTITY_MEM_DATA_H
+#define ENTITY_MEM_DATA_H
+
+#include <ctime>
+
+#include "fwd.h"
+
+//
+// A mob's memory of a character it has encountered (who, how it feels about
+// them, and when). Plain value type; a char owns these by value in a
+// std::list<MEM_DATA> (ch->memory).
+//
+// The mob-memory mechanic is not wired up yet, but the type is a real part of
+// the intended game and is kept for it. std::list matches the other
+// intrusive-list conversions; there is no usage to audit for pointer stability,
+// and a memory list that ages entries out is exactly the shape that tends to
+// hold element references across mutations in this codebase, so list is the
+// safe default.
+//
+struct mem_data
+{
+	int id = 0;					// pc/mob id of the remembered character
+	int reaction = 0;			// how the mob feels about them
+	time_t when = 0;			// when it last saw them
+};
+
+#endif /* ENTITY_MEM_DATA_H */

--- a/code/entity/mob_index_data.h
+++ b/code/entity/mob_index_data.h
@@ -1,9 +1,12 @@
 #ifndef ENTITY_MOB_INDEX_DATA_H
 #define ENTITY_MOB_INDEX_DATA_H
 
+#include <list>
+
 #include "fwd.h"
 #include "limits.h"
 #include "spec_func.h"
+#include "speech_data.h"						// SPEECH_DATA held by value in mob->speech
 #include "../characterClasses/class.h"		// CClass, used by the inline accessors
 
 //
@@ -19,7 +22,7 @@ public:
 	BARRED_DATA *barred_entry; //dev
 	MPROG_DATA *mprogs;
 	AREA_DATA *area;
-	SPEECH_DATA *speech;
+	std::list<SPEECH_DATA> speech;
 	long progtypes[MAX_BITVECTOR];
 	short vnum;
 	short group;

--- a/code/entity/obj_data.h
+++ b/code/entity/obj_data.h
@@ -6,6 +6,7 @@
 #include "fwd.h"
 #include "limits.h"
 #include "extra_descr.h"
+#include "affect_data.h"		// OBJ_APPLY_DATA held by value
 
 //
 // One object.
@@ -20,7 +21,7 @@ struct obj_data
 	OBJ_DATA *on;
 	CHAR_DATA *carried_by;
 	std::list<EXTRA_DESCR_DATA> extra_descr;
-	OBJ_APPLY_DATA *apply;
+	std::list<OBJ_APPLY_DATA> apply;
 	OBJ_AFFECT_DATA *affected;
 	AFFECT_DATA *charaffs;
 	OBJ_INDEX_DATA *pIndexData;

--- a/code/entity/obj_data.h
+++ b/code/entity/obj_data.h
@@ -1,8 +1,11 @@
 #ifndef ENTITY_OBJ_DATA_H
 #define ENTITY_OBJ_DATA_H
 
+#include <list>
+
 #include "fwd.h"
 #include "limits.h"
+#include "extra_descr.h"
 
 //
 // One object.
@@ -16,7 +19,7 @@ struct obj_data
 	OBJ_DATA *in_obj;
 	OBJ_DATA *on;
 	CHAR_DATA *carried_by;
-	EXTRA_DESCR_DATA *extra_descr;
+	std::list<EXTRA_DESCR_DATA> extra_descr;
 	OBJ_APPLY_DATA *apply;
 	OBJ_AFFECT_DATA *affected;
 	AFFECT_DATA *charaffs;

--- a/code/entity/obj_data.h
+++ b/code/entity/obj_data.h
@@ -23,7 +23,7 @@ struct obj_data
 	std::list<EXTRA_DESCR_DATA> extra_descr;
 	std::list<OBJ_APPLY_DATA> apply;
 	std::list<OBJ_AFFECT_DATA> affected;
-	AFFECT_DATA *charaffs;
+	std::list<AFFECT_DATA> charaffs;
 	OBJ_INDEX_DATA *pIndexData;
 	ROOM_INDEX_DATA *in_room;
 	RUNE_DATA *rune;

--- a/code/entity/obj_data.h
+++ b/code/entity/obj_data.h
@@ -22,7 +22,7 @@ struct obj_data
 	CHAR_DATA *carried_by;
 	std::list<EXTRA_DESCR_DATA> extra_descr;
 	std::list<OBJ_APPLY_DATA> apply;
-	OBJ_AFFECT_DATA *affected;
+	std::list<OBJ_AFFECT_DATA> affected;
 	AFFECT_DATA *charaffs;
 	OBJ_INDEX_DATA *pIndexData;
 	ROOM_INDEX_DATA *in_room;

--- a/code/entity/obj_index_data.h
+++ b/code/entity/obj_index_data.h
@@ -17,8 +17,8 @@ struct obj_index_data
 {
 	OBJ_INDEX_DATA *next;
 	std::list<EXTRA_DESCR_DATA> extra_descr;
-	AFFECT_DATA *affected;
-	AFFECT_DATA *charaffs;
+	std::list<AFFECT_DATA> affected;
+	std::list<AFFECT_DATA> charaffs;
 	std::list<OBJ_APPLY_DATA> apply;
 	AREA_DATA *area;
 	bool new_format;

--- a/code/entity/obj_index_data.h
+++ b/code/entity/obj_index_data.h
@@ -7,6 +7,7 @@
 #include "limits.h"
 #include "spec_func.h"
 #include "extra_descr.h"
+#include "affect_data.h"		// OBJ_APPLY_DATA held by value
 
 //
 // Prototype for an object.
@@ -18,7 +19,7 @@ struct obj_index_data
 	std::list<EXTRA_DESCR_DATA> extra_descr;
 	AFFECT_DATA *affected;
 	AFFECT_DATA *charaffs;
-	OBJ_APPLY_DATA *apply;
+	std::list<OBJ_APPLY_DATA> apply;
 	AREA_DATA *area;
 	bool new_format;
 	char *name;

--- a/code/entity/obj_index_data.h
+++ b/code/entity/obj_index_data.h
@@ -1,9 +1,12 @@
 #ifndef ENTITY_OBJ_INDEX_DATA_H
 #define ENTITY_OBJ_INDEX_DATA_H
 
+#include <list>
+
 #include "fwd.h"
 #include "limits.h"
 #include "spec_func.h"
+#include "extra_descr.h"
 
 //
 // Prototype for an object.
@@ -12,7 +15,7 @@
 struct obj_index_data
 {
 	OBJ_INDEX_DATA *next;
-	EXTRA_DESCR_DATA *extra_descr;
+	std::list<EXTRA_DESCR_DATA> extra_descr;
 	AFFECT_DATA *affected;
 	AFFECT_DATA *charaffs;
 	OBJ_APPLY_DATA *apply;

--- a/code/entity/pc_data.h
+++ b/code/entity/pc_data.h
@@ -139,6 +139,8 @@ struct pc_data
 	//
 
 	CProficiencies	profs;
+
+	~pc_data();		// frees the owned strings + buffer (body in recycle.c)
 };
 
 #endif /* ENTITY_PC_DATA_H */

--- a/code/entity/pc_data.h
+++ b/code/entity/pc_data.h
@@ -2,11 +2,13 @@
 #define ENTITY_PC_DATA_H
 
 #include <time.h>
+#include <list>
 
 #include "fwd.h"
 #include "limits.h"
 #include "../enums.h"		// SECT_MAX
 #include "../prof.h"		// CProficiencies is embedded by value
+#include "trophy_data.h"	// TROPHY_DATA held by value in pcdata->trophy
 
 //
 // Data which only PC's have.
@@ -94,7 +96,7 @@ struct pc_data
 	short style;
 	long styles[MAX_BITVECTOR];
 	long ele_sphere[MAX_BITVECTOR];
-	TROPHY_DATA *trophy;
+	std::list<TROPHY_DATA> trophy;
 	char *command[2];
 	
 	//

--- a/code/entity/room_index_data.h
+++ b/code/entity/room_index_data.h
@@ -5,6 +5,7 @@
 
 #include "fwd.h"
 #include "limits.h"
+#include "affect_data.h"					// ROOM_AFFECT_DATA held by value in room->affected
 #include "extra_descr.h"
 #include "track_data.h"
 
@@ -37,7 +38,7 @@ struct room_index_data
 	short mana_rate;
 	short cabal;
 	short guild;
-	ROOM_AFFECT_DATA *affected;
+	std::list<ROOM_AFFECT_DATA> affected;
 	long affected_by[MAX_BITVECTOR];
 	RPROG_DATA *rprogs;
 	long progtypes[MAX_BITVECTOR];

--- a/code/entity/room_index_data.h
+++ b/code/entity/room_index_data.h
@@ -1,8 +1,11 @@
 #ifndef ENTITY_ROOM_INDEX_DATA_H
 #define ENTITY_ROOM_INDEX_DATA_H
 
+#include <list>
+
 #include "fwd.h"
 #include "limits.h"
+#include "extra_descr.h"
 
 //
 // Room type.
@@ -15,7 +18,7 @@ struct room_index_data
 	ROOM_INDEX_DATA *aff_next;
 	CHAR_DATA *people;
 	OBJ_DATA *contents;
-	EXTRA_DESCR_DATA *extra_descr;
+	std::list<EXTRA_DESCR_DATA> extra_descr;
 	AREA_DATA *area;
 	EXIT_DATA *exit[6];
 	TRACK_DATA *tracks[20];

--- a/code/entity/room_index_data.h
+++ b/code/entity/room_index_data.h
@@ -6,6 +6,7 @@
 #include "fwd.h"
 #include "limits.h"
 #include "extra_descr.h"
+#include "track_data.h"
 
 //
 // Room type.
@@ -21,7 +22,7 @@ struct room_index_data
 	std::list<EXTRA_DESCR_DATA> extra_descr;
 	AREA_DATA *area;
 	EXIT_DATA *exit[6];
-	TRACK_DATA *tracks[20];
+	TRACK_DATA tracks[20];
 	PATHFIND_DATA *path;				// For smart tracking
 	char *name;
 	char *alt_name;

--- a/code/entity/speech_data.h
+++ b/code/entity/speech_data.h
@@ -1,0 +1,39 @@
+#ifndef ENTITY_SPEECH_DATA_H
+#define ENTITY_SPEECH_DATA_H
+
+#include <list>
+
+#include "fwd.h"
+#include "line_data.h"
+
+//
+// A named mob speech: an ordered list of lines the mob plays out, plus a cursor
+// (current_line) into that list marking where playback is. A mob prototype owns
+// these by value in a std::list<SPEECH_DATA> (mob->speech). Owns its `name`.
+//
+// std::list at both levels is deliberate: speech playback is driven through the
+// event queue, which holds a SPEECH_DATA* and advances current_line across
+// queued callbacks (act_comm.c speech_handler). std::list gives the node/address
+// stability those held references need; a vector would dangle them.
+//
+// Immovable/uncopyable: mob->speech only emplaces/erases/iterates, so no
+// rule-of-5 is needed -- and immovability keeps line addresses and the
+// current_line iterator stable. current_line sits at first_line.end() when
+// playback is unstarted/reset (the old raw-pointer null state).
+//
+struct speech_data
+{
+	char *name = nullptr;					// Speech keyword (owned).
+	std::list<LINE_DATA> first_line;		// The lines, in order.
+	std::list<LINE_DATA>::iterator current_line;	// Playback cursor; end() == reset.
+
+	speech_data() : current_line(first_line.end()) {}
+	~speech_data();
+
+	speech_data(const speech_data &) = delete;
+	speech_data &operator=(const speech_data &) = delete;
+	speech_data(speech_data &&) = delete;
+	speech_data &operator=(speech_data &&) = delete;
+};
+
+#endif /* ENTITY_SPEECH_DATA_H */

--- a/code/entity/time_info_data.h
+++ b/code/entity/time_info_data.h
@@ -1,0 +1,20 @@
+#ifndef ENTITY_TIME_INFO_DATA_H
+#define ENTITY_TIME_INFO_DATA_H
+
+#include "fwd.h"
+
+//
+// The in-game world clock (hour/day/month/season/year). Plain POD value type;
+// held by value both by the global `time_info` and by each room track.
+//
+struct time_info_data
+{
+	bool half;
+	int hour;
+	int day;
+	int month;
+	int season;
+	int year;
+};
+
+#endif /* ENTITY_TIME_INFO_DATA_H */

--- a/code/entity/track_data.h
+++ b/code/entity/track_data.h
@@ -1,0 +1,29 @@
+#ifndef ENTITY_TRACK_DATA_H
+#define ENTITY_TRACK_DATA_H
+
+#include "fwd.h"
+#include "time_info_data.h"
+
+//
+// A single recorded footprint in a room: who passed through, when, and which
+// way they went. A room owns a fixed array of these by value (room->tracks;
+// only the first MAX_TRACKS slots are used) -- there is no heap allocation and
+// no free list; an empty slot is one whose `prey` is null. The member
+// initializers below give a default-constructed track the same empty state
+// new_track_data() used to hand out (`prey == nullptr`, `direction == -1`).
+//
+// `prey` is a non-owning back-pointer to a character owned elsewhere, so it
+// stays a raw pointer.
+//
+struct track_data
+{
+	CHAR_DATA *prey = nullptr;			// Who passed through.
+	TIME_INFO_DATA time = {};			// When they passed through.
+	short direction = -1;				// Which way they went.
+	bool flying = false;				// Are they?
+	bool sneaking = false;				// Are they?
+	int legs = 0;						// How many?
+	bool bleeding = false;				// Are they?
+};
+
+#endif /* ENTITY_TRACK_DATA_H */

--- a/code/entity/trophy_data.h
+++ b/code/entity/trophy_data.h
@@ -1,0 +1,32 @@
+#ifndef ENTITY_TROPHY_DATA_H
+#define ENTITY_TROPHY_DATA_H
+
+#include "fwd.h"
+
+//
+// One scalp on a Horde trophy belt: the name of a character the owner trophied.
+// Owns its `victname` string (palloc_string / free_pstring). A player holds
+// these by value in a std::list<TROPHY_DATA> (pcdata->trophy).
+//
+// std::list matches the intrusive list it replaces; the trophy list is tiny
+// (bounded by belt scalps) and nothing caches an element pointer across a
+// mutation, so a vector would have been safe too -- list is chosen for
+// consistency with the other intrusive-list conversions. The rule-of-5 below
+// keeps copies deep and moves cheap; bodies live in recycle.c by the memory
+// helpers they call.
+//
+struct trophy_data
+{
+	char *victname = nullptr;			// Name of the trophied character.
+
+	trophy_data() = default;
+	explicit trophy_data(const char *name);
+	~trophy_data();
+
+	trophy_data(const trophy_data &other);
+	trophy_data &operator=(const trophy_data &other);
+	trophy_data(trophy_data &&other) noexcept;
+	trophy_data &operator=(trophy_data &&other) noexcept;
+};
+
+#endif /* ENTITY_TROPHY_DATA_H */

--- a/code/fight.c
+++ b/code/fight.c
@@ -1183,10 +1183,14 @@ int damage_new(CHAR_DATA *ch, CHAR_DATA *victim, int idam, int dt, int dam_type,
 	/* empathy */
 	if (is_affected(victim, gsn_empathy))
 	{
-		for (laf = victim->affected; laf != nullptr; laf = laf->next)
+		laf = nullptr;
+		for (auto &laf_elem : victim->affected)
 		{
-			if (laf->type == gsn_empathy)
+			if (laf_elem.type == gsn_empathy)
+			{
+				laf = &laf_elem;
 				break;
+			}
 		}
 
 		if (ch != victim)
@@ -3263,7 +3267,7 @@ void raw_kill(CHAR_DATA *ch, CHAR_DATA *victim)
 {
 	int i, sn;
 	ROOM_INDEX_DATA *location;
-	AFFECT_DATA af, *paf, *paf_next;
+	AFFECT_DATA af;
 	ROOM_AFFECT_DATA raf;
 	AREA_AFFECT_DATA aaf;
 	CHAR_DATA *gch, *gch_next;
@@ -3398,26 +3402,26 @@ void raw_kill(CHAR_DATA *ch, CHAR_DATA *victim)
 	if (is_affected(victim, gsn_disguise))
 		do_undisguise(victim, "");
 
-	for (paf = victim->affected; paf != nullptr; paf = paf_next)
+	for (auto it = victim->affected.begin(); it != victim->affected.end(); )
 	{
-		paf_next = paf->next;
+		auto next = std::next(it);
 
-		if (IS_SET(paf->bitvector, AFF_PERMANENT))
-			continue;
+		if (!IS_SET(it->bitvector, AFF_PERMANENT))
+			affect_remove(victim, &*it);
 
-		affect_remove(victim, paf);
+		it = next;
 	}
 
 	extract_char(victim, false);
 
-	for (paf = victim->affected; paf != nullptr; paf = paf_next)
+	for (auto it = victim->affected.begin(); it != victim->affected.end(); )
 	{
-		paf_next = paf->next;
+		auto next = std::next(it);
 
-		if (IS_SET(paf->bitvector, AFF_PERMANENT))
-			continue;
+		if (!IS_SET(it->bitvector, AFF_PERMANENT))
+			affect_remove(victim, &*it);
 
-		affect_remove(victim, paf);
+		it = next;
 	}
 
 	victim->talismanic = 0;

--- a/code/fight.c
+++ b/code/fight.c
@@ -8961,7 +8961,6 @@ void trophy_corpse(CHAR_DATA *ch, CHAR_DATA *victim)
 {
 	OBJ_DATA *corpse, *belt, *newbelt;
 	OBJ_AFFECT_DATA oaf;
-	TROPHY_DATA *placeholder;
 	int i, scalps;
 
 	for (corpse = ch->in_room->contents; corpse; corpse = corpse->next_content)
@@ -8987,7 +8986,7 @@ void trophy_corpse(CHAR_DATA *ch, CHAR_DATA *victim)
 	act("$n smoothly slices $N's scalp from $S head and attaches it to $s belt!", ch, 0, victim, TO_NOTVICT);
 	check_improve(ch, gsn_trophy, true, 1);
 
-	if (!ch->pcdata->trophy)
+	if (ch->pcdata->trophy.empty())
 		belt->value[4] = 0;
 
 	/* Update the hit/dam mods on the belt. */
@@ -9021,26 +9020,30 @@ void trophy_corpse(CHAR_DATA *ch, CHAR_DATA *victim)
 
 	if (newbelt->value[4] == 0)
 	{
-
-		ch->pcdata->trophy = new_trophy_data(victim->true_name);
+		ch->pcdata->trophy.clear();
+		ch->pcdata->trophy.emplace_back(victim->true_name);
 	}
 	else
 	{
-		placeholder = ch->pcdata->trophy;
+		auto it = ch->pcdata->trophy.begin();
 
 		for (i = 1; i < newbelt->value[4]; i++)
 		{
-			if (!ch->pcdata->trophy)
+			if (it == ch->pcdata->trophy.end())
 				break;
 
-			if (!ch->pcdata->trophy->next)
+			if (std::next(it) == ch->pcdata->trophy.end())
 				break;
 
-			ch->pcdata->trophy = ch->pcdata->trophy->next;
+			++it;
 		}
 
-		ch->pcdata->trophy = ch->pcdata->trophy->next = new_trophy_data(victim->true_name);
-		ch->pcdata->trophy = placeholder;
+		// Append after `it`, dropping anything past it -- mirrors the old
+		// `it->next = new`, which orphaned the cursor's old tail.
+		if (it != ch->pcdata->trophy.end())
+			ch->pcdata->trophy.erase(std::next(it), ch->pcdata->trophy.end());
+
+		ch->pcdata->trophy.emplace_back(victim->true_name);
 	}
 
 	newbelt->value[4]++;

--- a/code/handler.c
+++ b/code/handler.c
@@ -738,7 +738,6 @@ void reset_char(CHAR_DATA *ch)
 {
 	int loc, stat;
 	OBJ_DATA *obj;
-	AFFECT_DATA *af;
 	int i;
 
 	if (is_npc(ch))
@@ -757,9 +756,9 @@ void reset_char(CHAR_DATA *ch)
 			if (obj == nullptr)
 				continue;
 
-			for (af = obj->charaffs; af != nullptr; af = af->next)
+			for (auto &af : obj->charaffs)
 			{
-				affect_strip(ch, af->type);
+				affect_strip(ch, af.type);
 			}
 
 			for (const auto &app : obj->apply)
@@ -819,9 +818,9 @@ void reset_char(CHAR_DATA *ch)
 			ch->armor[i] += apply_ac(obj, loc, i);
 		}
 
-		for (af = obj->charaffs; af != nullptr; af = af->next)
+		for (auto &af : obj->charaffs)
 		{
-			affect_modify(ch, af, true);
+			affect_modify(ch, &af, true);
 		}
 
 		for (const auto &app : obj->apply)
@@ -831,9 +830,9 @@ void reset_char(CHAR_DATA *ch)
 	}
 
 	/* now add back spell effects */
-	for (af = ch->affected; af != nullptr; af = af->next)
+	for (auto &af : ch->affected)
 	{
-		modify_location(ch, af->location, af->modifier, true);
+		modify_location(ch, af.location, af.modifier, true);
 	}
 
 	/* make sure sex is RIGHT!!!! */
@@ -1316,14 +1315,12 @@ void affect_modify(CHAR_DATA *ch, AFFECT_DATA *paf, bool fAdd)
 }
 
 /* find an effect in an affect list */
-AFFECT_DATA *affect_find(AFFECT_DATA *paf, int sn)
+AFFECT_DATA *affect_find(std::list<AFFECT_DATA> &affects, int sn)
 {
-	AFFECT_DATA *paf_find;
-
-	for (paf_find = paf; paf_find != nullptr; paf_find = paf_find->next)
+	for (auto &paf : affects)
 	{
-		if (paf_find->type == sn)
-			return paf_find;
+		if (paf.type == sn)
+			return &paf;
 	}
 
 	return nullptr;
@@ -1365,14 +1362,12 @@ AREA_AFFECT_DATA *affect_find_area(std::list<AREA_AFFECT_DATA> &affects, int sn)
 /* fix object affects when removing one */
 void affect_check(CHAR_DATA *ch, int where, long vector[])
 {
-	AFFECT_DATA *paf;
-
 	if (where == TO_OBJECT || where == TO_WEAPON || vector == 0)
 		return;
 
-	for (paf = ch->affected; paf != nullptr; paf = paf->next)
+	for (auto &paf : ch->affected)
 	{
-		if (paf->where == where && vector_equal(paf->bitvector, vector))
+		if (paf.where == where && vector_equal(paf.bitvector, vector))
 		{
 			switch (where)
 			{
@@ -1405,8 +1400,6 @@ void affect_to_char(CHAR_DATA *ch, AFFECT_DATA *paf)
 
 void new_affect_to_char(CHAR_DATA *ch, AFFECT_DATA *paf)
 {
-	AFFECT_DATA *paf_new;
-
 	if (IS_SET(ch->imm_flags, IMM_SLEEP) && IS_SET(paf->bitvector, AFF_SLEEP) && paf->where == TO_AFFECTS)
 	{
 		send_to_char("You are unaffected.\n\r", ch);
@@ -1426,16 +1419,9 @@ void new_affect_to_char(CHAR_DATA *ch, AFFECT_DATA *paf)
 	// set initial duration
 	paf->init_duration = paf->duration;
 
-	paf_new = new_affect();
-	*paf_new = *paf;
+	ch->affected.push_front(*paf);
 
-	paf_new->next = ch->affected;
-	ch->affected = paf_new;
-
-	/* Morg - Valgrind fix */
-	paf_new->valid = true;
-
-	affect_modify(ch, paf_new, true);
+	affect_modify(ch, &ch->affected.front(), true);
 }
 
 /*
@@ -1446,7 +1432,7 @@ void affect_remove(CHAR_DATA *ch, AFFECT_DATA *paf)
 	int where;
 	long vector[MAX_BITVECTOR];
 
-	if (ch->affected == nullptr)
+	if (ch->affected.empty())
 	{
 		RS.Logger.Warn("Affect_remove: no affect on {}.", ch->name);
 		return;
@@ -1459,31 +1445,23 @@ void affect_remove(CHAR_DATA *ch, AFFECT_DATA *paf)
 	where = paf->where;
 	copy_vector(vector, paf->bitvector);
 
-	if (paf == ch->affected)
+	bool found = false;
+	for (auto it = ch->affected.begin(); it != ch->affected.end(); ++it)
 	{
-		ch->affected = paf->next;
-	}
-	else
-	{
-		AFFECT_DATA *prev;
-
-		for (prev = ch->affected; prev != nullptr; prev = prev->next)
+		if (&*it == paf)
 		{
-			if (prev->next == paf)
-			{
-				prev->next = paf->next;
-				break;
-			}
-		}
-
-		if (prev == nullptr)
-		{
-			RS.Logger.Warn("Affect_remove: cannot find paf.");
-			return;
+			ch->affected.erase(it);
+			found = true;
+			break;
 		}
 	}
 
-	free_affect(paf);
+	if (!found)
+	{
+		RS.Logger.Warn("Affect_remove: cannot find paf.");
+		return;
+	}
+
 	affect_check(ch, where, vector);
 }
 
@@ -1492,17 +1470,14 @@ void affect_remove(CHAR_DATA *ch, AFFECT_DATA *paf)
  */
 void affect_strip(CHAR_DATA *ch, int sn)
 {
-	AFFECT_DATA *paf;
-	AFFECT_DATA *paf_next;
-
-	for (paf = ch->affected; paf != nullptr; paf = paf_next)
+	for (auto it = ch->affected.begin(); it != ch->affected.end(); )
 	{
-		paf_next = paf->next;
+		auto next = std::next(it);
 
-		if (paf->type == sn)
-		{
-			affect_remove(ch, paf);
-		}
+		if (it->type == sn)
+			affect_remove(ch, &*it);
+
+		it = next;
 	}
 }
 
@@ -1511,14 +1486,12 @@ void affect_strip(CHAR_DATA *ch, int sn)
  */
 bool is_affected(CHAR_DATA *ch, int sn)
 {
-	AFFECT_DATA *paf;
-
 	if (!ch)
 		return false;
 
-	for (paf = ch->affected; paf != nullptr; paf = paf->next)
+	for (auto &paf : ch->affected)
 	{
-		if (paf->type == sn)
+		if (paf.type == sn)
 			return true;
 	}
 
@@ -1552,17 +1525,15 @@ void affect_join(CHAR_DATA *ch, AFFECT_DATA *paf)
 
 void new_affect_join(CHAR_DATA *ch, AFFECT_DATA *paf)
 {
-	AFFECT_DATA *paf_old;
-
-	for (paf_old = ch->affected; paf_old != nullptr; paf_old = paf_old->next)
+	for (auto &paf_old : ch->affected)
 	{
-		if (paf_old->type == paf->type)
+		if (paf_old.type == paf->type)
 		{
-			paf->level = (paf->level + paf_old->level) / 2;
-			paf->duration += paf_old->duration;
-			paf->modifier += paf_old->modifier;
+			paf->level = (paf->level + paf_old.level) / 2;
+			paf->duration += paf_old.duration;
+			paf->modifier += paf_old.modifier;
 
-			affect_remove(ch, paf_old);
+			affect_remove(ch, &paf_old);
 			break;
 		}
 	}
@@ -1647,10 +1618,14 @@ void char_from_room(CHAR_DATA *ch)
 	}
 	if (!is_affected(ch, gsn_pull) && (check_entwine(ch, 1) || check_entwine(ch, 2)))
 	{
-		for (aaf = ch->affected; aaf != nullptr; aaf = aaf->next)
+		aaf = nullptr;
+		for (auto &aaf_elem : ch->affected)
 		{
-			if (aaf->type == gsn_entwine && (aaf->modifier == 1 || aaf->location == APPLY_DEX))
+			if (aaf_elem.type == gsn_entwine && (aaf_elem.modifier == 1 || aaf_elem.location == APPLY_DEX))
+			{
+				aaf = &aaf_elem;
 				break;
+			}
 		}
 
 		do_uncoil(aaf->owner, "automagic");
@@ -1712,12 +1687,13 @@ void char_to_room(CHAR_DATA *ch, ROOM_INDEX_DATA *pRoomIndex)
 
 	if (is_affected_by(ch, AFF_PLAGUE))
 	{
-		AFFECT_DATA *af;
+		AFFECT_DATA *af = nullptr;
 
-		for (af = ch->affected; af; af = af->next)
+		for (auto &af_elem : ch->affected)
 		{
-			if (af->tick_fun == plague_tick)
+			if (af_elem.tick_fun == plague_tick)
 			{
+				af = &af_elem;
 				break;
 			}
 		}
@@ -1874,7 +1850,6 @@ bool is_worn(OBJ_DATA *obj)
  */
 void equip_char(CHAR_DATA *ch, OBJ_DATA *obj, int iWear, bool show)
 {
-	AFFECT_DATA *paf, *fmaf;
 	int i;
 	bool status;
 
@@ -1889,17 +1864,16 @@ void equip_char(CHAR_DATA *ch, OBJ_DATA *obj, int iWear, bool show)
 
 	if (!is_npc(ch) && is_affected(ch, gsn_false_motives))
 	{
-		AFFECT_DATA *pal;
-		for (pal = ch->affected; pal; pal = pal->next)
+		for (auto &pal : ch->affected)
 		{
-			if (pal->type == gsn_false_motives && pal->location == APPLY_ALIGNMENT)
-				palign -= pal->modifier;
+			if (pal.type == gsn_false_motives && pal.location == APPLY_ALIGNMENT)
+				palign -= pal.modifier;
 		}
 
-		for (pal = ch->affected; pal; pal = pal->next)
+		for (auto &pal : ch->affected)
 		{
-			if (pal->type == gsn_false_motives && pal->location == APPLY_ETHOS)
-				pethos -= pal->modifier;
+			if (pal.type == gsn_false_motives && pal.location == APPLY_ETHOS)
+				pethos -= pal.modifier;
 		}
 	}
 
@@ -1947,9 +1921,9 @@ void equip_char(CHAR_DATA *ch, OBJ_DATA *obj, int iWear, bool show)
 		modify_location(ch, app.location, app.modifier, true);
 	}
 
-	for (paf = obj->charaffs; paf != nullptr; paf = paf->next)
+	for (auto &paf : obj->charaffs)
 	{
-		affect_to_char(ch, paf);
+		affect_to_char(ch, &paf);
 	}
 
 	if ((obj->item_type == ITEM_LIGHT || is_obj_stat(obj, ITEM_GLOW)) && ch->in_room)
@@ -1967,7 +1941,6 @@ void equip_char(CHAR_DATA *ch, OBJ_DATA *obj, int iWear, bool show)
  */
 void unequip_char(CHAR_DATA *ch, OBJ_DATA *obj, bool show)
 {
-	AFFECT_DATA *paf = nullptr;
 	int i, wearloc = obj->wear_loc;
 
 	if (obj->wear_loc == WEAR_NONE)
@@ -2006,9 +1979,9 @@ void unequip_char(CHAR_DATA *ch, OBJ_DATA *obj, bool show)
 		modify_location(ch, app.location, app.modifier, false);
 	}
 
-	for (paf = obj->charaffs; paf != nullptr; paf = paf->next)
+	for (auto &paf : obj->charaffs)
 	{
-		affect_strip(ch, paf->type);
+		affect_strip(ch, paf.type);
 	}
 
 	if ((obj->item_type == ITEM_LIGHT || is_obj_stat(obj, ITEM_GLOW)) && ch->in_room)
@@ -2249,7 +2222,6 @@ void extract_char(CHAR_DATA *ch, bool fPull)
 	OBJ_DATA *obj_next;
 	CHAR_DATA *tch;
 	ROOM_INDEX_DATA *room;
-	AFFECT_DATA *af;
 
 	if (ch->in_room == nullptr)
 	{
@@ -2274,10 +2246,10 @@ void extract_char(CHAR_DATA *ch, bool fPull)
 		if (!is_npc(tch) && !is_npc(ch) && tch->pcdata->trusting == ch)
 			tch->pcdata->trusting = nullptr;
 
-		for (af = tch->affected; af; af = af->next)
+		for (auto &af : tch->affected)
 		{
-			if (af->owner == ch)
-				af->owner = nullptr;
+			if (af.owner == ch)
+				af.owner = nullptr;
 		}
 	}
 
@@ -4217,56 +4189,32 @@ char *raffect_bit_name(long vector[])
 
 void charaff_to_obj(OBJ_DATA *obj, AFFECT_DATA *paf)
 {
-	AFFECT_DATA *paf_new;
-
-	paf_new = new_affect();
-	*paf_new = *paf;
-	paf_new->next = obj->charaffs;
-	obj->charaffs = paf_new;
+	obj->charaffs.push_front(*paf);
 }
 
 void charaff_to_obj_index(OBJ_INDEX_DATA *obj, AFFECT_DATA *paf)
 {
-	AFFECT_DATA *paf_new;
-
-	paf_new = new_affect();
-	*paf_new = *paf;
-	paf_new->next = obj->charaffs;
-	obj->charaffs = paf_new;
+	obj->charaffs.push_front(*paf);
 }
 
 void charaff_from_obj_index(OBJ_INDEX_DATA *obj, AFFECT_DATA *paf)
 {
-	if (obj->charaffs == nullptr)
+	if (obj->charaffs.empty())
 	{
 		RS.Logger.Warn("charaff_from_obj_index: no affect.");
 		return;
 	}
 
-	if (paf == obj->charaffs)
+	for (auto it = obj->charaffs.begin(); it != obj->charaffs.end(); ++it)
 	{
-		obj->charaffs = paf->next;
-	}
-	else
-	{
-		AFFECT_DATA *prev;
-		for (prev = obj->charaffs; prev != nullptr; prev = prev->next)
+		if (&*it == paf)
 		{
-			if (prev->next == paf)
-			{
-				prev->next = paf->next;
-				break;
-			}
-		}
-
-		if (prev == nullptr)
-		{
-			RS.Logger.Warn("charaff_from_obj_index: cannot find paf.");
+			obj->charaffs.erase(it);
 			return;
 		}
 	}
 
-	free_affect(paf);
+	RS.Logger.Warn("charaff_from_obj_index: cannot find paf.");
 }
 
 /*

--- a/code/handler.c
+++ b/code/handler.c
@@ -739,7 +739,6 @@ void reset_char(CHAR_DATA *ch)
 	int loc, stat;
 	OBJ_DATA *obj;
 	AFFECT_DATA *af;
-	OBJ_APPLY_DATA *app;
 	int i;
 
 	if (is_npc(ch))
@@ -763,9 +762,9 @@ void reset_char(CHAR_DATA *ch)
 				affect_strip(ch, af->type);
 			}
 
-			for (app = obj->apply; app != nullptr; app = app->next)
+			for (const auto &app : obj->apply)
 			{
-				modify_location(ch, app->location, app->modifier, false);
+				modify_location(ch, app.location, app.modifier, false);
 			}
 		}
 
@@ -825,9 +824,9 @@ void reset_char(CHAR_DATA *ch)
 			affect_modify(ch, af, true);
 		}
 
-		for (app = obj->apply; app != nullptr; app = app->next)
+		for (const auto &app : obj->apply)
 		{
-			modify_location(ch, app->location, app->modifier, true);
+			modify_location(ch, app.location, app.modifier, true);
 		}
 	}
 
@@ -1886,7 +1885,6 @@ bool is_worn(OBJ_DATA *obj)
 void equip_char(CHAR_DATA *ch, OBJ_DATA *obj, int iWear, bool show)
 {
 	AFFECT_DATA *paf, *fmaf;
-	OBJ_APPLY_DATA *app;
 	int i;
 	bool status;
 
@@ -1954,9 +1952,9 @@ void equip_char(CHAR_DATA *ch, OBJ_DATA *obj, int iWear, bool show)
 		ch->armor[i] += apply_ac(obj, iWear, i);
 	}
 
-	for (app = obj->apply; app; app = app->next)
+	for (const auto &app : obj->apply)
 	{
-		modify_location(ch, app->location, app->modifier, true);
+		modify_location(ch, app.location, app.modifier, true);
 	}
 
 	for (paf = obj->charaffs; paf != nullptr; paf = paf->next)
@@ -1980,7 +1978,6 @@ void equip_char(CHAR_DATA *ch, OBJ_DATA *obj, int iWear, bool show)
 void unequip_char(CHAR_DATA *ch, OBJ_DATA *obj, bool show)
 {
 	AFFECT_DATA *paf = nullptr;
-	OBJ_APPLY_DATA *app;
 	int i, wearloc = obj->wear_loc;
 
 	if (obj->wear_loc == WEAR_NONE)
@@ -2014,9 +2011,9 @@ void unequip_char(CHAR_DATA *ch, OBJ_DATA *obj, bool show)
 	BITWISE_XOR(ch->res_flags, obj->res_flags);
 	BITWISE_XOR(ch->vuln_flags, obj->vuln_flags);
 
-	for (app = obj->apply; app; app = app->next)
+	for (const auto &app : obj->apply)
 	{
-		modify_location(ch, app->location, app->modifier, false);
+		modify_location(ch, app.location, app.modifier, false);
 	}
 
 	for (paf = obj->charaffs; paf != nullptr; paf = paf->next)
@@ -4340,8 +4337,6 @@ void affect_modify_obj(OBJ_DATA *obj, OBJ_AFFECT_DATA *paf, bool fAdd)
 {
 	CHAR_DATA *ch;
 	int mod, wear;
-	OBJ_APPLY_DATA *app, *p_app;
-
 	mod = paf->modifier;
 
 	if (fAdd)
@@ -4358,12 +4353,11 @@ void affect_modify_obj(OBJ_DATA *obj, OBJ_AFFECT_DATA *paf, bool fAdd)
 				if (ch && (wear != WEAR_NONE))
 					unequip_char(ch, obj, false);
 
-				app = new_apply_data();
-				app->location = paf->location;
-				app->modifier = paf->modifier;
-				app->type = paf->type;
-				app->next = obj->apply;
-				obj->apply = app;
+				OBJ_APPLY_DATA app;
+				app.location = paf->location;
+				app.modifier = paf->modifier;
+				app.type = paf->type;
+				obj->apply.push_front(app);
 
 				if (ch && (wear != WEAR_NONE))
 					equip_char(ch, obj, wear, false);
@@ -4385,34 +4379,23 @@ void affect_modify_obj(OBJ_DATA *obj, OBJ_AFFECT_DATA *paf, bool fAdd)
 			if (ch && (wear != WEAR_NONE))
 				unequip_char(ch, obj, false);
 
-			for (app = obj->apply; app; app = app->next)
 			{
-				if (app->type == paf->type && app->location == paf->location)
-					break;
-			}
-
-			if (!app)
-			{
-				if (ch && (wear != WEAR_NONE))
-					equip_char(ch, obj, wear, false);
-
-				break;
-			}
-			if (obj->apply != app)
-			{
-				for (p_app = obj->apply; p_app; p_app = p_app->next)
+				auto it = obj->apply.begin();
+				for (; it != obj->apply.end(); ++it)
 				{
-					if (p_app->next == app)
+					if (it->type == paf->type && it->location == paf->location)
 						break;
 				}
 
-				p_app->next = app->next;
-				free_apply(app);
-			}
-			else
-			{
-				obj->apply = app->next;
-				free_apply(app);
+				if (it == obj->apply.end())
+				{
+					if (ch && (wear != WEAR_NONE))
+						equip_char(ch, obj, wear, false);
+
+					break;
+				}
+
+				obj->apply.erase(it);
 			}
 
 			if (ch && (wear != WEAR_NONE))

--- a/code/handler.c
+++ b/code/handler.c
@@ -1355,14 +1355,12 @@ ROOM_AFFECT_DATA *affect_find_room(ROOM_AFFECT_DATA *paf, int sn)
 	return nullptr;
 }
 
-AREA_AFFECT_DATA *affect_find_area(AREA_AFFECT_DATA *paf, int sn)
+AREA_AFFECT_DATA *affect_find_area(std::list<AREA_AFFECT_DATA> &affects, int sn)
 {
-	AREA_AFFECT_DATA *paf_find;
-
-	for (paf_find = paf; paf_find != nullptr; paf_find = paf_find->next)
+	for (auto &paf : affects)
 	{
-		if (paf_find->type == sn)
-			return paf_find;
+		if (paf.type == sn)
+			return &paf;
 	}
 
 	return nullptr;
@@ -2869,13 +2867,9 @@ bool can_see(CHAR_DATA *ch, CHAR_DATA *victim)
 
 	if (is_affected_area(ch->in_room->area, gsn_whiteout) && is_outside(ch))
 	{
-		for (paf = ch->in_room->area->affected; paf; paf = paf->next)
-		{
-			if (paf->type == gsn_whiteout)
-				break;
-		}
+		paf = affect_find_area(ch->in_room->area->affected, gsn_whiteout);
 
-		if (paf->owner != ch)
+		if (paf && paf->owner != ch)
 			return false;
 	}
 
@@ -2982,11 +2976,7 @@ bool can_see_obj(CHAR_DATA *ch, OBJ_DATA *obj)
 
 	if (is_affected_area(ch->in_room->area, gsn_whiteout) && is_outside(ch) && obj->item_type != ITEM_POTION)
 	{
-		for (paf = ch->in_room->area->affected; paf; paf = paf->next)
-		{
-			if (paf->type == gsn_whiteout)
-				break;
-		}
+		paf = affect_find_area(ch->in_room->area->affected, gsn_whiteout);
 
 		if (paf && paf->owner != ch)
 			return false;
@@ -4687,27 +4677,19 @@ void affect_modify_area(AREA_DATA *area, AREA_AFFECT_DATA *paf, bool fAdd)
 
 void affect_to_area(AREA_DATA *area, AREA_AFFECT_DATA *paf)
 {
-	AREA_AFFECT_DATA *paf_new;
+	area->affected.push_front(*paf);
 
-	paf_new = new_affect_area();
-
-	*paf_new = *paf;
-	paf_new->next = area->affected;
-	area->affected = paf_new;
-
-	affect_modify_area(area, paf_new, true);
+	affect_modify_area(area, &area->affected.front(), true);
 }
 
 void affect_check_area(AREA_DATA *area, int where, long vector[])
 {
-	AREA_AFFECT_DATA *paf;
-
 	if (vector == 0)
 		return;
 
-	for (paf = area->affected; paf != nullptr; paf = paf->next)
+	for (auto &paf : area->affected)
 	{
-		if (paf->where == where && vector_equal(paf->bitvector, vector))
+		if (paf.where == where && vector_equal(paf.bitvector, vector))
 		{
 			switch (where)
 			{
@@ -4726,7 +4708,7 @@ void affect_remove_area(AREA_DATA *area, AREA_AFFECT_DATA *paf)
 	int where;
 	long vector[MAX_BITVECTOR];
 
-	if (!area->affected)
+	if (area->affected.empty())
 	{
 		RS.Logger.Warn("affect_remove_area: no affect!");
 		return;
@@ -4739,46 +4721,36 @@ void affect_remove_area(AREA_DATA *area, AREA_AFFECT_DATA *paf)
 	where = paf->where;
 	copy_vector(vector, paf->bitvector);
 
-	if (paf == area->affected)
+	bool found = false;
+	for (auto it = area->affected.begin(); it != area->affected.end(); ++it)
 	{
-		area->affected = paf->next;
-	}
-	else
-	{
-		AREA_AFFECT_DATA *prev;
-
-		for (prev = area->affected; prev != nullptr; prev = prev->next)
+		if (&*it == paf)
 		{
-			if (prev->next == paf)
-			{
-				prev->next = paf->next;
-				break;
-			}
-		}
-
-		if (!prev)
-		{
-			RS.Logger.Warn("affect_remove_area: cannot find paf!");
-			return;
+			area->affected.erase(it);
+			found = true;
+			break;
 		}
 	}
 
-	free_affect_area(paf);
+	if (!found)
+	{
+		RS.Logger.Warn("affect_remove_area: cannot find paf!");
+		return;
+	}
 
 	affect_check_area(area, where, vector);
 }
 
 void affect_strip_area(AREA_DATA *area, int sn)
 {
-	AREA_AFFECT_DATA *paf;
-	AREA_AFFECT_DATA *paf_next;
-
-	for (paf = area->affected; paf != nullptr; paf = paf_next)
+	for (auto it = area->affected.begin(); it != area->affected.end(); )
 	{
-		paf_next = paf->next;
+		auto next = std::next(it);
 
-		if (paf->type == sn)
-			affect_remove_area(area, paf);
+		if (it->type == sn)
+			affect_remove_area(area, &*it);
+
+		it = next;
 	}
 }
 
@@ -4787,9 +4759,9 @@ bool is_affected_area(AREA_DATA *area, int sn)
 	if (area == nullptr)
 		return false;
 
-	for (auto paf = area->affected; paf != nullptr; paf = paf->next)
+	for (auto &paf : area->affected)
 	{
-		if (paf->type == sn)
+		if (paf.type == sn)
 			return true;
 	}
 
@@ -4798,16 +4770,14 @@ bool is_affected_area(AREA_DATA *area, int sn)
 
 void affect_join_area(AREA_DATA *area, AREA_AFFECT_DATA *paf)
 {
-	AREA_AFFECT_DATA *paf_old;
-
-	for (paf_old = area->affected; paf_old != nullptr; paf_old = paf_old->next)
+	for (auto &paf_old : area->affected)
 	{
-		if (paf_old->type == paf->type)
+		if (paf_old.type == paf->type)
 		{
-			paf->level = (paf->level + paf_old->level) / 2;
-			paf->duration += paf_old->duration;
-			paf->modifier += paf_old->modifier;
-			affect_remove_area(area, paf_old);
+			paf->level = (paf->level + paf_old.level) / 2;
+			paf->duration += paf_old.duration;
+			paf->modifier += paf_old.modifier;
+			affect_remove_area(area, &paf_old);
 			break;
 		}
 	}

--- a/code/handler.c
+++ b/code/handler.c
@@ -1329,14 +1329,12 @@ AFFECT_DATA *affect_find(AFFECT_DATA *paf, int sn)
 	return nullptr;
 }
 
-OBJ_AFFECT_DATA *affect_find_obj(OBJ_AFFECT_DATA *paf, int sn)
+OBJ_AFFECT_DATA *affect_find_obj(std::list<OBJ_AFFECT_DATA> &affects, int sn)
 {
-	OBJ_AFFECT_DATA *paf_find;
-
-	for (paf_find = paf; paf_find != nullptr; paf_find = paf_find->next)
+	for (auto &paf : affects)
 	{
-		if (paf_find->type == sn)
-			return paf_find;
+		if (paf.type == sn)
+			return &paf;
 	}
 
 	return nullptr;
@@ -2947,11 +2945,7 @@ bool can_see_obj(CHAR_DATA *ch, OBJ_DATA *obj)
 
 	if (is_affected_obj(obj, gsn_stash))
 	{
-		for (oaf = obj->affected; oaf != nullptr; oaf = oaf->next)
-		{
-			if (oaf->type == gsn_stash)
-				break;
-		}
+		oaf = affect_find_obj(obj->affected, gsn_stash);
 
 		if (oaf->owner != ch && !is_immortal(ch))
 			return false;
@@ -4408,27 +4402,19 @@ void affect_modify_obj(OBJ_DATA *obj, OBJ_AFFECT_DATA *paf, bool fAdd)
 
 void affect_to_obj(OBJ_DATA *obj, OBJ_AFFECT_DATA *paf)
 {
-	OBJ_AFFECT_DATA *paf_new;
+	obj->affected.push_front(*paf);
 
-	paf_new = new_affect_obj();
-
-	*paf_new = *paf;
-	paf_new->next = obj->affected;
-	obj->affected = paf_new;
-
-	affect_modify_obj(obj, paf_new, true);
+	affect_modify_obj(obj, &obj->affected.front(), true);
 }
 
 void affect_check_obj(OBJ_DATA *obj, int where, long vector[])
 {
-	OBJ_AFFECT_DATA *paf;
-
 	if (IS_ZERO_VECTOR(vector))
 		return;
 
-	for (paf = obj->affected; paf != nullptr; paf = paf->next)
+	for (auto &paf : obj->affected)
 	{
-		if (paf->where == where && vector_equal(paf->bitvector, vector))
+		if (paf.where == where && vector_equal(paf.bitvector, vector))
 		{
 			switch (where)
 			{
@@ -4447,7 +4433,7 @@ void affect_remove_obj(OBJ_DATA *obj, OBJ_AFFECT_DATA *paf, bool show)
 	int where;
 	long vector[MAX_BITVECTOR];
 
-	if (!obj->affected)
+	if (obj->affected.empty())
 	{
 		RS.Logger.Warn("affect_remove_obj: no affect!");
 		return;
@@ -4460,55 +4446,44 @@ void affect_remove_obj(OBJ_DATA *obj, OBJ_AFFECT_DATA *paf, bool show)
 	where = paf->where;
 	copy_vector(vector, paf->bitvector);
 
-	if (paf == obj->affected)
+	bool found = false;
+	for (auto it = obj->affected.begin(); it != obj->affected.end(); ++it)
 	{
-		obj->affected = paf->next;
-	}
-	else
-	{
-		OBJ_AFFECT_DATA *prev;
-
-		for (prev = obj->affected; prev != nullptr; prev = prev->next)
+		if (&*it == paf)
 		{
-			if (prev->next == paf)
-			{
-				prev->next = paf->next;
-				break;
-			}
-		}
-
-		if (!prev)
-		{
-			RS.Logger.Warn("affect_remove_obj: cannot find paf on obj #{}!", obj->pIndexData->vnum);
-			return;
+			obj->affected.erase(it);
+			found = true;
+			break;
 		}
 	}
 
-	free_affect_obj(paf);
+	if (!found)
+	{
+		RS.Logger.Warn("affect_remove_obj: cannot find paf on obj #{}!", obj->pIndexData->vnum);
+		return;
+	}
+
 	affect_check_obj(obj, where, vector);
 }
 
 void affect_strip_obj(OBJ_DATA *obj, int sn)
 {
-	OBJ_AFFECT_DATA *paf;
-	OBJ_AFFECT_DATA *paf_next;
-
-	for (paf = obj->affected; paf != nullptr; paf = paf_next)
+	for (auto it = obj->affected.begin(); it != obj->affected.end(); )
 	{
-		paf_next = paf->next;
+		auto next = std::next(it);
 
-		if (paf->type == sn)
-			affect_remove_obj(obj, paf, true);
+		if (it->type == sn)
+			affect_remove_obj(obj, &*it, true);
+
+		it = next;
 	}
 }
 
 bool is_affected_obj(OBJ_DATA *obj, int sn)
 {
-	OBJ_AFFECT_DATA *paf;
-
-	for (paf = obj->affected; paf != nullptr; paf = paf->next)
+	for (auto &paf : obj->affected)
 	{
-		if (paf->type == sn)
+		if (paf.type == sn)
 			return true;
 	}
 
@@ -4517,16 +4492,14 @@ bool is_affected_obj(OBJ_DATA *obj, int sn)
 
 void affect_join_obj(OBJ_DATA *obj, OBJ_AFFECT_DATA *paf)
 {
-	OBJ_AFFECT_DATA *paf_old;
-
-	for (paf_old = obj->affected; paf_old != nullptr; paf_old = paf_old->next)
+	for (auto &paf_old : obj->affected)
 	{
-		if (paf_old->type == paf->type)
+		if (paf_old.type == paf->type)
 		{
-			paf->level = (paf->level + paf_old->level) / 2;
-			paf->duration += paf_old->duration;
-			paf->modifier += paf_old->modifier;
-			affect_remove_obj(obj, paf_old, true);
+			paf->level = (paf->level + paf_old.level) / 2;
+			paf->duration += paf_old.duration;
+			paf->modifier += paf_old.modifier;
+			affect_remove_obj(obj, &paf_old, true);
 			break;
 		}
 	}

--- a/code/handler.c
+++ b/code/handler.c
@@ -1342,14 +1342,12 @@ OBJ_AFFECT_DATA *affect_find_obj(OBJ_AFFECT_DATA *paf, int sn)
 	return nullptr;
 }
 
-ROOM_AFFECT_DATA *affect_find_room(ROOM_AFFECT_DATA *paf, int sn)
+ROOM_AFFECT_DATA *affect_find_room(std::list<ROOM_AFFECT_DATA> &affects, int sn)
 {
-	ROOM_AFFECT_DATA *paf_find;
-
-	for (paf_find = paf; paf_find != nullptr; paf_find = paf_find->next)
+	for (auto &paf : affects)
 	{
-		if (paf_find->type == sn)
-			return paf_find;
+		if (paf.type == sn)
+			return &paf;
 	}
 
 	return nullptr;
@@ -1644,11 +1642,7 @@ void char_from_room(CHAR_DATA *ch)
 
 	if (is_affected_room(prev_room, gsn_gravity_well))
 	{
-		for (af = prev_room->affected; af != nullptr; af = af->next)
-		{
-			if (af->type == gsn_gravity_well)
-				break;
-		}
+		af = affect_find_room(prev_room->affected, gsn_gravity_well);
 
 		if (ch == af->owner)
 			gravity_well_explode(prev_room, af);
@@ -2257,7 +2251,6 @@ void extract_char(CHAR_DATA *ch, bool fPull)
 	OBJ_DATA *obj_next;
 	CHAR_DATA *tch;
 	ROOM_INDEX_DATA *room;
-	ROOM_AFFECT_DATA *raf;
 	AFFECT_DATA *af;
 
 	if (ch->in_room == nullptr)
@@ -2343,12 +2336,14 @@ void extract_char(CHAR_DATA *ch, bool fPull)
 
 	for (room = top_affected_room; room; room = room->aff_next)
 	{
-		for (raf = room->affected; raf != nullptr; raf = raf->next)
+		for (auto it = room->affected.begin(); it != room->affected.end(); )
 		{
-			if (raf->owner == ch)
-			{
-				affect_remove_room(room, raf);
-			}
+			auto next = std::next(it);
+
+			if (it->owner == ch)
+				affect_remove_room(room, &*it);
+
+			it = next;
 		}
 	}
 
@@ -3929,8 +3924,6 @@ void init_affect_room(ROOM_AFFECT_DATA *paf)
 	paf->tick_fun = nullptr;
 	paf->end_fun = nullptr;
 	paf->owner = nullptr;
-	/* Morg - Valgrind fix */
-	paf->valid= false;
 }
 
 void affect_modify_room(ROOM_INDEX_DATA *room, ROOM_AFFECT_DATA *paf, bool fAdd)
@@ -4002,10 +3995,9 @@ void affect_to_room(ROOM_INDEX_DATA *room, ROOM_AFFECT_DATA *paf)
 
 void new_affect_to_room(ROOM_INDEX_DATA *room, ROOM_AFFECT_DATA *paf)
 {
-	ROOM_AFFECT_DATA *paf_new;
 	ROOM_INDEX_DATA *pRoomIndex;
 
-	if (!room->affected)
+	if (room->affected.empty())
 	{
 		if (top_affected_room)
 		{
@@ -4025,25 +4017,19 @@ void new_affect_to_room(ROOM_INDEX_DATA *room, ROOM_AFFECT_DATA *paf)
 		room->aff_next = nullptr;
 	}
 
-	paf_new = new_affect_room();
+	room->affected.push_front(*paf);
 
-	*paf_new = *paf;
-	paf_new->next = room->affected;
-	room->affected = paf_new;
-
-	affect_modify_room(room, paf_new, true);
+	affect_modify_room(room, &room->affected.front(), true);
 }
 
 void affect_check_room(ROOM_INDEX_DATA *room, int where, long vector[])
 {
-	ROOM_AFFECT_DATA *paf;
-
 	if (IS_ZERO_VECTOR(vector))
 		return;
 
-	for (paf = room->affected; paf != nullptr; paf = paf->next)
+	for (auto &paf : room->affected)
 	{
-		if (paf->where == where && vector_equal(paf->bitvector, vector))
+		if (paf.where == where && vector_equal(paf.bitvector, vector))
 		{
 			switch (where)
 			{
@@ -4070,7 +4056,7 @@ void affect_remove_room(ROOM_INDEX_DATA *room, ROOM_AFFECT_DATA *paf)
 	int where;
 	long vector[MAX_BITVECTOR];
 
-	if (room->affected == nullptr)
+	if (room->affected.empty())
 	{
 		RS.Logger.Warn("Affect_remove_room: no affect.");
 		return;
@@ -4083,31 +4069,24 @@ void affect_remove_room(ROOM_INDEX_DATA *room, ROOM_AFFECT_DATA *paf)
 	where = paf->where;
 	copy_vector(vector, paf->bitvector);
 
-	if (paf == room->affected)
+	bool found = false;
+	for (auto it = room->affected.begin(); it != room->affected.end(); ++it)
 	{
-		room->affected = paf->next;
-	}
-	else
-	{
-		ROOM_AFFECT_DATA *prev;
-
-		for (prev = room->affected; prev != nullptr; prev = prev->next)
+		if (&*it == paf)
 		{
-			if (prev->next == paf)
-			{
-				prev->next = paf->next;
-				break;
-			}
-		}
-
-		if (prev == nullptr)
-		{
-			RS.Logger.Warn("Affect_remove_room: cannot find paf.");
-			return;
+			room->affected.erase(it);
+			found = true;
+			break;
 		}
 	}
 
-	if (!room->affected)
+	if (!found)
+	{
+		RS.Logger.Warn("Affect_remove_room: cannot find paf.");
+		return;
+	}
+
+	if (room->affected.empty())
 	{
 		ROOM_INDEX_DATA *prev;
 
@@ -4136,8 +4115,6 @@ void affect_remove_room(ROOM_INDEX_DATA *room, ROOM_AFFECT_DATA *paf)
 		room->aff_next = nullptr;
 	}
 
-	free_affect_room(paf);
-
 	affect_check_room(room, where, vector);
 }
 
@@ -4146,15 +4123,14 @@ void affect_remove_room(ROOM_INDEX_DATA *room, ROOM_AFFECT_DATA *paf)
  */
 void affect_strip_room(ROOM_INDEX_DATA *room, int sn)
 {
-	ROOM_AFFECT_DATA *paf;
-	ROOM_AFFECT_DATA *paf_next;
-
-	for (paf = room->affected; paf != nullptr; paf = paf_next)
+	for (auto it = room->affected.begin(); it != room->affected.end(); )
 	{
-		paf_next = paf->next;
+		auto next = std::next(it);
 
-		if (paf->type == sn)
-			affect_remove_room(room, paf);
+		if (it->type == sn)
+			affect_remove_room(room, &*it);
+
+		it = next;
 	}
 }
 
@@ -4163,14 +4139,12 @@ void affect_strip_room(ROOM_INDEX_DATA *room, int sn)
  */
 bool is_affected_room(ROOM_INDEX_DATA *room, int sn)
 {
-	ROOM_AFFECT_DATA *paf;
-
 	if (!room)
 		return false;
 
-	for (paf = room->affected; paf != nullptr; paf = paf->next)
+	for (auto &paf : room->affected)
 	{
-		if (paf->type == sn)
+		if (paf.type == sn)
 			return true;
 	}
 
@@ -4182,16 +4156,14 @@ bool is_affected_room(ROOM_INDEX_DATA *room, int sn)
  */
 void affect_join_room(ROOM_INDEX_DATA *room, ROOM_AFFECT_DATA *paf)
 {
-	ROOM_AFFECT_DATA *paf_old;
-
-	for (paf_old = room->affected; paf_old != nullptr; paf_old = paf_old->next)
+	for (auto &paf_old : room->affected)
 	{
-		if (paf_old->type == paf->type)
+		if (paf_old.type == paf->type)
 		{
-			paf->level = (paf->level + paf_old->level) / 2;
-			paf->duration += paf_old->duration;
-			paf->modifier += paf_old->modifier;
-			affect_remove_room(room, paf_old);
+			paf->level = (paf->level + paf_old.level) / 2;
+			paf->duration += paf_old.duration;
+			paf->modifier += paf_old.modifier;
+			affect_remove_room(room, &paf_old);
 			break;
 		}
 	}

--- a/code/handler.h
+++ b/code/handler.h
@@ -84,7 +84,7 @@ void init_affect (AFFECT_DATA *paf);
  */
 void affect_modify (CHAR_DATA *ch, AFFECT_DATA *paf, bool fAdd);
 /* find an effect in an affect list */
-AFFECT_DATA *affect_find (AFFECT_DATA *paf, int sn);
+AFFECT_DATA *affect_find (std::list<AFFECT_DATA> &affects, int sn);
 OBJ_AFFECT_DATA *affect_find_obj (std::list<OBJ_AFFECT_DATA> &affects, int sn);
 ROOM_AFFECT_DATA *affect_find_room (std::list<ROOM_AFFECT_DATA> &affects, int sn);
 AREA_AFFECT_DATA *affect_find_area (std::list<AREA_AFFECT_DATA> &affects, int sn);

--- a/code/handler.h
+++ b/code/handler.h
@@ -1,6 +1,7 @@
 #ifndef HANDLER_H
 #define HANDLER_H
 
+#include <list>
 #include <string>
 
 #include "entity/fwd.h"
@@ -86,7 +87,7 @@ void affect_modify (CHAR_DATA *ch, AFFECT_DATA *paf, bool fAdd);
 AFFECT_DATA *affect_find (AFFECT_DATA *paf, int sn);
 OBJ_AFFECT_DATA *affect_find_obj (OBJ_AFFECT_DATA *paf, int sn);
 ROOM_AFFECT_DATA *affect_find_room (ROOM_AFFECT_DATA *paf, int sn);
-AREA_AFFECT_DATA *affect_find_area (AREA_AFFECT_DATA *paf, int sn);
+AREA_AFFECT_DATA *affect_find_area (std::list<AREA_AFFECT_DATA> &affects, int sn);
 /* fix object affects when removing one */
 void affect_check (CHAR_DATA *ch, int where, long vector[]);
 /*

--- a/code/handler.h
+++ b/code/handler.h
@@ -86,7 +86,7 @@ void affect_modify (CHAR_DATA *ch, AFFECT_DATA *paf, bool fAdd);
 /* find an effect in an affect list */
 AFFECT_DATA *affect_find (AFFECT_DATA *paf, int sn);
 OBJ_AFFECT_DATA *affect_find_obj (OBJ_AFFECT_DATA *paf, int sn);
-ROOM_AFFECT_DATA *affect_find_room (ROOM_AFFECT_DATA *paf, int sn);
+ROOM_AFFECT_DATA *affect_find_room (std::list<ROOM_AFFECT_DATA> &affects, int sn);
 AREA_AFFECT_DATA *affect_find_area (std::list<AREA_AFFECT_DATA> &affects, int sn);
 /* fix object affects when removing one */
 void affect_check (CHAR_DATA *ch, int where, long vector[]);

--- a/code/handler.h
+++ b/code/handler.h
@@ -85,7 +85,7 @@ void init_affect (AFFECT_DATA *paf);
 void affect_modify (CHAR_DATA *ch, AFFECT_DATA *paf, bool fAdd);
 /* find an effect in an affect list */
 AFFECT_DATA *affect_find (AFFECT_DATA *paf, int sn);
-OBJ_AFFECT_DATA *affect_find_obj (OBJ_AFFECT_DATA *paf, int sn);
+OBJ_AFFECT_DATA *affect_find_obj (std::list<OBJ_AFFECT_DATA> &affects, int sn);
 ROOM_AFFECT_DATA *affect_find_room (std::list<ROOM_AFFECT_DATA> &affects, int sn);
 AREA_AFFECT_DATA *affect_find_area (std::list<AREA_AFFECT_DATA> &affects, int sn);
 /* fix object affects when removing one */

--- a/code/iprog.c
+++ b/code/iprog.c
@@ -1408,7 +1408,7 @@ bool death_prog_trophy_belt(OBJ_DATA *belt, CHAR_DATA *ch)
 	obj_to_char(newbelt, ch);
 	equip_char(ch, newbelt, WEAR_WAIST, false);
 
-	free_trophy(ch->pcdata->trophy);
+	ch->pcdata->trophy.clear();
 
 	newbelt->value[4] = 0;
 	return false;

--- a/code/magic.c
+++ b/code/magic.c
@@ -3379,9 +3379,9 @@ void spell_identify(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 			break;
 	}
 
-	for (app = obj->apply; app; app = app->next)
+	for (const auto &app : obj->apply)
 	{
-		sprintf(buf, "Affects %s by %d.\n\r", affect_loc_name(app->location), app->modifier);
+		sprintf(buf, "Affects %s by %d.\n\r", affect_loc_name(app.location), app.modifier);
 		send_to_char(buf, ch);
 	}
 }

--- a/code/magic.c
+++ b/code/magic.c
@@ -3495,7 +3495,7 @@ void spell_lightning_bolt(int sn, int level, CHAR_DATA *ch, void *vo, int target
 void spell_locate_object(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 {
 	char buf[MAX_INPUT_LENGTH];
-	BUFFER *buffer;
+	BUFFER buffer;
 	OBJ_DATA *obj;
 	OBJ_DATA *in_obj;
 	bool found;
@@ -3504,8 +3504,6 @@ void spell_locate_object(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 	found = false;
 	number = 0;
 	max_found = is_immortal(ch) ? 200 : 2 * level;
-
-	buffer = new_buf();
 
 	for (obj = object_list; obj != nullptr; obj = obj->next)
 	{
@@ -3554,7 +3552,7 @@ void spell_locate_object(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 
 		buf[0] = UPPER(buf[0]);
 
-		add_buf(buffer, buf);
+		buffer.add(buf);
 
 		if (number >= max_found)
 			break;
@@ -3563,9 +3561,8 @@ void spell_locate_object(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 	if (!found)
 		send_to_char("Nothing like that in heaven or earth.\n\r", ch);
 	else
-		page_to_char(buf_string(buffer), ch);
+		page_to_char(buffer.str(), ch);
 
-	free_buf(buffer);
 }
 
 void spell_magic_missile(int sn, int level, CHAR_DATA *ch, void *vo, int target)

--- a/code/magic.c
+++ b/code/magic.c
@@ -317,7 +317,6 @@ bool saves_dispel(int dis_level, int spell_level, int duration)
 
 bool check_dispel(int dis_level, CHAR_DATA *victim, int sn)
 {
-	AFFECT_DATA *af;
 
 	if (is_affected(victim, gsn_indom))
 	{
@@ -327,11 +326,11 @@ bool check_dispel(int dis_level, CHAR_DATA *victim, int sn)
 
 	if (is_affected(victim, sn))
 	{
-		for (af = victim->affected; af != nullptr; af = af->next)
+		for (auto &af : victim->affected)
 		{
-			if (af->type == sn)
+			if (af.type == sn)
 			{
-				if (!saves_dispel(dis_level, af->level, af->duration) && !IS_SET(af->bitvector, AFF_PERMANENT))
+				if (!saves_dispel(dis_level, af.level, af.duration) && !IS_SET(af.bitvector, AFF_PERMANENT))
 				{
 					affect_strip(victim, sn);
 
@@ -357,7 +356,6 @@ bool check_dispel(int dis_level, CHAR_DATA *victim, int sn)
 
 bool check_dispel_cancellation(int dis_level, CHAR_DATA *victim, CHAR_DATA *ch, int sn, bool commune, bool cancel)
 {
-	AFFECT_DATA *af;
 	char buf[MAX_STRING_LENGTH];
 
 	if (is_affected(victim, gsn_indom))
@@ -368,13 +366,13 @@ bool check_dispel_cancellation(int dis_level, CHAR_DATA *victim, CHAR_DATA *ch, 
 
 	if (is_affected(victim, sn))
 	{
-		for (af = victim->affected; af != nullptr; af = af->next)
+		for (auto &af : victim->affected)
 		{
-			if (af->type == sn)
+			if (af.type == sn)
 			{
-				if (af->aftype == AFT_SPELL)
+				if (af.aftype == AFT_SPELL)
 				{
-					if (!saves_dispel(dis_level, af->level, af->duration) && !IS_SET(af->bitvector, AFF_PERMANENT))
+					if (!saves_dispel(dis_level, af.level, af.duration) && !IS_SET(af.bitvector, AFF_PERMANENT))
 					{
 						sprintf(buf, "The magic of your %s spell unravels.\n\r", skill_table[sn].name);
 						affect_strip(victim, sn);
@@ -407,9 +405,9 @@ bool check_dispel_cancellation(int dis_level, CHAR_DATA *victim, CHAR_DATA *ch, 
 						}
 					}
 				}
-				else if (af->aftype == AFT_COMMUNE && commune && cancel)
+				else if (af.aftype == AFT_COMMUNE && commune && cancel)
 				{
-					if (!saves_dispel(dis_level, af->level, af->duration) && !IS_SET(af->bitvector, AFF_PERMANENT))
+					if (!saves_dispel(dis_level, af.level, af.duration) && !IS_SET(af.bitvector, AFF_PERMANENT))
 					{
 						sprintf(buf, "The power of your %s supplication unravels.\n\r", skill_table[sn].name);
 						affect_strip(victim, sn);
@@ -1511,13 +1509,15 @@ void spell_cancellation(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 			send_to_char("You failed.\n\r", ch);
 		}
 
-		for (af = victim->affected; af != nullptr; af = af->next)
+		std::vector<int> cancel_types;
+		for (auto &af : victim->affected)
+			if (skill_table[af.type].dispel & CAN_CANCEL)
+				cancel_types.push_back(af.type);
+
+		for (int cancel_type : cancel_types)
 		{
-			if (skill_table[af->type].dispel & CAN_CANCEL)
-			{
-				check_dispel_cancellation(level, victim, ch, af->type, commune, true);
-				found = true;
-			}
+			check_dispel_cancellation(level, victim, ch, cancel_type, commune, true);
+			found = true;
 		}
 	}
 	else
@@ -1527,10 +1527,14 @@ void spell_cancellation(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 		if (spell < 1)
 			return;
 
-		for (af = victim->affected; af != nullptr; af = af->next)
+		af = nullptr;
+		for (auto &af_elem : victim->affected)
 		{
-			if (af->type == spell)
+			if (af_elem.type == spell)
+			{
+				af = &af_elem;
 				break;
+			}
 		}
 
 		if (!af || !af->type || !(skill_table[af->type].dispel & CAN_CANCEL))
@@ -2168,7 +2172,6 @@ void spell_curse(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 	CHAR_DATA *victim;
 	OBJ_DATA *obj;
 	AFFECT_DATA af;
-	OBJ_AFFECT_DATA oaf;
 
 	/* deal with the object case first
 	if (target == TARGET_OBJ)
@@ -2673,13 +2676,15 @@ void spell_dispel_magic(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 
 	if (arg2[0] == '\0')
 	{
-		for (af = victim->affected; af != nullptr; af = af->next)
+		std::vector<int> dispel_types;
+		for (auto &af : victim->affected)
+			if (skill_table[af.type].dispel & CAN_DISPEL)
+				dispel_types.push_back(af.type);
+
+		for (int dispel_type : dispel_types)
 		{
-			if (skill_table[af->type].dispel & CAN_DISPEL)
-			{
-				check_dispel_cancellation(level, victim, ch, af->type, commune, false);
-				found = true;
-			}
+			check_dispel_cancellation(level, victim, ch, dispel_type, commune, false);
+			found = true;
 		}
 	}
 	else
@@ -2689,10 +2694,14 @@ void spell_dispel_magic(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 		if (spell < 1)
 			return;
 
-		for (af = victim->affected; af != nullptr; af = af->next)
+		af = nullptr;
+		for (auto &af_elem : victim->affected)
 		{
-			if (af->type == spell)
+			if (af_elem.type == spell)
+			{
+				af = &af_elem;
 				break;
+			}
 		}
 
 		if (!af || !af->type || !(skill_table[af->type].dispel & CAN_DISPEL))
@@ -6589,7 +6598,7 @@ void spell_deafen(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 
 void spell_talismanic_aura(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 {
-	AFFECT_DATA af, *paf;
+	AFFECT_DATA af;
 	float reduction;
 
 	if (ch->talismanic > 2)
@@ -6598,9 +6607,9 @@ void spell_talismanic_aura(int sn, int level, CHAR_DATA *ch, void *vo, int targe
 		return;
 	}
 
-	for (paf = ch->affected; paf != nullptr; paf = paf->next)
+	for (auto &paf : ch->affected)
 	{
-		if (paf->type == gsn_talismanic)
+		if (paf.type == gsn_talismanic)
 			break;
 	}
 

--- a/code/mem.c
+++ b/code/mem.c
@@ -339,7 +339,7 @@ OBJ_INDEX_DATA *new_obj_index(void)
 
 	pObj->next = nullptr;
 	pObj->extra_descr.clear();
-	pObj->affected = nullptr;
+	pObj->affected.clear();
 	pObj->area = nullptr;
 	pObj->name = palloc_string("no name");
 	pObj->level = 1;
@@ -369,7 +369,7 @@ OBJ_INDEX_DATA *new_obj_index(void)
 	pObj->cabal = 0;
 	pObj->notes = nullptr;
 	pObj->wear_loc_name = nullptr;
-	pObj->charaffs = nullptr;
+	pObj->charaffs.clear();
 	pObj->extra_descr.clear();
 	pObj->apply.clear();
 
@@ -392,17 +392,12 @@ OBJ_INDEX_DATA *new_obj_index(void)
 
 void free_obj_index(OBJ_INDEX_DATA *pObj)
 {
-	AFFECT_DATA *pAf;
-
 	free_pstring(pObj->name);
 	free_pstring(pObj->short_descr);
 	free_pstring(pObj->description);
 
-	for (pAf = pObj->affected; pAf; pAf = pAf->next)
-	{
-		free_affect(pAf);
-	}
-
+	pObj->affected.clear();
+	pObj->charaffs.clear();
 	pObj->extra_descr.clear();
 
 	pObj->next = obj_index_free;

--- a/code/mem.c
+++ b/code/mem.c
@@ -223,7 +223,7 @@ ROOM_INDEX_DATA *new_room_index(void)
 	pRoom->aff_next = nullptr;
 	pRoom->people = nullptr;
 	pRoom->contents = nullptr;
-	pRoom->extra_descr = nullptr;
+	pRoom->extra_descr.clear();
 	pRoom->area = nullptr;
 	pRoom->alt_description = nullptr;
 	pRoom->alt_name = nullptr;
@@ -341,7 +341,7 @@ OBJ_INDEX_DATA *new_obj_index(void)
 	}
 
 	pObj->next = nullptr;
-	pObj->extra_descr = nullptr;
+	pObj->extra_descr.clear();
 	pObj->affected = nullptr;
 	pObj->area = nullptr;
 	pObj->name = palloc_string("no name");
@@ -373,7 +373,7 @@ OBJ_INDEX_DATA *new_obj_index(void)
 	pObj->notes = nullptr;
 	pObj->wear_loc_name = nullptr;
 	pObj->charaffs = nullptr;
-	pObj->extra_descr = nullptr;
+	pObj->extra_descr.clear();
 	pObj->apply = nullptr;
 
 	for (value = 0; value < 5; value++) /* 5 - ROM */
@@ -395,7 +395,6 @@ OBJ_INDEX_DATA *new_obj_index(void)
 
 void free_obj_index(OBJ_INDEX_DATA *pObj)
 {
-	EXTRA_DESCR_DATA *pExtra;
 	AFFECT_DATA *pAf;
 
 	free_pstring(pObj->name);
@@ -407,10 +406,7 @@ void free_obj_index(OBJ_INDEX_DATA *pObj)
 		free_affect(pAf);
 	}
 
-	for (pExtra = pObj->extra_descr; pExtra; pExtra = pExtra->next)
-	{
-		free_extra_descr(pExtra);
-	}
+	pObj->extra_descr.clear();
 
 	pObj->next = obj_index_free;
 	obj_index_free = pObj;

--- a/code/mem.c
+++ b/code/mem.c
@@ -204,7 +204,7 @@ void free_extra_descr(EXTRA_DESCR_DATA *pExtra)
 ROOM_INDEX_DATA *new_room_index(void)
 {
 	ROOM_INDEX_DATA *pRoom;
-	int door, i;
+	int door;
 
 	if (!room_index_free)
 	{
@@ -233,11 +233,6 @@ ROOM_INDEX_DATA *new_room_index(void)
 	for (door = 0; door < MAX_DIR; door++)
 	{
 		pRoom->exit[door] = nullptr;
-	}
-
-	for (i = 0; i < MAX_TRACKS; i++)
-	{
-		pRoom->tracks[i] = new_track_data();
 	}
 
 	pRoom->path = nullptr;

--- a/code/mem.c
+++ b/code/mem.c
@@ -415,8 +415,7 @@ MOB_INDEX_DATA *new_mob_index(void)
 
 	if (!mob_index_free)
 	{
-		pMob = new MOB_INDEX_DATA;
-		CLEAR_MEM(pMob, sizeof(MOB_INDEX_DATA))
+		pMob = new MOB_INDEX_DATA();
 		top_mob_index++;
 	}
 	else
@@ -491,7 +490,7 @@ MOB_INDEX_DATA *new_mob_index(void)
 		pMob->cast_spell[i] = nullptr;
 	}
 
-	pMob->speech = nullptr; // DIE MORGLUM DIE
+	pMob->speech.clear(); // DIE MORGLUM DIE
 	pMob->cabal = 0;
 	pMob->attack_yell = nullptr;
 	pMob->notes = nullptr;
@@ -517,6 +516,8 @@ void free_mob_index(MOB_INDEX_DATA *pMob)
 	free_pstring(pMob->description);
 
 	free_shop(pMob->pShop);
+
+	pMob->speech.clear();
 
 	pMob->next = mob_index_free;
 	mob_index_free = pMob;

--- a/code/mem.c
+++ b/code/mem.c
@@ -249,7 +249,7 @@ ROOM_INDEX_DATA *new_room_index(void)
 	pRoom->mana_rate = 100;
 	pRoom->cabal = 0;
 	pRoom->guild = 0;
-	pRoom->affected = nullptr;
+	pRoom->affected.clear();
 
 	zero_vector(pRoom->affected_by);
 

--- a/code/mem.c
+++ b/code/mem.c
@@ -208,8 +208,9 @@ ROOM_INDEX_DATA *new_room_index(void)
 
 	if (!room_index_free)
 	{
-		pRoom = new ROOM_INDEX_DATA;
-		CLEAR_MEM(pRoom, sizeof(ROOM_INDEX_DATA))
+		// value-init zeroes the scalar members AND constructs the std::list member;
+		// CLEAR_MEM (byte-zero) would corrupt the list's internal state.
+		pRoom = new ROOM_INDEX_DATA();
 		top_room++;
 	}
 	else
@@ -328,9 +329,9 @@ OBJ_INDEX_DATA *new_obj_index(void)
 
 	if (!obj_index_free)
 	{
-		pObj = new OBJ_INDEX_DATA;
-
-		CLEAR_MEM(pObj, sizeof(OBJ_INDEX_DATA))
+		// value-init zeroes the scalar members AND constructs the std::list members;
+		// CLEAR_MEM (byte-zero) would corrupt the lists' internal state.
+		pObj = new OBJ_INDEX_DATA();
 
 		top_obj_index++;
 	}
@@ -374,7 +375,7 @@ OBJ_INDEX_DATA *new_obj_index(void)
 	pObj->wear_loc_name = nullptr;
 	pObj->charaffs = nullptr;
 	pObj->extra_descr.clear();
-	pObj->apply = nullptr;
+	pObj->apply.clear();
 
 	for (value = 0; value < 5; value++) /* 5 - ROM */
 	{

--- a/code/mem.c
+++ b/code/mem.c
@@ -82,8 +82,7 @@ AREA_DATA *new_area(void)
 
 	if (!area_free)
 	{
-		pArea = new AREA_DATA;
-		CLEAR_MEM(pArea, sizeof(AREA_DATA))
+		pArea = new AREA_DATA();
 		top_area++;
 	}
 	else
@@ -125,6 +124,8 @@ void free_area(AREA_DATA *pArea)
 	free_pstring(pArea->name);
 	free_pstring(pArea->file_name);
 	free_pstring(pArea->builders);
+
+	pArea->affected.clear();
 
 	pArea->next = area_free->next;
 	area_free = pArea;

--- a/code/merc.h
+++ b/code/merc.h
@@ -1260,18 +1260,7 @@ struct aprog_data
 
 #include "entity/pc_data.h"
 
-//
-// Data for generating characters -- only used during generation
-//
-
-struct gen_data
-{
-	GEN_DATA *next;
-	bool valid;
-	bool skill_chosen[MAX_SKILL];
-	bool group_chosen[MAX_GROUP];
-	int points_chosen;
-};
+#include "entity/gen_data.h"
 
 #include "entity/extra_descr.h"
 

--- a/code/merc.h
+++ b/code/merc.h
@@ -286,12 +286,6 @@ struct improg_type
 	char *owner;
 };
 
-#define MAX_ARG						6
-
-#define FUN_GENERIC					0
-#define FUN_ACT						1
-
-typedef void FUNC 	  (void*, void*, void*, void*, void*, void*);
 typedef bool RUNE_FUN (void*, void*, void*, void*);
 typedef void RUNE_END (RUNE_DATA *rune);
 
@@ -310,16 +304,6 @@ struct rune_data
 	RUNE_DATA *next;
 	RUNE_DATA *next_content;
 	RUNE_END *end_fun;
-};
-
-struct queue_data
-{
-	int timer;
-	int funtype;
-	FUNC *function;
-	void *arg[MAX_ARG];
-	int act_to;
-	QUEUE_DATA *next;
 };
 
 struct descriptor_data
@@ -1349,7 +1333,6 @@ struct pathfind_data
 
 //TODO: Find out where these are implemented
 extern const struct class_type class_table[MAX_CLASS];
-extern QUEUE_DATA *global_queue;
 
 #define MULT_EXP					5
 

--- a/code/merc.h
+++ b/code/merc.h
@@ -266,15 +266,7 @@ private:
 #define RS_EPOCH					972370801
 
 
-struct time_info_data
-{
-	bool half;
-	int hour;
-	int day;
-	int month;
-	int season;
-	int year;
-};
+#include "entity/time_info_data.h"
 
 
 //
@@ -1314,6 +1306,8 @@ struct gen_data
 #include "entity/area_data.h"
 
 
+#include "entity/track_data.h"
+
 #include "entity/room_index_data.h"
 
 struct trap_data
@@ -1339,21 +1333,6 @@ struct trophy_data
 {
 	char *victname;
 	TROPHY_DATA *next;
-};
-
-//
-// Data stored in rooms to facilitate PC and mob tracking
-//
-
-struct track_data
-{
-	CHAR_DATA *prey;					// Who passed through.
-	TIME_INFO_DATA time;				// When they passed through.
-	short direction;					// Which way they went.
-	bool flying;						// Are they?
-	bool sneaking;						// Are they?
-	int legs;							// How many?
-	bool bleeding;						// Are they?
 };
 
 struct pathfind_data

--- a/code/merc.h
+++ b/code/merc.h
@@ -1273,6 +1273,8 @@ struct aprog_data
 	char *myell_name;
 };
 
+#include "entity/trophy_data.h"
+
 #include "entity/pc_data.h"
 
 //
@@ -1328,12 +1330,6 @@ struct trap_data
 //
 // Solution to Horde trophy ugliness
 //
-
-struct trophy_data
-{
-	char *victname;
-	TROPHY_DATA *next;
-};
 
 struct pathfind_data
 {

--- a/code/merc.h
+++ b/code/merc.h
@@ -243,13 +243,21 @@ int remove();
 #define NOTE_UNSTARTED				0
 #define NOTE_IN_PROGRESS			1
 
-struct buf_type
+// A crash-proof, growable scratch string. Owns its storage: the destructor
+// releases it, so a stack `BUFFER` needs no manual free (formerly new_buf/free_buf).
+class buf_type
 {
-	BUFFER *next;
-	bool valid;
-	short state;	// error state of the buffer
-	short size;		// size in k
-	char *string;	// buffer's string
+public:
+	~buf_type();
+
+	bool add(const char *text);		// append text; was add_buf
+	void clear();					// reset to empty; was clear_buf
+	const char *str() const;		// current contents; was buf_string
+
+private:
+	short state = 0;				// BUFFER_SAFE; error state of the buffer
+	short size = 0;					// size in k
+	char *string = nullptr;			// buffer's string
 };
 
 

--- a/code/merc.h
+++ b/code/merc.h
@@ -1180,19 +1180,6 @@ struct line_data
 #define ANSI_BLINK					"\x01B[5m"
 #define ANSI_REVERSE				"\x01B[7m"
 
-//
-// memory for mobs
-//
-
-struct mem_data
-{
-	MEM_DATA *next;
-	bool valid;
-	int id; 
-	int reaction;
-	time_t when;
-};
-
 
 struct mprog_data
 {

--- a/code/merc.h
+++ b/code/merc.h
@@ -1135,6 +1135,10 @@ struct kill_data
 
 
 
+#include "entity/line_data.h"
+
+#include "entity/speech_data.h"
+
 #include "entity/mob_index_data.h"
 
 //
@@ -1142,27 +1146,6 @@ struct kill_data
 //
 
 
-struct speech_data
-{
-	MOB_INDEX_DATA *mob;
-	SPEECH_DATA *next;
-	SPEECH_DATA *prev;
-	char *name;
-	LINE_DATA *first_line;
-	LINE_DATA *current_line;
-};
-
-struct line_data
-{
-	SPEECH_DATA *speech;
-	LINE_DATA *next;
-	LINE_DATA *prev;
-	int number;
-	int delay;
-	short type;
-	char *text;
-};
-	
 //
 // Color codes
 //

--- a/code/misc.c
+++ b/code/misc.c
@@ -301,13 +301,12 @@ void do_rngtest(CHAR_DATA *ch, char *argument)
 
 int next_sline(SPEECH_DATA *speech)
 {
-	LINE_DATA *lptr;
 	int max = 0;
 
-	for (lptr = speech->first_line; lptr; lptr = lptr->next)
+	for (auto &line : speech->first_line)
 	{
-		if (lptr->number > max)
-			max = lptr->number;
+		if (line.number > max)
+			max = line.number;
 	}
 
 	return max + 1;
@@ -315,45 +314,11 @@ int next_sline(SPEECH_DATA *speech)
 
 void sort_speech(SPEECH_DATA *speech)
 {
-	LINE_DATA *lptr, *hold;
-	bool sorted= false, first= false;
-
-	while (!sorted)
-	{
-		sorted = true;
-
-		for (lptr = speech->first_line; lptr; lptr = lptr->next)
-		{
-			first= false;
-
-			if (!lptr->next)
-				break;
-
-			if (lptr == speech->first_line)
-				first = true;
-
-			if (lptr->number > lptr->next->number)
-			{
-				sorted= false;
-
-				if (lptr->next->next)
-					lptr->next->next->prev = lptr;
-
-				lptr->next->prev = lptr->prev;
-
-				if (!first)
-					lptr->prev->next = lptr->next;
-
-				lptr->prev = lptr->next;
-				hold = lptr->next->next;
-				lptr->next->next = lptr;
-				lptr->next = hold;
-
-				if (first)
-					speech->first_line = lptr->prev;
-			}
-		}
-	}
+	// std::list::sort is a stable relink (element addresses -- and so the
+	// current_line cursor -- stay valid), matching the old ascending bubble sort.
+	speech->first_line.sort([](const LINE_DATA &a, const LINE_DATA &b) {
+		return a.number < b.number;
+	});
 }
 
 void BITWISE_OR(long bit1[], const long bit2[])

--- a/code/moremagic.c
+++ b/code/moremagic.c
@@ -309,10 +309,10 @@ bool cleansed(CHAR_DATA *ch, CHAR_DATA *victim, int diffmodifier, int sn)
 int get_affect_level(CHAR_DATA *ch, int sn)
 {
 	// Go through all affects on ch and return the level of the one that matches sn.
-	for (AFFECT_DATA *paf = ch->affected; paf != nullptr; paf = paf->next)
+	for (auto &paf : ch->affected)
 	{
-		if (paf->type == sn)
-			return paf->level;
+		if (paf.type == sn)
+			return paf.level;
 	}
 
 	return -1;
@@ -379,10 +379,14 @@ void spell_awaken(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 		return;
 	}
 
-	for (laf = victim->affected; laf != nullptr; laf = laf->next)
+	laf = nullptr;
+	for (auto &laf_elem : victim->affected)
 	{
-		if (IS_SET(laf->bitvector, AFF_SLEEP))
+		if (IS_SET(laf_elem.bitvector, AFF_SLEEP))
+		{
+			laf = &laf_elem;
 			break;
+		}
 	}
 
 	if (laf == nullptr)

--- a/code/mprog.c
+++ b/code/mprog.c
@@ -2497,11 +2497,13 @@ void pulse_prog_wizard_summon(CHAR_DATA *mob)
 
 		if (is_affected(mob, gsn_bash))
 		{
-			for (paf = mob->affected; paf; paf = paf->next)
+			paf = nullptr;
+			for (auto &paf_elem : mob->affected)
 			{
-				if (paf->type == gsn_bash && paf->owner == vch)
+				if (paf_elem.type == gsn_bash && paf_elem.owner == vch)
 				{
 					found = true;
+					paf = &paf_elem;
 					break;
 				}
 			}

--- a/code/mprog.c
+++ b/code/mprog.c
@@ -659,7 +659,7 @@ void greet_prog_ruins_mouth(CHAR_DATA *mob, CHAR_DATA *ch)
 void speech_prog_testmob(CHAR_DATA *mob, CHAR_DATA *ch, char *speech)
 {
 	if (strstr(speech, "test"))
-		execute_speech(ch, mob, mob->pIndexData->speech);
+		execute_speech(ch, mob, mob->pIndexData->speech.empty() ? nullptr : &mob->pIndexData->speech.front());
 }
 
 void speech_prog_ruins_mouth(CHAR_DATA *mob, CHAR_DATA *ch, char *speech)

--- a/code/note.c
+++ b/code/note.c
@@ -287,7 +287,7 @@ void update_read(CHAR_DATA *ch, long stamp, int type)
 void parse_note(CHAR_DATA *ch, char *argument, int type)
 {
 	// TODO: Break this function up into its constituent parts. It's doing like 12 different things.
-	BUFFER *buffer;
+	BUFFER buffer;
 	char buf[MAX_STRING_LENGTH];
 	char arg[MAX_INPUT_LENGTH];
 	char *list_name;
@@ -524,16 +524,12 @@ void parse_note(CHAR_DATA *ch, char *argument, int type)
 			return;
 		}
 
-		buffer = new_buf();
-
-		add_buf(buffer, ch->pnote->text);
-		add_buf(buffer, argument);
-		add_buf(buffer, "\n\r");
+		buffer.add(ch->pnote->text);
+		buffer.add(argument);
+		buffer.add("\n\r");
 
 		free_pstring(ch->pnote->text);
-		ch->pnote->text = palloc_string(buf_string(buffer));
-
-		free_buf(buffer);
+		ch->pnote->text = palloc_string(buffer.str());
 
 		send_to_char("Ok.\n\r", ch);
 		return;

--- a/code/olc_act.c
+++ b/code/olc_act.c
@@ -2371,12 +2371,12 @@ bool redit_show(CHAR_DATA *ch, char *argument)
 		strcat(buf1, "none]\n\r");
 	}
 
-	if (pRoom->extra_descr)
+	if (!pRoom->extra_descr.empty())
 	{
-		for (EXTRA_DESCR_DATA *ed = pRoom->extra_descr; ed; ed = ed->next)
+		for (const auto &ed : pRoom->extra_descr)
 		{
 			strcat(buf1, "Extra Desc Keyword: ");
-			strcat(buf1, ed->keyword);
+			strcat(buf1, ed.keyword);
 			strcat(buf1, "\n\r");
 		}
 	}
@@ -2814,7 +2814,6 @@ bool redit_down(CHAR_DATA *ch, char *argument)
 bool redit_ed(CHAR_DATA *ch, char *argument)
 {
 	ROOM_INDEX_DATA *pRoom;
-	EXTRA_DESCR_DATA *ed;
 	char command[MAX_INPUT_LENGTH];
 
 	EDIT_ROOM(ch, pRoom);
@@ -2838,13 +2837,12 @@ bool redit_ed(CHAR_DATA *ch, char *argument)
 			return false;
 		}
 
-		ed = new_extra_descr();
-		ed->keyword = palloc_string(argument);
-		ed->description = palloc_string("");
-		ed->next = pRoom->extra_descr;
-		pRoom->extra_descr = ed;
+		EXTRA_DESCR_DATA ed;
+		ed.keyword = palloc_string(argument);
+		ed.description = palloc_string("");
+		pRoom->extra_descr.push_front(std::move(ed));
 
-		string_append(ch, &ed->description);
+		string_append(ch, &pRoom->extra_descr.front().description);
 
 		return true;
 	}
@@ -2857,10 +2855,14 @@ bool redit_ed(CHAR_DATA *ch, char *argument)
 			return false;
 		}
 
-		for (ed = pRoom->extra_descr; ed; ed = ed->next)
+		EXTRA_DESCR_DATA *ed = nullptr;
+		for (auto &e : pRoom->extra_descr)
 		{
-			if (is_name(argument, ed->keyword))
+			if (is_name(argument, e.keyword))
+			{
+				ed = &e;
 				break;
+			}
 		}
 
 		if (!ed)
@@ -2876,34 +2878,26 @@ bool redit_ed(CHAR_DATA *ch, char *argument)
 
 	if (!str_cmp(command, "delete"))
 	{
-		EXTRA_DESCR_DATA *ped = nullptr;
-
 		if (argument[0] == '\0')
 		{
 			send_to_char("Syntax:  ed delete [keyword]\n\r", ch);
 			return false;
 		}
 
-		for (ed = pRoom->extra_descr; ed; ed = ed->next)
+		auto it = pRoom->extra_descr.begin();
+		for (; it != pRoom->extra_descr.end(); ++it)
 		{
-			if (is_name(argument, ed->keyword))
+			if (is_name(argument, it->keyword))
 				break;
-
-			ped = ed;
 		}
 
-		if (!ed)
+		if (it == pRoom->extra_descr.end())
 		{
 			send_to_char("REdit:  Extra description keyword not found.\n\r", ch);
 			return false;
 		}
 
-		if (!ped)
-			pRoom->extra_descr = ed->next;
-		else
-			ped->next = ed->next;
-
-		free_extra_descr(ed);
+		pRoom->extra_descr.erase(it);		// element dtor frees the strings
 
 		send_to_char("Extra description deleted.\n\r", ch);
 		return true;
@@ -2917,10 +2911,14 @@ bool redit_ed(CHAR_DATA *ch, char *argument)
 			return false;
 		}
 
-		for (ed = pRoom->extra_descr; ed; ed = ed->next)
+		EXTRA_DESCR_DATA *ed = nullptr;
+		for (auto &e : pRoom->extra_descr)
 		{
-			if (is_name(argument, ed->keyword))
+			if (is_name(argument, e.keyword))
+			{
+				ed = &e;
 				break;
+			}
 		}
 
 		if (!ed)
@@ -4193,12 +4191,12 @@ bool oedit_show(CHAR_DATA *ch, char *argument)
 		}
 	}
 
-	if (pObj->extra_descr)
+	if (!pObj->extra_descr.empty())
 	{
-		for (EXTRA_DESCR_DATA *ed = pObj->extra_descr; ed; ed = ed->next)
+		for (const auto &ed : pObj->extra_descr)
 		{
 			send_to_char("Extra Desc Keyword: ", ch);
-			send_to_char(ed->keyword, ch);
+			send_to_char(ed.keyword, ch);
 			send_to_char("\n\r", ch);
 		}
 	}
@@ -4945,7 +4943,6 @@ bool oedit_create(CHAR_DATA *ch, char *argument)
 bool oedit_ed(CHAR_DATA *ch, char *argument)
 {
 	OBJ_INDEX_DATA *pObj;
-	EXTRA_DESCR_DATA *ed;
 	char command[MAX_INPUT_LENGTH];
 
 	EDIT_OBJ(ch, pObj);
@@ -4969,12 +4966,11 @@ bool oedit_ed(CHAR_DATA *ch, char *argument)
 			return false;
 		}
 
-		ed = new_extra_descr();
-		ed->keyword = palloc_string(argument);
-		ed->next = pObj->extra_descr;
-		pObj->extra_descr = ed;
+		EXTRA_DESCR_DATA ed;
+		ed.keyword = palloc_string(argument);
+		pObj->extra_descr.push_front(std::move(ed));
 
-		string_append(ch, &ed->description);
+		string_append(ch, &pObj->extra_descr.front().description);
 
 		return true;
 	}
@@ -4987,10 +4983,14 @@ bool oedit_ed(CHAR_DATA *ch, char *argument)
 			return false;
 		}
 
-		for (ed = pObj->extra_descr; ed; ed = ed->next)
+		EXTRA_DESCR_DATA *ed = nullptr;
+		for (auto &e : pObj->extra_descr)
 		{
-			if (is_name(argument, ed->keyword))
+			if (is_name(argument, e.keyword))
+			{
+				ed = &e;
 				break;
+			}
 		}
 
 		if (!ed)
@@ -5006,33 +5006,26 @@ bool oedit_ed(CHAR_DATA *ch, char *argument)
 
 	if (!str_cmp(command, "delete"))
 	{
-		EXTRA_DESCR_DATA *ped = nullptr;
-
 		if (argument[0] == '\0')
 		{
 			send_to_char("Syntax:  ed delete [keyword]\n\r", ch);
 			return false;
 		}
 
-		for (ed = pObj->extra_descr; ed; ed = ed->next)
+		auto it = pObj->extra_descr.begin();
+		for (; it != pObj->extra_descr.end(); ++it)
 		{
-			if (is_name(argument, ed->keyword))
+			if (is_name(argument, it->keyword))
 				break;
-			ped = ed;
 		}
 
-		if (!ed)
+		if (it == pObj->extra_descr.end())
 		{
 			send_to_char("OEdit:  Extra description keyword not found.\n\r", ch);
 			return false;
 		}
 
-		if (!ped)
-			pObj->extra_descr = ed->next;
-		else
-			ped->next = ed->next;
-
-		free_extra_descr(ed);
+		pObj->extra_descr.erase(it);		// element dtor frees the strings
 
 		send_to_char("Extra description deleted.\n\r", ch);
 		return true;
@@ -5040,19 +5033,20 @@ bool oedit_ed(CHAR_DATA *ch, char *argument)
 
 	if (!str_cmp(command, "format"))
 	{
-		EXTRA_DESCR_DATA *ped = nullptr;
-
 		if (argument[0] == '\0')
 		{
 			send_to_char("Syntax:  ed format [keyword]\n\r", ch);
 			return false;
 		}
 
-		for (ed = pObj->extra_descr; ed; ed = ed->next)
+		EXTRA_DESCR_DATA *ed = nullptr;
+		for (auto &e : pObj->extra_descr)
 		{
-			if (is_name(argument, ed->keyword))
+			if (is_name(argument, e.keyword))
+			{
+				ed = &e;
 				break;
-			ped = ed;
+			}
 		}
 
 		if (!ed)

--- a/code/olc_act.c
+++ b/code/olc_act.c
@@ -304,7 +304,7 @@ bool redit_rlist(CHAR_DATA *ch, char *argument)
 	ROOM_INDEX_DATA *pRoomIndex;
 	AREA_DATA *pArea;
 	char buf[MAX_STRING_LENGTH];
-	BUFFER *buf1;
+	BUFFER buf1;
 	char arg[MAX_INPUT_LENGTH];
 	bool found;
 	int vnum;
@@ -313,7 +313,6 @@ bool redit_rlist(CHAR_DATA *ch, char *argument)
 	one_argument(argument, arg);
 
 	pArea = ch->in_room->area;
-	buf1 = new_buf();
 	/*    buf1[0] = '\0'; */
 	found = false;
 
@@ -325,10 +324,10 @@ bool redit_rlist(CHAR_DATA *ch, char *argument)
 			found = true;
 
 			sprintf(buf, "[%5d] %-17.16s", vnum, capitalize(pRoomIndex->name));
-			add_buf(buf1, buf);
+			buf1.add(buf);
 
 			if (++col % 3 == 0)
-				add_buf(buf1, "\n\r");
+				buf1.add("\n\r");
 		}
 	}
 
@@ -339,10 +338,9 @@ bool redit_rlist(CHAR_DATA *ch, char *argument)
 	}
 
 	if (col % 3 != 0)
-		add_buf(buf1, "\n\r");
+		buf1.add("\n\r");
 
-	page_to_char(buf_string(buf1), ch);
-	free_buf(buf1);
+	page_to_char(buf1.str(), ch);
 	return false;
 }
 
@@ -400,7 +398,7 @@ bool redit_mlist(CHAR_DATA *ch, char *argument)
 	MOB_INDEX_DATA *pMobIndex;
 	AREA_DATA *pArea;
 	char buf[MAX_STRING_LENGTH];
-	BUFFER *buf1;
+	BUFFER buf1;
 	char arg[MAX_INPUT_LENGTH];
 	bool fAll, found;
 	int vnum;
@@ -414,7 +412,6 @@ bool redit_mlist(CHAR_DATA *ch, char *argument)
 		return false;
 	}
 
-	buf1 = new_buf();
 	pArea = ch->in_room->area;
 	/*    buf1[0] = '\0'; */
 	fAll = !str_cmp(arg, "all");
@@ -431,10 +428,10 @@ bool redit_mlist(CHAR_DATA *ch, char *argument)
 				found = true;
 
 				sprintf(buf, "[%5d] %-17.16s", pMobIndex->vnum, capitalize(pMobIndex->short_descr));
-				add_buf(buf1, buf);
+				buf1.add(buf);
 
 				if (++col % 3 == 0)
-					add_buf(buf1, "\n\r");
+					buf1.add("\n\r");
 			}
 		}
 	}
@@ -446,10 +443,9 @@ bool redit_mlist(CHAR_DATA *ch, char *argument)
 	}
 
 	if (col % 3 != 0)
-		add_buf(buf1, "\n\r");
+		buf1.add("\n\r");
 
-	page_to_char(buf_string(buf1), ch);
-	free_buf(buf1);
+	page_to_char(buf1.str(), ch);
 	return false;
 }
 
@@ -458,7 +454,7 @@ bool redit_olist(CHAR_DATA *ch, char *argument)
 	OBJ_INDEX_DATA *pObjIndex;
 	AREA_DATA *pArea;
 	char buf[MAX_STRING_LENGTH];
-	BUFFER *buf1;
+	BUFFER buf1;
 	char arg[MAX_INPUT_LENGTH];
 	bool fAll, found;
 	int vnum;
@@ -473,7 +469,6 @@ bool redit_olist(CHAR_DATA *ch, char *argument)
 	}
 
 	pArea = ch->in_room->area;
-	buf1 = new_buf();
 	/*    buf1[0] = '\0'; */
 	fAll = !str_cmp(arg, "all");
 	found = false;
@@ -489,10 +484,10 @@ bool redit_olist(CHAR_DATA *ch, char *argument)
 				found = true;
 
 				sprintf(buf, "[%5d] %-17.16s", pObjIndex->vnum, capitalize(pObjIndex->short_descr));
-				add_buf(buf1, buf);
+				buf1.add(buf);
 
 				if (++col % 3 == 0)
-					add_buf(buf1, "\n\r");
+					buf1.add("\n\r");
 			}
 		}
 	}
@@ -504,10 +499,9 @@ bool redit_olist(CHAR_DATA *ch, char *argument)
 	}
 
 	if (col % 3 != 0)
-		add_buf(buf1, "\n\r");
+		buf1.add("\n\r");
 
-	page_to_char(buf_string(buf1), ch);
-	free_buf(buf1);
+	page_to_char(buf1.str(), ch);
 	return false;
 }
 
@@ -6939,15 +6933,13 @@ bool medit_hitroll(CHAR_DATA *ch, char *argument)
 
 bool oedit_liqlist(CHAR_DATA *ch, char *argument)
 {
-	BUFFER *buffer;
+	BUFFER buffer;
 	char buf[MAX_STRING_LENGTH];
-
-	buffer = new_buf();
 
 	for (int liq = 0; liq_table[liq].liq_name != nullptr; liq++)
 	{
 		if (liq % 21 == 0)
-			add_buf(buffer, "Name                 Color          Proof Full Thirst Food Ssize\n\r");
+			buffer.add("Name                 Color          Proof Full Thirst Food Ssize\n\r");
 
 		sprintf(buf, "%-20s %-14s %5d %4d %6d %4d %5d\n\r",
 			liq_table[liq].liq_name,
@@ -6957,11 +6949,10 @@ bool oedit_liqlist(CHAR_DATA *ch, char *argument)
 			liq_table[liq].liq_affect[2],
 			liq_table[liq].liq_affect[3],
 			liq_table[liq].liq_affect[4]);
-		add_buf(buffer, buf);
+		buffer.add(buf);
 	}
 
-	page_to_char(buf_string(buffer), ch);
-	free_buf(buffer);
+	page_to_char(buffer.str(), ch);
 
 	return true;
 }

--- a/code/olc_act.c
+++ b/code/olc_act.c
@@ -3912,9 +3912,7 @@ bool oedit_show(CHAR_DATA *ch, char *argument)
 {
 	OBJ_INDEX_DATA *pObj;
 	char buf[MAX_STRING_LENGTH];
-	OBJ_APPLY_DATA *paf;
 	int cnt, i;
-	AFFECT_DATA *af;
 
 	EDIT_OBJ(ch, pObj);
 
@@ -4148,7 +4146,7 @@ bool oedit_show(CHAR_DATA *ch, char *argument)
 	if (!IS_ZERO_VECTOR(pObj->imm_flags)
 		|| !IS_ZERO_VECTOR(pObj->res_flags)
 		|| !IS_ZERO_VECTOR(pObj->vuln_flags)
-		|| pObj->charaffs)
+		|| !pObj->charaffs.empty())
 	{
 		send_to_char("Flag data:\n\r", ch);
 
@@ -4170,17 +4168,17 @@ bool oedit_show(CHAR_DATA *ch, char *argument)
 			send_to_char(buf, ch);
 		}
 
-		if (pObj->charaffs)
+		if (!pObj->charaffs.empty())
 		{
 			i = 0;
 
 			std::string buffer = std::string(" AFF ");
-			for (af = pObj->charaffs; af; af = af->next)
+			for (auto &af : pObj->charaffs)
 			{
 				if (i > 0)
 					buffer += fmt::format("{}     ", buffer);
 
-				buffer += fmt::format("[{}]\n\r", skill_table[af->type].name);
+				buffer += fmt::format("[{}]\n\r", skill_table[af.type].name);
 				i++;
 			}
 
@@ -4660,11 +4658,7 @@ bool oedit_flag(CHAR_DATA *ch, char *argument)
 
 		if (!str_cmp(arg3, "delete"))
 		{
-			for (af = pObj->charaffs; af != nullptr; af = af->next)
-			{
-				if (af->type == skill_lookup(arg2))
-					break;
-			}
+			af = affect_find(pObj->charaffs, skill_lookup(arg2));
 
 			if (af == nullptr || skill_lookup(arg2) == -1)
 			{

--- a/code/olc_act.c
+++ b/code/olc_act.c
@@ -663,9 +663,8 @@ bool medit_group(CHAR_DATA *ch, char *argument)
 bool medit_speech(CHAR_DATA *ch, char *argument)
 {
 	MOB_INDEX_DATA *pMobIndex;
-	SPEECH_DATA *speech, *sptr;
+	SPEECH_DATA *speech;
 	char buf[MSL], cmd[MSL], name[MSL], arg3[MSL], arg4[MSL], arg5[MSL];
-	LINE_DATA *lptr, *new_line;
 	int type;
 
 	EDIT_MOB(ch, pMobIndex);
@@ -700,7 +699,7 @@ bool medit_speech(CHAR_DATA *ch, char *argument)
 			{
 				if (!str_prefix(arg3, "list"))
 				{
-					if (!speech->first_line)
+					if (speech->first_line.empty())
 					{
 						send_to_char("This speech has no lines.\n\r", ch);
 						return false;
@@ -709,13 +708,13 @@ bool medit_speech(CHAR_DATA *ch, char *argument)
 					sprintf(buf, "%s Lines:\n\r", speech->name);
 					send_to_char(buf, ch);
 
-					for (lptr = speech->first_line; lptr; lptr = lptr->next)
+					for (auto &line : speech->first_line)
 					{
 						sprintf(buf, "Line #%d: %d %s %s\n\r",
-							lptr->number,
-							lptr->delay,
-							flag_name_lookup(lptr->type, speech_table),
-							lptr->text);
+							line.number,
+							line.delay,
+							flag_name_lookup(line.type, speech_table),
+							line.text);
 						send_to_char(buf, ch);
 					}
 				}
@@ -723,9 +722,7 @@ bool medit_speech(CHAR_DATA *ch, char *argument)
 				{
 					argument = one_argument(argument, arg4);
 					argument = one_argument(argument, arg5);
-					new_line = new_line_data();
 
-					new_line->delay = atoi(arg4);
 					type = flag_lookup(arg5, speech_table);
 
 					if (type == NO_FLAG)
@@ -734,13 +731,16 @@ bool medit_speech(CHAR_DATA *ch, char *argument)
 						return false;
 					}
 
-					new_line->type = type;
-					new_line->text = palloc_string(argument);
-
-					for (lptr = speech->first_line; lptr->next != nullptr; lptr = lptr->next)
-					{
-						lptr->next = new_line;
-					}
+					// Append to the end of the line list. (The old code walked
+					// off the end and orphaned the tail, and never assigned a
+					// line number; std::list appends cleanly and next_sline
+					// gives the new line its number.)
+					int number = next_sline(speech);
+					LINE_DATA &new_line = speech->first_line.emplace_back();
+					new_line.number = number;
+					new_line.delay = atoi(arg4);
+					new_line.type = type;
+					new_line.text = palloc_string(argument);
 
 					send_to_char("Added.\n\r", ch);
 					return true;
@@ -749,13 +749,14 @@ bool medit_speech(CHAR_DATA *ch, char *argument)
 				{
 					argument = one_argument(argument, arg4);
 
-					for (lptr = speech->first_line; lptr; lptr = lptr->next)
+					auto lptr = speech->first_line.begin();
+					for (; lptr != speech->first_line.end(); ++lptr)
 					{
 						if (lptr->number == atoi(arg3))
 							break;
 					}
 
-					if (!lptr)
+					if (lptr == speech->first_line.end())
 					{
 						send_to_char("Not a valid line number.\n\r", ch);
 						return false;
@@ -764,7 +765,9 @@ bool medit_speech(CHAR_DATA *ch, char *argument)
 					{
 						if (!str_cmp(arg4, "delete"))
 						{
-							delete lptr;
+							// Properly unlink and free (the old code did a raw
+							// `delete` that left a dangling node in the list).
+							speech->first_line.erase(lptr);
 							send_to_char("Deleted.\n\r", ch);
 							return true;
 						}
@@ -813,7 +816,7 @@ bool medit_speech(CHAR_DATA *ch, char *argument)
 		}
 		else if (!str_prefix(cmd, "list"))
 		{
-			if (!pMobIndex->speech)
+			if (pMobIndex->speech.empty())
 			{
 				send_to_char("Mobile has no speeches defined.\n\r", ch);
 				return false;
@@ -821,9 +824,9 @@ bool medit_speech(CHAR_DATA *ch, char *argument)
 
 			send_to_char("Mobile has the following speeches defined:\n\r", ch);
 
-			for (sptr = pMobIndex->speech; sptr; sptr = sptr->next)
+			for (auto &sp : pMobIndex->speech)
 			{
-				sprintf(buf, "%s\n\r", sptr->name);
+				sprintf(buf, "%s\n\r", sp.name);
 				send_to_char(buf, ch);
 			}
 		}
@@ -835,19 +838,8 @@ bool medit_speech(CHAR_DATA *ch, char *argument)
 				return false;
 			}
 
-			speech = new_speech_data();
-			speech->name = palloc_string(name);
-
-			if (!pMobIndex->speech)
-			{
-				pMobIndex->speech = speech;
-			}
-			else
-			{
-				for (sptr = pMobIndex->speech; sptr->next; sptr = sptr->next);
-				sptr->next = speech;
-				speech->prev = sptr;
-			}
+			SPEECH_DATA &sp = pMobIndex->speech.emplace_back();
+			sp.name = palloc_string(name);
 
 			send_to_char("Speech added.\n\r", ch);
 			return true;
@@ -860,15 +852,20 @@ bool medit_speech(CHAR_DATA *ch, char *argument)
 				return false;
 			}
 
-			speech = find_speech(pMobIndex, name);
+			auto sit = pMobIndex->speech.begin();
+			for (; sit != pMobIndex->speech.end(); ++sit)
+			{
+				if (!str_cmp(sit->name, name))
+					break;
+			}
 
-			if (!speech)
+			if (sit == pMobIndex->speech.end())
 			{
 				send_to_char("No speech by that name found.\n\r", ch);
 				return false;
 			}
 
-			free_speech(speech);
+			pMobIndex->speech.erase(sit);
 			send_to_char("Speech deleted.\n\r", ch);
 			return true;
 		}

--- a/code/olc_act.c
+++ b/code/olc_act.c
@@ -4201,7 +4201,8 @@ bool oedit_show(CHAR_DATA *ch, char *argument)
 		}
 	}
 
-	for (cnt = 0, paf = pObj->apply; paf; paf = paf->next)
+	cnt = 0;
+	for (const auto &paf : pObj->apply)
 	{
 		if (cnt == 0)
 		{
@@ -4209,7 +4210,7 @@ bool oedit_show(CHAR_DATA *ch, char *argument)
 			send_to_char("------ -------- -------\n\r", ch);
 		}
 
-		sprintf(buf, "[%4d] %-8d %s\n\r", cnt, paf->modifier, flag_string_old(apply_flags, paf->location));
+		sprintf(buf, "[%4d] %-8d %s\n\r", cnt, paf.modifier, flag_string_old(apply_flags, paf.location));
 		send_to_char(buf, ch);
 		cnt++;
 	}
@@ -4226,7 +4227,6 @@ bool oedit_addapply(CHAR_DATA *ch, char *argument)
 {
 	int value;
 	OBJ_INDEX_DATA *pObj;
-	OBJ_APPLY_DATA *pAf;
 	char loc[MAX_STRING_LENGTH];
 	char mod[MAX_STRING_LENGTH];
 
@@ -4249,11 +4249,10 @@ bool oedit_addapply(CHAR_DATA *ch, char *argument)
 		return false;
 	}
 
-	pAf = new_apply_data();
-	pAf->location = value;
-	pAf->modifier = atoi(mod);
-	pAf->next = pObj->apply;
-	pObj->apply = pAf;
+	OBJ_APPLY_DATA pAf;
+	pAf.location = value;
+	pAf.modifier = atoi(mod);
+	pObj->apply.push_front(pAf);
 
 	send_to_char("Affect added.\n\r", ch);
 	return true;
@@ -4312,11 +4311,8 @@ bool oedit_addaffect(CHAR_DATA *ch, char *argument)
 bool oedit_delapply(CHAR_DATA *ch, char *argument)
 {
 	OBJ_INDEX_DATA *pObj;
-	OBJ_APPLY_DATA *pAf;
-	OBJ_APPLY_DATA *pAf_next;
 	char apply[MAX_STRING_LENGTH];
 	int value;
-	int cnt = 0;
 
 	EDIT_OBJ(ch, pObj);
 
@@ -4336,36 +4332,23 @@ bool oedit_delapply(CHAR_DATA *ch, char *argument)
 		return false;
 	}
 
-	if (!(pAf = pObj->apply))
+	if (pObj->apply.empty())
 	{
 		send_to_char("OEdit:  Non-existant apply.\n\r", ch);
 		return false;
 	}
 
-	if (value == 0) /* First case: Remove first affect */
-	{
-		pAf = pObj->apply;
-		pObj->apply = pAf->next;
-		free_apply(pAf);
-	}
-	else /* Affect to remove is not the first */
-	{
-		while ((pAf_next = pAf->next) && (++cnt < value))
-		{
-			pAf = pAf_next;
-		}
+	auto it = pObj->apply.begin();
+	for (int cnt = 0; cnt < value && it != pObj->apply.end(); ++cnt)
+		++it;
 
-		if (pAf_next) /* See if it's the next affect */
-		{
-			pAf->next = pAf_next->next;
-			free_apply(pAf_next);
-		}
-		else /* Doesn't exist */
-		{
-			send_to_char("No such affect.\n\r", ch);
-			return false;
-		}
+	if (it == pObj->apply.end()) /* Doesn't exist */
+	{
+		send_to_char("No such affect.\n\r", ch);
+		return false;
 	}
+
+	pObj->apply.erase(it);
 
 	send_to_char("Affect removed.\n\r", ch);
 	return true;

--- a/code/olc_save.c
+++ b/code/olc_save.c
@@ -480,11 +480,11 @@ void save_object(FILE *fp, OBJ_INDEX_DATA *pObjIndex)
 			fprintf(fp, "ITEM %s\n", (upstring(flag_name_lookup(i, extra_flags))));
 	}
 
-	for (app = pObjIndex->apply; app; app = app->next)
+	for (const auto &app : pObjIndex->apply)
 	{
 		fprintf(fp, "APPLY %s %d\n",
-			upstring(display_name_lookup(app->location, apply_locations)),
-			app->modifier);
+			upstring(display_name_lookup(app.location, apply_locations)),
+			app.modifier);
 	}
 
 	fprintf(fp, "LIMIT %d\n", pObjIndex->limtotal);

--- a/code/olc_save.c
+++ b/code/olc_save.c
@@ -376,7 +376,6 @@ void save_object(FILE *fp, OBJ_INDEX_DATA *pObjIndex)
 	long dummy[MAX_BITVECTOR];
 	OBJ_APPLY_DATA *app;
 	AFFECT_DATA *paf;
-	EXTRA_DESCR_DATA *ed;
 
 	zero_vector(dummy);
 
@@ -537,10 +536,8 @@ void save_object(FILE *fp, OBJ_INDEX_DATA *pObjIndex)
 	if (pObjIndex->notes)
 		fprintf(fp, "NOTES %s~\n", pObjIndex->notes);
 
-	for (ed = pObjIndex->extra_descr; ed; ed = ed->next)
-	{
-		fprintf(fp, "E %s~\n%s~\n", ed->keyword, munch(ed->description));
-	}
+	for (const auto &ed : pObjIndex->extra_descr)
+		fprintf(fp, "E %s~\n%s~\n", ed.keyword, munch(ed.description));
 
 	fprintf(fp, "\n");
 }
@@ -563,7 +560,6 @@ void save_objects(FILE *fp, AREA_DATA *pArea)
 void save_rooms(FILE *fp, AREA_DATA *pArea)
 {
 	ROOM_INDEX_DATA *pRoom;
-	EXTRA_DESCR_DATA *ed;
 	EXIT_DATA *pexit;
 	char buf1[MSL], buf2[MSL];
 	long i;
@@ -630,10 +626,8 @@ void save_rooms(FILE *fp, AREA_DATA *pArea)
 					pRoom->alt_description);
 			}
 
-			for (ed = pRoom->extra_descr; ed; ed = ed->next)
-			{
-				fprintf(fp, "E %s~\n%s~\n", ed->keyword, munch(ed->description));
-			}
+			for (const auto &ed : pRoom->extra_descr)
+				fprintf(fp, "E %s~\n%s~\n", ed.keyword, munch(ed.description));
 
 			if (pRoom->cabal)
 				fprintf(fp, "CABAL %s\n", cabal_table[pRoom->cabal].name);

--- a/code/olc_save.c
+++ b/code/olc_save.c
@@ -369,7 +369,6 @@ void save_object(FILE *fp, OBJ_INDEX_DATA *pObjIndex)
 	long i;
 	long dummy[MAX_BITVECTOR];
 	OBJ_APPLY_DATA *app;
-	AFFECT_DATA *paf;
 
 	zero_vector(dummy);
 
@@ -516,12 +515,12 @@ void save_object(FILE *fp, OBJ_INDEX_DATA *pObjIndex)
 			fprintf(fp, "FLAG VUL %s\n", (upstring(flag_name_lookup(i, imm_flags))));
 	}
 
-	for (paf = pObjIndex->charaffs; paf; paf = paf->next)
+	for (auto &paf : pObjIndex->charaffs)
 	{
 		fprintf(fp, "FLAG AFF '%s' %s %s\n",
-			skill_table[paf->type].name,
-			affect_bit_name(paf->bitvector),
-			paf->aftype == AFT_SPELL ? "SHOW" : "NOSHOW");
+			skill_table[paf.type].name,
+			affect_bit_name(paf.bitvector),
+			paf.aftype == AFT_SPELL ? "SHOW" : "NOSHOW");
 	}
 
 	if (pObjIndex->wear_loc_name)

--- a/code/olc_save.c
+++ b/code/olc_save.c
@@ -332,25 +332,19 @@ void save_mobile(FILE *fp, MOB_INDEX_DATA *pMobIndex)
 		}
 	}
 
-	if (pMobIndex->speech)
+	for (auto &speech : pMobIndex->speech)
 	{
-		SPEECH_DATA *sptr;
-		LINE_DATA *lptr;
+		fprintf(fp, "SPEECH %s\n", speech.name);
 
-		for (sptr = pMobIndex->speech; sptr; sptr = sptr->next)
+		for (auto &line : speech.first_line)
 		{
-			fprintf(fp, "SPEECH %s\n", sptr->name);
-
-			for (lptr = sptr->first_line; lptr; lptr = lptr->next)
-			{
-				fprintf(fp, "LINE %d %s %s~\n",
-					lptr->delay,
-					flag_name_lookup(lptr->type, speech_table),
-					lptr->text);
-			}
-
-			fprintf(fp, "END\n");
+			fprintf(fp, "LINE %d %s %s~\n",
+				line.delay,
+				flag_name_lookup(line.type, speech_table),
+				line.text);
 		}
+
+		fprintf(fp, "END\n");
 	}
 }
 

--- a/code/prof.c
+++ b/code/prof.c
@@ -929,13 +929,10 @@ void prof_tracking(CHAR_DATA *ch, char *argument)
 	char *direction = nullptr;
 	for (auto i = 0; i < MAX_TRACKS; i++)
 	{
-		if (!ch->in_room->tracks[i])
-			break;
-
-		if (ch->in_room->tracks[i]->prey != victim || ch->in_room->tracks[i]->flying || ch->in_room->tracks[i]->sneaking)
+		if (ch->in_room->tracks[i].prey != victim || ch->in_room->tracks[i].flying || ch->in_room->tracks[i].sneaking)
 			continue;
 
-		auto &ttime = ch->in_room->tracks[i]->time;
+		auto &ttime = ch->in_room->tracks[i].time;
 		if (abs(ttime.day - time_info.day) > 1 || (ttime.month != time_info.month && ttime.day != 30))
 			continue;
 
@@ -947,7 +944,7 @@ void prof_tracking(CHAR_DATA *ch, char *argument)
 		}
 
 		int diruse = (number_percent() > (35 - (ch->Profs()->GetProf("tracking")) * 2))
-			? ch->in_room->tracks[i]->direction
+			? ch->in_room->tracks[i].direction
 			: number_range(0, MAX_DIR - 1);
 
 		direction = flag_name_lookup(diruse, direction_table);

--- a/code/prof.c
+++ b/code/prof.c
@@ -827,9 +827,9 @@ void add_prof_affect(CHAR_DATA *ch, char *name, int duration, bool fInvis = true
 /// @returns true if the character is affected by the specific proficiency affliction.
 bool is_affected_prof(CHAR_DATA *ch, char *prof)
 {
-	for (auto paf = ch->affected; paf; paf = paf->next)
+	for (auto &paf : ch->affected)
 	{
-		if (paf->type == gsn_timer && paf->name && !str_cmp(paf->name, prof))
+		if (paf.type == gsn_timer && paf.name && !str_cmp(paf.name, prof))
 			return true;
 	}
 

--- a/code/quest.c
+++ b/code/quest.c
@@ -185,13 +185,14 @@ void store_quest_val(CHAR_DATA *ch, char *valname, short value)
 
 void setbit_quest_val(CHAR_DATA *ch, char *valname, long value)
 {
-	AFFECT_DATA *paf;
+	AFFECT_DATA *paf = nullptr;
 
-	for (paf = ch->affected; paf; paf = paf->next)
+	for (auto &paf_elem : ch->affected)
 	{
-		if (paf->type == gsn_timer && paf->name && !str_cmp(paf->name, valname))
+		if (paf_elem.type == gsn_timer && paf_elem.name && !str_cmp(paf_elem.name, valname))
 		{
-			SET_BIT_OLD(paf->level, value);
+			SET_BIT_OLD(paf_elem.level, value);
+			paf = &paf_elem;
 			break;
 		}
 	}
@@ -202,12 +203,10 @@ void setbit_quest_val(CHAR_DATA *ch, char *valname, long value)
 
 int get_quest_val(CHAR_DATA *ch, char *valname)
 {
-	AFFECT_DATA *paf;
-
-	for (paf = ch->affected; paf; paf = paf->next)
+	for (auto &paf : ch->affected)
 	{
-		if (paf->type == gsn_timer && paf->name && !str_cmp(paf->name, valname))
-			return paf->level;
+		if (paf.type == gsn_timer && paf.name && !str_cmp(paf.name, valname))
+			return paf.level;
 	}
 
 	return -1;
@@ -215,14 +214,14 @@ int get_quest_val(CHAR_DATA *ch, char *valname)
 
 void delete_quest_val(CHAR_DATA *ch, char *valname)
 {
-	AFFECT_DATA *paf, *paf_next = nullptr;
-
-	for (paf = ch->affected; paf; paf = paf_next)
+	for (auto it = ch->affected.begin(); it != ch->affected.end(); )
 	{
-		paf_next = paf->next;
+		auto next = std::next(it);
 
-		if (paf->type == gsn_timer && paf->name && !str_cmp(paf->name, valname))
-			affect_remove(ch, paf);
+		if (it->type == gsn_timer && it->name && !str_cmp(it->name, valname))
+			affect_remove(ch, &*it);
+
+		it = next;
 	}
 }
 
@@ -1128,7 +1127,6 @@ BEGIN_SPEC(mspec_academy_smith)
 	END_EVENT
 
 	EVENT_MGIVE
-		OBJ_AFFECT_DATA *paf;
 		if (!can_do_quest(ch, SMITH_QUEST))
 			return 0;
 		if (STAGE(ch) == 2)

--- a/code/recycle.c
+++ b/code/recycle.c
@@ -57,7 +57,6 @@
 const int buf_size[MAX_BUF_LIST] = {16, 32, 64, 128, 256, 1024, 2048, 4096, 8192, 16384};
 
 DESCRIPTOR_DATA *descriptor_free;
-GEN_DATA *gen_data_free;
 RUNE_DATA *rune_free;
 QUEUE_DATA *queue_free;
 OBJ_DATA *obj_free;
@@ -100,38 +99,6 @@ void free_descriptor(DESCRIPTOR_DATA *d)
 	d->valid = false;
 	d->next = descriptor_free;
 	descriptor_free = d;
-}
-
-/* stuff for recycling gen_data */
-GEN_DATA *new_gen_data(void)
-{
-	static GEN_DATA gen_zero;
-	GEN_DATA *gen;
-
-	if (gen_data_free == nullptr)
-	{
-		gen = new GEN_DATA;
-	}
-	else
-	{
-		gen = gen_data_free;
-		gen_data_free = gen_data_free->next;
-	}
-
-	*gen = gen_zero;
-
-	gen->valid = true;
-	return gen;
-}
-
-void free_gen_data(GEN_DATA *gen)
-{
-	if (!(gen != nullptr && gen->valid))
-		return;
-
-	gen->valid = false;
-	gen->next = gen_data_free;
-	gen_data_free = gen;
 }
 
 /* Trophy list elements own their victname string (rule-of-5). */
@@ -637,6 +604,7 @@ void free_char(CHAR_DATA *ch)
 	free_pstring(ch->prefix);
 
 	ch->pcdata.reset();
+	ch->gen_data.reset();
 
 	ch->next = char_free;
 	char_free = ch;

--- a/code/recycle.c
+++ b/code/recycle.c
@@ -58,7 +58,6 @@ const int buf_size[MAX_BUF_LIST] = {16, 32, 64, 128, 256, 1024, 2048, 4096, 8192
 
 DESCRIPTOR_DATA *descriptor_free;
 RUNE_DATA *rune_free;
-QUEUE_DATA *queue_free;
 OBJ_DATA *obj_free;
 CHAR_DATA *char_free;
 OLD_CHAR *oldtype_free;
@@ -427,31 +426,6 @@ void free_rune(RUNE_DATA *rune)
 {
 	rune->next = rune_free;
 	rune_free = rune;
-}
-
-QUEUE_DATA *new_queue(void)
-{
-	static QUEUE_DATA queue_zero;
-	QUEUE_DATA *queue;
-
-	if (queue_free == nullptr)
-	{
-		queue = new QUEUE_DATA;
-	}
-	else
-	{
-		queue = queue_free;
-		queue_free = queue->next;
-	}
-
-	*queue = queue_zero;
-	return queue;
-}
-
-void free_queue(QUEUE_DATA *queue)
-{
-	queue->next = queue_free;
-	queue_free = queue;
 }
 
 /* stuff for recycling objects */

--- a/code/recycle.c
+++ b/code/recycle.c
@@ -190,80 +190,16 @@ trophy_data &trophy_data::operator=(trophy_data &&other) noexcept
 
 /* mob speech memory management */
 
-SPEECH_DATA *new_speech_data(void)
+/* Speech/line list elements own their strings (freed on destruction; the
+   parent std::list handles the unlinking the old free_speech/free_line did). */
+line_data::~line_data()
 {
-	SPEECH_DATA *speech = new SPEECH_DATA;
-
-	speech->next = nullptr;
-	speech->prev = nullptr;
-	speech->mob = nullptr;
-	speech->name = nullptr;
-	speech->first_line = nullptr;
-	speech->current_line = nullptr;
-
-	return speech;
+	free_pstring(text);
 }
 
-void free_speech(SPEECH_DATA *speech)
+speech_data::~speech_data()
 {
-	free_pstring(speech->name);
-
-	if (speech->next)
-	{
-		if (speech->prev)
-		{
-			speech->prev->next = speech->next;
-			speech->next->prev = speech->prev;
-		}
-		else
-		{
-			speech->mob->speech = speech->next;
-		}
-	}
-
-	delete speech;
-}
-
-void free_line(LINE_DATA *line)
-{
-	LINE_DATA *lptr;
-
-	free_pstring(line->text);
-
-	if (line->next)
-	{
-		if (line->prev)
-		{
-			line->prev->next = line->next;
-			line->next->prev = line->prev;
-		}
-		else
-		{
-			line->speech->first_line = line->next;
-		}
-	}
-
-	for (lptr = line; lptr; lptr = lptr->next)
-	{
-		lptr->number--;
-	}
-
-	delete line;
-}
-
-LINE_DATA *new_line_data(void)
-{
-	LINE_DATA *line = new LINE_DATA;
-
-	line->speech = nullptr;
-	line->next = nullptr;
-	line->prev = nullptr;
-	line->number = -1;
-	line->delay = -1;
-	line->type = -1;
-	line->text = nullptr;
-
-	return line;
+	free_pstring(name);
 }
 
 IPROG_DATA *new_iprog(void)

--- a/code/recycle.c
+++ b/code/recycle.c
@@ -58,7 +58,6 @@ const int buf_size[MAX_BUF_LIST] = {16, 32, 64, 128, 256, 1024, 2048, 4096, 8192
 
 DESCRIPTOR_DATA *descriptor_free;
 GEN_DATA *gen_data_free;
-EXTRA_DESCR_DATA *extra_descr_free;
 OBJ_APPLY_DATA *apply_free;
 AFFECT_DATA *affect_free;
 ROOM_AFFECT_DATA *raffect_free;
@@ -372,38 +371,57 @@ void free_path(PATHFIND_DATA *path)
 
 /* stuff for recycling extended descs -- UGLY */
 
-EXTRA_DESCR_DATA *new_extra_descr(void)
+extra_descr_data::~extra_descr_data()
 {
-	EXTRA_DESCR_DATA *ed;
-
-	if (extra_descr_free == nullptr)
-	{
-		ed = new EXTRA_DESCR_DATA;
-	}
-	else
-	{
-		ed = extra_descr_free;
-		extra_descr_free = extra_descr_free->next;
-	}
-
-	ed->keyword = &str_empty[0];
-	ed->description = &str_empty[0];
-
-	ed->valid = true;
-	return ed;
+	free_pstring(keyword);
+	free_pstring(description);
 }
 
-void free_extra_descr(EXTRA_DESCR_DATA *ed)
+extra_descr_data::extra_descr_data(const extra_descr_data &other)
+	: keyword(other.keyword ? palloc_string(other.keyword) : nullptr)
+	, description(other.description ? palloc_string(other.description) : nullptr)
 {
-	if (!(ed != nullptr && ed->valid))
-		return;
+}
 
-	free_pstring(ed->keyword);
-	free_pstring(ed->description);
+extra_descr_data &extra_descr_data::operator=(const extra_descr_data &other)
+{
+	if (this != &other)
+	{
+		char *new_keyword = other.keyword ? palloc_string(other.keyword) : nullptr;
+		char *new_description = other.description ? palloc_string(other.description) : nullptr;
 
-	ed->valid = false;
-	ed->next = extra_descr_free;
-	extra_descr_free = ed;
+		free_pstring(keyword);
+		free_pstring(description);
+
+		keyword = new_keyword;
+		description = new_description;
+	}
+
+	return *this;
+}
+
+extra_descr_data::extra_descr_data(extra_descr_data &&other) noexcept
+	: keyword(other.keyword)
+	, description(other.description)
+{
+	other.keyword = nullptr;
+	other.description = nullptr;
+}
+
+extra_descr_data &extra_descr_data::operator=(extra_descr_data &&other) noexcept
+{
+	if (this != &other)
+	{
+		free_pstring(keyword);
+		free_pstring(description);
+
+		keyword = other.keyword;
+		description = other.description;
+		other.keyword = nullptr;
+		other.description = nullptr;
+	}
+
+	return *this;
 }
 
 OBJ_APPLY_DATA *new_apply_data(void)
@@ -657,7 +675,6 @@ OBJ_DATA *new_obj(void)
 void free_obj(OBJ_DATA *obj)
 {
 	OBJ_AFFECT_DATA *paf, *paf_next;
-	EXTRA_DESCR_DATA *ed, *ed_next;
 
 	if (!(obj != nullptr && obj->valid))
 		return;
@@ -670,13 +687,7 @@ void free_obj(OBJ_DATA *obj)
 
 	obj->affected = nullptr;
 
-	for (ed = obj->extra_descr; ed != nullptr; ed = ed_next)
-	{
-		ed_next = ed->next;
-		free_extra_descr(ed);
-	}
-
-	obj->extra_descr = nullptr;
+	obj->extra_descr.clear();
 
 	free_pstring(obj->name);
 	free_pstring(obj->description);

--- a/code/recycle.c
+++ b/code/recycle.c
@@ -59,7 +59,6 @@ const int buf_size[MAX_BUF_LIST] = {16, 32, 64, 128, 256, 1024, 2048, 4096, 8192
 DESCRIPTOR_DATA *descriptor_free;
 GEN_DATA *gen_data_free;
 AFFECT_DATA *affect_free;
-ROOM_AFFECT_DATA *raffect_free;
 OBJ_AFFECT_DATA *oaffect_free;
 RUNE_DATA *rune_free;
 QUEUE_DATA *queue_free;
@@ -456,37 +455,6 @@ void free_affect(AFFECT_DATA *af)
 	af->valid = false;
 	af->next = affect_free;
 	affect_free = af;
-}
-
-ROOM_AFFECT_DATA *new_affect_room(void)
-{
-	static ROOM_AFFECT_DATA af_zero;
-	ROOM_AFFECT_DATA *af;
-
-	if (raffect_free == nullptr)
-	{
-		af = new ROOM_AFFECT_DATA;
-	}
-	else
-	{
-		af = raffect_free;
-		raffect_free = raffect_free->next;
-	}
-
-	*af = af_zero;
-
-	af->valid = true;
-	return af;
-}
-
-void free_affect_room(ROOM_AFFECT_DATA *af)
-{
-	if (!(af != nullptr && af->valid))
-		return;
-
-	af->valid = false;
-	af->next = raffect_free;
-	raffect_free = af;
 }
 
 OBJ_AFFECT_DATA *new_affect_obj(void)

--- a/code/recycle.c
+++ b/code/recycle.c
@@ -59,7 +59,6 @@ const int buf_size[MAX_BUF_LIST] = {16, 32, 64, 128, 256, 1024, 2048, 4096, 8192
 DESCRIPTOR_DATA *descriptor_free;
 GEN_DATA *gen_data_free;
 AFFECT_DATA *affect_free;
-OBJ_AFFECT_DATA *oaffect_free;
 RUNE_DATA *rune_free;
 QUEUE_DATA *queue_free;
 OBJ_DATA *obj_free;
@@ -457,37 +456,6 @@ void free_affect(AFFECT_DATA *af)
 	affect_free = af;
 }
 
-OBJ_AFFECT_DATA *new_affect_obj(void)
-{
-	static OBJ_AFFECT_DATA af_zero;
-	OBJ_AFFECT_DATA *af;
-
-	if (oaffect_free == nullptr)
-	{
-		af = new OBJ_AFFECT_DATA;
-	}
-	else
-	{
-		af = oaffect_free;
-		oaffect_free = oaffect_free->next;
-	}
-
-	*af = af_zero;
-
-	af->valid = true;
-	return af;
-}
-
-void free_affect_obj(OBJ_AFFECT_DATA *af)
-{
-	if (!(af != nullptr && af->valid))
-		return;
-
-	af->valid = false;
-	af->next = oaffect_free;
-	oaffect_free = af;
-}
-
 /* stuff for recycling objects */
 
 OBJ_DATA *new_obj(void)
@@ -513,19 +481,10 @@ OBJ_DATA *new_obj(void)
 
 void free_obj(OBJ_DATA *obj)
 {
-	OBJ_AFFECT_DATA *paf, *paf_next;
-
 	if (!(obj != nullptr && obj->valid))
 		return;
 
-	for (paf = obj->affected; paf != nullptr; paf = paf_next)
-	{
-		paf_next = paf->next;
-		free_affect_obj(paf);
-	}
-
-	obj->affected = nullptr;
-
+	obj->affected.clear();
 	obj->extra_descr.clear();
 	obj->apply.clear();		// obj owns its apply copy now (was shared with the index)
 

--- a/code/recycle.c
+++ b/code/recycle.c
@@ -68,7 +68,6 @@ OBJ_DATA *obj_free;
 CHAR_DATA *char_free;
 PC_DATA *pcdata_free;
 OLD_CHAR *oldtype_free;
-MEM_DATA *mem_data_free;
 
 long last_pc_id;
 long last_mob_id;
@@ -762,6 +761,8 @@ void free_char(CHAR_DATA *ch)
 		affect_remove(ch, paf);
 	}
 
+	ch->memory.clear();
+
 	free_pstring(ch->name);
 	free_pstring(ch->short_descr);
 	free_pstring(ch->long_descr);
@@ -892,39 +893,6 @@ long get_mob_id(void)
 {
 	last_mob_id++;
 	return last_mob_id;
-}
-
-/* procedures and constants needed for buffering */
-
-MEM_DATA *new_mem_data(void)
-{
-	MEM_DATA *memory;
-
-	if (mem_data_free == nullptr)
-		memory = new MEM_DATA;
-	else
-	{
-		memory = mem_data_free;
-		mem_data_free = mem_data_free->next;
-	}
-
-	memory->next = nullptr;
-	memory->id = 0;
-	memory->reaction = 0;
-	memory->when = 0;
-	memory->valid = true;
-
-	return memory;
-}
-
-void free_pstruct_data(MEM_DATA *memory)
-{
-	if (!(memory != nullptr && memory->valid))
-		return;
-
-	memory->next = mem_data_free;
-	mem_data_free = memory;
-	memory->valid = false;
 }
 
 /* local procedure for finding the next acceptable size */

--- a/code/recycle.c
+++ b/code/recycle.c
@@ -58,7 +58,6 @@ const int buf_size[MAX_BUF_LIST] = {16, 32, 64, 128, 256, 1024, 2048, 4096, 8192
 
 DESCRIPTOR_DATA *descriptor_free;
 GEN_DATA *gen_data_free;
-AFFECT_DATA *affect_free;
 RUNE_DATA *rune_free;
 QUEUE_DATA *queue_free;
 OBJ_DATA *obj_free;
@@ -356,27 +355,72 @@ extra_descr_data &extra_descr_data::operator=(extra_descr_data &&other) noexcept
 	return *this;
 }
 
-/* stuff for recycling affects */
-
-AFFECT_DATA *new_affect(void)
+/* An affect owns its `name` string; the rest of its fields are trivially
+ * copied. `owner` is a non-owning back-reference copied as-is. */
+static void copy_affect_payload(AFFECT_DATA &dst, const AFFECT_DATA &src)
 {
-	static AFFECT_DATA af_zero;
-	AFFECT_DATA *af;
+	dst.owner = src.owner;
+	dst.where = src.where;
+	dst.type = src.type;
+	dst.level = src.level;
+	dst.duration = src.duration;
+	dst.location = src.location;
+	dst.modifier = src.modifier;
+	dst.mod_name = src.mod_name;
+	copy_vector(dst.bitvector, src.bitvector);
+	dst.aftype = src.aftype;
+	dst.tick_fun = src.tick_fun;
+	dst.pulse_fun = src.pulse_fun;
+	dst.end_fun = src.end_fun;
+	dst.init_duration = src.init_duration;
+	dst.beat_fun = src.beat_fun;
+}
 
-	if (affect_free == nullptr)
+affect_data::~affect_data()
+{
+	free_pstring(name);
+}
+
+affect_data::affect_data(const affect_data &other)
+{
+	copy_affect_payload(*this, other);
+	name = other.name ? palloc_string(other.name) : nullptr;
+}
+
+affect_data &affect_data::operator=(const affect_data &other)
+{
+	if (this != &other)
 	{
-		af = new AFFECT_DATA;
+		char *new_name = other.name ? palloc_string(other.name) : nullptr;
+
+		free_pstring(name);
+		name = new_name;
+
+		copy_affect_payload(*this, other);
 	}
-	else
+
+	return *this;
+}
+
+affect_data::affect_data(affect_data &&other) noexcept
+{
+	copy_affect_payload(*this, other);
+	name = other.name;
+	other.name = nullptr;
+}
+
+affect_data &affect_data::operator=(affect_data &&other) noexcept
+{
+	if (this != &other)
 	{
-		af = affect_free;
-		affect_free = affect_free->next;
+		free_pstring(name);
+
+		copy_affect_payload(*this, other);
+		name = other.name;
+		other.name = nullptr;
 	}
 
-	*af = af_zero;
-
-	af->valid = true;
-	return af;
+	return *this;
 }
 
 TRAP_DATA *new_trap(void)
@@ -444,18 +488,6 @@ void free_queue(QUEUE_DATA *queue)
 	queue_free = queue;
 }
 
-void free_affect(AFFECT_DATA *af)
-{
-	if (!(af != nullptr && af->valid))
-		return;
-
-	free_pstring(af->name);
-
-	af->valid = false;
-	af->next = affect_free;
-	affect_free = af;
-}
-
 /* stuff for recycling objects */
 
 OBJ_DATA *new_obj(void)
@@ -485,6 +517,7 @@ void free_obj(OBJ_DATA *obj)
 		return;
 
 	obj->affected.clear();
+	obj->charaffs.clear();	// obj owns its charaffs copy now (was shared with the index)
 	obj->extra_descr.clear();
 	obj->apply.clear();		// obj owns its apply copy now (was shared with the index)
 
@@ -569,8 +602,6 @@ void free_char(CHAR_DATA *ch)
 {
 	OBJ_DATA *obj;
 	OBJ_DATA *obj_next;
-	AFFECT_DATA *paf;
-	AFFECT_DATA *paf_next;
 
 	if (!(ch != nullptr && ch->valid) || !ch)
 		return;
@@ -584,13 +615,14 @@ void free_char(CHAR_DATA *ch)
 		extract_obj(obj);
 	}
 
-	for (paf = ch->affected; paf != nullptr; paf = paf_next)
+	for (auto it = ch->affected.begin(); it != ch->affected.end(); )
 	{
-		paf_next = paf->next;
-		paf->pulse_fun = nullptr;
-		paf->tick_fun = nullptr;
-		paf->end_fun = nullptr;
-		affect_remove(ch, paf);
+		auto next = std::next(it);
+		it->pulse_fun = nullptr;
+		it->tick_fun = nullptr;
+		it->end_fun = nullptr;
+		affect_remove(ch, &*it);
+		it = next;
 	}
 
 	ch->memory.clear();

--- a/code/recycle.c
+++ b/code/recycle.c
@@ -58,7 +58,6 @@ const int buf_size[MAX_BUF_LIST] = {16, 32, 64, 128, 256, 1024, 2048, 4096, 8192
 
 DESCRIPTOR_DATA *descriptor_free;
 GEN_DATA *gen_data_free;
-OBJ_APPLY_DATA *apply_free;
 AFFECT_DATA *affect_free;
 ROOM_AFFECT_DATA *raffect_free;
 OBJ_AFFECT_DATA *oaffect_free;
@@ -424,38 +423,6 @@ extra_descr_data &extra_descr_data::operator=(extra_descr_data &&other) noexcept
 	return *this;
 }
 
-OBJ_APPLY_DATA *new_apply_data(void)
-{
-	static OBJ_APPLY_DATA app_zero;
-	OBJ_APPLY_DATA *app;
-
-	if (apply_free == nullptr)
-	{
-		app = new OBJ_APPLY_DATA;
-	}
-	else
-	{
-		app = apply_free;
-		apply_free = apply_free->next;
-	}
-
-	*app = app_zero;
-	app->type = 0;
-
-	app->valid = true;
-	return app;
-}
-
-void free_apply(OBJ_APPLY_DATA *app)
-{
-	if (!(app != nullptr && app->valid))
-		return;
-
-	app->valid = false;
-	app->next = apply_free;
-	apply_free = app;
-}
-
 /* stuff for recycling affects */
 
 AFFECT_DATA *new_affect(void)
@@ -688,6 +655,7 @@ void free_obj(OBJ_DATA *obj)
 	obj->affected = nullptr;
 
 	obj->extra_descr.clear();
+	obj->apply.clear();		// obj owns its apply copy now (was shared with the index)
 
 	free_pstring(obj->name);
 	free_pstring(obj->description);

--- a/code/recycle.c
+++ b/code/recycle.c
@@ -308,24 +308,6 @@ void free_race_data(RACE_DATA *race_specs)
 	}
 }
 
-/* Stuff for recycling track data */
-
-TRACK_DATA *new_track_data(void)
-{
-	TRACK_DATA *tracks = new TRACK_DATA;
-
-	tracks->prey = nullptr;
-	tracks->time = time_info;
-	tracks->direction = -1;
-
-	return tracks;
-}
-
-void free_track(TRACK_DATA *tracks)
-{
-	delete tracks;
-}
-
 PATHFIND_DATA *new_path_data(void)
 {
 	PATHFIND_DATA *path = new PATHFIND_DATA;

--- a/code/recycle.c
+++ b/code/recycle.c
@@ -61,7 +61,6 @@ GEN_DATA *gen_data_free;
 AFFECT_DATA *affect_free;
 ROOM_AFFECT_DATA *raffect_free;
 OBJ_AFFECT_DATA *oaffect_free;
-AREA_AFFECT_DATA *aaffect_free;
 RUNE_DATA *rune_free;
 QUEUE_DATA *queue_free;
 OBJ_DATA *obj_free;
@@ -519,37 +518,6 @@ void free_affect_obj(OBJ_AFFECT_DATA *af)
 	af->valid = false;
 	af->next = oaffect_free;
 	oaffect_free = af;
-}
-
-AREA_AFFECT_DATA *new_affect_area(void)
-{
-	static AREA_AFFECT_DATA af_zero;
-	AREA_AFFECT_DATA *af;
-
-	if (aaffect_free == nullptr)
-	{
-		af = new AREA_AFFECT_DATA;
-	}
-	else
-	{
-		af = aaffect_free;
-		aaffect_free = aaffect_free->next;
-	}
-
-	*af = af_zero;
-
-	af->valid = true;
-	return af;
-}
-
-void free_affect_area(AREA_AFFECT_DATA *af)
-{
-	if (!(af != nullptr && af->valid))
-		return;
-
-	af->valid = false;
-	af->next = aaffect_free;
-	aaffect_free = af;
 }
 
 /* stuff for recycling objects */

--- a/code/recycle.c
+++ b/code/recycle.c
@@ -71,7 +71,6 @@ CHAR_DATA *char_free;
 PC_DATA *pcdata_free;
 OLD_CHAR *oldtype_free;
 MEM_DATA *mem_data_free;
-BUFFER *buf_free;
 
 long last_pc_id;
 long last_mob_id;
@@ -826,7 +825,7 @@ PC_DATA *new_pcdata(void)
 		pcdata->alias_sub[alias] = nullptr;
 	}
 
-	pcdata->buffer = new_buf();
+	pcdata->buffer = new BUFFER;
 
 	pcdata->valid = true;
 
@@ -874,7 +873,7 @@ void free_pcdata(PC_DATA *pcdata)
 	free_pstring(pcdata->bamfin);
 	free_pstring(pcdata->bamfout);
 	free_pstring(pcdata->title);
-	free_buf(pcdata->buffer);
+	delete pcdata->buffer;
 
 	for (int i = 0; i < 100; i++)
 	{
@@ -964,97 +963,55 @@ int get_size(int val)
 	return -1;
 }
 
-BUFFER *new_buf()
+buf_type::~buf_type()
 {
-	BUFFER *buffer;
-
-	if (buf_free == nullptr)
-	{
-		buffer = new BUFFER;
-	}
-	else
-	{
-		buffer = buf_free;
-		buf_free = buf_free->next;
-	}
-
-	buffer->next = nullptr;
-	buffer->state = BUFFER_SAFE;
-
-	/*
-	buffer->size = get_size(BASE_BUF);
-
-	buffer->string = palloc_struct(buffer->size);
-	buffer->string[0] = '\0';						//JUST SAY NO TO DIKU.  --D
-	*/
-
-	buffer->size = 0;
-	buffer->string = nullptr;
-
-	buffer->valid = true;
-	return buffer;
+	if (string)
+		free_pstring(string);
 }
 
-void free_buf(BUFFER *buffer)
-{
-	if (!(buffer != nullptr && buffer->valid))
-		return;
-
-	if (buffer->string)
-		free_pstring(buffer->string);
-
-	buffer->string = nullptr;
-	buffer->size = 0;
-	buffer->state = BUFFER_FREED;
-
-	buffer->valid = false;
-	buffer->next = buf_free;
-	buf_free = buffer;
-}
-
-bool add_buf(BUFFER *buffer, char *string)
+bool buf_type::add(const char *text)
 {
 	int len;
 	char *tptr;
 
-	if (string[0] == '\0' || string == nullptr)
+	if (text[0] == '\0' || text == nullptr)
 		return false;
 
-	if (!buffer->string || !strlen(buffer->string)) // like a virgin.. touched for the very first tiiiiime
+	if (!string || !strlen(string)) // like a virgin.. touched for the very first tiiiiime
 	{
-		buffer->string = palloc_string(string);
-		buffer->size = strlen(string) + 1;
+		string = palloc_string(text);
+		size = strlen(text) + 1;
 		return true;
 	}
 
-	len = strlen(buffer->string) + strlen(string) + 1;
+	len = strlen(string) + strlen(text) + 1;
 
 	if (len > 32766)
 		return true;
 
-	tptr = buffer->string;
-	buffer->string = new char[len];
+	tptr = string;
+	string = new char[len];
 
-	if (!buffer->string)
+	if (!string)
 		return false;
 
-	buffer->size = len;
+	size = len;
 
-	strcpy(buffer->string, tptr);
-	strcat(buffer->string, string);
+	strcpy(string, tptr);
+	strcat(string, text);
 
 	delete[] tptr;
 	return true;
 }
 
-void clear_buf(BUFFER *buffer)
+void buf_type::clear()
 {
-	free_pstring(buffer->string);
-	buffer->string = nullptr;
-	buffer->state = BUFFER_SAFE;
+	free_pstring(string);
+	string = nullptr;
+	state = BUFFER_SAFE;
 }
 
-char *buf_string(BUFFER *buffer)
+const char *buf_type::str() const
 {
-	return buffer->string;
+	return string;
 }

--- a/code/recycle.c
+++ b/code/recycle.c
@@ -139,34 +139,53 @@ void free_gen_data(GEN_DATA *gen)
 	gen_data_free = gen;
 }
 
-/* Stuff for recycling trophy lists */
-TROPHY_DATA *new_trophy_data(char *victname)
+/* Trophy list elements own their victname string (rule-of-5). */
+trophy_data::trophy_data(const char *name)
+	: victname(name ? palloc_string(name) : nullptr)
 {
-	TROPHY_DATA *trophy = new TROPHY_DATA;
-
-	trophy->victname = palloc_string(victname);
-	trophy->next = nullptr;
-
-	return trophy;
 }
 
-void free_trophy(TROPHY_DATA *trophy)
+trophy_data::~trophy_data()
 {
-	if (!trophy)
+	free_pstring(victname);
+}
+
+trophy_data::trophy_data(const trophy_data &other)
+	: victname(other.victname ? palloc_string(other.victname) : nullptr)
+{
+}
+
+trophy_data &trophy_data::operator=(const trophy_data &other)
+{
+	if (this != &other)
 	{
-		RS.Logger.Warn("ERROR: Null trophy freed!");
-		return;
+		char *new_victname = other.victname ? palloc_string(other.victname) : nullptr;
+
+		free_pstring(victname);
+
+		victname = new_victname;
 	}
 
-	if (trophy->next == nullptr)
+	return *this;
+}
+
+trophy_data::trophy_data(trophy_data &&other) noexcept
+	: victname(other.victname)
+{
+	other.victname = nullptr;
+}
+
+trophy_data &trophy_data::operator=(trophy_data &&other) noexcept
+{
+	if (this != &other)
 	{
-		delete trophy;
+		free_pstring(victname);
+
+		victname = other.victname;
+		other.victname = nullptr;
 	}
-	else
-	{
-		free_trophy(trophy->next);
-		delete trophy;
-	}
+
+	return *this;
 }
 
 /* mob speech memory management */
@@ -842,6 +861,8 @@ void free_pcdata(PC_DATA *pcdata)
 		if (pcdata->recentkills[i] != nullptr)
 			free_pstring(pcdata->recentkills[i]);
 	}
+
+	pcdata->trophy.clear();
 
 	/*
 	for (alias = 0; alias < MAX_ALIAS; alias++)

--- a/code/recycle.c
+++ b/code/recycle.c
@@ -62,7 +62,6 @@ RUNE_DATA *rune_free;
 QUEUE_DATA *queue_free;
 OBJ_DATA *obj_free;
 CHAR_DATA *char_free;
-PC_DATA *pcdata_free;
 OLD_CHAR *oldtype_free;
 
 long last_pc_id;
@@ -535,7 +534,6 @@ void free_obj(OBJ_DATA *obj)
 
 CHAR_DATA *new_char(void)
 {
-	static CHAR_DATA ch_zero;
 	CHAR_DATA *ch;
 	int i;
 
@@ -552,7 +550,10 @@ CHAR_DATA *new_char(void)
 		char_free = char_free->next;
 	}
 
-	*ch = ch_zero;
+	// Reset to a pristine char. A unique_ptr member rules out the old
+	// `*ch = ch_zero` copy-assign; move-assigning a value-initialized
+	// temporary zeroes the PODs and frees/clears the owned members.
+	*ch = CHAR_DATA();
 
 	ch->valid = true;
 
@@ -635,8 +636,7 @@ void free_char(CHAR_DATA *ch)
 	free_pstring(ch->prompt);
 	free_pstring(ch->prefix);
 
-	if (ch->pcdata != nullptr)
-		free_pcdata(ch->pcdata);
+	ch->pcdata.reset();
 
 	ch->next = char_free;
 	char_free = ch;
@@ -644,37 +644,13 @@ void free_char(CHAR_DATA *ch)
 	ch->valid = false;
 }
 
-PC_DATA *new_pcdata(void)
+std::unique_ptr<PC_DATA> new_pcdata(void)
 {
-	int alias;
-
-	static PC_DATA pcdata_zero;
-	PC_DATA *pcdata;
-
-	if (pcdata_free == nullptr)
-	{
-		pcdata = new PC_DATA;
-	}
-	else
-	{
-		pcdata = pcdata_free;
-		pcdata_free = pcdata_free->next;
-	}
-
-	*pcdata = pcdata_zero;
-
-	for (alias = 0; alias < MAX_ALIAS; alias++)
-	{
-		pcdata->alias[alias] = nullptr;
-		pcdata->alias_sub[alias] = nullptr;
-	}
+	auto pcdata = std::make_unique<PC_DATA>();	// value-init zeroes every POD field
 
 	pcdata->buffer = new BUFFER;
-
 	pcdata->valid = true;
 
-	pcdata->trusting = nullptr;
-	pcdata->death_status = 0;
 	return pcdata;
 }
 
@@ -708,40 +684,23 @@ void free_oldchar(OLD_CHAR *old)
 	oldtype_free = old;
 }
 
-void free_pcdata(PC_DATA *pcdata)
+pc_data::~pc_data()
 {
-	if (!(pcdata != nullptr && pcdata->valid))
-		return;
-
-	free_pstring(pcdata->pwd);
-	free_pstring(pcdata->bamfin);
-	free_pstring(pcdata->bamfout);
-	free_pstring(pcdata->title);
-	delete pcdata->buffer;
+	free_pstring(pwd);
+	free_pstring(bamfin);
+	free_pstring(bamfout);
+	free_pstring(title);
+	delete buffer;
 
 	for (int i = 0; i < 100; i++)
 	{
-		if (pcdata->recentkills[i] != nullptr)
-			free_pstring(pcdata->recentkills[i]);
+		if (recentkills[i] != nullptr)
+			free_pstring(recentkills[i]);
 	}
 
-	pcdata->trophy.clear();
-
-	/*
-	for (alias = 0; alias < MAX_ALIAS; alias++)
-	{
-		if(pcdata->alias[alias] != nullptr)
-		{
-			free_pstring(pcdata->alias[alias]);
-			free_pstring(pcdata->alias_sub[alias]);
-		}
-	}
-	*/
-
-	pcdata->valid = false;
-
-	pcdata->next = pcdata_free;
-	pcdata_free = pcdata;
+	// trophy (std::list) and profs (CProficiencies) auto-destruct.
+	// alias[]/alias_sub[] are intentionally not freed, matching the prior
+	// free_pcdata (a pre-existing leak preserved here, not introduced).
 }
 
 /* stuff for setting ids */

--- a/code/recycle.h
+++ b/code/recycle.h
@@ -38,7 +38,6 @@
 
 /* externals for counting purposes */
 extern DESCRIPTOR_DATA *descriptor_free;
-extern AFFECT_DATA *affect_free;
 extern OBJ_DATA *obj_free;
 extern CHAR_DATA *char_free;
 extern PC_DATA *pcdata_free;
@@ -73,16 +72,14 @@ void free_race_data(RACE_DATA *race_specs);
 PATHFIND_DATA *new_path_data(void);
 void free_path(PATHFIND_DATA *path);
 /* extra descr — value type owned by parents in std::list; see entity/extra_descr.h */
+/* affect — value type owned by parents in std::list; see entity/affect_data.h */
 /* apply — value type owned by parents in std::list; see entity/affect_data.h */
-/* stuff for recycling affects */
-AFFECT_DATA *new_affect(void);
 TRAP_DATA *new_trap(void);
 void free_trap(TRAP_DATA *trap);
 RUNE_DATA *new_rune(void);
 void free_rune(RUNE_DATA *rune);
 QUEUE_DATA *new_queue(void);
 void free_queue(QUEUE_DATA *queue);
-void free_affect(AFFECT_DATA *af);
 /* object recycling */
 OBJ_DATA *new_obj(void);
 void free_obj(OBJ_DATA *obj);

--- a/code/recycle.h
+++ b/code/recycle.h
@@ -65,11 +65,6 @@ void free_descriptor(DESCRIPTOR_DATA *d);
 /* char gen data recycling */
 GEN_DATA *new_gen_data(void);
 void free_gen_data(GEN_DATA * gen);
-/* speech recycling */
-SPEECH_DATA *new_speech_data(void);
-void free_speech(SPEECH_DATA *speech);
-void free_line(LINE_DATA *line);
-LINE_DATA *new_line_data(void);
 IPROG_DATA *new_iprog(void);
 /* race_data recycling (never gonna happen!) */
 RACE_DATA *new_race_data(void);

--- a/code/recycle.h
+++ b/code/recycle.h
@@ -83,8 +83,6 @@ void free_rune(RUNE_DATA *rune);
 QUEUE_DATA *new_queue(void);
 void free_queue(QUEUE_DATA *queue);
 void free_affect(AFFECT_DATA *af);
-ROOM_AFFECT_DATA *new_affect_room(void);
-void free_affect_room(ROOM_AFFECT_DATA *af);
 OBJ_AFFECT_DATA *new_affect_obj(void);
 void free_affect_obj(OBJ_AFFECT_DATA *af);
 /* object recycling */

--- a/code/recycle.h
+++ b/code/recycle.h
@@ -34,13 +34,14 @@
 #ifndef RECYCLE_H
 #define RECYCLE_H
 
+#include <memory>
+
 #include "entity/fwd.h"
 
 /* externals for counting purposes */
 extern DESCRIPTOR_DATA *descriptor_free;
 extern OBJ_DATA *obj_free;
 extern CHAR_DATA *char_free;
-extern PC_DATA *pcdata_free;
 
 
 /* stuff for providing a crash-proof buffer */
@@ -86,10 +87,9 @@ void free_obj(OBJ_DATA *obj);
 /* character recycling */
 CHAR_DATA *new_char(void);
 void free_char(CHAR_DATA *ch);
-PC_DATA *new_pcdata(void);
+std::unique_ptr<PC_DATA> new_pcdata(void);
 OLD_CHAR *new_oldchar(void);
 void free_oldchar(OLD_CHAR *old);
-void free_pcdata(PC_DATA *pcdata);
 /* mob id procedures */
 long get_pc_id(void);
 long get_mob_id(void);

--- a/code/recycle.h
+++ b/code/recycle.h
@@ -87,8 +87,6 @@ ROOM_AFFECT_DATA *new_affect_room(void);
 void free_affect_room(ROOM_AFFECT_DATA *af);
 OBJ_AFFECT_DATA *new_affect_obj(void);
 void free_affect_obj(OBJ_AFFECT_DATA *af);
-AREA_AFFECT_DATA *new_affect_area(void);
-void free_affect_area(AREA_AFFECT_DATA *af);
 /* object recycling */
 OBJ_DATA *new_obj(void);
 void free_obj(OBJ_DATA *obj);

--- a/code/recycle.h
+++ b/code/recycle.h
@@ -83,8 +83,6 @@ void free_rune(RUNE_DATA *rune);
 QUEUE_DATA *new_queue(void);
 void free_queue(QUEUE_DATA *queue);
 void free_affect(AFFECT_DATA *af);
-OBJ_AFFECT_DATA *new_affect_obj(void);
-void free_affect_obj(OBJ_AFFECT_DATA *af);
 /* object recycling */
 OBJ_DATA *new_obj(void);
 void free_obj(OBJ_DATA *obj);

--- a/code/recycle.h
+++ b/code/recycle.h
@@ -62,9 +62,6 @@ extern CHAR_DATA *char_free;
 /* descriptor recycling */
 DESCRIPTOR_DATA *new_descriptor(void);
 void free_descriptor(DESCRIPTOR_DATA *d);
-/* char gen data recycling */
-GEN_DATA *new_gen_data(void);
-void free_gen_data(GEN_DATA * gen);
 IPROG_DATA *new_iprog(void);
 /* race_data recycling (never gonna happen!) */
 RACE_DATA *new_race_data(void);

--- a/code/recycle.h
+++ b/code/recycle.h
@@ -123,11 +123,6 @@ void free_pstruct_data(MEM_DATA *memory);
 /* local procedure for finding the next acceptable size */
 /* -1 indicates out-of-boundary error */
 int get_size(int val);
-/* buffer procedures */
-BUFFER *new_buf(void);
-void free_buf(BUFFER *buffer);
-bool add_buf(BUFFER *buffer, char *string);
-void clear_buf(BUFFER *buffer);
-char *buf_string(BUFFER *buffer);
+/* buffer procedures — see buf_type in merc.h (add/clear/str are members now) */
 
 #endif /* RECYCLE_H */

--- a/code/recycle.h
+++ b/code/recycle.h
@@ -65,9 +65,6 @@ void free_descriptor(DESCRIPTOR_DATA *d);
 /* char gen data recycling */
 GEN_DATA *new_gen_data(void);
 void free_gen_data(GEN_DATA * gen);
-/* trophy recycling */
-TROPHY_DATA *new_trophy_data(char *victname);
-void free_trophy(TROPHY_DATA *trophy);
 /* speech recycling */
 SPEECH_DATA *new_speech_data(void);
 void free_speech(SPEECH_DATA *speech);

--- a/code/recycle.h
+++ b/code/recycle.h
@@ -77,9 +77,6 @@ IPROG_DATA *new_iprog(void);
 /* race_data recycling (never gonna happen!) */
 RACE_DATA *new_race_data(void);
 void free_race_data(RACE_DATA *race_specs);
-/* tracks recycling */
-TRACK_DATA *new_track_data(void);
-void free_track(TRACK_DATA *tracks);
 /* pathfind recycling */
 PATHFIND_DATA *new_path_data(void);
 void free_path(PATHFIND_DATA *path);

--- a/code/recycle.h
+++ b/code/recycle.h
@@ -84,9 +84,7 @@ void free_track(TRACK_DATA *tracks);
 PATHFIND_DATA *new_path_data(void);
 void free_path(PATHFIND_DATA *path);
 /* extra descr — value type owned by parents in std::list; see entity/extra_descr.h */
-/* apply recycling */
-OBJ_APPLY_DATA *new_apply_data(void);
-void free_apply(OBJ_APPLY_DATA *apply);
+/* apply — value type owned by parents in std::list; see entity/affect_data.h */
 /* stuff for recycling affects */
 AFFECT_DATA *new_affect(void);
 TRAP_DATA *new_trap(void);

--- a/code/recycle.h
+++ b/code/recycle.h
@@ -76,8 +76,6 @@ TRAP_DATA *new_trap(void);
 void free_trap(TRAP_DATA *trap);
 RUNE_DATA *new_rune(void);
 void free_rune(RUNE_DATA *rune);
-QUEUE_DATA *new_queue(void);
-void free_queue(QUEUE_DATA *queue);
 /* object recycling */
 OBJ_DATA *new_obj(void);
 void free_obj(OBJ_DATA *obj);

--- a/code/recycle.h
+++ b/code/recycle.h
@@ -110,11 +110,9 @@ PC_DATA *new_pcdata(void);
 OLD_CHAR *new_oldchar(void);
 void free_oldchar(OLD_CHAR *old);
 void free_pcdata(PC_DATA *pcdata);
-/* mob id and memory procedures */
+/* mob id procedures */
 long get_pc_id(void);
 long get_mob_id(void);
-MEM_DATA *new_mem_data(void);
-void free_pstruct_data(MEM_DATA *memory);
 /* local procedure for finding the next acceptable size */
 /* -1 indicates out-of-boundary error */
 int get_size(int val);

--- a/code/recycle.h
+++ b/code/recycle.h
@@ -38,7 +38,6 @@
 
 /* externals for counting purposes */
 extern DESCRIPTOR_DATA *descriptor_free;
-extern EXTRA_DESCR_DATA	*extra_descr_free;
 extern AFFECT_DATA *affect_free;
 extern OBJ_DATA *obj_free;
 extern CHAR_DATA *char_free;
@@ -84,9 +83,7 @@ void free_track(TRACK_DATA *tracks);
 /* pathfind recycling */
 PATHFIND_DATA *new_path_data(void);
 void free_path(PATHFIND_DATA *path);
-/* extra descr recycling */
-EXTRA_DESCR_DATA *new_extra_descr(void);
-void free_extra_descr(EXTRA_DESCR_DATA *ed);
+/* extra descr — value type owned by parents in std::list; see entity/extra_descr.h */
 /* apply recycling */
 OBJ_APPLY_DATA *new_apply_data(void);
 void free_apply(OBJ_APPLY_DATA *apply);

--- a/code/save.c
+++ b/code/save.c
@@ -243,7 +243,6 @@ void fwrite_char(CHAR_DATA *ch, FILE *fp)
 	int i, j;
 	OBJ_DATA *obj;
 	OBJ_DATA *belt;
-	TROPHY_DATA *placeholder;
 
 	fprintf(fp, "#%s\n", is_npc(ch) ? "MOB" : "PLAYER");
 	fprintf(fp, "Name %s~\n", ch->true_name);
@@ -597,8 +596,8 @@ void fwrite_char(CHAR_DATA *ch, FILE *fp)
 			paf->owner ? paf->owner->name : "none", paf->name ? paf->name : "none");
 	}
 
-	if (ch->pcdata->trophy
-		&& ch->pcdata->trophy->victname
+	if (!ch->pcdata->trophy.empty()
+		&& ch->pcdata->trophy.front().victname
 		&& ch->cabal == CABAL_HORDE
 		&& (belt = get_eq_char(ch, WEAR_WAIST)) != nullptr
 		&& belt->pIndexData->vnum == OBJ_VNUM_TROPHY_BELT
@@ -607,23 +606,22 @@ void fwrite_char(CHAR_DATA *ch, FILE *fp)
 		fprintf(fp, "Trophies ");
 		fprintf(fp, "%d ", belt->value[4]);
 
-		placeholder = ch->pcdata->trophy;
+		auto it = ch->pcdata->trophy.begin();
 
 		for (j = 1; j <= belt->value[4]; j++)
 		{
-			if (!ch->pcdata->trophy)
+			if (it == ch->pcdata->trophy.end())
 				break;
 
-			fprintf(fp, "%s%s", ch->pcdata->trophy->victname, " ");
+			fprintf(fp, "%s%s", it->victname, " ");
 
-			if (!ch->pcdata->trophy->next)
+			if (std::next(it) == ch->pcdata->trophy.end())
 				break;
 
-			ch->pcdata->trophy = ch->pcdata->trophy->next;
+			++it;
 		}
 
 		fprintf(fp, "XYZ\n\r");
-		ch->pcdata->trophy = placeholder;
 	}
 
 	if (ch->pcdata->logon_time)
@@ -1158,7 +1156,6 @@ void fread_char(CHAR_DATA *ch, FILE *fp)
 	int lastlogoff = current_time;
 	int percent;
 	int i, scalps;
-	TROPHY_DATA *placeholder;
 
 	RS.Logger.Info("Loading {}.", ch->name);
 
@@ -1778,21 +1775,23 @@ void fread_char(CHAR_DATA *ch, FILE *fp)
 				if (!str_cmp(word, "Trophies"))
 				{
 					scalps = fread_number(fp);
-					ch->pcdata->trophy = new_trophy_data(fread_word(fp));
-					placeholder = ch->pcdata->trophy;
+					ch->pcdata->trophy.clear();
+					ch->pcdata->trophy.emplace_back(fread_word(fp));
 
 					for (i = 2; i <= scalps; i++)
 					{
-						ch->pcdata->trophy = ch->pcdata->trophy->next = new_trophy_data(fread_word(fp));
+						const char *victname = fread_word(fp);
 
-						if (!str_cmp(ch->pcdata->trophy->victname, "XYZ"))
-						{
-							free_pstring(ch->pcdata->trophy->victname);
+						// "XYZ" is the terminator the save side writes; consume
+						// it but don't add it as a trophy. (The old code created
+						// the node then freed its victname, leaving a dangling
+						// string on the last node.)
+						if (!str_cmp(victname, "XYZ"))
 							break;
-						}
+
+						ch->pcdata->trophy.emplace_back(victname);
 					}
 
-					ch->pcdata->trophy = placeholder;
 					fMatch = true;
 					break;
 				}

--- a/code/save.c
+++ b/code/save.c
@@ -238,7 +238,6 @@ void fread_charmie(CHAR_DATA *ch, FILE *fp)
 
 void fwrite_char(CHAR_DATA *ch, FILE *fp)
 {
-	AFFECT_DATA *paf;
 	int sn, gn, pos;
 	int i, j;
 	OBJ_DATA *obj;
@@ -574,26 +573,26 @@ void fwrite_char(CHAR_DATA *ch, FILE *fp)
 		}
 	}
 
-	for (paf = ch->affected; paf != nullptr; paf = paf->next)
+	for (auto &paf : ch->affected)
 	{
-		if (paf->type < 0 || paf->type >= MAX_SKILL)
+		if (paf.type < 0 || paf.type >= MAX_SKILL)
 			continue;
 
-		if (paf->type == gsn_word_of_command || paf->type == gsn_disguise || paf->type == gsn_indomitable_spirit)
+		if (paf.type == gsn_word_of_command || paf.type == gsn_disguise || paf.type == gsn_indomitable_spirit)
 			continue;
 
-		paf->aftype = isAftSpell(paf->aftype);
+		paf.aftype = isAftSpell(paf.aftype);
 
 		fprintf(fp, "Affc '%s' %3d %3d %3d %3d %3d %s %3d %s '%s'\n",
-			skill_table[paf->type].name,
-			paf->where,
-			paf->level,
-			paf->duration,
-			paf->modifier,
-			paf->location,
-			print_flags(paf->bitvector),
-			paf->aftype,
-			paf->owner ? paf->owner->name : "none", paf->name ? paf->name : "none");
+			skill_table[paf.type].name,
+			paf.where,
+			paf.level,
+			paf.duration,
+			paf.modifier,
+			paf.location,
+			print_flags(paf.bitvector),
+			paf.aftype,
+			paf.owner ? paf.owner->name : "none", paf.name ? paf.name : "none");
 	}
 
 	if (!ch->pcdata->trophy.empty()
@@ -1236,49 +1235,47 @@ void fread_char(CHAR_DATA *ch, FILE *fp)
 
 				if (!str_cmp(word, "Affc"))
 				{
-					AFFECT_DATA *paf;
+					AFFECT_DATA paf;
 					CHAR_DATA *wch;
 					char *owner;
 					char *afname;
 					int sn;
 
-					paf = new_affect();
-					init_affect(paf);
+					init_affect(&paf);
 					sn = skill_lookup(fread_word(fp));
 
 					if (sn < 0)
 						RS.Logger.Warn("Fread_char: unknown skill.");
 					else
-						paf->type = sn;
+						paf.type = sn;
 
-					paf->where = fread_number(fp);
-					paf->level = fread_number(fp);
-					paf->duration = fread_number(fp);
-					paf->modifier = fread_number(fp);
-					paf->location = fread_number(fp);
-					fread_flag_new(paf->bitvector, fp);
-					paf->aftype = fread_number(fp);
+					paf.where = fread_number(fp);
+					paf.level = fread_number(fp);
+					paf.duration = fread_number(fp);
+					paf.modifier = fread_number(fp);
+					paf.location = fread_number(fp);
+					fread_flag_new(paf.bitvector, fp);
+					paf.aftype = fread_number(fp);
 
 					owner = fread_word(fp);
 					for (wch = char_list; wch; wch = wch->next)
 					{
 						if (!str_cmp(wch->name, owner))
 						{
-							paf->owner = wch;
+							paf.owner = wch;
 							break;
 						}
 					}
 
 					if (!str_cmp(ch->name, owner))
-						paf->owner = ch;
+						paf.owner = ch;
 
 					afname = fread_word(fp);
 
 					if (str_cmp(afname, "none"))
-						paf->name = palloc_string(afname);
+						paf.name = palloc_string(afname);
 
-					paf->next = ch->affected;
-					ch->affected = paf;
+					ch->affected.push_front(paf);
 					fMatch = true;
 					break;
 				}
@@ -1891,38 +1888,37 @@ void fread_pet(CHAR_DATA *ch, FILE *fp)
 					CHAR_DATA *wch = nullptr;
 					char *owner;
 					char *afname;
-					AFFECT_DATA *paf;
+					AFFECT_DATA paf;
 					int sn;
 
-					paf = new_affect();
-					init_affect(paf);
+					init_affect(&paf);
 					sn = skill_lookup(fread_word(fp));
 
 					if (sn < 0)
 						RS.Logger.Warn("Fread_char: unknown skill.");
 					else
-						paf->type = sn;
+						paf.type = sn;
 
-					paf->where = fread_number(fp);
-					paf->level = fread_number(fp);
-					paf->duration = fread_number(fp);
-					paf->modifier = fread_number(fp);
-					paf->location = fread_number(fp);
+					paf.where = fread_number(fp);
+					paf.level = fread_number(fp);
+					paf.duration = fread_number(fp);
+					paf.modifier = fread_number(fp);
+					paf.location = fread_number(fp);
 
-					fread_flag_new(paf->bitvector, fp);
+					fread_flag_new(paf.bitvector, fp);
 
-					paf->aftype = fread_number(fp);
+					paf.aftype = fread_number(fp);
 
 					owner = fread_word(fp);
 
 					if (strcmp(owner, "none")) // safe default
-						paf->owner = ch;
+						paf.owner = ch;
 
 					for (wch = char_list; wch; wch = wch->next)
 					{
 						if (!str_cmp(wch->name, owner))
 						{
-							paf->owner = wch;
+							paf.owner = wch;
 							break;
 						}
 					}
@@ -1930,10 +1926,9 @@ void fread_pet(CHAR_DATA *ch, FILE *fp)
 					afname = fread_word(fp);
 
 					if (str_cmp(afname, "none"))
-						paf->name = palloc_string(afname);
+						paf.name = palloc_string(afname);
 
-					paf->next = pet->affected;
-					pet->affected = paf;
+					pet->affected.push_front(paf);
 					fMatch = true;
 					break;
 				}

--- a/code/save.c
+++ b/code/save.c
@@ -755,8 +755,6 @@ void fwrite_pet(CHAR_DATA *pet, FILE *fp)
  */
 void fwrite_obj(CHAR_DATA *ch, OBJ_DATA *obj, FILE *fp, int iNest)
 {
-	OBJ_AFFECT_DATA *paf;
-
 	/*
 	 * Slick recursion to write lists backwards,
 	 *   so loading them will load in forwards order.
@@ -857,23 +855,23 @@ void fwrite_obj(CHAR_DATA *ch, OBJ_DATA *obj, FILE *fp, int iNest)
 			break;
 	}
 
-	for (paf = obj->affected; paf != nullptr; paf = paf->next)
+	for (auto &paf : obj->affected)
 	{
-		if (paf->type < 0 || paf->type >= MAX_SKILL)
+		if (paf.type < 0 || paf.type >= MAX_SKILL)
 			continue;
 
-		paf->aftype = isAftSpell(paf->aftype);
+		paf.aftype = isAftSpell(paf.aftype);
 
 		fprintf(fp, "Affc '%s' %3d %3d %3d %3d %3d %s %d %s\n",
-			skill_table[paf->type].name,
-			paf->where,
-			paf->level,
-			paf->duration,
-			paf->modifier,
-			paf->location,
-			print_flags(paf->bitvector),
-			paf->aftype,
-			paf->owner ? paf->owner->name : "none");
+			skill_table[paf.type].name,
+			paf.where,
+			paf.level,
+			paf.duration,
+			paf.modifier,
+			paf.location,
+			print_flags(paf.bitvector),
+			paf.aftype,
+			paf.owner ? paf.owner->name : "none");
 	}
 
 	// Save only applies the object has beyond its prototype. The list was a
@@ -2114,26 +2112,25 @@ void fread_obj(CHAR_DATA *ch, FILE *fp)
 				{
 					CHAR_DATA *wch;
 					char *owner;
-					OBJ_AFFECT_DATA *paf;
+					OBJ_AFFECT_DATA paf;
 					int sn;
 
-					paf = new_affect_obj();
-					init_affect_obj(paf);
+					init_affect_obj(&paf);
 					sn = skill_lookup(fread_word(fp));
 
 					if (sn < 0)
 						RS.Logger.Warn("Fread_obj: unknown skill.");
 					else
-						paf->type = sn;
+						paf.type = sn;
 
-					paf->where = fread_number(fp);
-					paf->level = fread_number(fp);
-					paf->duration = fread_number(fp);
-					paf->modifier = fread_number(fp);
-					paf->location = fread_number(fp);
+					paf.where = fread_number(fp);
+					paf.level = fread_number(fp);
+					paf.duration = fread_number(fp);
+					paf.modifier = fread_number(fp);
+					paf.location = fread_number(fp);
 
-					fread_flag_new(paf->bitvector, fp);
-					paf->aftype = fread_number(fp);
+					fread_flag_new(paf.bitvector, fp);
+					paf.aftype = fread_number(fp);
 
 					owner = fread_word(fp);
 
@@ -2141,16 +2138,15 @@ void fread_obj(CHAR_DATA *ch, FILE *fp)
 					{
 						if (!str_cmp(wch->name, owner))
 						{
-							paf->owner = wch;
+							paf.owner = wch;
 							break;
 						}
 					}
 
 					if (!str_cmp(ch->name, owner))
-						paf->owner = ch;
+						paf.owner = ch;
 
-					paf->next = obj->affected;
-					obj->affected = paf;
+					obj->affected.push_front(paf);
 					fMatch = true;
 					break;
 				}

--- a/code/save.c
+++ b/code/save.c
@@ -758,7 +758,6 @@ void fwrite_pet(CHAR_DATA *pet, FILE *fp)
 void fwrite_obj(CHAR_DATA *ch, OBJ_DATA *obj, FILE *fp, int iNest)
 {
 	OBJ_AFFECT_DATA *paf;
-	OBJ_APPLY_DATA *oad;
 
 	/*
 	 * Slick recursion to write lists backwards,
@@ -879,18 +878,25 @@ void fwrite_obj(CHAR_DATA *ch, OBJ_DATA *obj, FILE *fp, int iNest)
 			paf->owner ? paf->owner->name : "none");
 	}
 
-	OBJ_APPLY_DATA *ioad;
-
-	for (oad = obj->apply; oad; oad = oad->next)
+	// Save only applies the object has beyond its prototype. The list was a
+	// shared pointer before, so identity told them apart; now obj->apply holds
+	// copies, so we compare by value (index applies have type 0; enchant applies
+	// carry a gsn type, so a private apply never collides with an inherited one).
+	for (const auto &oad : obj->apply)
 	{
-		for (ioad = obj->pIndexData->apply; ioad; ioad = ioad->next)
+		bool inherited = false;
+
+		for (const auto &ioad : obj->pIndexData->apply)
 		{
-			if (ioad == oad)
+			if (ioad.location == oad.location && ioad.modifier == oad.modifier && ioad.type == oad.type)
+			{
+				inherited = true;
 				break;
+			}
 		}
 
-		if (!ioad)
-			fprintf(fp, "AddApp %d %d %d\n", oad->location, oad->modifier, oad->type);
+		if (!inherited)
+			fprintf(fp, "AddApp %d %d %d\n", oad.location, oad.modifier, oad.type);
 	}
 
 	if (!obj->extra_descr.empty())
@@ -2152,12 +2158,11 @@ void fread_obj(CHAR_DATA *ch, FILE *fp)
 
 				if (!str_cmp(word, "AddApp"))
 				{
-					OBJ_APPLY_DATA *oad = new_apply_data();
-					oad->location = fread_number(fp);
-					oad->modifier = fread_number(fp);
-					oad->type = fread_number(fp);
-					oad->next = obj->apply;
-					obj->apply = oad;
+					OBJ_APPLY_DATA oad;
+					oad.location = fread_number(fp);
+					oad.modifier = fread_number(fp);
+					oad.type = fread_number(fp);
+					obj->apply.push_front(oad);
 					fMatch = true;
 					break;
 				}

--- a/code/save.c
+++ b/code/save.c
@@ -757,7 +757,6 @@ void fwrite_pet(CHAR_DATA *pet, FILE *fp)
  */
 void fwrite_obj(CHAR_DATA *ch, OBJ_DATA *obj, FILE *fp, int iNest)
 {
-	EXTRA_DESCR_DATA *ed = nullptr;
 	OBJ_AFFECT_DATA *paf;
 	OBJ_APPLY_DATA *oad;
 
@@ -894,10 +893,12 @@ void fwrite_obj(CHAR_DATA *ch, OBJ_DATA *obj, FILE *fp, int iNest)
 			fprintf(fp, "AddApp %d %d %d\n", oad->location, oad->modifier, oad->type);
 	}
 
-	if ((ed = obj->extra_descr) != nullptr)
+	if (!obj->extra_descr.empty())
 	{
-		if ((!obj->pIndexData->extra_descr) || (str_cmp(ed->keyword, obj->pIndexData->extra_descr->keyword)))
-			fprintf(fp, "ExDe %s~ %s~\n", ed->keyword, ed->description);
+		const EXTRA_DESCR_DATA &ed = obj->extra_descr.front();
+
+		if (obj->pIndexData->extra_descr.empty() || str_cmp(ed.keyword, obj->pIndexData->extra_descr.front().keyword))
+			fprintf(fp, "ExDe %s~ %s~\n", ed.keyword, ed.description);
 	}
 
 	fprintf(fp, "End\n\n");
@@ -2181,20 +2182,16 @@ void fread_obj(CHAR_DATA *ch, FILE *fp)
 
 				if (!str_cmp(word, "ExtraDescr") || !str_cmp(word, "ExDe"))
 				{
-					EXTRA_DESCR_DATA *ed = new_extra_descr();
+					EXTRA_DESCR_DATA ed;
 
-					ed->keyword = fread_string(fp);
+					ed.keyword = fread_string(fp);
 
-					/* Don't repeat extra descriptions... */
-					if ((obj->extra_descr != nullptr) && !str_cmp(ed->keyword, obj->extra_descr->keyword))
+					/* Don't repeat extra descriptions; a duplicate of the head descr is
+					   dropped when ed goes out of scope (its dtor frees the keyword). */
+					if (obj->extra_descr.empty() || str_cmp(ed.keyword, obj->extra_descr.front().keyword))
 					{
-						free_extra_descr(ed);
-					}
-					else
-					{
-						ed->description = fread_string(fp);
-						ed->next = obj->extra_descr;
-						obj->extra_descr = ed;
+						ed.description = fread_string(fp);
+						obj->extra_descr.insert(obj->extra_descr.begin(), std::move(ed));
 					}
 
 					fMatch = true;

--- a/code/skills.c
+++ b/code/skills.c
@@ -120,7 +120,7 @@ void do_gain(CHAR_DATA *ch, char *argument)
 
 void do_spells(CHAR_DATA *ch, char *argument)
 {
-	BUFFER *buffer;
+	BUFFER buffer;
 	char arg[MAX_INPUT_LENGTH];
 	char spell_list[LEVEL_HERO + 1][MAX_STRING_LENGTH];
 	char spell_columns[LEVEL_HERO + 1];
@@ -243,22 +243,19 @@ void do_spells(CHAR_DATA *ch, char *argument)
 		return;
 	}
 
-	buffer = new_buf();
-
 	for (level = 0; level < LEVEL_HERO + 1; level++)
 	{
 		if (spell_list[level][0] != '\0')
-			add_buf(buffer, spell_list[level]);
+			buffer.add(spell_list[level]);
 	}
 
-	add_buf(buffer, "\n\r");
-	page_to_char(buf_string(buffer), ch);
-	free_buf(buffer);
+	buffer.add("\n\r");
+	page_to_char(buffer.str(), ch);
 }
 
 void do_skills(CHAR_DATA *ch, char *argument)
 {
-	BUFFER *buffer;
+	BUFFER buffer;
 	char arg[MAX_INPUT_LENGTH];
 	char skill_list[LEVEL_HERO + 1][MAX_STRING_LENGTH];
 	char skill_columns[LEVEL_HERO + 1];
@@ -437,17 +434,14 @@ void do_skills(CHAR_DATA *ch, char *argument)
 		return;
 	}
 
-	buffer = new_buf();
-
 	for (level = 0; level < LEVEL_HERO + 1; level++)
 	{
 		if (skill_list[level][0] != '\0')
-			add_buf(buffer, skill_list[level]);
+			buffer.add(skill_list[level]);
 	}
 
-	add_buf(buffer, "\n\r");
-	page_to_char(buf_string(buffer), ch);
-	free_buf(buffer);
+	buffer.add("\n\r");
+	page_to_char(buffer.str(), ch);
 }
 
 /* shows skills, groups and costs (only if not bought) */

--- a/code/update.c
+++ b/code/update.c
@@ -1469,7 +1469,6 @@ void obj_update(void)
 {
 	OBJ_DATA *obj;
 	OBJ_DATA *obj_next;
-	OBJ_AFFECT_DATA *paf, *paf_next;
 	CHAR_DATA *owner, *cguard;
 
 	for (obj = object_list; obj != nullptr; obj = obj_next)
@@ -1496,13 +1495,20 @@ void obj_update(void)
 		}
 
 		/* go through affects and decrement */
-		for (paf = obj->affected; paf != nullptr; paf = paf_next)
+		for (auto it = obj->affected.begin(); it != obj->affected.end(); )
 		{
-			paf_next = paf->next;
+			auto next = std::next(it);
+			OBJ_AFFECT_DATA *paf = &*it;
 
 			if (paf->duration != 0)
 				if (paf->tick_fun)
 					(*paf->tick_fun)(obj, paf);
+
+			/* A tick can extract (free) the object — e.g. a spent crystal
+			 * crumbling to dust — which clears its affect list. Stop before
+			 * touching the now-invalidated iterator. */
+			if (!obj->valid)
+				break;
 
 			if (paf->duration > 0)
 			{
@@ -1513,12 +1519,15 @@ void obj_update(void)
 			}
 			else if (paf->duration < 0)
 			{
+				it = next;
 				continue;
 			}
 			else
 			{
 				affect_remove_obj(obj, paf, true);
 			}
+
+			it = next;
 		}
 
 		/* crumbling stuff */
@@ -2278,7 +2287,6 @@ void affect_update(void)
 	ROOM_INDEX_DATA *room;
 	AREA_DATA *area;
 	AFFECT_DATA *paf, *paf_next;
-	OBJ_AFFECT_DATA *oaf, *oaf_next;
 
 	for (ch = char_list; ch; ch = ch_next)
 	{
@@ -2312,12 +2320,14 @@ void affect_update(void)
 	{
 		obj_next = obj->next;
 
-		for (oaf = obj->affected; oaf; oaf = oaf_next)
+		for (auto it = obj->affected.begin(); it != obj->affected.end(); )
 		{
-			oaf_next = oaf->next;
+			auto next = std::next(it);
 
-			if (oaf->pulse_fun)
-				(*oaf->pulse_fun)(obj, oaf);
+			if (it->pulse_fun)
+				(*it->pulse_fun)(obj, &*it);
+
+			it = next;
 		}
 	}
 

--- a/code/update.c
+++ b/code/update.c
@@ -1168,8 +1168,6 @@ void char_update(void)
 	for (ch = char_list; ch != nullptr; ch = ch_next)
 	{
 		CHAR_DATA *master;
-		AFFECT_DATA *paf;
-		AFFECT_DATA *paf_next;
 		bool charm_gone;
 
 		ch_next = ch->next;
@@ -1351,9 +1349,11 @@ void char_update(void)
 		}
 		else
 		{
-			for (paf = ch->affected; paf != nullptr; paf = paf_next)
+			for (auto it = ch->affected.begin(); it != ch->affected.end(); )
 			{
-				paf_next = paf->next;
+				auto next = std::next(it);
+				AFFECT_DATA *paf = &*it;
+				AFFECT_DATA *paf_next = (next != ch->affected.end()) ? &*next : nullptr;
 				charm_gone= false;
 
 				if (!ghost && ch->ghost > 0)
@@ -1364,11 +1364,16 @@ void char_update(void)
 					if (paf->tick_fun)
 						(*paf->tick_fun)(ch, paf);
 
-					if (!ch || (!ghost && ch->ghost > 0))
+					/* A tick can extract (free) the character, clearing its
+					 * affect list; stop before touching the stale iterator. */
+					if (!ch->valid || (!ghost && ch->ghost > 0))
 						break;
 
 					if (!paf)
+					{
+						it = next;
 						continue;
+					}
 
 					paf->duration--;
 
@@ -1380,7 +1385,7 @@ void char_update(void)
 					if (paf->tick_fun)
 						(*paf->tick_fun)(ch, paf);
 
-					if (!ghost && ch->ghost > 0)
+					if (!ch->valid || (!ghost && ch->ghost > 0))
 						break;
 				}
 				else if (paf->type == gsn_entwine
@@ -1411,6 +1416,7 @@ void char_update(void)
 
 							paf->duration = paf->init_duration;
 							ch->mana = std::max(ch->mana - skill_table[paf->type].min_mana, 0);
+							it = next;
 							continue;
 						}
 					}
@@ -1428,6 +1434,8 @@ void char_update(void)
 					}
 					affect_remove(ch, paf);
 				}
+
+				it = next;
 			}
 		}
 
@@ -1793,7 +1801,6 @@ void aggr_update(void)
 	CHAR_DATA *vch;
 	CHAR_DATA *vch_next;
 	CHAR_DATA *victim;
-	AFFECT_DATA *paf;
 	int timer;
 	char buf[MAX_STRING_LENGTH];
 
@@ -1810,10 +1817,12 @@ void aggr_update(void)
 		if (is_npc(wch) && IS_SET(wch->progtypes, MPROG_BEAT))
 			(wch->pIndexData->mprogs->beat_prog)(wch);
 
-		for (paf = wch->affected; paf; paf = paf->next)
+		for (auto it = wch->affected.begin(); it != wch->affected.end(); )
 		{
-			if (paf->beat_fun)
-				(*paf->beat_fun)(wch, paf);
+			auto next = std::next(it);
+			if (it->beat_fun)
+				(*it->beat_fun)(wch, &*it);
+			it = next;
 		}
 
 		if ((!is_npc(wch) && wch->pulseTimer <= pc_race_table[wch->race].racePulse)
@@ -1922,14 +1931,17 @@ void aggr_update(void)
 			&& !wch->fighting
 			&& !(wch->desc == nullptr && !is_npc(wch)))
 		{
-			paf = affect_find(wch->affected, gsn_mark_of_wrath);
+			AFFECT_DATA *paf = affect_find(wch->affected, gsn_mark_of_wrath);
 
 			for (vch = wch->in_room->people; vch; vch = vch_next)
 			{
 				vch_next = vch->next_in_room;
 
 				if (paf->owner->ghost > 0)
+				{
 					affect_remove(wch, paf);
+					break;		// paf is gone; nothing further reads the mark
+				}
 
 				if (wch == vch || !can_see(wch, vch))
 					continue;
@@ -2286,7 +2298,6 @@ void affect_update(void)
 	OBJ_DATA *obj, *obj_next;
 	ROOM_INDEX_DATA *room;
 	AREA_DATA *area;
-	AFFECT_DATA *paf, *paf_next;
 
 	for (ch = char_list; ch; ch = ch_next)
 	{
@@ -2307,12 +2318,14 @@ void affect_update(void)
 			RS.Logger.Info(buf);
 		}
 
-		for (paf = ch->affected; paf; paf = paf_next)
+		for (auto it = ch->affected.begin(); it != ch->affected.end(); )
 		{
-			paf_next = paf->next;
+			auto next = std::next(it);
 
-			if (paf->pulse_fun)
-				(*paf->pulse_fun)(ch, paf);
+			if (it->pulse_fun)
+				(*it->pulse_fun)(ch, &*it);
+
+			it = next;
 		}
 	}
 
@@ -2682,10 +2695,14 @@ void room_affect_update(void)
 							new_affect_to_char(vch, &cvaf);
 						}
 
-						for (paf = vch->affected; paf != nullptr; paf = paf->next)
+						paf = nullptr;
+						for (auto &paf_elem : vch->affected)
 						{
-							if (paf->type == gsn_noxious_fumes)
+							if (paf_elem.type == gsn_noxious_fumes)
+							{
+								paf = &paf_elem;
 								break;
+							}
 						}
 
 						paf->modifier = URANGE(0, paf->modifier, 5);

--- a/code/update.c
+++ b/code/update.c
@@ -2278,7 +2278,6 @@ void affect_update(void)
 	ROOM_INDEX_DATA *room;
 	AREA_DATA *area;
 	AFFECT_DATA *paf, *paf_next;
-	ROOM_AFFECT_DATA *raf, *raf_next;
 	OBJ_AFFECT_DATA *oaf, *oaf_next;
 
 	for (ch = char_list; ch; ch = ch_next)
@@ -2324,12 +2323,14 @@ void affect_update(void)
 
 	for (room = top_affected_room; room; room = room->aff_next)
 	{
-		for (raf = room->affected; raf; raf = raf_next)
+		for (auto it = room->affected.begin(); it != room->affected.end(); )
 		{
-			raf_next = raf->next;
+			auto next = std::next(it);
 
-			if (raf->pulse_fun)
-				(*raf->pulse_fun)(room, raf);
+			if (it->pulse_fun)
+				(*it->pulse_fun)(room, &*it);
+
+			it = next;
 		}
 
 		if (IS_SET(room->progtypes, RPROG_PULSE))
@@ -2360,26 +2361,25 @@ void room_update(void)
 
 	for (room = top_affected_room; room; room = room_next)
 	{
-		ROOM_AFFECT_DATA *paf;
-		ROOM_AFFECT_DATA *paf_next;
-
 		room_next = room->aff_next;
 
-		for (paf = room->affected; paf != nullptr; paf = paf_next)
+		for (auto it = room->affected.begin(); it != room->affected.end(); )
 		{
-			paf_next = paf->next;
+			auto next = std::next(it);
 
-			if (paf->duration != 0)
+			if (it->duration != 0)
 			{
-				if (paf->tick_fun)
-					(*paf->tick_fun)(room, paf);
+				if (it->tick_fun)
+					(*it->tick_fun)(room, &*it);
 			}
 
-			if (paf->duration > 0)
-				paf->duration--;
-			else if (paf->duration < 0); //TODO: possible logic error
+			if (it->duration > 0)
+				it->duration--;
+			else if (it->duration < 0); //TODO: possible logic error
 			else
-				affect_remove_room(room, paf);
+				affect_remove_room(room, &*it);
+
+			it = next;
 		}
 	}
 }
@@ -2405,11 +2405,7 @@ void room_affect_update(void)
 			OBJ_DATA *well;
 			char *dirname;
 
-			for (af = room->affected; af != nullptr; af = af->next)
-			{
-				if (af->type == gsn_gravity_well)
-					break;
-			}
+			af = affect_find_room(room->affected, gsn_gravity_well);
 
 			for (well = object_list; well != nullptr; well = well->next)
 			{
@@ -2483,11 +2479,7 @@ void room_affect_update(void)
 
 		if (is_affected_room(room, gsn_vacuum))
 		{
-			for (af = room->affected; af != nullptr; af = af->next)
-			{
-				if (af->type == gsn_vacuum)
-					break;
-			}
+			af = affect_find_room(room->affected, gsn_vacuum);
 
 			af->modifier++;
 
@@ -2523,11 +2515,7 @@ void room_affect_update(void)
 
 		if (is_affected_room(room, gsn_earthquake))
 		{
-			for (af = room->affected; af != nullptr; af = af->next)
-			{
-				if (af->type == gsn_earthquake)
-					break;
-			}
+			af = affect_find_room(room->affected, gsn_earthquake);
 
 			if (number_range(1, 4) == 1)
 			{
@@ -2553,10 +2541,14 @@ void room_affect_update(void)
 
 		if (is_affected_room(room, gsn_tidalwave))
 		{
-			for (af = room->affected; af != nullptr; af = af->next)
+			af = nullptr;
+			for (auto &r : room->affected)
 			{
-				if (af->type == gsn_tidalwave && af->location == APPLY_ROOM_NONE)
+				if (r.type == gsn_tidalwave && r.location == APPLY_ROOM_NONE)
+				{
+					af = &r;
 					break;
+				}
 			}
 
 			if (af->modifier == 1)
@@ -2573,10 +2565,14 @@ void room_affect_update(void)
 			}
 			else if (af->modifier == 0)
 			{
-				for (af2 = room->affected; af2 != nullptr; af2 = af2->next)
+				af2 = nullptr;
+				for (auto &r : room->affected)
 				{
-					if (af2->type == gsn_tidalwave && af2->location == APPLY_ROOM_NOPE)
+					if (r.type == gsn_tidalwave && r.location == APPLY_ROOM_NOPE)
+					{
+						af2 = &r;
 						break;
+					}
 				}
 
 				for (vch = room->people; vch != nullptr; vch = vch->next_in_room)
@@ -2655,11 +2651,7 @@ void room_affect_update(void)
 				{
 					v_next = vch->next_in_room;
 
-					for (af = vch->in_room->affected; af != nullptr; af = af->next)
-					{
-						if (af->type == gsn_caustic_vapor)
-							break;
-					}
+					af = affect_find_room(vch->in_room->affected, gsn_caustic_vapor);
 
 					if (is_immortal(vch))
 						continue;

--- a/code/update.c
+++ b/code/update.c
@@ -2280,7 +2280,6 @@ void affect_update(void)
 	AFFECT_DATA *paf, *paf_next;
 	ROOM_AFFECT_DATA *raf, *raf_next;
 	OBJ_AFFECT_DATA *oaf, *oaf_next;
-	AREA_AFFECT_DATA *aaf, *aaf_next;
 
 	for (ch = char_list; ch; ch = ch_next)
 	{
@@ -2339,12 +2338,14 @@ void affect_update(void)
 
 	for (area = area_first; area; area = area->next)
 	{
-		for (aaf = area->affected; aaf; aaf = aaf_next)
+		for (auto it = area->affected.begin(); it != area->affected.end(); )
 		{
-			aaf_next = aaf->next;
+			auto next = std::next(it);
 
-			if (aaf->pulse_fun)
-				(*aaf->pulse_fun)(area, aaf);
+			if (it->pulse_fun)
+				(*it->pulse_fun)(area, &*it);
+
+			it = next;
 		}
 
 		if (IS_SET(area->progtypes, APROG_PULSE))
@@ -2746,11 +2747,7 @@ void room_affect_update(void)
 
 		if (is_affected_area(room->area, gsn_cyclone))
 		{
-			for (aaf = room->area->affected; aaf; aaf = aaf->next)
-			{
-				if (aaf->type == gsn_cyclone)
-					break;
-			}
+			aaf = affect_find_area(room->area->affected, gsn_cyclone);
 
 			for (obj = room->contents; obj != nullptr; obj = obj->next_content)
 			{

--- a/tests/act_obj_tests.c
+++ b/tests/act_obj_tests.c
@@ -71,7 +71,7 @@ char_data* TestHelperCreatePlayer(char *name, obj_data *item = nullptr)
 	auto player = new char_data();
 	player->name = name;
 	auto dnew = new descriptor_data();
-	player->pcdata = new pc_data();
+	player->pcdata = std::make_unique<pc_data>();
 	TestHelperLoadCClass();
 	player->SetClass(5);
 	player->level = 51;

--- a/tests/cabal_tests.c
+++ b/tests/cabal_tests.c
@@ -9,7 +9,7 @@
 char_data* TestHelperCreatePlayer(char *name = "player 1")
 {
 	auto player = new char_data();
-	player->pcdata = new pc_data();
+	player->pcdata = std::make_unique<pc_data>();
 	player->name = name;
 	auto dnew = new descriptor_data();
 	dnew->showstr_head = nullptr;

--- a/tests/handler_tests.c
+++ b/tests/handler_tests.c
@@ -602,3 +602,139 @@ SCENARIO("Testing deduct gold cost from character","[deduct_cost]")
 		}
 	}
 }
+
+// Characterization tests for the char-affect list handlers (affect_to_char,
+// affect_remove, affect_strip). These pin the observable add/find/remove/strip
+// contract via the stable API (is_affected / affect_find) so it is provably
+// preserved when ch->affected changes container.
+SCENARIO("affect_to_char adds a char affect", "[affect_to_char]")
+{
+	GIVEN("a fresh character")
+	{
+		auto ch = new char_data();
+		ch->name = "tester";
+
+		WHEN("an affect is given to the character")
+		{
+			AFFECT_DATA af;
+			init_affect(&af);
+			af.type = 100;
+			af.where = TO_AFFECTS;
+			af.level = 7;
+			af.duration = 5;
+			af.modifier = 3;
+			affect_to_char(ch, &af);
+
+			THEN("the character reports being affected by it")
+			{
+				REQUIRE(is_affected(ch, 100) == true);
+				REQUIRE(is_affected(ch, 999) == false);
+			}
+
+			THEN("the stored affect carries the same fields")
+			{
+				AFFECT_DATA *found = affect_find(ch->affected, 100);
+				REQUIRE(found != nullptr);
+				REQUIRE(found->level == 7);
+				REQUIRE(found->duration == 5);
+				REQUIRE(found->modifier == 3);
+			}
+
+			THEN("init_duration is seeded from duration")
+			{
+				AFFECT_DATA *found = affect_find(ch->affected, 100);
+				REQUIRE(found != nullptr);
+				REQUIRE(found->init_duration == 5);
+			}
+		}
+	}
+}
+
+SCENARIO("affect_remove removes a char affect", "[affect_remove]")
+{
+	GIVEN("a character with a single affect")
+	{
+		auto ch = new char_data();
+		ch->name = "tester";
+
+		AFFECT_DATA af;
+		init_affect(&af);
+		af.type = 100;
+		af.where = TO_AFFECTS;
+		af.duration = 5;
+		affect_to_char(ch, &af);
+
+		WHEN("that affect is removed")
+		{
+			affect_remove(ch, affect_find(ch->affected, 100));
+
+			THEN("the character is no longer affected")
+			{
+				REQUIRE(is_affected(ch, 100) == false);
+				REQUIRE(affect_find(ch->affected, 100) == nullptr);
+			}
+		}
+	}
+}
+
+SCENARIO("removing one of several char affects preserves the rest", "[affect_remove]")
+{
+	GIVEN("a character with three distinct affects")
+	{
+		auto ch = new char_data();
+		ch->name = "tester";
+
+		for (int type : {100, 101, 102})
+		{
+			AFFECT_DATA af;
+			init_affect(&af);
+			af.type = type;
+			af.where = TO_AFFECTS;
+			af.duration = 5;
+			affect_to_char(ch, &af);
+		}
+
+		WHEN("the middle-added affect is removed")
+		{
+			affect_remove(ch, affect_find(ch->affected, 101));
+
+			THEN("only that affect is gone")
+			{
+				REQUIRE(is_affected(ch, 100) == true);
+				REQUIRE(is_affected(ch, 101) == false);
+				REQUIRE(is_affected(ch, 102) == true);
+			}
+		}
+	}
+}
+
+SCENARIO("affect_strip removes all affects of a type but leaves others", "[affect_strip]")
+{
+	GIVEN("a character affected twice by one type and once by another")
+	{
+		auto ch = new char_data();
+		ch->name = "tester";
+
+		for (int type : {100, 100, 101})
+		{
+			AFFECT_DATA af;
+			init_affect(&af);
+			af.type = type;
+			af.where = TO_AFFECTS;
+			af.duration = 5;
+			affect_to_char(ch, &af);
+		}
+
+		WHEN("that type is stripped")
+		{
+			affect_strip(ch, 100);
+
+			THEN("every instance of it is gone and the other type remains")
+			{
+				REQUIRE(is_affected(ch, 100) == false);
+				REQUIRE(affect_find(ch->affected, 100) == nullptr);
+				REQUIRE(is_affected(ch, 101) == true);
+			}
+		}
+	}
+}

--- a/tests/prof_tests.c
+++ b/tests/prof_tests.c
@@ -1255,7 +1255,7 @@ SCENARIO("testing interpreting proficiency commands", "[InterpCommand]")
 		{
 			auto player = new char_data();
 			player->name = "player1";
-			player->pcdata = new pc_data();
+			player->pcdata = std::make_unique<pc_data>();
 
 			player->Profs()->SetChar(player);
 
@@ -1276,7 +1276,7 @@ SCENARIO("testing interpreting proficiency commands", "[InterpCommand]")
 		{
 			auto player = new char_data();
 			player->name = "player1";
-			player->pcdata = new pc_data();
+			player->pcdata = std::make_unique<pc_data>();
 
 			player->Profs()->SetChar(player);
 
@@ -1294,7 +1294,7 @@ SCENARIO("testing interpreting proficiency commands", "[InterpCommand]")
 		{
 			auto player = new char_data();
 			player->name = "player1";
-			player->pcdata = new pc_data();
+			player->pcdata = std::make_unique<pc_data>();
 			player->in_room = new room_index_data();
 			player->in_room->sector_type = SECT_WATER;
 

--- a/tests/test_helpers.c
+++ b/tests/test_helpers.c
@@ -4,7 +4,7 @@
 void TestHelperSetupPlayerBuffer(CHAR_DATA *player, char *name = "player1", char *room_name = "room1")
 {
 	player->name = name;
-	player->pcdata = new pc_data();
+	player->pcdata = std::make_unique<pc_data>();
 	player->desc = new descriptor_data();
 	player->desc->outbuf = new char[2];
 	player->desc->outtop = 0;
@@ -39,8 +39,7 @@ void TestHelperCleanupPlayerObject(CHAR_DATA *player)
 		delete player->pIndexData;
 	}
 
-	if (player->pcdata != nullptr)
-		delete player->pcdata;
+	player->pcdata.reset();
 
 	if (player->in_room != nullptr)
 		delete player->in_room;

--- a/tests/utility_tests.c
+++ b/tests/utility_tests.c
@@ -741,7 +741,7 @@ SCENARIO("checking if a player character is ethicallly lawful", "[is_lawful]")
 		WHEN("is_lawful is called")
 		{
 			auto pc = new char_data();
-			pc->pcdata = new PC_DATA();
+			pc->pcdata = std::make_unique<pc_data>();
 			pc->pcdata->ethos = 1000;
 			auto isLawful = is_lawful(pc);
 
@@ -757,7 +757,7 @@ SCENARIO("checking if a player character is ethicallly lawful", "[is_lawful]")
 		WHEN("is_lawful is called")
 		{
 			auto pc = new char_data();
-			pc->pcdata = new PC_DATA();
+			pc->pcdata = std::make_unique<pc_data>();
 			pc->pcdata->ethos = 0;
 			auto isLawful = is_lawful(pc);
 
@@ -789,7 +789,7 @@ SCENARIO("checking if a player character is ethicallly chaotic", "[is_chaotic]")
 		WHEN("is_chaotic is called")
 		{
 			auto pc = new char_data();
-			pc->pcdata = new PC_DATA();
+			pc->pcdata = std::make_unique<pc_data>();
 			pc->pcdata->ethos = -1000;
 			auto isChaotic = is_chaotic(pc);
 
@@ -805,7 +805,7 @@ SCENARIO("checking if a player character is ethicallly chaotic", "[is_chaotic]")
 		WHEN("is_chaotic is called")
 		{
 			auto pc = new char_data();
-			pc->pcdata = new PC_DATA();
+			pc->pcdata = std::make_unique<pc_data>();
 			pc->pcdata->ethos = 0;
 			auto isChaotic = is_chaotic(pc);
 
@@ -837,7 +837,7 @@ SCENARIO("checking if a player character is ethicallly neutral", "[is_eneutral]"
 		WHEN("is_eneutral is called")
 		{
 			auto pc = new char_data();
-			pc->pcdata = new PC_DATA();
+			pc->pcdata = std::make_unique<pc_data>();
 			pc->pcdata->ethos = 0;
 			auto isNeutral = is_eneutral(pc);
 
@@ -853,7 +853,7 @@ SCENARIO("checking if a player character is ethicallly neutral", "[is_eneutral]"
 		WHEN("is_neutral is called")
 		{
 			auto pc = new char_data();
-			pc->pcdata = new PC_DATA();
+			pc->pcdata = std::make_unique<pc_data>();
 			pc->pcdata->ethos = 1000;
 			auto isNeutral = is_eneutral(pc);
 


### PR DESCRIPTION
This PR refactors several struct/classes to use RAII for automatic memory menagement. RAII constructs / destructsobjects automatically so no bookkeeping methods are needed.

In converting objects to use RAII, I found several use after free and undefined behavior bugs in the code. These bugs were the result of misusing C style linked lists. Those linked lists are converted to modern data structures in the PR.

