### PR TITLE
Fix bugs centered around creating new characters.

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -139,3 +139,28 @@ jobs:
           RIFT_BIN: ${{ github.workspace }}/build-asan/code/rift
           ASAN_OPTIONS: detect_leaks=0:detect_odr_violation=0
           UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=1
+
+      # Goes past the greeting: creates a character, keeps it in the world while
+      # the game ticks, then logs it out again.
+      - name: Smoke test (new player, under ASAN)
+        run: tests/smoke/new_player_test.sh
+        env:
+          RIFT_BIN: ${{ github.workspace }}/build-asan/code/rift
+          RIFT_SMOKE_BOOT_TIMEOUT: 240
+          ASAN_OPTIONS: detect_leaks=0:detect_odr_violation=0
+          UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=1
+
+      # And again unsanitized. Not redundant: the heap overrun that motivated
+      # this test was invisible to ASAN. free_obj recycles onto a free list
+      # rather than returning memory, so there was nothing for ASAN to poison
+      # and announced itself only as a glibc allocator abort in a plain build.
+      - name: Configure (unsanitized)
+        run: cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Debug
+
+      - name: Build (unsanitized)
+        run: cmake --build build
+
+      - name: Smoke test (new player, unsanitized)
+        run: tests/smoke/new_player_test.sh
+        env:
+          RIFT_BIN: ${{ github.workspace }}/build/code/rift

--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,7 @@ bld/
 [Ll]og/
 [Ll]ogs/
 
+
+# Python bytecode (tests/smoke helpers)
+__pycache__/
+*.pyc

--- a/code/comm.c
+++ b/code/comm.c
@@ -496,7 +496,12 @@ void init_descriptor(int control)
 
 		addr = ntohl(sock.sin_addr.s_addr);
 
-		RS.Logger.Info("Sock.sinaddr:  {}.{}.{}.{}", (addr >> 24) & 0xFF, (addr >> 16) & 0xFF, (addr >> 8) & 0xFF, (addr)&0xFF);
+		// buf is both the subject of the banned-range check below and the host
+		// string used when the reverse lookup fails, so it has to be built here
+		// rather than formatted straight into the log line.
+		sprintf(buf, "%d.%d.%d.%d", (addr >> 24) & 0xFF, (addr >> 16) & 0xFF, (addr >> 8) & 0xFF, (addr)&0xFF);
+
+		RS.Logger.Info("Sock.sinaddr:  {}", buf);
 
 		if (strstr(buf, "204.82.56."))
 		{
@@ -1173,6 +1178,11 @@ void bust_a_prompt(CHAR_DATA *ch)
 			++point, ++i;
 		}
 	}
+
+	// The literal-character branch above advances point without terminating, so a
+	// prompt that does not end in a % substitution leaves buf unterminated. We
+	// therefore need to terminate it here so we avoid stack garabage.
+	*point = '\0';
 
 	write_to_buffer(ch->desc, buf, point - buf);
 	//   free_pstring(orig);

