### PR TITLE
Fix for mob load bug

### DIFF
--- a/code/bit.c
+++ b/code/bit.c
@@ -174,13 +174,14 @@ char *style_string(const struct style_type *style_table, long bits[])
 
 	buf[0] = '\0';
 
-	for (flag = 0; flag < MAX_STYLE; flag++)
+	// Entry 0 is the STYLE_NONE sentinel of -1, which IS_SET cannot shift by,
+	// so start at the first real style. Every entry appended is therefore
+	// space-prefixed, and the leading space is trimmed by the return below.
+	for (flag = 1; flag < MAX_STYLE; flag++)
 	{
 		if (IS_SET(bits, style_table[flag].bit))
 		{
-			if (flag > 0)
-				strcat(buf, " ");
-
+			strcat(buf, " ");
 			strcat(buf, style_table[flag].name);
 		}
 	}

--- a/code/db2.c
+++ b/code/db2.c
@@ -608,12 +608,17 @@ void load_mobs(FILE *fp)
 				pMobIndex->SetClass(CClass::Lookup(bword));
 				if (pMobIndex->Class()->GetIndex() == CLASS_WARRIOR)
 				{
-					long bit;
+					// Warriors always carry two style words; unspecialized slots are
+					// written as "none". style_lookup returns 0 for those (and for any
+					// unrecognized word), and style_table[0].bit is the STYLE_NONE
+					// sentinel of -1, which SET_BIT cannot shift by. Skip those slots.
+					for (int i = 0; i < 2; i++)
+					{
+						int style = style_lookup(fread_word(fp));
 
-					bit = style_table[style_lookup(fread_word(fp))].bit;
-					SET_BIT(pMobIndex->styles, bit);
-					bit = style_table[style_lookup(fread_word(fp))].bit;
-					SET_BIT(pMobIndex->styles, bit);
+						if (style != 0)
+							SET_BIT(pMobIndex->styles, style_table[style].bit);
+					}
 				}
 				else if (pMobIndex->Class()->GetIndex() == CLASS_SORCERER)
 				{


### PR DESCRIPTION
This PR fixes a bug exposed in the smoke test related to mob loading. The bug is exposed by the line

```
CLASS warrior none none
```

The logic in the loading of mobs was trying to bit shift a -1 sentinel value `STYLE_NONE` which caused the smoke test to trip.