--- a/docs/area-file-format.md
+++ b/docs/area-file-format.md
@@ -1,0 +1,472 @@
+# Riftshadow Area File (`.are`) Format
+
+This document describes the on-disk format of area files (`area/*.are`) — the files that
+define the game world: mobiles, objects, rooms, resets, programs, and specials. It is a
+reference for builders and developers debugging world data.
+
+Everything here is derived directly from the loaders and the OLC writer; line references
+point at the authoritative implementation:
+
+- **Section dispatcher:** `boot_db` loop, [mud.c:395](../code/mud.c#L395)
+- **Loaders:** [db.c](../code/db.c) and [db2.c](../code/db2.c)
+- **Writer (the canonical spec for the write format):** `save_area()`, [olc_save.c:929](../code/olc_save.c#L929)
+- **Parsing primitives & flag decode:** [db.c:2573-2763](../code/db.c#L2573)
+
+Reference samples: [area/academy.are](../area/academy.are), [area/area0.are](../area/area0.are).
+The master list of areas to load is `area/area.lst`.
+
+> **Naming note:** Riftshadow's section keywords differ from stock ROM/DikuMUD. It uses
+> `#MOBS`/`#OBJS` (not `#MOBILES`/`#OBJECTS`), adds `#IMPROGS`/`#SPECS`, and splits resets
+> into `#RESETS` (keyword form) vs `#OLDRESETS` (numeric form). See §12 for the full list
+> of deviations.
+
+---
+
+## 1. Overall structure
+
+An area file is a flat sequence of `#`-prefixed sections. The boot loop
+([mud.c:399](../code/mud.c#L399)) reads a `#`, then a section keyword, and dispatches. It
+loops until it reads a keyword starting with `$` (`#$`, end of file).
+
+```
+#AREA          (or #AREADATA)   ← header; exactly one, first
+#MOBS   ... #0
+#OBJS   ... #0
+#ROOMS  ... #0
+#RESETS ... S                   (or #OLDRESETS ... S)
+#IMPROGS ... END
+#SPECS  ... END
+#$                              ← end-of-file marker
+```
+
+Section keyword → loader ([mud.c:407-416](../code/mud.c#L407)):
+
+| Keyword    | Loader           | Notes |
+|------------|------------------|-------|
+| `#AREA`    | `load_area`      | Positional header (current). |
+| `#AREADATA`| `new_load_area`  | Keyed header (legacy/OLC alternate). |
+| `#MOBS`    | `load_mobs`      | Mobile prototypes. |
+| `#OBJS`    | `load_objs`      | Object prototypes. |
+| `#ROOMS`   | `load_rooms`     | Rooms + exits. |
+| `#RESETS`  | `load_newresets` | Keyword-argument reset form (current). |
+| `#OLDRESETS`| `load_resets`   | Numeric-argument reset form (legacy). |
+| `#IMPROGS` | `load_improgs`   | Mob/obj/room/area program bindings. |
+| `#SPECS`   | `load_specs`     | Hardcoded C spec-function bindings. |
+| `#SOCIALS` | `load_socials`   | Only in `social.are`. |
+| `#$`       | breaks loop      | End of file. |
+
+The write order (`save_area`, [olc_save.c:958](../code/olc_save.c#L958)) is: MOBS, OBJS,
+ROOMS, RESETS, IMPROGS, SPECS. There is **no** `#SHOPS`, `#SPECIALS`, `#HELPS`, or
+`#MOBPROGS` section — shops are inline in mob records, and mob/obj/room programs live in
+`#IMPROGS`. An unknown section produces a "Boot_db: bad section name" warning.
+
+---
+
+## 2. Parsing primitives (how fields are tokenized)
+
+Defined in [db.c:2573-2958](../code/db.c#L2573):
+
+- `fread_letter` — skip whitespace, return one char.
+- `fread_number` — skip ws, optional `+`/`-`, digits. A trailing `|` means "OR with the
+  next number". Saturates at `INT_MAX`; a malformed number is fatal (`exit(1)`).
+- `fread_word` — skip ws; if the first char is `'` or `"`, read until the matching quote
+  (spaces allowed inside, e.g. `'detect invis'`); otherwise read until whitespace.
+- `fread_string` — skip leading ws, read until a `~`. Converts `\n`→`\n\r`, drops bare
+  `\r`. An immediate `~` yields the empty string. **The `~` terminates every descriptive
+  string.**
+- `fread_string_eol` — read until end-of-line (no `~`); used by socials.
+- `fread_to_eol` — discard the rest of a line (used to swallow trailing args/comments).
+- A leading `*` on a reset/prog line is a comment (skipped to end of line).
+
+---
+
+## 3. Flag encoding
+
+There are **three distinct flag encodings** in area files. Mixing them up is the most
+common source of confusion when hand-editing.
+
+### 3a. Named-token lookup (most common)
+Flags written as words: `ACT SENTINEL`, `AFF DETECT_INVIS`, `WEAR TAKE`, `ITEM GLOW`,
+`ROOM DARK`. `flag_lookup` ([lookup.c:46](../code/lookup.c#L46)) does a case-insensitive
+**prefix** match against a named table and returns the bit; `-1` (`NO_FLAG`) on miss.
+Because it is prefix-matched, `SENT` still matches `SENTINEL`. Tables live in `tables.c`
+(`act_flags`, `affect_flags`, `off_flags`, `imm_flags`, `wear_flags`, `extra_flags`,
+`room_flags`, `sect_table`, `direction_table`, `position_table`, etc.).
+
+### 3b. Letter-run bitvector — `fread_flag_new` ([db.c:2700](../code/db.c#L2700))
+Used for multi-word bitvectors: **area flags, room exit_info, mob FORM, mob PARTS**. Each
+set bit is one letter (`vector_convert`, [db.c:2726](../code/db.c#L2726)):
+`A`–`Z` → bits 0–25, `a`–`z` → bits 26–51. A single `0` = no bits; `|` chains runs.
+Example: `AC` = bits 0 and 2.
+
+### 3c. Letter-run single long — `fread_flag` ([db.c:2651](../code/db.c#L2651))
+Used for **object `value[]` slots that hold flags** (weapon flags, container flags, etc.,
+and the generic default value line). Different math (`flag_convert`,
+[db.c:2738](../code/db.c#L2738)): each letter is a power of two summed into one integer —
+`A`=1, `B`=2, … `Z`=2²⁵, `a`=2²⁶ … `z`=2⁵¹. `0` = none; `|` chains; leading `-` negates.
+
+> Encodings 3b and 3c agree on **which bit** a given letter means (`A`=bit0); they differ
+> only in representation (multi-word vector vs single accumulated long). This is the same
+> convention used in player files — see [player-file-format.md §3](player-file-format.md).
+
+---
+
+## 4. `#AREA` header
+
+Positional, one field per line; strings end in `~`. Loader: `load_area`
+([db.c:721](../code/db.c#L721)). Decoded against [area/academy.are](../area/academy.are):
+
+```
+#AREA
+academy.are~                        file_name    (fread_string)
+The Shalaran Academy~               name
+Seikilos~                           credits
+1 10                                low_range high_range   (recommended level range)
+24500 24599                         min_vnum max_vnum       (vnum bounds)
+normal                              area_type    flag_lookup(word, area_type_table)
+none                                climate      climate_lookup(word)
+0                                   area_flags   fread_flag_new (letter-run bitvector)
+9                                   security     (fread_number)
+Seikilos Jathruk Zethus Carantoc~   builders
+```
+
+- **`credits`** (line 3) and **`builders`** (line 10) are distinct string fields — do not
+  confuse them. In the sample, `Seikilos` is the credit line and the last line lists all
+  builders.
+- `area_type` (`area_type_table`): `normal, road_river, cabal, quest, city, unopened,
+  shrine`. `unopened` triggers extra vnum validation on resets; `shrine` auto-sets
+  no-summon/no-gate on all its rooms ([db.c:4076](../code/db.c#L4076)).
+- On load, the `AREA_LOADING` bit is force-set and `age` defaults to 15.
+
+### `#AREADATA` alternate (legacy)
+Keyed rather than positional, terminated by `End` (`new_load_area`,
+[db.c:841](../code/db.c#L841)):
+
+```
+#AREADATA
+Name <text>~
+Builders <text>~
+Credits <text>~
+Security <n>
+VNUMs <min> <max>
+End
+```
+
+Modern saves always use `#AREA`.
+
+---
+
+## 5. `#MOBS` — mobile prototypes
+
+Records repeat until a `#0` vnum line. Loader: `load_mobs`
+([db2.c:408](../code/db2.c#L408)); writer: `save_mobile`
+([olc_save.c:133](../code/olc_save.c#L133)).
+
+### 5a. Header lines
+```
+#24500                       vnum           '#' + number (0 ends the section)
+blacksmith black smith ...~  player_name    keywords
+a dwarven blacksmith~        short_descr
+A short, powerfully ...~     long_descr     (multi-line; first char upper-cased)
+Powerful muscles ...~        description    (multi-line look text)
+0 0 0 dwarf~                 alignment group xp_mod race
+```
+
+The `0 0 0 dwarf~` line is: `alignment`, `group`, `xp_mod`, then `race` (a `~`-terminated
+string, `race_lookup`).
+
+### 5b. Numeric stat lines ([db2.c:464-531](../code/db2.c#L464))
+```
+55 1d1+4999 8d8+20 0 100 pound       level  hitdice  damagedice  hitroll  dam_mod  attacktype
+0 0 0 0                               ac[PIERCE] ac[BASH] ac[SLASH] ac[EXOTIC]
+standing male none                   start_pos  sex  wealth
+0 0 medium                           FORM  PARTS  size
+```
+
+- **Dice** `XdY+Z`: `X`=number of dice, `Y`=size, `Z`=bonus. Parsed as number / skip `d` /
+  number / skip `+` / number.
+- **⚠ No mana dice.** Unlike stock ROM, the mob stat line has **only** hit and damage dice.
+  Mana is hardcoded to `1d1+99` ([db2.c:489](../code/db2.c#L489)); the ROM mana-read is
+  commented out. This is the single biggest deviation from a stock ROM mob record.
+- `attacktype` via `attack_lookup` (e.g. `pound`, `pierce`, `none`).
+- `start_pos`, `sex`, `size` via their named-table lookups.
+- **`wealth`**: the token — whether a numeric literal or a `wealth_table` word — is used as
+  an **exponent**, and the stored wealth is `pow(10, token-1)` (values ≤ 0 store 0). A
+  numeric token is **not** stored verbatim: e.g. `3` stores `100`, not `3`
+  ([db2.c:522-531](../code/db2.c#L522)). The table words map to their index:
+  `none`→0, `poor`→1, `moderate`→10, `affluent`→100, `rich`→1000, `peerless`→10000. The
+  writer always emits the word form, so numeric literals only appear in hand-edited files.
+- `FORM` and `PARTS` are letter-run bitvectors, OR-merged with race defaults.
+
+**Race seeding:** before the flag block is read, `act`/`aff`/`off`/`imm`/`res`/`vuln`/
+`form`/`parts` are copied from the mob's **race table** and `ACT_IS_NPC` is force-set
+([db2.c:510](../code/db2.c#L510)). The file then stores only the *delta*.
+
+### 5c. Two-token flag block ([db2.c:553](../code/db2.c#L553))
+Lines of `KEYWORD VALUE`, each OR-ing one named flag into a field. The loader stays in this
+block while the token pair matches one of these prefixes:
+
+| Line | Table | Field |
+|------|-------|-------|
+| `ACT <flag>`  | `act_flags`    | `act` |
+| `AFF <flag>`  | `affect_flags` | `affected_by` |
+| `OFF <flag>`  | `off_flags`    | `off_flags` |
+| `IMM <flag>`  | `imm_flags`    | `imm_flags` |
+| `RES <flag>`  | `imm_flags`    | `res_flags` |
+| `VUL <flag>`  | `imm_flags`    | `vuln_flags` |
+
+Two richer sub-blocks also appear here:
+
+- **`CLASS <classname> …`** ([db2.c:607](../code/db2.c#L607)) — sets the mob's class. A
+  `warrior` is followed by two combat `style` tokens; a `sorcerer` by two element tokens
+  (`ele_major ele_para`).
+- **`SPEECH <name>`** ([db2.c:626](../code/db2.c#L626)) — opens a scripted-dialogue block of
+  `LINE <delay> <type> <text>~` lines (type via `speech_table`), terminated by `END`.
+
+### 5d. Single-letter directive block ([db2.c:714](../code/db2.c#L714))
+After the two-token block, a loop reads one leading letter; an unknown letter is pushed
+back (`ungetc`) and ends the record. Each keyword's **first letter is the code**; the rest
+of the word is discarded.
+
+| Keyword | Meaning |
+|---------|---------|
+| `F <field> <flags>` | **Remove** race-granted flags from a field (`act/aff/off/imm/res/vul/for/par`). |
+| `A '<skill>' <affflag>` | Spell-affect the mob radiates (`skill_lookup` + `affect_flags`). |
+| `C '<spell>'` | Auto-cast spell name. |
+| `CA <disc> <cabal>` | Cabal assignment (`cabal_lookup`). |
+| `B <criterion> <cmp> <value> <vnum> <msgtype> <msg>~` | **Barred entry** gate (Rift-specific). `cmp` = `EQUALTO`/`LESSTHAN`/`GREATERTHAN`; `msgtype` = `SAY`/`EMOTE`/`ECHO` (ECHO takes two `~` strings). |
+| `NOTES <text>~` | Builder notes. |
+| `LIMIT <low> <high>` | Level restriction (`restrict_low/high`). |
+| `SHOPKEEPER OPEN <h> CLOSE <h> EXIT <dir>` | Inline **shop** (replaces the old `#SHOPS`). |
+| `TEACHES <profname>~` | Proficiency taught. |
+| `YELL <text>~` | Attack yell. |
+
+Sample: `B level GREATERTHAN 3 24563 SAY Hold, $n...~` and
+`SHOPKEEPER OPEN 12 CLOSE 12 EXIT east`.
+
+The record is hashed by `vnum % MAX_KEY_HASH`; a `#0` vnum line ends the section.
+
+---
+
+## 6. `#OBJS` — object prototypes
+
+Records until `#0`. Loader: `load_objs` ([db2.c:1002](../code/db2.c#L1002)); writer:
+`save_object` ([olc_save.c:372](../code/olc_save.c#L372)).
+
+### 6a. Header
+```
+#24507                    vnum       ('#'+number; 0 ends)
+warm copper ring~         name       (keywords)
+a warm copper ring~       short_descr
+A glowing copper ring..~  description
+treasure                  item_type  item_lookup(word) → type_flags
+copper~                   material   (fread_string; material_lookup)
+```
+
+### 6b. Value line — `value[0..4]`, meaning depends on `item_type`
+([db2.c:1083](../code/db2.c#L1083) load / [olc_save.c:389](../code/olc_save.c#L389) write):
+
+| item_type | value[0] | value[1] | value[2] | value[3] | value[4] |
+|-----------|----------|----------|----------|----------|----------|
+| `weapon` | weapon class | num dice | dice type | attack type | weapon flags (`fread_flag`) |
+| `container` | capacity | flags (`fread_flag`) | key vnum | max weight | weight mult |
+| `drinkcontainer`/`fountain` | capacity | current | liquid | poisoned | — |
+| `wand`/`staff` | level | max charges | cur charges | spell | — |
+| `potion`/`pill`/`scroll` | level | spell1 | spell2 | spell3 | spell4 |
+| `armor` / default | 5 numbers/flags (default branch reads all 5 via `fread_flag`) | | | | |
+
+Spell/liquid/attack values are name tokens (quoted on write) resolved via `skill_lookup` /
+`liq_lookup` / `attack_lookup`.
+
+### 6c. Level / weight / cost / condition ([db2.c:1133](../code/db2.c#L1133))
+```
+1 1 35 P        level  weight  cost  <condition-letter>
+```
+Condition letter → percent: `P`=100, `G`=90, `A`=75, `W`=50, `D`=25, `B`=10, `R`=0
+(default 100).
+
+### 6d. Trailing single-letter directives ([db2.c:1169](../code/db2.c#L1169))
+A loop reads a leading letter, discards the remainder of the word, then reads args. An
+unknown letter ends the record; a blank line separates records.
+
+| Keyword | Meaning |
+|---------|---------|
+| `WEAR <flag>` | Wear-location bit (`wear_flags`). |
+| `ITEM <flag>` | Extra flag (`extra_flags`) — e.g. `GLOW`, `NOLOCATE`. |
+| `RESTRICT <flag>` | Usage restriction (`restrict_lookup`). |
+| `APPLY <location> <modifier>` | Stat apply (`apply_locations` + number). |
+| `FLAG AFF '<skill>' <affflag> <SHOW\|NOSHOW>` | Char-affect while worn. |
+| `FLAG IMM/RES/VUL <flag>` | Object imm/res/vuln (`imm_flags`). |
+| `E <keyword>~ <text>~` | Extra description. |
+| `MSG WEAR <s1>~ <s2>~` / `MSG REMOVE <s1>~ <s2>~` | Wear/remove echoes. |
+| `CABAL <name>` | Cabal binding. |
+| `LIMIT <n>` | Global instance limit (`limtotal`). |
+| `TIMER <n>` | Start timer. |
+| `VERB <word>` | Trigger verb. |
+| `NAMEOFLOC <text>~` | Custom wear-location name. |
+| `NOTES <text>~` | Builder notes. |
+
+---
+
+## 7. `#ROOMS`
+
+Records until `#0`. Loader: `load_rooms` ([db.c:3999](../code/db.c#L3999)); writer:
+`save_rooms` ([olc_save.c:562](../code/olc_save.c#L562)).
+
+### 7a. Header
+```
+#24576                    vnum
+Bloodhawk Meadow~         name          (trailing '.' is chopped)
+The meadow opens ...~     description   (multi-line)
+field                     sector_type   sect_lookup(word)
+```
+
+### 7b. Body — leading-letter directives, terminated by `S` ([db.c:4094](../code/db.c#L4094))
+
+| Letter | Format | Meaning |
+|--------|--------|---------|
+| `H <n>` | Heal rate (default 100). |
+| `M <n>` | Mana rate (default 100). |
+| `G <n>` | Guild number. |
+| `D <dir> <toVnum> <exitflags> <key>` + `<keyword>~` + `<description>~` | **Exit** (see below). |
+| `E <keyword>~ <desc>~` | Extra description. |
+| `A <word> <cond> <alt_name>~ <alt_desc>~` | Conditional (ALTDESC) description. |
+| `C <word> <cabal>` | Cabal binding. |
+| `T <word> <type> <quality> <complexity> <timer> <trig_echo>~ <exec_echo>~` | Trap (`trap_table`; quality ≤ 10). |
+| `O <word> <owner>~` | Room owner string. |
+| `R <word> <flag>` | Room flag (`room_flags`; special-cases `dark`). |
+| `S` | End of room record. |
+
+**Exit (`D`)** ([db.c:4125](../code/db.c#L4125)): `direction` via `direction_table` (must
+be 0–5); the destination room vnum; `exit_info` as a letter-run bitvector
+(door/closed/locked/pickproof/…); the key vnum; then the `keyword~` and `description~`
+strings. Example:
+```
+D NORTH 24580 0 0
+~
+The meadow continues to the north.
+~
+```
+= a north exit to room 24580, no exit flags, no key, empty keyword, one-line description.
+
+---
+
+## 8. `#RESETS` — how the world is populated
+
+Current keyword-argument form (`load_newresets`, [db.c:4211](../code/db.c#L4211); writer
+`save_resets`, [olc_save.c:870](../code/olc_save.c#L870)), terminated by a lone `S`. Each
+line begins with a command letter; the descriptive words (`TO`, `IN`, `GLIMIT`, `LLIMIT`,
+`COUNT`) are read and discarded. Placement state is tracked so `GIVE`/`EQUIP`/`PUT` attach
+to the most recently loaded mob/object.
+
+| Line (as written) | letter | Meaning |
+|-------------------|--------|---------|
+| `MOB <vnum> TO <room> GLIMIT <g> LLIMIT <l>` | `M` | Load mob into room, with global + per-room limits. |
+| `OBJECT <vnum> TO <room>` | `O` | Load object into room. |
+| `PUT <vnum> IN <container> COUNT <n>` | `P` | Put object(s) into a container. |
+| `GIVE <vnum>` | `G` | Give object to the last-loaded mob. |
+| `EQUIP <vnum> <wearloc>` | `E` | Equip object on the last-loaded mob (`wear_locations`). |
+| `DOOR <room> <dir> <OPEN\|CLOSED\|LOCKED>` | `D` | Set a door's initial state. |
+| `FOLLOW <leaderVnum> <mobNo>` | `F` | Make the last mob follow a leader. |
+| `RANDOMIZE <room> <n>` | `R` | Randomize a room's exits. |
+
+### `#OLDRESETS` (legacy numeric form)
+`load_resets` ([db.c:954](../code/db.c#L954)) uses the same command letters but purely
+positional numbers: `<letter> <if_flag> <arg1> <arg2> [<arg3>] [<arg4>]`. Door `arg3` is
+`0/1/2` = open/closed/locked. Terminated by `S`.
+
+---
+
+## 9. `#IMPROGS` — program bindings
+
+Binds named C program functions to mobs/objects/rooms/the area. Loader: `load_improgs`
+([db2.c:253](../code/db2.c#L253)); writer: `save_progs`
+([olc_save.c:648](../code/olc_save.c#L648)). Terminated by `END`.
+
+Line format: `<letter> [<vnum>] <progtype> <funcname>`.
+
+| Letter | Target | Format |
+|--------|--------|--------|
+| `A` | Area | `A <progtype> <funcname>` |
+| `M` | Mob | `M <vnum> <progtype> <funcname>` |
+| `I` | Object (item) | `I <vnum> <progtype> <funcname>` |
+| `R` | Room | `R <vnum> <progtype> <funcname>` |
+| `E` | `END` — end section | |
+
+`progtype` selects the trigger (e.g. mob: `greet/give/fight/death/speech/…`; room:
+`entry/move/drop/speech/open`; item: `wear/get/drop/invoke/verb/…`; area:
+`pulse/reset/sun/tick/aggress`). Each binding sets a bit in the target's `progtypes` mask
+and stores the function name. Example: `A tick_prog tick_prog_academy_reset`.
+
+---
+
+## 10. `#SPECS` — hardcoded special functions
+
+Binds compiled C `spec_func`s (from `mspec_table`/`ispec_table`) to mobs/objects. Loader:
+`load_specs` ([db2.c:330](../code/db2.c#L330)); writer: `save_specs`
+([olc_save.c:821](../code/olc_save.c#L821)). Terminated by `END`.
+
+| Letter | Format | Table |
+|--------|--------|-------|
+| `M <vnum> <specname>` | Mob special | `mspec_table` |
+| `I <vnum> <specname>` | Object special | `ispec_table` |
+| `E` | `END` — end section | |
+
+Example: `M 24500 mspec_academy_smith`. An unknown spec name warns but is not fatal.
+
+---
+
+## 11. `#SOCIALS` (only `social.are`)
+
+Not part of normal areas. Loader: `load_socials` ([db2.c:63](../code/db2.c#L63)). Per
+social: a name line, then **8 message lines read with `fread_string_eol`**
+(line-terminated, **not** `~`-terminated), in order: `char_no_arg`, `others_no_arg`,
+`char_found`, `others_found`, `vict_found`, `char_not_found`, `char_auto`, `others_auto`.
+A line of `$` means that message is `nullptr`; `#0` as the name ends the section.
+
+---
+
+## 12. Gotchas & Riftshadow-specific notes
+
+- **`~` is the universal string terminator.** An empty string is a bare `~`. Embedded `\r`
+  is stripped; `\n` becomes `\n\r`. On write, strings are sanitized so a stray `~`/`\r`
+  can't corrupt the terminator.
+- **Three flag encodings** (§3). Multi-word bitvectors (area flags, exit_info, FORM, PARTS)
+  use `fread_flag_new` (`A`=bit0 positional); object value slots use `fread_flag`
+  (`A`=2⁰ power-of-two sum); everything else uses prefix-matched named tokens. They are not
+  interchangeable in the file even though 3b/3c agree on bit meaning.
+- **Prefix-matched named flags.** `flag_lookup` matches by prefix, so a truncated token
+  (`SENT` → `SENTINEL`) still resolves; a genuinely unknown token returns `NO_FLAG` and
+  several loaders treat that as fatal.
+- **`|` is an OR operator** inside `fread_number`, `fread_flag`, and `fread_flag_new`
+  (`A|B|32`).
+- **Section keywords are renamed vs stock ROM:** `#MOBS`/`#OBJS`, plus Rift-only
+  `#IMPROGS`/`#SPECS` and the `#OLDRESETS`/`#RESETS` split. Reset lines are self-describing
+  keywords (`MOB … TO … GLIMIT …`) rather than terse ROM numeric codes.
+- **Mobs have no mana dice** — hit + damage dice only; mana is hardcoded `1d1+99`.
+- **Mob flags are race-seeded, then edited.** act/aff/off/imm/res/vuln/form/parts start
+  from the race table; the file stores only the delta (`ACT/AFF/…` add lines and `F` lines
+  that *remove* race-granted bits). A mob record is therefore **not self-contained** — it
+  depends on the race tables.
+- **Shops are inline in the mob** (`SHOPKEEPER OPEN … CLOSE … EXIT …`); the standalone
+  `#SHOPS`/`load_shops`/`save_shops` are stubbed out. **Wealth** is a power-of-ten derived
+  from a table index, not a raw gold amount.
+- **Rift-only extensions** worth knowing when debugging: mob `B` barred-entry gates,
+  `CLASS`+styles/elements, `SPEECH`/`LINE` dialogue, `TEACHES`, `YELL`; room heal/mana/
+  guild rates, ALTDESC (`A`), traps (`T`), owners (`O`), per-flag `R` lines; object
+  `FLAG AFF/IMM/RES/VUL`, `RESTRICT`, `VERB`, `MSG WEAR/REMOVE`, condition letter.
+- **End markers vary by section:** `#0` ends MOBS/OBJS/ROOMS/SOCIALS; a lone `S` ends
+  RESETS and each room record; `END` ends IMPROGS/SPECS; `#$` ends the file. Mob/object
+  records also end implicitly when the next `#` or an unrecognized directive letter is seen
+  (`ungetc`).
+- **Duplicate vnums and malformed numbers are fatal** during boot. A malformed number and
+  a duplicate mob/object vnum call `exit(1)`; a duplicate room vnum exits via `bugout()`
+  with `exit(3)` ([db.c:4034](../code/db.c#L4034)). Either way, the game will not boot.
+
+---
+
+## See also
+
+- [player-file-format.md](player-file-format.md) — the companion reference for `.plr`
+  files. The two formats share the flag-encoding conventions and the `~` string terminator.
+- [olc.hlp](olc.hlp) — in-game OLC (online creation) command help.

--- a/docs/player-file-format.md
+++ b/docs/player-file-format.md
@@ -1,0 +1,395 @@
+# Riftshadow Player File (`.plr`) Format
+
+This document describes the on-disk format of player save files (`player/<Name>.plr`).
+It is a reference for developers and builders debugging player data. Everything here is
+derived directly from the load/save code in [code/save.c](../code/save.c); line
+references point at the authoritative implementation.
+
+- **Written by:** `save_char_obj()` → `fwrite_char()` / `fwrite_obj()` / `fwrite_pet()` / `fwrite_charmie()` ([save.c:90](../code/save.c#L90))
+- **Read by:** `load_char_obj()` → `fread_char()` / `fread_obj()` / `fread_pet()` / `fread_charmie()` ([save.c:908](../code/save.c#L908))
+- **Location:** `RIFT_PLAYER_DIR/<Capitalized-Name>.plr`
+- **Current version:** `6` (the `Vers` field, [save.c:249](../code/save.c#L249); `VERSION` in [merc.h:227](../code/merc.h#L227))
+
+Players are **not** saved when they are an NPC or when the game is running on port
+4000 (the test port) — see [save.c:97](../code/save.c#L97).
+
+---
+
+## 1. Overall structure
+
+A `.plr` file is a sequence of **sections**, each introduced by a `#`-prefixed keyword
+on its own token. The dispatcher is `load_char_obj()` ([save.c:1029](../code/save.c#L1029)).
+
+| Section     | Meaning                                          | Reader            |
+|-------------|--------------------------------------------------|-------------------|
+| `#PLAYER`   | The character record itself (always first)       | `fread_char`      |
+| `#O`        | A carried/worn object (repeats; may nest)        | `fread_obj`       |
+| `#OBJECT`   | Legacy alias for `#O`                             | `fread_obj`       |
+| `#PET`      | The character's charmed pet (0 or 1)             | `fread_pet`       |
+| `#CHARMED`  | A saved charmie (undead/necromancer minions)     | `fread_charmie`   |
+| `#END`      | End-of-file marker; stops the loader             | —                 |
+
+Example skeleton (see [player/Zorro.plr](../player/Zorro.plr) for a real file):
+
+```
+#PLAYER
+Name Zorro~
+... fields ...
+End
+
+#O
+Vnum 24571
+... object fields ...
+End
+
+#PET
+Vnum 80
+... pet fields ...
+End
+#END
+```
+
+**Write order** ([save.c:134-159](../code/save.c#L134)): `#PLAYER`, then all carried
+objects, then the pet (only if it is in the same room as the player), then any charmed
+undead minions, then `#END`.
+
+### Section body grammar
+
+Inside a section, each line is `Keyword value(s)`. The reader loops reading a *word*
+(`fread_word`), switches on `UPPER(word[0])`, and matches the full keyword. The section
+terminator is the literal word `End` (note: **`End`**, not `#END` — the `#END` at the
+very bottom is the whole-file terminator). An unrecognized keyword is skipped to
+end-of-line (`fread_to_eol`), so unknown/legacy fields are silently ignored rather than
+causing a load failure.
+
+Two parser conventions from [merc.h:63-92](../code/merc.h#L63):
+
+- `KEY("Literal", field, value)` — matches a keyword and assigns a scalar/string.
+- `KEYV("Literal", field)` — matches a keyword and reads a **flag vector** (`fread_flag_new`).
+
+---
+
+## 2. String and number conventions
+
+- **Strings** end with a tilde `~` (`fread_string`). A string may span multiple lines;
+  everything up to the next `~` is the value. Example:
+  ```
+  Desc Obscured within a cloud of smoke...
+  hovers near its master.
+  ~
+  ```
+- **Words** (`fread_word`) are whitespace/quote-delimited single tokens. Skill and group
+  names are written single-quoted, e.g. `Sk 59 'dagger'`.
+- **Numbers** (`fread_number`) are plain integers; a leading `-` is allowed and `|` can
+  chain values. Overflow saturates at `INT_MAX`.
+- Fields marked below as "written only if non-default" are **omitted** from the file when
+  they equal the default/prototype value, so a given `.plr` will not contain every key.
+
+---
+
+## 3. Flag encoding (shared by the whole game)
+
+Many fields are bit flags rendered as **letter runs**. This is the single most important
+convention to understand when reading these files by eye.
+
+**Writing** — `print_flags()` ([save.c:38](../code/save.c#L38)) emits one letter per set
+bit, by bit **index**:
+
+| Bit index | 0 | 1 | 2 | ... | 25 | 26 | 27 | ... | 51 |
+|-----------|---|---|---|-----|----|----|----|-----|----|
+| Letter    | A | B | C | ... | Z  | a  | b  | ... | z  |
+
+So `Act BCDGIQ` means bits **1, 2, 3, 6, 8, 16** are set. An empty flag set is written as
+the single character `0`.
+
+**Reading** — `fread_flag_new()` ([db.c:2700](../code/db.c#L2700)) reverses this
+(`vector_convert`, [db.c:2726](../code/db.c#L2726)): `A`–`Z` → bits 0–25, `a`–`z` → bits
+26–51. A leading `0` means "no bits". (There is also an older single-`long` variant,
+`fread_flag`/`flag_convert`, used mainly by area files; it maps the *same letters to the
+same bits*, just accumulated into one integer.)
+
+To decode a specific field you look up the bit **index** in the relevant table in
+[merc.h](../code/merc.h) — e.g. `Act` uses the `PLR_*` constants, `Comm` uses `COMM_*`,
+`AfBy` uses `AFF_*`.
+
+---
+
+## 4. `#PLAYER` section — field reference
+
+Written by `fwrite_char()` ([save.c:235](../code/save.c#L235)); read by `fread_char()`
+([save.c:1141](../code/save.c#L1141)). Many keys have both a long historical name and a
+short name (the reader accepts both; the writer only emits the short one). Both are listed.
+
+### 4.1 Identity & meta
+
+| Key | Values | Meaning |
+|-----|--------|---------|
+| `Name` | string~ | Character's true name (also the filename). |
+| `Ghost` | int~ | Ghost/decay timer state. |
+| `Id` | long | Unique player id. |
+| `LogO` | long | Last logoff time (Unix epoch). On load this drives HP/mana/move regen for time offline, [save.c:1435](../code/save.c#L1435). |
+| `Vers` / `Version` | int | Save format version (currently 6). Gates several fields — see §6. |
+| `ShD` | string~ | Short description (immortal/polymorph). |
+| `LnD` | string~ | Long description. |
+| `Desc` | string~ | Full look description. |
+| `Prom` | string~ | Custom prompt string. |
+| `Race` | string~ | Race name (`race_lookup`). |
+| `Cla` | string~ | Class name (`CClass::Lookup`). |
+| `Cabal` | string~ | Cabal name (`cabal_lookup`). Only written if the player is in a cabal ([save.c:274](../code/save.c#L274)). |
+| `CabalLevel` | int | Rank/level within the cabal (paired with `Cabal`). |
+| `Tribe` | int | Horde tribe id. Only written when the cabal is `CABAL_HORDE` ([save.c:280](../code/save.c#L280)). |
+| `Newbie` | int~ | Newbie flag (reset to false at the start of every load, [save.c:1158](../code/save.c#L1158)). |
+| `Sex` | int | Current sex (0 neuter / 1 male / 2 female). |
+| `TSex` / `TrueSex` | int | True sex (before `change sex` etc.). |
+| `Beauty` | int | Beauty stat. |
+| `Levl` / `Level` / `Lev` | int | Level. |
+| `LLev` / `LastLevel` | int | Last level (for de-leveling checks). |
+| `Tru` / `Trust` | int | Trust/admin override level (omitted if 0). |
+| `Sec` | int | OLC security clearance. |
+| `Plyd` / `Played` | int | Total seconds played. |
+| `Titl` / `Title` | string~ | Player title (a leading space is auto-added unless it starts with punctuation, [save.c:1753](../code/save.c#L1753)). |
+| `EXTitl` / `EXTitle` | string~ | Extended title. |
+| `Pass` / `Password` | string~ | Encrypted password. |
+| `Bin` / `Bamfin` | string~ | Custom teleport-in ("bamf") message (immortals). |
+| `Bout` / `Bamfout` | string~ | Custom teleport-out message. |
+| `Dmsg` | string~ | Custom immortal death message. |
+| `Role` | string~ | Player-written roleplay bio. |
+| `History` | string~ | Buffered communication history. |
+| `LogonTime` | string~ | Human-readable last logon (write-only, see §7). |
+| `TimePlayed` | int~ | Minutes this session (write-only, informational). |
+
+### 4.2 Location, vitals, stats
+
+| Key | Values | Meaning |
+|-----|--------|---------|
+| `HomeTown` | int | Hometown/recall id. |
+| `Room` | int | Room vnum to load into (falls back to Limbo if the room is gone). |
+| `HMV` / `HpManaMove` | 6 ints | `hit max_hit mana max_mana move max_move`. |
+| `HMVP` / `HpManaMovePerm` | 3 ints | Permanent `hit mana move` (trained maxes). |
+| `Attr` / `AttrPerm` | 5 ints | Permanent stats: `STR INT WIS DEX CON`. |
+| `AMod` / `AttrMod` | 5 ints | Stat modifiers (same order). |
+| `ACs` | 4 ints | Armor class: pierce, bash, slash, exotic (`AC_PIERCE/BASH/SLASH/EXOTIC`). The 4th slot is shown to players in-game as "magic", [act_info.c:2593](../code/act_info.c#L2593). |
+| `Hit` / `Hitroll` | int | Hitroll (omitted if 0). |
+| `Dam` / `Damroll` | int | Damroll (omitted if 0). |
+| `Save` / `SavingThrow` | int | Saving throw (omitted if 0). |
+| `Alig` / `Alignment` | int | Alignment (-1000..1000). |
+| `Etho` | int | Ethos. |
+| `OAli`, `OEth` | int | "Original" align/ethos (pre-corruption). |
+| `Indu` | int | Cabal induction counter. |
+| `Wimp` / `Wimpy` | int | Wimpy flee threshold (omitted if 0). |
+| `Pos` / `Position` | int | Position enum (see §8). `FIGHTING` is saved as `STANDING`. |
+| `Prac` / `Practice` | int | Practice sessions (omitted if 0). |
+| `Trai` | int | Training sessions (omitted if 0). |
+| `Scro` | int | Scroll/pager line count. |
+| `Cnd` / `Condition` | 6 ints | Conditions: drunk, full, thirst, hunger, starving, dehydrated (`COND_*`, [merc.h:2111](../code/merc.h#L2111)). The last two only exist in v6 — see §6. |
+
+### 4.3 Currency, experience, progression
+
+| Key | Values | Meaning |
+|-----|--------|---------|
+| `Gold` | long | Gold on hand (written as 0 if none). |
+| `Bgold` | long | Banked gold. |
+| `Exp` | int | Experience points. |
+| `Sp` | int | Spendable stat/skill points. |
+| `Deaths` | int | Death count. |
+| `Died` | int | Death status (only written when `HAS_DIED`). |
+| `Dtime` | int | Death timer (paired with `Died`). |
+| `DeathTime` | int | Aggregate death time. |
+| `RollTime` | long | When the character was last re-rolled. |
+| `Born` | int | Birth date (in-game). |
+| `Agemod` | int | Age modifier. |
+| `Rep` | int | Reputation. |
+| `Special` | int | Class "special" resource. |
+| `Bounty` | long | Bounty on this player. |
+| `BountyKilled` | int | Times killed as a bounty target. |
+| `BCredits` | int | Bounty credits earned. |
+| `Paladin_path` | int | Paladin subclass path. |
+| `EleMaj`, `ElePar` | int | Sorcerer major/paragon element (only for sorcerers). |
+| `Souls` | int | Necromancer soul count (only for necromancers). |
+| `StartWeap` | int | Starting weapon skill index (omitted if < 0). |
+| `ProfPoints` | 2 ints | Proficiency points + proficiency-advance timer. |
+| `Prof` | string~ int | One proficiency: name + level (repeats). |
+
+### 4.4 Flag fields (letter-encoded — see §3)
+
+| Key | Constants | Meaning |
+|-----|-----------|---------|
+| `Act` | `PLR_*` | Player action flags (autoloot, holylight, deny, etc.). Omitted if empty. |
+| `AfBy` / `AffectedBy` | `AFF_*` | Currently-affected-by flags. Omitted if empty. |
+| `Comm` | `COMM_*` | Communication/channel toggles. |
+| `Wizn` | `WIZ_*` | Wiznet subscription (immortals; omitted if empty). |
+| `Immune` | `IMM_*` | Immunity flags. |
+| `Resist` | `RES_*` | Resistance flags. |
+| `Vuln` | `VULN_*` | Vulnerability flags. |
+| `Styles` | style bits | Known combat styles. |
+| `TrSet` | trust bits | Granted trust/permission set. |
+| `Invi` / `InvisLevel` | int | Wizinvis level (omitted if 0). |
+| `Inco` | int | Incognito level (omitted if 0). |
+| `Instyle` | int | Currently active style index. |
+
+> Note: on load, race-granted `imm/res/vuln/form/parts` are re-applied from the race
+> table and OR-ed with the saved `Immune/Resist/Vuln` values ([save.c:1113-1124](../code/save.c#L1113)).
+
+### 4.5 Repeating / list fields
+
+| Key | Values | Meaning |
+|-----|--------|---------|
+| `Sk` / `Skill` | int `'name'` | Learned skill: percent + quoted skill name. One line per skill. Value `-2` is a *remembered-but-suppressed* sentinel (e.g. a revoked cabal skill): it is written so it round-trips, but `get_skill` treats it as 0% ([handler.c:518](../code/handler.c#L518), [dioextra.c:927](../code/dioextra.c#L927)). Only skills with `learned > 0` **or** `== -2` are saved ([save.c:563](../code/save.c#L563)). |
+| `Gr` / `Group` | `'name'` | A known skill group. Adds all its skills. |
+| `Alias` / `Alia` | word string~ | A command alias: keyword + expansion. Up to `MAX_ALIAS`. |
+| `Quest` | int int | `index value` for a completed/active quest slot. |
+| `CScheme` | word word | Color scheme: `event_name color_name` (one line per event). |
+| `Not` | 5 longs | Last-read timestamps: note, idea, penalty, news, changes. |
+| `Sect` | ints `-1` | Time spent in each sector type, one number per slot in `sect_time[]` index order, `-1` terminated. **Note:** the first number is slot 0, which has no `SECT_*` constant (the named sectors in §8 start at value 1), so the Nth number (0-indexed) is the time for sector *value* N. |
+| `DeposItems` | ints | Vnums of items in bank deposit (`MAX_STORED_ITEMS`). |
+| `kls` | 4 ints | PK kills: total, good, neutral, evil. |
+| `frg` | 4 ints | PK frags ×1,000,000 (stored as fixed-point). |
+| `kld` | 2 ints | Times killed: by-PC, by-mob. |
+| `frgd` | int | Times fragged ×1,000,000. |
+| `rkls` … `EndRKLS` | words | Recent-kill victim names (up to 100). |
+| `Lssr` / `Grtr` / `Arch` | ints | Anti-paladin lesser/greater/arch devil data (anti-paladins only). |
+| `Trophies` … `XYZ` | int names | Horde trophy-belt scalps (count then names; `XYZ` sentinel). |
+| `FingEQ` | ints | Vnums worn in each `MAX_WEAR` slot (write-only, see §7). |
+| `TrackAObj`, `TrackLObj` | int~ | Carried-object counts (write-only, informational). |
+
+### 4.6 Affects (`Affc`)
+
+Each active magical/skill affect is one `Affc` line ([write save.c:584](../code/save.c#L584),
+[read save.c:1231](../code/save.c#L1231)):
+
+```
+Affc '<skill>' <where> <level> <duration> <modifier> <location> <bitvector> <aftype> <owner> '<name>'
+```
+
+| Field | Meaning |
+|-------|---------|
+| `'<skill>'` | Skill/spell name (`skill_lookup`). |
+| `<where>` | Target field: `TO_*` — 0 affects, 1 object, 2 immune, 3 resist, 4 vuln, 5 weapon ([merc.h:843](../code/merc.h#L843)). |
+| `<level>` | Caster level. |
+| `<duration>` | Ticks remaining (`-1` = permanent). |
+| `<modifier>` | Magnitude applied to `location`. |
+| `<location>` | `APPLY_*` stat/attribute affected ([merc.h:1770](../code/merc.h#L1770)). |
+| `<bitvector>` | Letter-encoded `AFF_*` bits set while active. |
+| `<aftype>` | `AFT_*` — 0 spell, 1 skill, 2 power, 3 malady, 4 commune, 5 invis, 6 rune, 7 timer ([merc.h:792](../code/merc.h#L792)). |
+| `<owner>` | Name of the caster/owner, or `none`. |
+| `'<name>'` | Custom affect name, or `'none'`. |
+
+The example from Zorro: `Affc 'outfit' 0 0 67 0 0 Z 2 none 'none'` → the *outfit* affect,
+on the character (`where`=0), 67 ticks left, `AFF` bit 25 (`Z`), aftype 2 (power),
+no owner, unnamed.
+
+Affects with type `word of command`, `disguise`, or `indomitable spirit` are deliberately
+**not** saved ([save.c:579](../code/save.c#L579)).
+
+---
+
+## 5. `#O` object section — field reference
+
+Written by `fwrite_obj()` ([save.c:754](../code/save.c#L754)); read by `fread_obj()`
+([save.c:2038](../code/save.c#L2038)).
+
+**Key design point:** an object is stored as a *diff against its prototype*
+(`pIndexData`). A field is written **only if it differs** from the vnum's template. This
+is why a real `#O` block (like Zorro's) is short — most fields inherit from the area file.
+
+| Key | Values | Meaning |
+|-----|--------|---------|
+| `Vnum` | int | Object prototype vnum (should be the first key). |
+| `Oldstyle` | (flag) | Present if the prototype is old-format; forces a fresh clone on load. |
+| `Nest` | int | Container nesting depth (0 = top level). See §5.1. |
+| `Name` | string~ | Keywords (only if changed from proto). |
+| `ShD` | string~ | Short description (only if changed). |
+| `Desc` | string~ | Ground/long description (only if changed). |
+| `Owner` | string~ | Owner name (personalized/quest items). |
+| `ExtF` / `ExtraFlags` | flags | `ITEM_*` extra flags (glow, hum, nodrop, …), letter-encoded. |
+| `WeaF` / `WearFlags` | flags | Wearable-location flags, letter-encoded. |
+| `Ityp` / `ItemType` | int | Item type override (`ITEM_*`, see §8). |
+| `Wt` / `Weight` | int | Weight (if changed). |
+| `Mat` | string~ | Material name (if changed). |
+| `WLName` | string~ | Custom wear-location display name. |
+| `Cond` | int | Condition/durability (0-100ish). |
+| `Wear` / `WearLoc` | int | Currently worn slot (`WEAR_*`; `-1` = carried, not worn). |
+| `Lev` / `Level` | int | Object level (if changed). |
+| `Time` / `Timer` | int | Decay timer (omitted if 0). |
+| `Cost` | int | Value in gold. |
+| `Val` | 5 ints | `value[0..4]` — type-specific slots. |
+| `Vals` / `Values` | 4 ints | Legacy 4-value form (read only). |
+| `Spell` | int `'name'` | Spell baked into a slot: `slot(1-3) skillname` (potions/scrolls/pills/wands/staves). |
+| `Affc` | … | Object affect, same layout as §4.6 but with no trailing `'name'` field ([save.c:867](../code/save.c#L867)). |
+| `AddApp` | 3 ints | Extra apply added beyond the prototype: `location modifier type`. |
+| `ExDe` / `ExtraDescr` | string~ string~ | An added extra description: `keyword~ text~`. |
+
+**Not saved:** keys (`ITEM_KEY`) and empty maps are dropped on save
+([save.c:770](../code/save.c#L770)) — they are re-created from resets rather than persisted.
+
+### 5.1 Object nesting (`Nest`)
+
+Containers and their contents are flattened using the `Nest` depth counter. The writer
+recurses so that, on read, items load front-to-back ([save.c:764](../code/save.c#L764)).
+On load, an object with `Nest N` (N>0) is placed inside the most recent object recorded at
+depth `N-1` via the `rgObjNest[]` stack ([save.c:2249](../code/save.c#L2249)). `MAX_NEST`
+bounds the depth.
+
+---
+
+## 6. Version differences (`Vers`)
+
+The `Vers`/`Version` field selects backward-compatible behavior:
+
+- **`Cnd` / `Condition`** — versions **> 5** store **6** condition values; older files store
+  4 and the last two default to 0 ([save.c:1348-1374](../code/save.c#L1348)).
+- **version < 2** — on load, the class base/default skill groups and `recall` at 50% are
+  granted to backfill skills added after the file was written
+  ([save.c:1128](../code/save.c#L1128)).
+
+New saves always use version 6.
+
+---
+
+## 7. Gotchas & asymmetries
+
+- **Diff-against-prototype (objects & pets).** `#O` and `#PET` records only contain fields
+  that differ from the prototype mob/object. Editing an area file's prototype changes what
+  a player "inherits" on next load. Do not assume a missing key means a zero value — it
+  means "same as prototype".
+- **Write-only / informational fields.** Several fields are written by `fwrite_char` but
+  have **no reader** in `fread_char`, so they are ignored on load and exist only for
+  external tooling / eyeballing: `FingEQ`, `LogonTime`, `TimePlayed`, `TrackAObj`,
+  `TrackLObj`. Do not rely on them round-tripping.
+- **`End` vs `#END`.** `End` closes a section; `#END` closes the file. A stray `#END`
+  inside a section, or a missing `End`, will desync the loader.
+- **Fixed-point frags.** `frg`/`frgd` are floats multiplied by 1,000,000 on write and
+  divided back on read — expect large integers in the file.
+- **Position normalization.** A player caught mid-fight is saved as `STANDING`, never
+  `FIGHTING` ([save.c:380](../code/save.c#L380)).
+- **Regen on load.** HP/mana/move are boosted on load proportional to time offline (capped
+  at 100%), unless poisoned/plagued ([save.c:1435](../code/save.c#L1435)).
+- **Unknown keys are ignored**, so a typo in a hand-edited file usually fails silently
+  (the line is skipped) rather than erroring.
+- **Pet affects are not saved** — the `Affc` loop in `fwrite_pet` is commented out and
+  flagged "VARY VARY BAD" ([save.c:725](../code/save.c#L725)).
+
+---
+
+## 8. Reference enums
+
+Quick decode tables. Authoritative source is [merc.h](../code/merc.h).
+
+**Positions** (`Pos`): 0 dead · 1 mortal · 2 incap · 3 stunned · 4 sleeping · 5 resting ·
+6 sitting · 7 fighting · 8 standing.
+
+**Wear locations** (`Wear`, and `FingEQ`/`Sect` ordering): -1 none · 0 light · 1 finger_L ·
+2 finger_R · 3 neck_1 · 4 neck_2 · 5 body · 6 head · 7 legs · 8 feet · 9 hands · 10 arms ·
+11 shield · 12 about · 13 waist · 14 wrist_L · 15 wrist_R · 16 wield · 17 hold ·
+18 dual_wield/float · 19 brand · 20 strapped · 21 cosmetic.
+
+**Item types** (`Ityp`): 1 light · 2 scroll · 3 wand · 4 staff · 5 weapon · 8 treasure ·
+9 armor · 10 potion · 11 clothing · 12 furniture · 13 trash · 15 container · 17 drink_con ·
+18 key · 19 food · 20 money · 22 boat · 23 corpse_npc · 24 corpse_pc · 25 fountain ·
+26 pill · 27 protect · 28 map · 29 portal · 30 warp_stone · 31 room_key · 32 gem ·
+33 jewelry · 34 campfire · 35 cabal_item · 36 skeleton · 37 urn · 38 gravitywell ·
+39 book · 40 pen · 41 altar · 43 stone.
+
+**Sectors** (`Sect` order): 1 city · 2 field · 3 forest · 4 hills · 5 mountain · 6 water ·
+7 inside · 8 underwater · 9 air · 10 desert · 11 road · 12 conflagration · 13 burning ·
+14 trail · 15 swamp · 16 park · 17 vertical · 20 cave.

--- a/tests/smoke/boot_test.sh
+++ b/tests/smoke/boot_test.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 #
-# This script creates a codified smoke test. It is a "boot-and-greet" test 
+# This script creates a codified smoke test. It is a "boot-and-greet" test
 # that ensures the MUD boots, loads areas, and serves a greeting screen.
 # It is designed to catch issues that may arise from changes in the codebase
-# that could cause the MUD to fail to load properly, even if all unit tests 
-# pass. The script requires a running, provisioned MariaDB and can be configured 
+# that could cause the MUD to fail to load properly, even if all unit tests
+# pass. The script requires a running, provisioned MariaDB and can be configured
 # via environment variables.
 #
 # It boots `rift` on a scratch port against a *provisioned* database (the
@@ -15,7 +15,9 @@
 #   3. a TCP client receives the greeting screen;
 #   4. no sanitizer report was emitted (meaningful under -DRIFT_SANITIZE=ON).
 #
-# Just these checks alone will catch a majority of the game bugs.
+# Just these checks alone will catch a majority of the game bugs. For what
+# happens after the greeting -- creating a character and living in the world --
+# see new_player_test.sh.
 #
 # Requires a running, provisioned MariaDB. CI wiring (a MariaDB service +
 # db/install.sh, under ASAN).
@@ -36,73 +38,14 @@ PORT="${RIFT_SMOKE_PORT:-9993}"
 BOOT_TIMEOUT="${RIFT_SMOKE_BOOT_TIMEOUT:-60}"
 MIN_AREAS="${RIFT_SMOKE_MIN_AREAS:-50}"
 
-# --- locate the binary ---------------------------------------------------------
-# Auto-detect the *most recently built* rift among the common in-source and
-# out-of-source locations. CI should pass RIFT_BIN explicitly for a deterministic
-# target.
-RIFT_BIN="${RIFT_BIN:-}"
-if [[ -z "$RIFT_BIN" ]]; then
-	newest=""
-	for cand in "$REPO_ROOT/code/rift" "$REPO_ROOT/build/code/rift"; do
-		if [[ -x "$cand" ]] && { [[ -z "$newest" ]] || [[ "$cand" -nt "$newest" ]]; }; then
-			newest="$cand"
-		fi
-	done
-	RIFT_BIN="$newest"
-fi
-[[ -n "$RIFT_BIN" && -x "$RIFT_BIN" ]] || {
-	echo "SMOKE FAIL: rift binary not found; build it or set RIFT_BIN" >&2
-	exit 1
-}
-
-# --- workspace + fixture config ------------------------------------------------
-WORK="$(mktemp -d)"
-LOG="$WORK/boot.log"
-
-RIFT_PID=""
-cleanup() {
-	if [[ -n "$RIFT_PID" ]]; then
-		kill "$RIFT_PID" 2>/dev/null || true
-		wait "$RIFT_PID" 2>/dev/null || true
-	fi
-	rm -rf "$WORK"
-}
-trap cleanup EXIT
-
-fail() {
-	echo "SMOKE FAIL: $*" >&2
-	echo "----- last 40 log lines -----" >&2
-	tail -40 "$LOG" >&2 2>/dev/null || true
-	exit 1
-}
-
-# In-memory rewire of our config file to the smoke tests values.
-SRC_CONFIG="${RIFT_CONFIG:-$REPO_ROOT/config.json}"
-[[ -f "$SRC_CONFIG" ]] || fail "config not found: $SRC_CONFIG"
-FIXTURE_CONFIG="$WORK/config.json"
-cp "$SRC_CONFIG" "$FIXTURE_CONFIG"
-sed -i -E "s/(\"Port\"[[:space:]]*:[[:space:]]*)[0-9]+/\1$PORT/" "$FIXTURE_CONFIG"
-
-# The area/player/logs/configs dirs are addressed relative to CWD's parent
-# (rift.h RIFT_ROOT_DIR ".."), which RIFT_CONFIG does *not* override -- so CWD
-# must be an immediate child of the repo root. code/ always is.
-RUN_CWD="$REPO_ROOT/code"
+# Binary lookup, fixture config, boot, teardown and the sanitizer check are
+# shared with new_player_test.sh.
+# shellcheck source=lib.sh
+source "$SCRIPT_DIR/lib.sh"
 
 # --- 1. boot ------------------------------------------------------------------
-echo "smoke: booting $RIFT_BIN on port $PORT (cwd=$RUN_CWD, config=$FIXTURE_CONFIG)"
-( cd "$RUN_CWD" && RIFT_CONFIG="$FIXTURE_CONFIG" exec "$RIFT_BIN" "$PORT" ) >"$LOG" 2>&1 &
-RIFT_PID=$!
-
-booted=0
-for _ in $(seq 1 $((BOOT_TIMEOUT * 2))); do
-	if ! kill -0 "$RIFT_PID" 2>/dev/null; then
-		fail "process exited during boot (before binding port $PORT)"
-	fi
-	if grep -q "binding on port $PORT" "$LOG"; then booted=1; break; fi
-	sleep 0.5
-done
-[[ "$booted" -eq 1 ]] || fail "did not reach 'binding on port $PORT' within ${BOOT_TIMEOUT}s"
-echo "smoke: PASS  boot reached port bind"
+smoke_setup
+smoke_boot
 
 # --- 2. areas actually loaded -------------------------------------------------
 areas="$(grep -oE "Loaded [0-9]+ areas\." "$LOG" | grep -oE "[0-9]+" | head -1 || true)"
@@ -127,9 +70,6 @@ echo "smoke: PASS  greeting served ($bytes bytes)"
 kill "$RIFT_PID" 2>/dev/null || true
 wait "$RIFT_PID" 2>/dev/null || true
 RIFT_PID=""
-if grep -qE "AddressSanitizer|LeakSanitizer|UndefinedBehaviorSanitizer|runtime error:|SUMMARY: .*Sanitizer" "$LOG"; then
-	fail "sanitizer report present in boot log"
-fi
-echo "smoke: PASS  no sanitizer report"
+smoke_assert_clean_log
 
 echo "SMOKE PASS: booted, $areas areas loaded, greeting served, clean log"

--- a/tests/smoke/lib.sh
+++ b/tests/smoke/lib.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+#
+# Shared scaffolding for the smoke tests: locating the binary, building a
+# throwaway config on a scratch port, booting, and tearing down.
+#
+# Sourced by boot_test.sh and new_player_test.sh. Not executable on its own.
+#
+# Callers set PORT (and may set BOOT_TIMEOUT) before sourcing, then call
+# smoke_setup / smoke_boot.
+
+# --- locate the binary ---------------------------------------------------------
+# Auto-detect the *most recently built* rift among the common in-source and
+# out-of-source locations. CI should pass RIFT_BIN explicitly for a deterministic
+# target.
+smoke_find_bin() {
+	if [[ -n "${RIFT_BIN:-}" ]]; then
+		[[ -x "$RIFT_BIN" ]] || fail "RIFT_BIN is not executable: $RIFT_BIN"
+		return
+	fi
+
+	local newest="" cand
+	for cand in "$REPO_ROOT/code/rift" "$REPO_ROOT/build/code/rift"; do
+		if [[ -x "$cand" ]] && { [[ -z "$newest" ]] || [[ "$cand" -nt "$newest" ]]; }; then
+			newest="$cand"
+		fi
+	done
+
+	RIFT_BIN="$newest"
+	[[ -n "$RIFT_BIN" && -x "$RIFT_BIN" ]] || {
+		echo "SMOKE FAIL: rift binary not found; build it or set RIFT_BIN" >&2
+		exit 1
+	}
+}
+
+fail() {
+	echo "SMOKE FAIL: $*" >&2
+	echo "----- last 40 log lines -----" >&2
+	tail -40 "$LOG" >&2 2>/dev/null || true
+	exit 1
+}
+
+# A caller with its own artifacts to remove sets SMOKE_CLEANUP_HOOK to a function
+# name rather than installing its own EXIT trap -- smoke_setup owns that trap and
+# would overwrite one registered beforehand.
+cleanup() {
+	if [[ -n "${SMOKE_CLEANUP_HOOK:-}" ]]; then
+		"$SMOKE_CLEANUP_HOOK" || true
+	fi
+	if [[ -n "${RIFT_PID:-}" ]]; then
+		kill "$RIFT_PID" 2>/dev/null || true
+		wait "$RIFT_PID" 2>/dev/null || true
+	fi
+	rm -rf "$WORK"
+}
+
+# --- workspace + fixture config ------------------------------------------------
+smoke_setup() {
+	WORK="$(mktemp -d)"
+	LOG="$WORK/boot.log"
+	RIFT_PID=""
+	trap cleanup EXIT
+
+	smoke_find_bin
+
+	# In-memory rewire of our config file to the smoke tests values.
+	local src_config="${RIFT_CONFIG:-$REPO_ROOT/config.json}"
+	[[ -f "$src_config" ]] || fail "config not found: $src_config"
+	FIXTURE_CONFIG="$WORK/config.json"
+	cp "$src_config" "$FIXTURE_CONFIG"
+	sed -i -E "s/(\"Port\"[[:space:]]*:[[:space:]]*)[0-9]+/\1$PORT/" "$FIXTURE_CONFIG"
+}
+
+# --- boot ----------------------------------------------------------------------
+smoke_boot() {
+	# The area/player/logs/configs dirs are addressed relative to CWD's parent
+	# (rift.h RIFT_ROOT_DIR ".."), which RIFT_CONFIG does *not* override -- so CWD
+	# must be an immediate child of the repo root. code/ always is.
+	local run_cwd="$REPO_ROOT/code"
+
+	echo "smoke: booting $RIFT_BIN on port $PORT (cwd=$run_cwd, config=$FIXTURE_CONFIG)"
+	( cd "$run_cwd" && RIFT_CONFIG="$FIXTURE_CONFIG" exec "$RIFT_BIN" "$PORT" ) >"$LOG" 2>&1 &
+	RIFT_PID=$!
+
+	local booted=0 _
+	for _ in $(seq 1 $((BOOT_TIMEOUT * 2))); do
+		if ! kill -0 "$RIFT_PID" 2>/dev/null; then
+			fail "process exited during boot (before binding port $PORT)"
+		fi
+		if grep -q "binding on port $PORT" "$LOG"; then booted=1; break; fi
+		sleep 0.5
+	done
+	[[ "$booted" -eq 1 ]] || fail "did not reach 'binding on port $PORT' within ${BOOT_TIMEOUT}s"
+	echo "smoke: PASS  boot reached port bind"
+}
+
+# --- sanitizer / allocator check -----------------------------------------------
+# Meaningful under -DRIFT_SANITIZE=ON, but the glibc allocator messages fire in
+# an ordinary build too -- they are how the new-player heap overrun announced
+# itself before it was fixed.
+SMOKE_BAD_LOG_RE="AddressSanitizer|LeakSanitizer|UndefinedBehaviorSanitizer|runtime error:|SUMMARY: .*Sanitizer|double free|corruption|invalid next size|malloc\(\): |free\(\): "
+
+# Non-fatal form, for polling a still-running server. Returns non-zero on a hit.
+smoke_assert_clean_log_quiet() {
+	! grep -qE "$SMOKE_BAD_LOG_RE" "$LOG"
+}
+
+smoke_assert_clean_log() {
+	if grep -qE "$SMOKE_BAD_LOG_RE" "$LOG"; then
+		fail "sanitizer or allocator reported a memory error"
+	fi
+	echo "smoke: PASS  no sanitizer or allocator report"
+}

--- a/tests/smoke/mkchar.py
+++ b/tests/smoke/mkchar.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""
+Drive a new character through nanny's creation sequence over TCP.
+
+Used by new_player_test.sh. Prints what it answered, and on failure the tail of
+what the server actually sent, so a broken run is diagnosable from a CI log
+alone.
+
+Usage:
+    mkchar.py <port> <name>
+
+Environment:
+    RIFT_HOST         host to connect to (default 127.0.0.1)
+    RIFT_SRC          source address to bind before connecting. 127.0.0.5 has no
+                      reverse DNS mapping, so it exercises init_descriptor's
+                      gethostbyaddr-failed path. Default: unbound.
+    RIFT_RACE         default planar
+    RIFT_CLASS        default healer
+    RIFT_HOMETOWN     default melcene
+    RIFT_IDLE_SECS    seconds to stay in game after login (default 20). Must
+                      outlast the queued academy-pet spawn, so that several world
+                      ticks run with the character in the room.
+
+Exit codes: 0 pass, 1 fail.
+"""
+
+import os
+import re
+import socket
+import sys
+import time
+
+HOST = os.environ.get("RIFT_HOST", "127.0.0.1")
+SRC = os.environ.get("RIFT_SRC", "")
+RACE = os.environ.get("RIFT_RACE", "planar")
+CLASS = os.environ.get("RIFT_CLASS", "healer")
+HOMETOWN = os.environ.get("RIFT_HOMETOWN", "melcene")
+IDLE_SECS = int(os.environ.get("RIFT_IDLE_SECS", "20"))
+PASSWORD = "smoketestpw"
+
+ANSI = re.compile(r"\x1b\[[0-9;]*[A-Za-z]")
+
+# Telnet negotiation: nanny appends IAC WILL ECHO to the password prompts, which
+# would otherwise sit between the prompt text and the end of the line and defeat
+# the anchors below. Covers IAC + WILL/WONT/DO/DONT + option, and the bare
+# two-byte commands.
+TELNET = re.compile(r"\xff(?:[\xfb-\xfe].|[\xf0-\xfa])")
+
+# Overall wall-clock budget for reaching the game, so a missed prompt fails with
+# a transcript instead of hanging a CI job.
+LOGIN_BUDGET = 180
+
+
+class Failure(Exception):
+    pass
+
+
+def rules(name):
+    """(pattern, reply) matched against the newest output, most specific first.
+
+    A reply of None means the server refused the character; that is a failure,
+    not something to answer.
+
+    Nanny asks some of these only for certain races and classes, so the driver
+    reacts to whatever prompt actually arrives rather than following a fixed
+    script. Most patterns are anchored at the end of a line because that is where
+    the live prompt sits -- the same words often appear earlier in help text.
+    """
+    return [
+        (r"Illegal name, try another",              None),
+        (r"This char is dead, choose another name", None),
+        (r"You are denied access",                  None),
+        (r"banned from this mud",                   None),
+        (r"game is (?:newlocked|currently wizlocked)", None),
+        (r"New players are not allowed",            None),
+
+        (r"is your name suitable\? $",              "y"),
+        (r"Did I get that right, \w+ \(Y/N\)\? $",  "y"),
+        (r"Please type Y or N\? $",                 "y"),
+        (r"Please enter yes or no",                 "y"),
+        (r"Please type Yes or No\? $",              "y"),
+        (r"By what name do you wish to be known, traveller\?$", name),
+        (r"^Name: $",                               name),
+
+        (r"Give me a password for \w+: $",          PASSWORD),
+        (r"Please retype password: $",              PASSWORD),
+        (r"^Retype password: $",                    PASSWORD),
+        (r"Password: $",                            PASSWORD),
+        (r"^Pass: $",                               PASSWORD),
+
+        (r"What is your race \(type 'help'[^)]*\)\? $", RACE),
+        (r"^Choose: $",                             "3"),   # appearance
+        (r"What is your sex \(M/F\)\? $",           "m"),
+        (r"What IS your sex\? $",                   "m"),
+        (r"(?:Choose your class|What is your class\?) \(type 'help'[^)]*\): $", CLASS),
+
+        (r"^> $",                                   "finish"),   # stat allocation
+        (r"Which alignment \([GNE/]+\)\? $",        "n"),
+        (r"Which ethos \(L/N/C\)\? $",              "n"),
+        (r"Choose your hometown\? $",               HOMETOWN),
+
+        (r"\[Hit Return to [Cc]ontinue\]",          ""),
+    ]
+
+
+class Session:
+    def __init__(self, port):
+        self.transcript = []
+        self.sock = socket.socket()
+        if SRC:
+            self.sock.bind((SRC, 0))
+        self.sock.settimeout(15)
+        self.sock.connect((HOST, port))
+        self.sock.settimeout(0.5)
+
+    def recv(self, quiet_for):
+        """Read until the server has been silent for `quiet_for` seconds.
+
+        The MUD writes "\\n\\r", not "\\r\\n", so every line after the first
+        would otherwise start with a stray CR. Strip CR outright: the patterns
+        anchor on line starts.
+        """
+        got = b""
+        deadline = time.time() + quiet_for
+        while time.time() < deadline:
+            try:
+                chunk = self.sock.recv(65536)
+            except socket.timeout:
+                continue
+            except ConnectionResetError:
+                raise Failure("server reset the connection")
+            if not chunk:
+                raise Failure("server closed the connection")
+            got += chunk
+            deadline = time.time() + quiet_for   # keep reading while it talks
+
+        text = got.decode("latin-1")
+        text = TELNET.sub("", text)
+        text = ANSI.sub("", text).replace("\r", "")
+        self.transcript.append(text)
+        return text
+
+    def send(self, line):
+        self.sock.sendall(line.encode() + b"\n")
+
+    def fail(self, msg):
+        raise Failure("%s\n--- last 1500 bytes received ---\n%s"
+                      % (msg, "".join(self.transcript)[-1500:]))
+
+
+def create_character(s, name):
+    deadline = time.time() + LOGIN_BUDGET
+    silent_rounds = 0
+
+    while True:
+        if time.time() > deadline:
+            s.fail("did not reach the game within %ds" % LOGIN_BUDGET)
+
+        out = s.recv(0.6)
+        if not out:
+            silent_rounds += 1
+            if silent_rounds > 20:
+                s.fail("server went silent before the character reached the game")
+            continue
+        silent_rounds = 0
+
+        if "Welcome to Riftshadow!" in out:
+            return
+
+        for pattern, reply in rules(name):
+            if not re.search(pattern, out, re.M):
+                continue
+            if reply is None:
+                s.fail("nanny refused the character: matched %r" % pattern)
+            print(">>> %-52s -> %r" % (pattern, reply))
+            s.send(reply)
+            break
+        else:
+            s.fail("no rule matched the current prompt")
+
+
+def main():
+    if len(sys.argv) != 3:
+        print(__doc__)
+        return 2
+
+    port, name = int(sys.argv[1]), sys.argv[2]
+    s = Session(port)
+
+    create_character(s, name)
+    print(">>> reached the game")
+
+    # The reported crash landed here: the room description and prompt arrived,
+    # then the next world tick walked a freed object and took the server down.
+    # Idling proves ticks keep running with the character in the room.
+    end = time.time() + IDLE_SECS
+    while time.time() < end:
+        s.recv(1.0)
+    print(">>> survived %ds in game" % IDLE_SECS)
+
+    # In-band liveness check: a dropped connection or a wedged server fails here
+    # without needing to inspect the server's own log.
+    s.send("look")
+    reply = s.recv(2.0)
+    if "[Exits:" not in reply:
+        s.fail("'look' did not produce a room description")
+    print(">>> server still answering commands")
+
+    s.sock.close()
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except Failure as e:
+        print("MKCHAR FAIL: %s" % e, file=sys.stderr)
+        sys.exit(1)

--- a/tests/smoke/new_player_test.sh
+++ b/tests/smoke/new_player_test.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+#
+# Smoke test: can a brand new character actually be created and stay in the world?
+#
+# boot_test.sh stops at the greeting screen, which is why a heap overrun in
+# bust_a_prompt -- triggered by the first prompt a new character is ever sent --
+# reached a release. This test goes the rest of the way: it drives nanny's whole
+# creation sequence over TCP, lands the character in the newbie academy, and
+# holds the connection open while the world ticks around it.
+#
+# Asserts, in order:
+#
+#   1. the process boots and reaches the port bind;
+#   2. a character can be created and reaches the game;
+#   3. it survives several world ticks in the room, and the server still answers
+#      commands afterwards;
+#   4. the server survives the character logging out again;
+#   5. no sanitizer report and no glibc allocator complaint in the log.
+#
+# Requires a running, provisioned MariaDB, same as boot_test.sh.
+#
+# Config (all overridable via env):
+#   RIFT_BIN                 path to the rift binary (auto-detected otherwise)
+#   RIFT_CONFIG              source config.json to base the fixture on
+#   RIFT_SMOKE_PORT          scratch port to bind (default 9994)
+#   RIFT_SMOKE_BOOT_TIMEOUT  seconds to wait for the bind line (default 60)
+#   RIFT_SMOKE_SETTLE        seconds to watch the server after logout (default 10)
+#   RIFT_IDLE_SECS           seconds to stay in game (default 20)
+#   plus the RIFT_RACE / RIFT_CLASS / RIFT_HOMETOWN knobs mkchar.py reads
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+PORT="${RIFT_SMOKE_PORT:-9994}"
+BOOT_TIMEOUT="${RIFT_SMOKE_BOOT_TIMEOUT:-60}"
+SETTLE="${RIFT_SMOKE_SETTLE:-10}"
+
+# shellcheck source=lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+# A random alphabetic name: nanny requires 2-12 letters, no digits, and rejects
+# anything matching a mob's name. Deleting the pfile afterwards is enough --
+# Player.lst is rebuilt from the directory on every boot.
+# Built in-shell rather than piped through head, which would SIGPIPE its producer
+# and trip pipefail.
+CHAR_NAME="Zz"
+alphabet="abcdefghijklmnopqrstuvwxyz"
+for _ in $(seq 1 8); do
+	CHAR_NAME+="${alphabet:RANDOM % 26:1}"
+done
+PFILE="$REPO_ROOT/player/$CHAR_NAME.plr"
+
+remove_pfile() {
+	rm -f "$PFILE"
+}
+SMOKE_CLEANUP_HOOK=remove_pfile
+
+smoke_setup
+smoke_boot
+
+# --- 2/3. create a character and keep it in the world --------------------------
+# Bind the client to 127.0.0.5, which has no reverse DNS mapping, so the run also
+# covers init_descriptor's gethostbyaddr-failed path.
+echo "smoke: creating $CHAR_NAME (${RIFT_RACE:-planar}/${RIFT_CLASS:-healer}/${RIFT_HOMETOWN:-melcene})"
+if ! RIFT_SRC="${RIFT_SRC:-127.0.0.5}" python3 "$SCRIPT_DIR/mkchar.py" "$PORT" "$CHAR_NAME"; then
+	fail "character creation failed"
+fi
+echo "smoke: PASS  new character created, survived in game, still responsive"
+
+# --- 4. survive the logout teardown --------------------------------------------
+# mkchar.py has closed its socket by now. Do not kill the server yet: the heap
+# overrun this test exists to catch stayed silent the whole time the character
+# was in the room, and only announced itself once extract_char freed the buffers
+# it had scribbled past. Whether that lands as a crash during play or as an
+# allocator abort at logout depends on the heap layout, so watch both, and give
+# the server a settle window instead of killing it straight away.
+echo "smoke: watching ${SETTLE}s of logout teardown"
+for _ in $(seq 1 "$SETTLE"); do
+	kill -0 "$RIFT_PID" 2>/dev/null || fail "server died after the character logged out"
+	smoke_assert_clean_log_quiet || fail "corruption reported after the character logged out"
+	sleep 1
+done
+echo "smoke: PASS  server survived logout"
+
+# --- 5. clean teardown, no sanitizer or allocator report -----------------------
+kill "$RIFT_PID" 2>/dev/null || true
+wait "$RIFT_PID" 2>/dev/null || true
+RIFT_PID=""
+smoke_assert_clean_log
+
+echo "SMOKE PASS: created $CHAR_NAME, survived in game, clean log"


### PR DESCRIPTION
This PR fixes a couple of bugs that caused the game to seg fault when creating a new character. The seg fault was caused by stack corruption due to an unterminated string.

Also expanded the smoke test to include creating a new character and letting them chill in the world for a bit to ensure proper functioning.


Also added some doc files describing player and area files.