### PR TITLE
Change raw long-lived pointers to generational handles

### DIFF
--- a/code/act_comm.c
+++ b/code/act_comm.c
@@ -337,26 +337,30 @@ void do_cb(CHAR_DATA *ch, char *argument)
 
 	for (auto d = descriptor_list; d != nullptr; d = d->next)
 	{
-		if (d->connected == CON_PLAYING && d->character != ch && ((is_same_cabal(ch, d->character) && !IS_SET(d->character->comm, COMM_NOCABAL) && !IS_SET(d->character->in_room->room_flags, ROOM_SILENCE)) || IS_SET(d->character->comm, COMM_ALL_CABALS)))
+		// Read once: this loop only formats and sends, and nothing in it can
+		// extract a listener.
+		CHAR_DATA *listener = Deref(d->character);
+
+		if (d->connected == CON_PLAYING && listener != ch && ((is_same_cabal(ch, listener) && !IS_SET(listener->comm, COMM_NOCABAL) && !IS_SET(listener->in_room->room_flags, ROOM_SILENCE)) || IS_SET(listener->comm, COMM_ALL_CABALS)))
 		{
-			if (IS_SET(d->character->comm, COMM_ANSI))
+			if (IS_SET(listener->comm, COMM_ANSI))
 			{
 				sprintf(buf, "%s%s: %s%s%s\n\r",
 						cabal_table[ch->cabal].who_name,
-						!is_npc(ch) && can_see(d->character, ch) ? ch->true_name : pers(ch, d->character),
-						get_char_color(d->character, "channels"),
+						!is_npc(ch) && can_see(listener, ch) ? ch->true_name : pers(ch, listener),
+						get_char_color(listener, "channels"),
 						argument,
-						END_COLOR(d->character));
+						END_COLOR(listener));
 			}
 			else
 			{
 				sprintf(buf, "%s%s: %s\n\r",
 						cabal_table[ch->cabal].who_name,
-						!is_npc(ch) && can_see(d->character, ch) ? ch->true_name : pers(ch, d->character),
+						!is_npc(ch) && can_see(listener, ch) ? ch->true_name : pers(ch, listener),
 						argument);
 			}
 
-			send_to_char(buf, d->character);
+			send_to_char(buf, listener);
 		}
 	}
 }
@@ -427,7 +431,7 @@ void do_newbie(CHAR_DATA *ch, char *argument)
 		if (is_npc(wch) && wch->desc == nullptr)
 			continue;
 
-		if ((wch->level <= 25 && !IS_SET(wch->comm, COMM_NONEWBIE)) || is_immortal(wch) || is_heroimm(wch) || (is_npc(wch) && (wch->desc != nullptr) && is_immortal(wch->desc->original)))
+		if ((wch->level <= 25 && !IS_SET(wch->comm, COMM_NONEWBIE)) || is_immortal(wch) || is_heroimm(wch) || (is_npc(wch) && (wch->desc != nullptr) && is_immortal(Deref(wch->desc->original))))
 		{
 			if (IS_SET(wch->comm, COMM_ANSI))
 			{
@@ -495,7 +499,7 @@ void do_builder(CHAR_DATA *ch, char *argument)
 		if (is_npc(wch) && wch->desc == nullptr)
 			continue;
 
-		if (is_immortal(wch) || IS_SET(wch->comm, COMM_BUILDER) || is_heroimm(wch) || (is_npc(wch) && (wch->desc != nullptr) && is_immortal(wch->desc->original)))
+		if (is_immortal(wch) || IS_SET(wch->comm, COMM_BUILDER) || is_heroimm(wch) || (is_npc(wch) && (wch->desc != nullptr) && is_immortal(Deref(wch->desc->original))))
 		{
 			if (IS_SET(wch->comm, COMM_ANSI))
 			{
@@ -584,7 +588,7 @@ void do_immtalk(CHAR_DATA *ch, char *argument)
 		if (is_npc(wch) && wch->desc == nullptr)
 			continue;
 
-		if ((is_immortal(wch) || IS_SET(wch->comm, COMM_IMMORTAL) || (is_npc(wch) && (wch->desc != nullptr) && is_immortal(wch->desc->original))) && get_trust(wch) >= std::max(level, 52))
+		if ((is_immortal(wch) || IS_SET(wch->comm, COMM_IMMORTAL) || (is_npc(wch) && (wch->desc != nullptr) && is_immortal(Deref(wch->desc->original)))) && get_trust(wch) >= std::max(level, 52))
 		{
 			if (IS_SET(wch->comm, COMM_ANSI))
 			{
@@ -1122,9 +1126,9 @@ void do_pray(CHAR_DATA *ch, char *argument)
 
 	for (auto d = descriptor_list; d != nullptr; d = d->next)
 	{
-		auto victim = d->original ? d->original : d->character;
+		auto victim = Deref(d->original) ? Deref(d->original) : Deref(d->character);
 
-		if (d->connected == CON_PLAYING && d->character != ch && !IS_SET(victim->comm, COMM_SHOUTSOFF) && !IS_SET(victim->comm, COMM_QUIET) && victim->level >= 52)
+		if (d->connected == CON_PLAYING && Deref(d->character) != ch && !IS_SET(victim->comm, COMM_SHOUTSOFF) && !IS_SET(victim->comm, COMM_QUIET) && victim->level >= 52)
 		{
 			sprintf(buf, "%s%s [%d] is PRAYing for: %s%s\n\r",
 					get_char_color(victim, "prays"),
@@ -1132,7 +1136,7 @@ void do_pray(CHAR_DATA *ch, char *argument)
 					ch->in_room->vnum,
 					argument,
 					END_COLOR(victim));
-			send_to_char(buf, d->character);
+			send_to_char(buf, Deref(d->character));
 		}
 	}
 }
@@ -1453,20 +1457,24 @@ void do_yell(CHAR_DATA *ch, char *argument)
 
 	for (auto d = descriptor_list; d != nullptr; d = d->next)
 	{
-		if (d->connected == CON_PLAYING && d->character != ch && d->character->in_room != nullptr && d->character->in_room->area == ch->in_room->area && !IS_SET(d->character->comm, COMM_QUIET))
+		// Read once: command_execute below can extract the listener, but it is
+		// the last thing this iteration does with it.
+		CHAR_DATA *listener = Deref(d->character);
+
+		if (d->connected == CON_PLAYING && listener != ch && listener->in_room != nullptr && listener->in_room->area == ch->in_room->area && !IS_SET(listener->comm, COMM_QUIET))
 		{
-			if (IS_SET(d->character->in_room->room_flags, ROOM_SILENCE))
+			if (IS_SET(listener->in_room->room_flags, ROOM_SILENCE))
 				continue;
 
 			/* Can't hear yells while asleep, MORGLUM */
-			if (!is_awake(d->character))
+			if (!is_awake(listener))
 				continue;
 
-			sprintf(buf, "$n yells '%s$t%s'", get_char_color(d->character, "yells"), END_COLOR(d->character));
-			act_new(buf, ch, argument, d->character, TO_VICT, POS_SLEEPING);
+			sprintf(buf, "$n yells '%s$t%s'", get_char_color(listener, "yells"), END_COLOR(listener));
+			act_new(buf, ch, argument, listener, TO_VICT, POS_SLEEPING);
 
-			if (is_affected(d->character, gsn_word_of_command) && strstr(argument, d->character->pcdata->command[0]))
-				command_execute(d->character);
+			if (is_affected(listener, gsn_word_of_command) && strstr(argument, listener->pcdata->command[0]))
+				command_execute(listener);
 		}
 	}
 
@@ -1482,13 +1490,13 @@ void do_myell(CHAR_DATA *ch, char *argument, CHAR_DATA *attacker)
 		for (d = descriptor_list; d; d = d->next)
 		{
 			if (d->connected == CON_PLAYING
-				&&  d->character->in_room != nullptr && ch->in_room != nullptr
-				&&  d->character->in_room->area == ch->in_room->area
-				&&  d->character != ch
-				&& !IS_SET(d->character->in_room->room_flags, ROOM_SILENCE))
+				&&  Deref(d->character)->in_room != nullptr && ch->in_room != nullptr
+				&&  Deref(d->character)->in_room->area == ch->in_room->area
+				&&  Deref(d->character) != ch
+				&& !IS_SET(Deref(d->character)->in_room->room_flags, ROOM_SILENCE))
 			{
-					send_to_char(form_table[ch->pcdata->shifted].yell,d->character);
-					send_to_char("\n\r",d->character);
+					send_to_char(form_table[ch->pcdata->shifted].yell,Deref(d->character));
+					send_to_char("\n\r",Deref(d->character));
 			}
 		}
 
@@ -1907,7 +1915,7 @@ void do_quit_new(CHAR_DATA *ch, char *argument, bool autoq)
 	/* toast evil cheating bastards */
 	for (d = descriptor_list; d != nullptr; d = d->next)
 	{
-		auto tch = d->original ? d->original : d->character;
+		auto tch = Deref(d->original) ? Deref(d->original) : Deref(d->character);
 		if (tch && tch->id == id)
 		{
 			extract_char(tch, true);

--- a/code/act_comm.c
+++ b/code/act_comm.c
@@ -1863,9 +1863,6 @@ void do_quit_new(CHAR_DATA *ch, char *argument, bool autoq)
 	{
 		wch_next = wch->next;
 
-		if (wch->defending != nullptr && wch->defending == ch)
-			wch->defending = nullptr;
-
 		if (is_affected(wch, gsn_empathy))
 		{
 			AFFECT_DATA *laf = nullptr;

--- a/code/act_comm.c
+++ b/code/act_comm.c
@@ -1960,15 +1960,17 @@ void do_follow(CHAR_DATA *ch, char *argument)
 		return;
 	}
 
-	if (is_affected_by(ch, AFF_CHARM) && Deref(ch->master) != nullptr)
+	CHAR_DATA *master = Deref(ch->master);
+
+	if (is_affected_by(ch, AFF_CHARM) && master != nullptr)
 	{
-		act("But you'd rather follow $N!", ch, nullptr, Deref(ch->master), TO_CHAR);
+		act("But you'd rather follow $N!", ch, nullptr, master, TO_CHAR);
 		return;
 	}
 
 	if (victim == ch)
 	{
-		if (Deref(ch->master) == nullptr)
+		if (master == nullptr)
 		{
 			send_to_char("You already follow yourself.\n\r", ch);
 			return;
@@ -2252,7 +2254,8 @@ void do_group(CHAR_DATA *ch, char *argument)
 	{
 		std::string buffer;
 		char buf2[MAX_STRING_LENGTH];
-		auto leader = Deref(ch->leader) != nullptr ? Deref(ch->leader) : ch;
+		auto chLeader = Deref(ch->leader);
+		auto leader = chLeader != nullptr ? chLeader : ch;
 
 		buffer = fmt::format("{}'s group:\n\r", pers(leader, ch));
 		send_to_char(buffer.c_str(), ch);
@@ -2303,7 +2306,9 @@ void do_group(CHAR_DATA *ch, char *argument)
 		return;
 	}
 
-	if (Deref(ch->master) != nullptr || (Deref(ch->leader) != nullptr && Deref(ch->leader) != ch))
+	auto leader = Deref(ch->leader);
+
+	if (Deref(ch->master) != nullptr || (leader != nullptr && leader != ch))
 	{
 		send_to_char("But you are following someone else!\n\r", ch);
 		return;

--- a/code/act_comm.c
+++ b/code/act_comm.c
@@ -39,6 +39,7 @@
 #include <stdlib.h>
 #include <time.h>
 #include "merc.h"
+#include "entity/handles.h"
 #include "act_comm.h"
 #include "rift.h"
 #include "recycle.h"
@@ -1268,7 +1269,7 @@ void do_tell(CHAR_DATA *ch, char *argument)
 	if (is_affected(victim, gsn_word_of_command) && strstr(argument, victim->pcdata->command[0]))
 		command_execute(victim);
 
-	victim->reply = ch;
+	victim->reply = ch->self;
 
 	if (deaf)
 		free_pstring(argument);
@@ -1285,7 +1286,7 @@ void do_noreply(CHAR_DATA *ch, char *argument)
 
 	for (auto vch = char_list; vch; vch = vch->next)
 	{
-		if (!is_npc(vch) && vch->reply == ch)
+		if (!is_npc(vch) && Deref(vch->reply) == ch)
 			vch->reply = nullptr;
 	}
 }
@@ -1298,7 +1299,7 @@ void do_reply(CHAR_DATA *ch, char *argument)
 		return;
 	}
 
-	auto victim = ch->reply;
+	auto victim = Deref(ch->reply);
 	if (victim == nullptr)
 	{
 		send_to_char("They aren't here.\n\r", ch);
@@ -1372,7 +1373,7 @@ void do_reply(CHAR_DATA *ch, char *argument)
 	if (IS_SET(victim->progtypes, MPROG_SPEECH) && victim != ch)
 		victim->pIndexData->mprogs->speech_prog(victim, ch, argument);
 
-	victim->reply = ch;
+	victim->reply = ch->self;
 
 	if (deaf)
 		free_pstring(argument);

--- a/code/act_comm.c
+++ b/code/act_comm.c
@@ -1791,7 +1791,7 @@ void do_quit_new(CHAR_DATA *ch, char *argument, bool autoq)
 		{
 			if (isCabalItem(obj))
 			{
-				if (obj->carried_by != nullptr && obj->carried_by == ch)
+				if (obj->carried_by == ch->self)
 				{
 					act("You cannot quit with cabal items in your inventory!", ch, 0, 0, TO_CHAR);
 					return;
@@ -1846,12 +1846,12 @@ void do_quit_new(CHAR_DATA *ch, char *argument, bool autoq)
 		obj_next = obj->next;
 		if (isCabalItem(obj))
 		{
-			if (obj->carried_by != nullptr && obj->carried_by == ch)
+			if (obj->carried_by == ch->self)
 				extract_obj(obj);
 		}
 		else if (obj->pIndexData->limtotal != 0 && ch->level < 10)
 		{
-			if (obj->carried_by == ch)
+			if (obj->carried_by == ch->self)
 				extract_obj(obj);
 		}
 	}

--- a/code/act_comm.c
+++ b/code/act_comm.c
@@ -1885,7 +1885,7 @@ void do_quit_new(CHAR_DATA *ch, char *argument, bool autoq)
 		if (!is_npc(wch))
 			continue;
 
-		if (is_npc(wch) && is_affected_by(wch, AFF_CHARM) && wch->master == ch && IS_SET(wch->act, ACT_UNDEAD))
+		if (is_npc(wch) && is_affected_by(wch, AFF_CHARM) && Deref(wch->master) == ch && IS_SET(wch->act, ACT_UNDEAD))
 		{
 			extract_char(wch, true);
 			continue;
@@ -1949,15 +1949,15 @@ void do_follow(CHAR_DATA *ch, char *argument)
 		return;
 	}
 
-	if (is_affected_by(ch, AFF_CHARM) && ch->master != nullptr)
+	if (is_affected_by(ch, AFF_CHARM) && Deref(ch->master) != nullptr)
 	{
-		act("But you'd rather follow $N!", ch, nullptr, ch->master, TO_CHAR);
+		act("But you'd rather follow $N!", ch, nullptr, Deref(ch->master), TO_CHAR);
 		return;
 	}
 
 	if (victim == ch)
 	{
-		if (ch->master == nullptr)
+		if (Deref(ch->master) == nullptr)
 		{
 			send_to_char("You already follow yourself.\n\r", ch);
 			return;
@@ -1989,7 +1989,7 @@ void do_follow(CHAR_DATA *ch, char *argument)
 
 	REMOVE_BIT(ch->act, PLR_NOFOLLOW);
 
-	if (ch->master != nullptr)
+	if (Deref(ch->master) != nullptr)
 		stop_follower(ch);
 
 	add_follower(ch, victim);
@@ -1997,13 +1997,13 @@ void do_follow(CHAR_DATA *ch, char *argument)
 
 void add_follower(CHAR_DATA *ch, CHAR_DATA *master)
 {
-	if (ch->master != nullptr)
+	if (Deref(ch->master) != nullptr)
 	{
 		RS.Logger.Debug("Add_follower: non-nullptr master.");
 		return;
 	}
 
-	ch->master = master;
+	ch->master = master->self;
 	ch->leader = nullptr;
 
 	auto chance = get_skill(ch, gsn_trail);
@@ -2041,7 +2041,11 @@ void add_follower(CHAR_DATA *ch, CHAR_DATA *master)
 
 void stop_follower(CHAR_DATA *ch)
 {
-	if (ch->master == nullptr)
+	CHAR_DATA *master;
+
+	master = Deref(ch->master);
+
+	if (master == nullptr)
 	{
 		RS.Logger.Debug("Stop_follower: nullptr master.");
 		return;
@@ -2053,16 +2057,17 @@ void stop_follower(CHAR_DATA *ch)
 		affect_strip(ch, gsn_charm_person);
 	}
 
-	if (can_see(ch->master, ch) && ch->in_room != nullptr && !(is_npc(ch) && ch->pIndexData->vnum == MOB_VNUM_ANCHOR))
+	if (can_see(master, ch) && ch->in_room != nullptr && !(is_npc(ch) && ch->pIndexData->vnum == MOB_VNUM_ANCHOR))
 	{
-		act("$n stops following you.", ch, nullptr, ch->master, TO_VICT);
-		act("You stop following $N.", ch, nullptr, ch->master, TO_CHAR);
+		act("$n stops following you.", ch, nullptr, master, TO_VICT);
+		act("You stop following $N.", ch, nullptr, master, TO_CHAR);
 
 		if (is_affected(ch, gsn_trail))
 			affect_strip(ch, gsn_trail);
 	}
-	if (ch->master->pet == ch)
-		ch->master->pet = nullptr;
+
+	if (Deref(master->pet) == ch)
+		master->pet = nullptr;
 
 	check_leadership_affect(ch);
 	ch->master = nullptr;
@@ -2072,7 +2077,7 @@ void stop_follower(CHAR_DATA *ch)
 /* nukes charmed monsters and pets */
 void nuke_pets(CHAR_DATA *ch)
 {
-	auto pet = ch->pet;
+	auto pet = Deref(ch->pet);
 	if (pet != nullptr)
 	{
 		stop_follower(pet);
@@ -2093,10 +2098,12 @@ void die_follower(CHAR_DATA *ch)
 		return;
 	}
 
-	if (ch->master != nullptr)
+	CHAR_DATA *master = Deref(ch->master);
+
+	if (master != nullptr)
 	{
-		if (ch->master->pet == ch)
-			ch->master->pet = nullptr;
+		if (Deref(master->pet) == ch)
+			master->pet = nullptr;
 
 		stop_follower(ch);
 	}
@@ -2114,7 +2121,7 @@ void die_follower(CHAR_DATA *ch)
 		}*/
 		if (is_npc(fch) && (is_affected(fch, gsn_animate_dead) || is_affected_by(fch, AFF_CHARM)))
 		{
-			if (fch->master == ch)
+			if (Deref(fch->master) == ch)
 			{
 				REMOVE_BIT(fch->affected_by, AFF_CHARM);
 				affect_strip(fch, gsn_animate_dead);
@@ -2124,11 +2131,11 @@ void die_follower(CHAR_DATA *ch)
 		}
 		else
 		{
-			if (fch->master == ch && !is_affected(fch, gsn_trail))
+			if (Deref(fch->master) == ch && !is_affected(fch, gsn_trail))
 				stop_follower(fch);
 
-			if (fch->leader == ch && !is_affected(fch, gsn_trail))
-				fch->leader = fch;
+			if (Deref(fch->leader) == ch && !is_affected(fch, gsn_trail))
+				fch->leader = fch->self;
 		}
 	}
 }
@@ -2168,7 +2175,7 @@ void do_order(CHAR_DATA *ch, char *argument)
 			return;
 		}
 
-		if (!is_affected_by(victim, AFF_CHARM) || victim->master != ch || (is_immortal(victim) && victim->trust >= ch->trust))
+		if (!is_affected_by(victim, AFF_CHARM) || Deref(victim->master) != ch || (is_immortal(victim) && victim->trust >= ch->trust))
 		{
 			send_to_char("Do it yourself!\n\r", ch);
 			return;
@@ -2195,7 +2202,7 @@ void do_order(CHAR_DATA *ch, char *argument)
 	{
 		och_next = och->next_in_room;
 
-		if (is_affected_by(och, AFF_CHARM) && och->master == ch && (fAll || och == victim))
+		if (is_affected_by(och, AFF_CHARM) && Deref(och->master) == ch && (fAll || och == victim))
 		{
 			if (is_npc(och) && och->pIndexData->vnum == ACADEMY_PET)
 				continue;
@@ -2234,7 +2241,7 @@ void do_group(CHAR_DATA *ch, char *argument)
 	{
 		std::string buffer;
 		char buf2[MAX_STRING_LENGTH];
-		auto leader = ch->leader != nullptr ? ch->leader : ch;
+		auto leader = Deref(ch->leader) != nullptr ? Deref(ch->leader) : ch;
 
 		buffer = fmt::format("{}'s group:\n\r", pers(leader, ch));
 		send_to_char(buffer.c_str(), ch);
@@ -2285,13 +2292,13 @@ void do_group(CHAR_DATA *ch, char *argument)
 		return;
 	}
 
-	if (ch->master != nullptr || (ch->leader != nullptr && ch->leader != ch))
+	if (Deref(ch->master) != nullptr || (Deref(ch->leader) != nullptr && Deref(ch->leader) != ch))
 	{
 		send_to_char("But you are following someone else!\n\r", ch);
 		return;
 	}
 
-	if (victim->master != ch && ch != victim)
+	if (Deref(victim->master) != ch && ch != victim)
 	{
 		act_new("$N isn't following you.", ch, nullptr, victim, TO_CHAR, POS_SLEEPING);
 		return;
@@ -2319,7 +2326,7 @@ void do_group(CHAR_DATA *ch, char *argument)
 		return;
 	}
 
-	victim->leader = ch;
+	victim->leader = ch->self;
 	act_new("$N joins $n's group.", ch, nullptr, victim, TO_NOTVICT, POS_RESTING);
 	act_new("You join $n's group.", ch, nullptr, victim, TO_VICT, POS_SLEEPING);
 	act_new("$N joins your group.", ch, nullptr, victim, TO_CHAR, POS_SLEEPING);
@@ -2638,11 +2645,11 @@ bool is_same_group(CHAR_DATA *ach, CHAR_DATA *bch)
 	/* if ( ( ach->level - bch->level > 8 || ach->level - bch->level < -8 ) && !is_npc(ach) )
 		return false;*/
 
-	if (ach->leader != nullptr)
-		ach = ach->leader;
+	if (Deref(ach->leader) != nullptr)
+		ach = Deref(ach->leader);
 
-	if (bch->leader != nullptr)
-		bch = bch->leader;
+	if (Deref(bch->leader) != nullptr)
+		bch = Deref(bch->leader);
 
 	return ach == bch;
 }
@@ -2665,7 +2672,7 @@ void do_release(CHAR_DATA *ch, char *argument)
 		return;
 	}
 
-	if (!is_affected_by(victim, AFF_CHARM) || victim->master != ch)
+	if (!is_affected_by(victim, AFF_CHARM) || Deref(victim->master) != ch)
 	{
 		send_to_char("They aren't under your control.\n\r", ch);
 		return;
@@ -2728,8 +2735,8 @@ void perm_death_log(CHAR_DATA *ch, int deltype)
 
 void temp_death_log(CHAR_DATA *killer, CHAR_DATA *dead)
 {
-	if (is_npc(killer) && (killer->master != nullptr))
-		killer = killer->master;
+	if (is_npc(killer) && (Deref(killer->master) != nullptr))
+		killer = Deref(killer->master);
 
 	if (is_npc(dead) || is_npc(killer))
 		return;

--- a/code/act_comm.c
+++ b/code/act_comm.c
@@ -428,10 +428,12 @@ void do_newbie(CHAR_DATA *ch, char *argument)
 
 	for (auto wch = char_list; wch != nullptr; wch = wch->next)
 	{
-		if (is_npc(wch) && wch->desc == nullptr)
+		DESCRIPTOR_DATA *connection = Deref(wch->desc);
+
+		if (is_npc(wch) && connection == nullptr)
 			continue;
 
-		if ((wch->level <= 25 && !IS_SET(wch->comm, COMM_NONEWBIE)) || is_immortal(wch) || is_heroimm(wch) || (is_npc(wch) && (wch->desc != nullptr) && is_immortal(Deref(wch->desc->original))))
+		if ((wch->level <= 25 && !IS_SET(wch->comm, COMM_NONEWBIE)) || is_immortal(wch) || is_heroimm(wch) || (is_npc(wch) && connection != nullptr && is_immortal(Deref(connection->original))))
 		{
 			if (IS_SET(wch->comm, COMM_ANSI))
 			{
@@ -496,10 +498,12 @@ void do_builder(CHAR_DATA *ch, char *argument)
 
 	for (auto wch = char_list; wch != nullptr; wch = wch->next)
 	{
-		if (is_npc(wch) && wch->desc == nullptr)
+		DESCRIPTOR_DATA *connection = Deref(wch->desc);
+
+		if (is_npc(wch) && connection == nullptr)
 			continue;
 
-		if (is_immortal(wch) || IS_SET(wch->comm, COMM_BUILDER) || is_heroimm(wch) || (is_npc(wch) && (wch->desc != nullptr) && is_immortal(Deref(wch->desc->original))))
+		if (is_immortal(wch) || IS_SET(wch->comm, COMM_BUILDER) || is_heroimm(wch) || (is_npc(wch) && connection != nullptr && is_immortal(Deref(connection->original))))
 		{
 			if (IS_SET(wch->comm, COMM_ANSI))
 			{
@@ -585,10 +589,12 @@ void do_immtalk(CHAR_DATA *ch, char *argument)
 
 	for (auto wch = char_list; wch != nullptr; wch = wch->next)
 	{
-		if (is_npc(wch) && wch->desc == nullptr)
+		DESCRIPTOR_DATA *connection = Deref(wch->desc);
+
+		if (is_npc(wch) && connection == nullptr)
 			continue;
 
-		if ((is_immortal(wch) || IS_SET(wch->comm, COMM_IMMORTAL) || (is_npc(wch) && (wch->desc != nullptr) && is_immortal(Deref(wch->desc->original)))) && get_trust(wch) >= std::max(level, 52))
+		if ((is_immortal(wch) || IS_SET(wch->comm, COMM_IMMORTAL) || (is_npc(wch) && connection != nullptr && is_immortal(Deref(connection->original)))) && get_trust(wch) >= std::max(level, 52))
 		{
 			if (IS_SET(wch->comm, COMM_ANSI))
 			{
@@ -1225,7 +1231,7 @@ void do_tell(CHAR_DATA *ch, char *argument)
 	}
 
 	char buf[MAX_STRING_LENGTH];
-	if (victim->desc == nullptr && !is_npc(victim))
+	if (Deref(victim->desc) == nullptr && !is_npc(victim))
 	{
 		act("$N seems to have lost consciousness...try again later.", ch, nullptr, victim, TO_CHAR);
 		sprintf(buf, "%s tells you '%s'\n\r", pers(ch, victim), argument);
@@ -1311,7 +1317,7 @@ void do_reply(CHAR_DATA *ch, char *argument)
 	}
 
 	char buf[MAX_STRING_LENGTH];
-	if (victim->desc == nullptr && !is_npc(victim) && !is_switched(victim) && victim->pcdata)
+	if (Deref(victim->desc) == nullptr && !is_npc(victim) && !is_switched(victim) && victim->pcdata)
 	{
 		act("$N seems to have lost consciousness...try again later.", ch, nullptr, victim, TO_CHAR);
 		sprintf(buf, "%s tells you '%s'\n\r", pers(ch, victim), argument);
@@ -1581,7 +1587,7 @@ void do_pmote(CHAR_DATA *ch, char *argument)
 	char last[MAX_INPUT_LENGTH];
 	for (auto vch = ch->in_room->people; vch != nullptr; vch = vch->next_in_room)
 	{
-		if (vch->desc == nullptr || vch == ch)
+		if (Deref(vch->desc) == nullptr || vch == ch)
 			continue;
 
 		letter = strstr(argument, vch->name);
@@ -1905,7 +1911,7 @@ void do_quit_new(CHAR_DATA *ch, char *argument, bool autoq)
 
 	save_char_obj(ch);
 	auto id = ch->id;
-	auto d = ch->desc;
+	auto d = Deref(ch->desc);
 
 	extract_char(ch, true);
 
@@ -2784,7 +2790,7 @@ void mob_death_log(CHAR_DATA *killer, CHAR_DATA *dead)
 /* type 0 = create, 1 = login, 2 = logout */
 void login_log(CHAR_DATA *ch, int type)
 {
-	if (!ch->pcdata->host && !ch->desc)
+	if (!ch->pcdata->host && !Deref(ch->desc))
 		return;
 
 	if (IS_SET(ch->comm, COMM_NOSOCKET))
@@ -2792,7 +2798,7 @@ void login_log(CHAR_DATA *ch, int type)
 
 	Login login;
 	login.name = ch->true_name;
-	login.site = ch->pcdata->host ? ch->pcdata->host : ch->desc->host;
+	login.site = ch->pcdata->host ? ch->pcdata->host : Deref(ch->desc)->host;
 	login.time = log_time();
 	login.ctime = current_time;
 	login.played = type == 2 ? (int)((current_time - ch->logon) / 60) : -1;

--- a/code/act_comm.c
+++ b/code/act_comm.c
@@ -1889,7 +1889,7 @@ void do_quit_new(CHAR_DATA *ch, char *argument, bool autoq)
 				}
 			}
 
-			if (laf->owner == ch)
+			if (Deref(laf->owner) == ch)
 				affect_strip(wch, gsn_empathy);
 		}
 
@@ -2349,7 +2349,7 @@ void do_group(CHAR_DATA *ch, char *argument)
 		af.where = TO_AFFECTS;
 		af.aftype = AFT_INVIS;
 		af.type = gsn_traitors_luck;
-		af.owner = ch;
+		af.owner = ch->self;
 		af.level = ch->level;
 		af.duration = -1;
 		SET_BIT(af.bitvector, AFF_PERMANENT);
@@ -2365,7 +2365,7 @@ void do_group(CHAR_DATA *ch, char *argument)
 		af.where = TO_AFFECTS;
 		af.aftype = AFT_INVIS;
 		af.type = gsn_traitors_luck;
-		af.owner = victim;
+		af.owner = victim->self;
 		af.level = ch->level;
 		af.duration = -1;
 		SET_BIT(af.bitvector, AFF_PERMANENT);

--- a/code/act_ente.c
+++ b/code/act_ente.c
@@ -37,6 +37,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include "merc.h"
+#include "entity/handles.h"
 #include "act_ente.h"
 #include "handler.h"
 #include "magic.h"
@@ -79,7 +80,7 @@ ROOM_INDEX_DATA *get_random_room(CHAR_DATA *ch)
 /* RT Enter portals */
 void do_enter(CHAR_DATA *ch, char *argument)
 {
-	if (ch->fighting != nullptr)
+	if (Deref(ch->fighting) != nullptr)
 		return;
 
 	/* nifty portal stuff */

--- a/code/act_ente.c
+++ b/code/act_ente.c
@@ -204,10 +204,10 @@ void do_enter(CHAR_DATA *ch, char *argument)
 		if (portal == nullptr || portal->value[0] == 0)
 			continue;
 
-		if (fch->master == ch && is_affected_by(fch, AFF_CHARM) && fch->position < POS_STANDING)
+		if (Deref(fch->master) == ch && is_affected_by(fch, AFF_CHARM) && fch->position < POS_STANDING)
 			do_stand(fch, "");
 
-		if (fch->master == ch && fch->position == POS_STANDING)
+		if (Deref(fch->master) == ch && fch->position == POS_STANDING)
 		{
 			if (IS_SET(ch->in_room->room_flags, ROOM_LAW) && (is_npc(fch) && IS_SET(fch->act, ACT_AGGRESSIVE)))
 			{

--- a/code/act_info.c
+++ b/code/act_info.c
@@ -48,6 +48,7 @@
 
 #include "merc.h"
 #include "act_info.h"
+#include "entity/handles.h"
 #include "rift.h"
 #include "weather_enums.h"
 #include "handler.h"
@@ -476,6 +477,7 @@ void show_char_to_char_0(CHAR_DATA *victim, CHAR_DATA *ch)
 		strcat(buf, victim->pcdata->title);
 
 	char message[MAX_STRING_LENGTH];
+	OBJ_DATA *seatedOn = Deref(victim->on);	// the furniture, if it is still around
 	switch (victim->position)
 	{
 		case POS_DEAD:
@@ -491,21 +493,21 @@ void show_char_to_char_0(CHAR_DATA *victim, CHAR_DATA *ch)
 			strcat(buf, " is lying here stunned.");
 			break;
 		case POS_SLEEPING:
-			if (victim->on != nullptr)
+			if (seatedOn != nullptr)
 			{
-				if (IS_SET_OLD(victim->on->value[2], SLEEP_AT))
+				if (IS_SET_OLD(seatedOn->value[2], SLEEP_AT))
 				{
-					sprintf(message, " is here, sleeping at %s.", victim->on->short_descr);
+					sprintf(message, " is here, sleeping at %s.", seatedOn->short_descr);
 					strcat(buf, message);
 				}
-				else if (IS_SET_OLD(victim->on->value[2], SLEEP_ON))
+				else if (IS_SET_OLD(seatedOn->value[2], SLEEP_ON))
 				{
-					sprintf(message, " is here, sleeping on %s.", victim->on->short_descr);
+					sprintf(message, " is here, sleeping on %s.", seatedOn->short_descr);
 					strcat(buf, message);
 				}
 				else
 				{
-					sprintf(message, " is here, sleeping in %s.", victim->on->short_descr);
+					sprintf(message, " is here, sleeping in %s.", seatedOn->short_descr);
 					strcat(buf, message);
 				}
 			}
@@ -515,26 +517,26 @@ void show_char_to_char_0(CHAR_DATA *victim, CHAR_DATA *ch)
 			}
 			break;
 		case POS_RESTING:
-			if (victim->on != nullptr)
+			if (seatedOn != nullptr)
 			{
-				if (IS_SET_OLD(victim->on->value[2], REST_AT))
+				if (IS_SET_OLD(seatedOn->value[2], REST_AT))
 				{
-					sprintf(message, " is here, resting at %s.", victim->on->short_descr);
+					sprintf(message, " is here, resting at %s.", seatedOn->short_descr);
 					strcat(buf, message);
 				}
-				else if (IS_SET_OLD(victim->on->value[2], REST_ON))
+				else if (IS_SET_OLD(seatedOn->value[2], REST_ON))
 				{
-					sprintf(message, " is here, resting on %s.", victim->on->short_descr);
+					sprintf(message, " is here, resting on %s.", seatedOn->short_descr);
 					strcat(buf, message);
 				}
-				else if (IS_SET_OLD(victim->on->value[2], LOUNGE_ON))
+				else if (IS_SET_OLD(seatedOn->value[2], LOUNGE_ON))
 				{
-					sprintf(message, " is here, lounging on %s.", victim->on->short_descr);
+					sprintf(message, " is here, lounging on %s.", seatedOn->short_descr);
 					strcat(buf, message);
 				}
 				else
 				{
-					sprintf(message, " is here, resting in %s.", victim->on->short_descr);
+					sprintf(message, " is here, resting in %s.", seatedOn->short_descr);
 					strcat(buf, message);
 				}
 			}
@@ -544,21 +546,21 @@ void show_char_to_char_0(CHAR_DATA *victim, CHAR_DATA *ch)
 			}
 			break;
 		case POS_SITTING:
-			if (victim->on != nullptr)
+			if (seatedOn != nullptr)
 			{
-				if (IS_SET_OLD(victim->on->value[2], SIT_AT))
+				if (IS_SET_OLD(seatedOn->value[2], SIT_AT))
 				{
-					sprintf(message, " is here, sitting at %s.", victim->on->short_descr);
+					sprintf(message, " is here, sitting at %s.", seatedOn->short_descr);
 					strcat(buf, message);
 				}
-				else if (IS_SET_OLD(victim->on->value[2], SIT_ON))
+				else if (IS_SET_OLD(seatedOn->value[2], SIT_ON))
 				{
-					sprintf(message, " is here, sitting on %s.", victim->on->short_descr);
+					sprintf(message, " is here, sitting on %s.", seatedOn->short_descr);
 					strcat(buf, message);
 				}
 				else
 				{
-					sprintf(message, " is here, sitting in %s.", victim->on->short_descr);
+					sprintf(message, " is here, sitting in %s.", seatedOn->short_descr);
 					strcat(buf, message);
 				}
 			}
@@ -568,21 +570,21 @@ void show_char_to_char_0(CHAR_DATA *victim, CHAR_DATA *ch)
 			}
 			break;
 		case POS_STANDING:
-			if (victim->on != nullptr)
+			if (seatedOn != nullptr)
 			{
-				if (IS_SET_OLD(victim->on->value[2], STAND_AT))
+				if (IS_SET_OLD(seatedOn->value[2], STAND_AT))
 				{
-					sprintf(message, " is here, standing at %s.", victim->on->short_descr);
+					sprintf(message, " is here, standing at %s.", seatedOn->short_descr);
 					strcat(buf, message);
 				}
-				else if (IS_SET_OLD(victim->on->value[2], STAND_ON))
+				else if (IS_SET_OLD(seatedOn->value[2], STAND_ON))
 				{
-					sprintf(message, " is here, standing on %s.", victim->on->short_descr);
+					sprintf(message, " is here, standing on %s.", seatedOn->short_descr);
 					strcat(buf, message);
 				}
 				else
 				{
-					sprintf(message, " is here, standing in %s.", victim->on->short_descr);
+					sprintf(message, " is here, standing in %s.", seatedOn->short_descr);
 					strcat(buf, message);
 				}
 			}

--- a/code/act_info.c
+++ b/code/act_info.c
@@ -2946,15 +2946,15 @@ void do_whois(CHAR_DATA *ch, char *argument)
 		char const *class_name;
 		char const *imm_lvl;
 
-		if (d->connected != CON_PLAYING || !can_see(ch, d->character))
+		if (d->connected != CON_PLAYING || !can_see(ch, Deref(d->character)))
 			continue;
 
-		auto wch = (d->original != nullptr) ? d->original : d->character;
+		auto wch = (Deref(d->original) != nullptr) ? Deref(d->original) : Deref(d->character);
 
 		if (!can_see(ch, wch))
 			continue;
 
-		if (is_affected(d->character, gsn_disguise))
+		if (is_affected(Deref(d->character), gsn_disguise))
 			continue;
 
 		if (str_cmp(wch->name, wch->true_name)
@@ -3294,12 +3294,12 @@ void do_who(CHAR_DATA *ch, char *argument)
 		 * Check for match against restrictions.
 		 * Don't use trust as that exposes trusted mortals.
 		 */
-		if (d->connected != CON_PLAYING || !can_see(ch, d->character))
+		if (d->connected != CON_PLAYING || !can_see(ch, Deref(d->character)))
 			continue;
 
-		auto wch = d->original != nullptr
-			? d->original
-			: d->character;
+		auto wch = Deref(d->original) != nullptr
+			? Deref(d->original)
+			: Deref(d->character);
 
 		if (!can_see(ch, wch))
 			continue;
@@ -3496,7 +3496,7 @@ void do_count(CHAR_DATA *ch, char *argument)
 	{
 		if (d->connected == CON_PLAYING)
 		{
-			if (can_see(ch, d->character) && !is_switched(d->character))
+			if (can_see(ch, Deref(d->character)) && !is_switched(Deref(d->character)))
 				count++;
 			else
 				not_seen++;
@@ -3693,7 +3693,7 @@ void do_where(CHAR_DATA *ch, char *argument)
 
 		for (auto d = descriptor_list; d; d = d->next)
 		{
-			auto victim = d->character;
+			auto victim = Deref(d->character);
 			if (d->connected == CON_PLAYING
 				&& victim != nullptr
 				&& !is_npc(victim)
@@ -3728,7 +3728,7 @@ void do_where(CHAR_DATA *ch, char *argument)
 	{
 		for (auto d = descriptor_list; d; d = d->next)
 		{
-			auto victim = d->character;
+			auto victim = Deref(d->character);
 			if (d->connected == CON_PLAYING
 				&& victim != nullptr
 				&& !is_npc(victim)

--- a/code/act_info.c
+++ b/code/act_info.c
@@ -598,19 +598,22 @@ void show_char_to_char_0(CHAR_DATA *victim, CHAR_DATA *ch)
 			}
 			break;
 		case POS_FIGHTING:
+		{
+			CHAR_DATA *opponent = Deref(victim->fighting);
+
 			strcat(buf, " is here, fighting ");
 
-			if (Deref(victim->fighting) == nullptr)
+			if (opponent == nullptr)
 			{
 				strcat(buf, "thin air??");
 			}
-			else if (Deref(victim->fighting) == ch)
+			else if (opponent == ch)
 			{
 				strcat(buf, "YOU!");
 			}
-			else if (victim->in_room == Deref(victim->fighting)->in_room)
+			else if (victim->in_room == opponent->in_room)
 			{
-				strcat(buf, pers(Deref(victim->fighting), ch));
+				strcat(buf, pers(opponent, ch));
 				strcat(buf, ".");
 			}
 			else
@@ -618,6 +621,7 @@ void show_char_to_char_0(CHAR_DATA *victim, CHAR_DATA *ch)
 				strcat(buf, "someone who left??");
 			}
 			break;
+		}
 	}
 
 	strcat(buf, "\n\r");

--- a/code/act_info.c
+++ b/code/act_info.c
@@ -189,7 +189,11 @@ char *format_obj_to_char(OBJ_DATA *obj, CHAR_DATA *ch, bool fShort)
 	if (is_affected_obj(obj, gsn_stash) && is_immortal(ch))
 	{
 		OBJ_AFFECT_DATA *oaf = affect_find_obj(obj->affected, gsn_stash);
-		sprintf(buf, "(Stashed by %s) ", oaf->owner->name);
+		CHAR_DATA *stasher = Deref(oaf->owner);
+
+		// An object outlives whoever stashed it, and nothing removes the affect
+		// when they go, so this is a routine case rather than a defensive one.
+		sprintf(buf, "(Stashed by %s) ", stasher ? stasher->name : "someone gone");
 	}
 
 	if (is_obj_stat(obj, ITEM_NOSHOW) && is_immortal(ch))
@@ -1003,7 +1007,7 @@ bool check_blind(CHAR_DATA *ch)
 	{
 		auto paf = affect_find_area(ch->in_room->area->affected, gsn_whiteout);
 
-		if (paf && paf->owner != ch)
+		if (paf && Deref(paf->owner) != ch)
 		{
 			send_to_char("You can't see a thing through the snow!\n\r", ch);
 			return false;
@@ -1855,7 +1859,7 @@ void do_look(CHAR_DATA *ch, char *argument)
 		{
 			for (auto &raf : ch->in_room->affected)
 			{
-				if (raf.type == gsn_riptide && raf.owner == ch && raf.location == APPLY_ROOM_NONE &&
+				if (raf.type == gsn_riptide && Deref(raf.owner) == ch && raf.location == APPLY_ROOM_NONE &&
 					raf.modifier == 1)
 				{
 					sprintf(buf, "%sThe calm surface of the water belies the deadly riptide churning beneath!%s\n\r",
@@ -1865,7 +1869,7 @@ void do_look(CHAR_DATA *ch, char *argument)
 					send_to_char(buf, ch);
 					break;
 				}
-				else if (raf.type == gsn_riptide && raf.owner == ch && raf.location == APPLY_ROOM_NONE &&
+				else if (raf.type == gsn_riptide && Deref(raf.owner) == ch && raf.location == APPLY_ROOM_NONE &&
 						 raf.modifier == 2)
 				{
 					sprintf(buf, "%sThe waters swirl menacingly, ready to receive the riptide's prey.%s\n\r",
@@ -1884,14 +1888,14 @@ void do_look(CHAR_DATA *ch, char *argument)
 
 			for (i = 0; i < MAX_TRACKS; i++)
 			{
-				if (ch->in_room->tracks[i].prey != af->owner)
+				if (ch->in_room->tracks[i].prey != Deref(af->owner))
 					continue;
 
 				direction = (char *)flag_name_lookup(ch->in_room->tracks[i].direction, direction_table);
 
 				sprintf(buf, "%sThrough the veil of your rage, you sense %s's tracks leading %s.%s\n\r",
 					get_char_color(ch, "lightred"),
-					af->owner->name,
+					Deref(af->owner)->name,
 					direction,
 					END_COLOR(ch));
 

--- a/code/act_info.c
+++ b/code/act_info.c
@@ -2664,9 +2664,11 @@ void do_score(CHAR_DATA *ch, char *argument)
 	else
 		send_to_char("chaotic ethos.\n\r", ch);
 
-	if (ch->pcdata->trusting)
+	CHAR_DATA *trusted = Deref(ch->pcdata->trusting);
+
+	if (trusted)
 	{
-		sprintf(buf, "You are trusting %s.\n\r", ch->pcdata->trusting->name);
+		sprintf(buf, "You are trusting %s.\n\r", trusted->name);
 		send_to_char(buf, ch);
 	}
 	if (ch->Class()->GetIndex() == CLASS_SORCERER)
@@ -5308,18 +5310,20 @@ void do_trustchar(CHAR_DATA *ch, char *argument)
 
 	if (!str_cmp(argument, "self"))
 	{
-		if (!ch->pcdata->trusting)
+		CHAR_DATA *trusted = Deref(ch->pcdata->trusting);
+
+		if (!trusted)
 		{
 			send_to_char("You are not trusting anybody specific.\n\r", ch);
 			return;
 		}
 
-		act("You no longer trust $N with questionable actions.", ch, 0, ch->pcdata->trusting, TO_CHAR);
+		act("You no longer trust $N with questionable actions.", ch, 0, trusted, TO_CHAR);
 		ch->pcdata->trusting = nullptr;
 		return;
 	}
 
-	ch->pcdata->trusting = victim;
+	ch->pcdata->trusting = victim->self;
 	act("You now trust $N with questionable actions.", ch, 0, victim, TO_CHAR);
 }
 

--- a/code/act_info.c
+++ b/code/act_info.c
@@ -215,7 +215,7 @@ char *format_obj_to_char(OBJ_DATA *obj, CHAR_DATA *ch, bool fShort)
  */
 void show_list_to_char(OBJ_DATA *list, CHAR_DATA *ch, bool fShort, bool fShowNothing)
 {
-	if (ch->desc == nullptr)
+	if (Deref(ch->desc) == nullptr)
 		return;
 
 	/*
@@ -1575,7 +1575,7 @@ void do_nosummon(CHAR_DATA *ch, char *argument)
 
 void do_glance(CHAR_DATA *ch, char *argument)
 {
-	if (ch->desc == nullptr)
+	if (Deref(ch->desc) == nullptr)
 		return;
 
 	if (argument[0] == '\0')
@@ -1617,7 +1617,7 @@ void do_glance(CHAR_DATA *ch, char *argument)
 
 void do_examine(CHAR_DATA *ch, char *argument)
 {
-	if (ch->desc == nullptr)
+	if (Deref(ch->desc) == nullptr)
 		return;
 
 	char arg[MAX_INPUT_LENGTH];
@@ -1710,7 +1710,7 @@ void do_look(CHAR_DATA *ch, char *argument)
 	int door;
 	int i;
 
-	if (ch->desc == nullptr)
+	if (Deref(ch->desc) == nullptr)
 		return;
 
 	if (ch->position < POS_SLEEPING)
@@ -2913,7 +2913,9 @@ void do_oldhelp(CHAR_DATA *ch, char *argument)
 			found = true;
 
 			/* small hack :) */
-			if (ch->desc != nullptr && ch->desc->connected != CON_PLAYING && ch->desc->connected != CON_GEN_GROUPS)
+			DESCRIPTOR_DATA *connection = Deref(ch->desc);
+
+			if (connection != nullptr && connection->connected != CON_PLAYING && connection->connected != CON_GEN_GROUPS)
 				break;
 		}
 	}

--- a/code/act_info.c
+++ b/code/act_info.c
@@ -596,17 +596,17 @@ void show_char_to_char_0(CHAR_DATA *victim, CHAR_DATA *ch)
 		case POS_FIGHTING:
 			strcat(buf, " is here, fighting ");
 
-			if (victim->fighting == nullptr)
+			if (Deref(victim->fighting) == nullptr)
 			{
 				strcat(buf, "thin air??");
 			}
-			else if (victim->fighting == ch)
+			else if (Deref(victim->fighting) == ch)
 			{
 				strcat(buf, "YOU!");
 			}
-			else if (victim->in_room == victim->fighting->in_room)
+			else if (victim->in_room == Deref(victim->fighting)->in_room)
 			{
-				strcat(buf, pers(victim->fighting, ch));
+				strcat(buf, pers(Deref(victim->fighting), ch));
 				strcat(buf, ".");
 			}
 			else
@@ -5216,10 +5216,12 @@ void do_xlook(CHAR_DATA *ch, char *argument)
 	if (foundIR == 0)
 		send_to_char("none.", ch);
 
-	if (victim->fighting != nullptr)
+	CHAR_DATA *opponent = Deref(victim->fighting);
+
+	if (opponent != nullptr)
 	{
 		send_to_char("\n\rFighting: ", ch);
-		send_to_char((is_npc(victim->fighting) ? victim->fighting->short_descr : victim->fighting->name), ch);
+		send_to_char((is_npc(opponent) ? opponent->short_descr : opponent->name), ch);
 	}
 	else
 	{

--- a/code/act_move.c
+++ b/code/act_move.c
@@ -1028,11 +1028,11 @@ void move_char(CHAR_DATA *ch, int door, bool automatic, bool fcharm)
 				CALL_IEVENT(obj, TRAP_IGREET, ch, obj);
 		}
 
-		if (is_npc(fch) && fch->last_fought == ch && number_percent() > 60)
+		if (is_npc(fch) && Deref(fch->last_fought) == ch && number_percent() > 60)
 		{
 			track_attack(fch, ch);
 		}
-		else if (is_npc(fch) && fch->last_fought == ch)
+		else if (is_npc(fch) && Deref(fch->last_fought) == ch)
 		{
 			RS.Queue.AddToQueue((number_percent() > 25) ? 1 : 2, "move_char", "track_attack", track_attack, fch, ch);
 		}

--- a/code/act_move.c
+++ b/code/act_move.c
@@ -183,9 +183,9 @@ void move_char(CHAR_DATA *ch, int door, bool automatic, bool fcharm)
 			{
 				act("The smoke parts for you allowing you passage.", ch, 0, 0, TO_CHAR);
 			}
-			else if (raf->owner == ch->master && automatic)
+			else if (raf->owner == Deref(ch->master) && automatic)
 			{
-				act("You follow $N through the smoke.", ch, 0, ch->master, TO_CHAR);
+				act("You follow $N through the smoke.", ch, 0, Deref(ch->master), TO_CHAR);
 			}
 		}
 		else
@@ -267,8 +267,8 @@ void move_char(CHAR_DATA *ch, int door, bool automatic, bool fcharm)
 	}
 
 	if (is_affected_by(ch, AFF_CHARM)
-		&& ch->master != nullptr
-		&& in_room == ch->master->in_room)
+		&& Deref(ch->master) != nullptr
+		&& in_room == Deref(ch->master)->in_room)
 	{
 		send_to_char("What?  And leave your beloved master?\n\r", ch);
 		return;
@@ -1060,10 +1060,10 @@ void move_char(CHAR_DATA *ch, int door, bool automatic, bool fcharm)
 		{
 			fch_next = fch->next_in_room;
 
-			if (fch->master == ch && is_affected_by(fch, AFF_CHARM) && fch->position < POS_STANDING)
+			if (Deref(fch->master) == ch && is_affected_by(fch, AFF_CHARM) && fch->position < POS_STANDING)
 				do_stand(fch, "");
 
-			if (fch->master == ch && fch->position == POS_STANDING && can_see_room(fch, to_room))
+			if (Deref(fch->master) == ch && fch->position == POS_STANDING && can_see_room(fch, to_room))
 			{
 				if (IS_SET(ch->in_room->room_flags, ROOM_LAW) && (is_npc(fch) && IS_SET(fch->act, ACT_AGGRESSIVE)))
 				{
@@ -3271,8 +3271,8 @@ void do_recall(CHAR_DATA *ch, char *argument)
 
 	do_look(ch, "auto");
 
-	if (ch->pet != nullptr)
-		do_recall(ch->pet, "");
+	if (Deref(ch->pet) != nullptr)
+		do_recall(Deref(ch->pet), "");
 }
 
 void do_train(CHAR_DATA *ch, char *argument)
@@ -3450,7 +3450,7 @@ void do_bear_call(CHAR_DATA *ch, char *argument)
 	auto found = false;
 	for (auto check = char_list; check != nullptr; check = check->next)
 	{
-		if (check->master == ch && check->pIndexData->vnum == MOB_VNUM_BEAR)
+		if (Deref(check->master) == ch && check->pIndexData->vnum == MOB_VNUM_BEAR)
 			found = true;
 	}
 
@@ -3497,7 +3497,7 @@ void do_bear_call(CHAR_DATA *ch, char *argument)
 		char_to_room(animal, ch->in_room);
 		add_follower(animal, ch);
 
-		animal->leader = ch;
+		animal->leader = ch->self;
 
 		SET_BIT(animal->affected_by, AFF_CHARM);
 
@@ -3594,7 +3594,7 @@ void do_animal_call(CHAR_DATA *ch, char *argument)
 	{
 		if (is_npc(mob)
 			&& is_affected_by(mob, AFF_CHARM)
-			&& (mob->master == ch)
+			&& (Deref(mob->master) == ch)
 			&& ((mob->pIndexData->vnum == MOB_VNUM_FALCON)
 				|| (mob->pIndexData->vnum == MOB_VNUM_WOLF)
 				|| (mob->pIndexData->vnum == MOB_VNUM_BEAR)
@@ -3721,10 +3721,10 @@ void do_animal_call(CHAR_DATA *ch, char *argument)
 	SET_BIT(animal1->affected_by, AFF_CHARM);
 	SET_BIT(animal2->affected_by, AFF_CHARM);
 
-	animal1->leader = ch;
-	animal2->leader = ch;
-	animal1->master = ch;
-	animal2->master = ch;
+	animal1->leader = ch->self;
+	animal2->leader = ch->self;
+	animal1->master = ch->self;
+	animal2->master = ch->self;
 	animal1->cabal = ch->cabal;
 	animal2->cabal = ch->cabal;
 

--- a/code/act_move.c
+++ b/code/act_move.c
@@ -179,11 +179,11 @@ void move_char(CHAR_DATA *ch, int door, bool automatic, bool fcharm)
 
 		if (raf != nullptr)
 		{
-			if (raf->owner == ch)
+			if (Deref(raf->owner) == ch)
 			{
 				act("The smoke parts for you allowing you passage.", ch, 0, 0, TO_CHAR);
 			}
-			else if (raf->owner == Deref(ch->master) && automatic)
+			else if (Deref(raf->owner) == Deref(ch->master) && automatic)
 			{
 				act("You follow $N through the smoke.", ch, 0, Deref(ch->master), TO_CHAR);
 			}
@@ -665,8 +665,8 @@ void move_char(CHAR_DATA *ch, int door, bool automatic, bool fcharm)
 
 		auto owner = ch;
 		imaf = affect_find(ch->affected, gsn_impale);
-		if (imaf && imaf->owner)
-			owner = imaf->owner;
+		if (imaf && Deref(imaf->owner))
+			owner = Deref(imaf->owner);
 
 		damage_new(owner, ch, dice(3, 3), TYPE_UNDEFINED, DAM_NONE, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "Your gaping wound*");
 
@@ -699,7 +699,7 @@ void move_char(CHAR_DATA *ch, int door, bool automatic, bool fcharm)
 		if (is_affected_by(ch, AFF_FLYING))
 			return;
 
-		if (raf->owner == ch)
+		if (Deref(raf->owner) == ch)
 		{
 			act("You gracefully step over your tripwire.", ch, 0, 0, TO_CHAR);
 		}
@@ -708,7 +708,7 @@ void move_char(CHAR_DATA *ch, int door, bool automatic, bool fcharm)
 			twchance = (get_skill(ch, gsn_tripwire) / 5);
 			twchance += (get_curr_stat(ch, STAT_DEX) + get_curr_stat(ch, STAT_INT) - 30) * 2;
 
-			if (!is_safe(raf->owner, ch) && (number_percent() > twchance))
+			if (!is_safe(Deref(raf->owner), ch) && (number_percent() > twchance))
 			{
 				act("You trip over a wire and fall flat on your face!", ch, 0, 0, TO_CHAR);
 				act("$n trips over a wire and falls flat on $s face!", ch, 0, 0, TO_ROOM);
@@ -728,7 +728,7 @@ void move_char(CHAR_DATA *ch, int door, bool automatic, bool fcharm)
 		{
 			if (raf.type == gsn_riptide && raf.location == APPLY_ROOM_NONE && raf.modifier == 1)
 			{
-				if (is_safe_new(raf.owner, ch, false) || raf.owner == ch)
+				if (is_safe_new(Deref(raf.owner), ch, false) || Deref(raf.owner) == ch)
 					break;
 
 				ROOM_INDEX_DATA *riptideroom = nullptr;
@@ -738,7 +738,7 @@ void move_char(CHAR_DATA *ch, int door, bool automatic, bool fcharm)
 					{
 						for (auto &raf_two : room->affected)
 						{
-							if (raf_two.type == gsn_riptide && raf_two.owner == raf.owner &&
+							if (raf_two.type == gsn_riptide && Deref(raf_two.owner) == Deref(raf.owner) &&
 								raf_two.location == APPLY_ROOM_NONE && raf_two.modifier == 2)
 								riptideroom = room;
 						}
@@ -775,10 +775,10 @@ void move_char(CHAR_DATA *ch, int door, bool automatic, bool fcharm)
 		if (is_affected_by(ch, AFF_FLYING))
 			break;
 
-		if (is_same_cabal(ch, raf->owner) || is_same_group(ch, raf->owner))
+		if (is_same_cabal(ch, Deref(raf->owner)) || is_same_group(ch, Deref(raf->owner)))
 			break;
 
-		if (is_safe(ch, raf->owner))
+		if (is_safe(ch, Deref(raf->owner)))
 			break;
 
 		if (number_percent() <= (5 * (get_curr_stat(ch, STAT_DEX) - 15)))
@@ -793,7 +793,7 @@ void move_char(CHAR_DATA *ch, int door, bool automatic, bool fcharm)
 
 		WAIT_STATE(ch, (ch->carry_weight / 150) * PULSE_VIOLENCE);
 
-		damage_new(raf->owner, ch, 5 + ch->carry_weight / 6, TYPE_UNDEFINED, DAM_BASH, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "the fall*");
+		damage_new(Deref(raf->owner), ch, 5 + ch->carry_weight / 6, TYPE_UNDEFINED, DAM_BASH, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "the fall*");
 
 		stop_fighting(ch, true);
 
@@ -808,7 +808,7 @@ void move_char(CHAR_DATA *ch, int door, bool automatic, bool fcharm)
 
 		auto raf = affect_find_room(to_room->affected, gsn_quicksand);
 
-		if (is_safe_new(raf->owner, ch, false) || is_same_group(raf->owner, ch) || is_same_cabal(raf->owner, ch))
+		if (is_safe_new(Deref(raf->owner), ch, false) || is_same_group(Deref(raf->owner), ch) || is_same_cabal(Deref(raf->owner), ch))
 			break;
 
 		if (is_affected(ch, gsn_ultradiffusion))
@@ -829,7 +829,7 @@ void move_char(CHAR_DATA *ch, int door, bool automatic, bool fcharm)
 		qs.where = TO_AFFECTS;
 		qs.aftype = AFT_INVIS;
 		qs.type = gsn_quicksand_sinking;
-		qs.owner = ch;
+		qs.owner = ch->self;
 		qs.level = raf->level;
 		qs.duration = -1;
 		qs.modifier = 1;
@@ -845,7 +845,7 @@ void move_char(CHAR_DATA *ch, int door, bool automatic, bool fcharm)
 	{
 		auto raf = affect_find_room(to_room->affected, gsn_stalactites);
 
-		if (is_safe_new(raf->owner, ch, false) || is_same_group(raf->owner, ch) || is_same_cabal(raf->owner, ch))
+		if (is_safe_new(Deref(raf->owner), ch, false) || is_same_group(Deref(raf->owner), ch) || is_same_cabal(Deref(raf->owner), ch))
 			break;
 
 		if (is_affected(ch, gsn_ultradiffusion))
@@ -858,13 +858,13 @@ void move_char(CHAR_DATA *ch, int door, bool automatic, bool fcharm)
 
 		if (number_percent() > (10 * get_curr_stat(ch, STAT_DEX) - 175))
 		{
-			damage_new(raf->owner, ch, dice(raf->level, 3), gsn_stalactites, DAM_PIERCE, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "the falling stalactite*");
+			damage_new(Deref(raf->owner), ch, dice(raf->level, 3), gsn_stalactites, DAM_PIERCE, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "the falling stalactite*");
 		}
 		else
 		{
 			act("The mass of ice shatters on the ground as you leap out of the way!", ch, 0, 0, TO_CHAR);
 			act("The mass of ice shatters on the ground as $n leaps out of the way!", ch, 0, 0, TO_ROOM);
-			damage_new(raf->owner, ch, 0, gsn_stalactites, DAM_PIERCE, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "the falling stalactite*");
+			damage_new(Deref(raf->owner), ch, 0, gsn_stalactites, DAM_PIERCE, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "the falling stalactite*");
 		}
 
 		if (!is_npc(ch))
@@ -886,7 +886,7 @@ void move_char(CHAR_DATA *ch, int door, bool automatic, bool fcharm)
 		if (is_immortal(ch))
 			return;
 
-		if (!is_safe(raf->owner, ch) && !is_affected(ch, gsn_neutralize))
+		if (!is_safe(Deref(raf->owner), ch) && !is_affected(ch, gsn_neutralize))
 		{
 			send_to_char("You choke and gasp for air as caustic vapors fill your lungs!\n\r", ch);
 
@@ -965,13 +965,13 @@ void move_char(CHAR_DATA *ch, int door, bool automatic, bool fcharm)
 
 			new_affect_join(ch, &cvaf2);
 
-			damage_new(raf->owner, ch, dam, raf->type, DAM_POISON, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "the noxious fumes*$");
+			damage_new(Deref(raf->owner), ch, dam, raf->type, DAM_POISON, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "the noxious fumes*$");
 
 			if (!ch->in_room || ch->ghost > 0)
 				return;
 		}
 
-		if (!is_safe(ch, raf->owner) && is_affected(ch, gsn_neutralize))
+		if (!is_safe(ch, Deref(raf->owner)) && is_affected(ch, gsn_neutralize))
 			send_to_char("The noxious fumes surround you, but you are unaffected.\n\r", ch);
 	}
 
@@ -1252,7 +1252,7 @@ void trap_execute(CHAR_DATA *victim, ROOM_INDEX_DATA *room, TRAP_DATA *trap)
 				af.location = APPLY_STR;
 				af.modifier = -5;
 				af.duration = trap->quality * 2;
-				af.owner = victim;
+				af.owner = victim->self;
 				SET_BIT(af.bitvector, AFF_POISON);
 				af.tick_fun = poison_tick;
 				affect_to_char(victim, &af);
@@ -1295,7 +1295,7 @@ void trap_execute(CHAR_DATA *victim, ROOM_INDEX_DATA *room, TRAP_DATA *trap)
 						af.aftype = AFT_MALADY;
 						af.type = gsn_sleep;
 						af.level = trap->quality * 6;
-						af.owner = vch;
+						af.owner = vch->self;
 						af.location = 0;
 						af.modifier = 0;
 						af.duration = trap->quality * 4;
@@ -1334,7 +1334,7 @@ void trap_execute(CHAR_DATA *victim, ROOM_INDEX_DATA *room, TRAP_DATA *trap)
 					af.aftype = AFT_MALADY;
 					af.type = gsn_mana_drain;
 					af.duration = trap->quality * 4;
-					af.owner = vch;
+					af.owner = vch->self;
 					af.modifier = 0;
 					af.location = 0;
 					af.pulse_fun = mana_drain_pulse;

--- a/code/act_move.c
+++ b/code/act_move.c
@@ -36,6 +36,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <math.h>
+#include <deque>
 #include "merc.h"
 #include "act_move.h"
 #include "entity/handles.h"
@@ -90,7 +91,6 @@ const short rev_dir[] =
 
 /* globals */
 
-PATHFIND_DATA *best_path;
 int iterations;
 
 void drowning_tick(CHAR_DATA *ch, AFFECT_DATA *af)
@@ -3800,43 +3800,15 @@ void smart_track(CHAR_DATA *ch, CHAR_DATA *mob)
 	if (Deref(mob->fighting))
 		return;
 
-	mob->path = nullptr;
-	best_path = nullptr;
-	iterations = 0;
+	auto dir = find_first_step(mob->in_room, ch->in_room);
 
-	auto path = new_path_data();
-	path->room = mob->in_room;
-	path->steps = 0;
-
-	mob->path = path;
-	mob->in_room->path = path;
-
-	find_path(mob->path, ch->in_room);
-
-	auto solve = best_path;
-	if (!best_path)
+	if (dir < 0)
 	{
 		/*
 		 * Typically this means they moved to a room not connected to the rest of the
 		 * area, i.e. you get there via a special prog that moves you
 		 */
-		/*
-		char buf[200];
-		bug ("Some weird tracking shit just happened with mob vnum %d.",mob->pIndexData->vnum);
-		sprintf(buf,"MOB %s tracking from ROOM %d to ROOM %d -- %d iterations.\n\r",
-			mob->name, mob->in_room->vnum,
-			ch->in_room->vnum,iterations);
-		RS.Logger.Warn(buf);
-		*/
 		return;
-	}
-
-	for (;;)
-	{
-		if (!solve->prev->prev)
-			break;
-
-		solve = solve->prev;
 	}
 
 	/* Uncomment for tracking info */
@@ -3848,17 +3820,11 @@ void smart_track(CHAR_DATA *ch, CHAR_DATA *mob)
 		iterations);
 	*/
 
-	move_char(mob, solve->dir_from, false, true);
-
-	free_path(mob->path);
-
-	best_path = nullptr;
-
-	for (auto room = room_list; room != nullptr; room = room->next_room)
-	{
-		if (room->path)
-			room->path = nullptr;
-	}
+	// The search is finished and torn down before this runs, which is the point
+	// of taking a direction back rather than a node: move_char can run progs,
+	// and a prog that starts another search used to overwrite the state this
+	// one still needed.
+	move_char(mob, dir, false, true);
 }
 
 void walk_to_room(CHAR_DATA *mob, ROOM_INDEX_DATA *goal)
@@ -3878,32 +3844,12 @@ void walk_to_room(CHAR_DATA *mob, ROOM_INDEX_DATA *goal)
 	if (Deref(mob->fighting))
 		return;
 
-	mob->path = nullptr;
-	best_path = nullptr;
-	iterations = 0;
+	auto dir = find_first_step(mob->in_room, goal);
 
-	auto path = new_path_data();
-	path->room = mob->in_room;
-	path->steps = 0;
-
-	mob->path = path;
-	mob->in_room->path = path;
-
-	find_path(mob->path, goal);
-
-	auto solve = best_path;
-	if (!best_path)
+	if (dir < 0)
 	{
 		RS.Logger.Warn("Some weird tracking shit just happened with mob vnum {}.", mob->pIndexData->vnum);
 		return;
-	}
-
-	for (;;)
-	{
-		if (!solve->prev->prev)
-			break;
-
-		solve = solve->prev;
 	}
 
 	/*
@@ -3914,98 +3860,182 @@ void walk_to_room(CHAR_DATA *mob, ROOM_INDEX_DATA *goal)
 		iterations);
 	*/
 
-	move_char(mob, solve->dir_from, false, true);
-
-	free_path(mob->path);
-
-	best_path = nullptr;
-
-	for (auto room = room_list; room != nullptr; room = room->next_room)
-	{
-		if (room->path)
-			room->path = nullptr;
-	}
+	move_char(mob, dir, false, true);
 }
 
-void find_path(PATHFIND_DATA *path, ROOM_INDEX_DATA *goal)
+namespace
 {
-	path->evaluated = true;
-	iterations++;
-
-	if (path->room == goal)
+	//
+	// One tracking search, and everything it allocates.
+	//
+	// The nodes used to be individually new'd, parked on the mob as mob->path,
+	// and released by a recursive walk of the tree -- but only on the way out
+	// where the search had found something, and only after move_char had
+	// already run. Two things outlived the search as a result:
+	//
+	//   * A search that found nothing leaked its whole tree and left every room
+	//     it had visited still naming a node in it. room->path is the visited
+	//     marker for ONE search, so the next one reads those as "already
+	//     reached in fewer steps, already evaluated" -- the exact test used to
+	//     decide a room is not worth expanding -- and prunes the only route it
+	//     has.
+	//   * best_path was a file-scope global, and move_char runs progs. A prog
+	//     that started another search overwrote it mid-use.
+	//
+	// Holding the nodes here ties both to the search's own lifetime. The
+	// destructor clears exactly the rooms this search marked, on every way out,
+	// and the callers take a direction back rather than a node so nothing
+	// survives into move_char at all.
+	//
+	class PathSearch
 	{
-		if (!best_path || best_path->steps > path->steps)
-			best_path = path;
-
-		return;
-	}
-
-	auto found = false;
-	for (auto i = 0; i < 6; i++)
-	{
-		if ((best_path && best_path->steps < 2)
-			|| (path->room->exit[i] 
-				&& path->room->exit[i]->u1.to_room
-				&& path->room->exit[i]->u1.to_room->area == goal->area
-				&& !(path->room->exit[i]->u1.to_room->path
-					&& path->room->exit[i]->u1.to_room->path->steps <= path->steps + 1
-					&& path->room->exit[i]->u1.to_room->path->evaluated)
-				&& !(path->room->exit[i]->u1.to_room->path
-					&& path->room->exit[i]->u1.to_room->path->steps < path->steps + 1
-					&& !path->room->exit[i]->u1.to_room->path->evaluated)))
+	public:
+		explicit PathSearch(ROOM_INDEX_DATA *start)
 		{
-			found = true;
-		}
-	}
-
-	if (!found)
-	{
-		for (auto i = 0; i < 6; i++)
-		{
-			path->dir_to[i] = nullptr;
+			root = Mark(start, nullptr, -1, 0);
 		}
 
-		return;
-	}
-
-	for (auto i = 0; i < 6; i++)
-	{
-		if (!path->room->exit[i]
-			|| !path->room->exit[i]->u1.to_room
-			|| path->room->exit[i]->u1.to_room->area != goal->area
-			|| (path->room->exit[i]->u1.to_room->path 
-				&& path->room->exit[i]->u1.to_room->path->steps <= path->steps + 1 
-				&& path->room->exit[i]->u1.to_room->path->evaluated)
-			|| (path->room->exit[i]->u1.to_room->path
-				&& path->room->exit[i]->u1.to_room->path->steps < path->steps + 1
-				&& !path->room->exit[i]->u1.to_room->path->evaluated))
+		~PathSearch()
 		{
-			continue;
+			for (auto room : marked)
+				room->path = nullptr;
 		}
 
-		auto next_path = new_path_data();
-		next_path->room = path->room->exit[i]->u1.to_room;
-		next_path->dir_from = i;
-		next_path->steps = path->steps + 1;
-		next_path->prev = path;
+		PathSearch(const PathSearch &) = delete;
+		PathSearch &operator=(const PathSearch &) = delete;
 
-		path->dir_to[i] = next_path;
-		path->room->exit[i]->u1.to_room->path = next_path;
-	}
-
-	for (auto i = 0; i < 6; i++)
-	{
-		if (!path->room->exit[i]
-			|| !path->dir_to[i]
-			|| !path->room->exit[i]->u1.to_room
-			|| path->room->exit[i]->u1.to_room->area != goal->area
-			|| path->room->exit[i]->u1.to_room->path->evaluated)
+		/// The shortest route found from the starting room to `goal`, or null
+		/// if the area graph has none.
+		PATHFIND_DATA *Run(ROOM_INDEX_DATA *goal)
 		{
-			continue;
+			Expand(root, goal);
+
+			return best;
 		}
 
-		find_path(path->dir_to[i], goal);
-	}
+	private:
+		PATHFIND_DATA *Mark(ROOM_INDEX_DATA *room, PATHFIND_DATA *prev, int dir_from, int steps)
+		{
+			// std::deque, not vector: Expand keeps node pointers -- in prev, in
+			// dir_to[] and in room->path -- across later insertions, so the
+			// nodes must not move.
+			nodes.emplace_back();
+
+			auto node = &nodes.back();
+
+			node->room = room;
+			node->evaluated = false;
+			node->dir_from = dir_from;
+			node->steps = steps;
+			node->prev = prev;
+
+			for (auto i = 0; i < MAX_EXIT; i++)
+				node->dir_to[i] = nullptr;
+
+			room->path = node;
+			marked.push_back(room);
+
+			return node;
+		}
+
+		void Expand(PATHFIND_DATA *path, ROOM_INDEX_DATA *goal)
+		{
+			path->evaluated = true;
+			iterations++;
+
+			if (path->room == goal)
+			{
+				if (!best || best->steps > path->steps)
+					best = path;
+
+				return;
+			}
+
+			auto found = false;
+			for (auto i = 0; i < MAX_EXIT; i++)
+			{
+				if ((best && best->steps < 2)
+					|| (path->room->exit[i]
+						&& path->room->exit[i]->u1.to_room
+						&& path->room->exit[i]->u1.to_room->area == goal->area
+						&& !(path->room->exit[i]->u1.to_room->path
+							&& path->room->exit[i]->u1.to_room->path->steps <= path->steps + 1
+							&& path->room->exit[i]->u1.to_room->path->evaluated)
+						&& !(path->room->exit[i]->u1.to_room->path
+							&& path->room->exit[i]->u1.to_room->path->steps < path->steps + 1
+							&& !path->room->exit[i]->u1.to_room->path->evaluated)))
+				{
+					found = true;
+				}
+			}
+
+			if (!found)
+			{
+				for (auto i = 0; i < MAX_EXIT; i++)
+				{
+					path->dir_to[i] = nullptr;
+				}
+
+				return;
+			}
+
+			for (auto i = 0; i < MAX_EXIT; i++)
+			{
+				if (!path->room->exit[i]
+					|| !path->room->exit[i]->u1.to_room
+					|| path->room->exit[i]->u1.to_room->area != goal->area
+					|| (path->room->exit[i]->u1.to_room->path
+						&& path->room->exit[i]->u1.to_room->path->steps <= path->steps + 1
+						&& path->room->exit[i]->u1.to_room->path->evaluated)
+					|| (path->room->exit[i]->u1.to_room->path
+						&& path->room->exit[i]->u1.to_room->path->steps < path->steps + 1
+						&& !path->room->exit[i]->u1.to_room->path->evaluated))
+				{
+					continue;
+				}
+
+				path->dir_to[i] = Mark(path->room->exit[i]->u1.to_room, path, i, path->steps + 1);
+			}
+
+			for (auto i = 0; i < MAX_EXIT; i++)
+			{
+				if (!path->room->exit[i]
+					|| !path->dir_to[i]
+					|| !path->room->exit[i]->u1.to_room
+					|| path->room->exit[i]->u1.to_room->area != goal->area
+					|| path->room->exit[i]->u1.to_room->path->evaluated)
+				{
+					continue;
+				}
+
+				Expand(path->dir_to[i], goal);
+			}
+		}
+
+		std::deque<PATHFIND_DATA>		nodes;
+		std::vector<ROOM_INDEX_DATA *>	marked;
+		PATHFIND_DATA *					root = nullptr;
+		PATHFIND_DATA *					best = nullptr;
+	};
+}
+
+int find_first_step(ROOM_INDEX_DATA *from, ROOM_INDEX_DATA *goal)
+{
+	iterations = 0;
+
+	PathSearch search(from);
+
+	auto solve = search.Run(goal);
+
+	// A null prev means the route is the starting room itself, so there is no
+	// step to take. The old loop read solve->prev->prev without checking.
+	if (solve == nullptr || solve->prev == nullptr)
+		return -1;
+
+	while (solve->prev->prev != nullptr)
+		solve = solve->prev;
+
+	return solve->dir_from;
 }
 
 void do_aura_of_sustenance(CHAR_DATA *ch, char *argument)

--- a/code/act_move.c
+++ b/code/act_move.c
@@ -38,6 +38,7 @@
 #include <math.h>
 #include "merc.h"
 #include "act_move.h"
+#include "entity/handles.h"
 #include "handler.h"
 #include "magic.h"
 #include "recycle.h"
@@ -2125,13 +2126,13 @@ void do_stand(CHAR_DATA *ch, char *argument)
 			return;
 		}
 
-		if (ch->on != obj && count_users(obj) >= obj->value[0])
+		if (ch->on != obj->self && count_users(obj) >= obj->value[0])
 		{
 			act_new("There's no room to stand on $p.", ch, obj, nullptr, TO_CHAR, POS_DEAD);
 			return;
 		}
 
-		ch->on = obj;
+		ch->on = obj->self;
 	}
 
 	switch (ch->position)
@@ -2236,7 +2237,7 @@ void do_rest(CHAR_DATA *ch, char *argument)
 	}
 	else
 	{
-		obj = ch->on;
+		obj = Deref(ch->on);
 	}
 
 	if (obj != nullptr)
@@ -2251,13 +2252,13 @@ void do_rest(CHAR_DATA *ch, char *argument)
 			return;
 		}
 
-		if (obj != nullptr && ch->on != obj && count_users(obj) >= obj->value[0])
+		if (obj != nullptr && ch->on != obj->self && count_users(obj) >= obj->value[0])
 		{
 			act_new("There's no more room on $p.", ch, obj, nullptr, TO_CHAR, POS_DEAD);
 			return;
 		}
 
-		ch->on = obj;
+		ch->on = obj->self;
 	}
 
 	switch (ch->position)
@@ -2396,7 +2397,7 @@ void do_sit(CHAR_DATA *ch, char *argument)
 	}
 	else
 	{
-		obj = ch->on;
+		obj = Deref(ch->on);
 	}
 
 	if (obj != nullptr)
@@ -2409,13 +2410,13 @@ void do_sit(CHAR_DATA *ch, char *argument)
 			return;
 		}
 
-		if (obj != nullptr && ch->on != obj && count_users(obj) >= obj->value[0])
+		if (obj != nullptr && ch->on != obj->self && count_users(obj) >= obj->value[0])
 		{
 			act_new("There's no more room on $p.", ch, obj, nullptr, TO_CHAR, POS_DEAD);
 			return;
 		}
 
-		ch->on = obj;
+		ch->on = obj->self;
 	}
 
 	switch (ch->position)
@@ -2531,7 +2532,7 @@ void do_sleep(CHAR_DATA *ch, char *argument)
 			else /* find an object and sleep on it */
 			{
 				if (argument[0] == '\0')
-					obj = ch->on;
+					obj = Deref(ch->on);
 				else
 					obj = get_obj_list(ch, argument, ch->in_room->contents);
 
@@ -2550,13 +2551,13 @@ void do_sleep(CHAR_DATA *ch, char *argument)
 					return;
 				}
 
-				if (ch->on != obj && count_users(obj) >= obj->value[0])
+				if (ch->on != obj->self && count_users(obj) >= obj->value[0])
 				{
 					act_new("There is no room on $p for you.", ch, obj, nullptr, TO_CHAR, POS_DEAD);
 					return;
 				}
 
-				ch->on = obj;
+				ch->on = obj->self;
 				if (IS_SET_OLD(obj->value[2], SLEEP_AT))
 				{
 					act("You go to sleep at $p.", ch, obj, nullptr, TO_CHAR);

--- a/code/act_move.c
+++ b/code/act_move.c
@@ -183,9 +183,12 @@ void move_char(CHAR_DATA *ch, int door, bool automatic, bool fcharm)
 			{
 				act("The smoke parts for you allowing you passage.", ch, 0, 0, TO_CHAR);
 			}
-			else if (Deref(raf->owner) == Deref(ch->master) && automatic)
+			else
 			{
-				act("You follow $N through the smoke.", ch, 0, Deref(ch->master), TO_CHAR);
+				CHAR_DATA *master = Deref(ch->master);
+
+				if (Deref(raf->owner) == master && automatic)
+					act("You follow $N through the smoke.", ch, 0, master, TO_CHAR);
 			}
 		}
 		else
@@ -266,9 +269,11 @@ void move_char(CHAR_DATA *ch, int door, bool automatic, bool fcharm)
 		return;
 	}
 
+	CHAR_DATA *master = Deref(ch->master);
+
 	if (is_affected_by(ch, AFF_CHARM)
-		&& Deref(ch->master) != nullptr
-		&& in_room == Deref(ch->master)->in_room)
+		&& master != nullptr
+		&& in_room == master->in_room)
 	{
 		send_to_char("What?  And leave your beloved master?\n\r", ch);
 		return;
@@ -665,8 +670,11 @@ void move_char(CHAR_DATA *ch, int door, bool automatic, bool fcharm)
 
 		auto owner = ch;
 		imaf = affect_find(ch->affected, gsn_impale);
-		if (imaf && Deref(imaf->owner))
-			owner = Deref(imaf->owner);
+
+		CHAR_DATA *impaler = imaf ? Deref(imaf->owner) : nullptr;
+
+		if (impaler)
+			owner = impaler;
 
 		damage_new(owner, ch, dice(3, 3), TYPE_UNDEFINED, DAM_NONE, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "Your gaping wound*");
 
@@ -728,7 +736,9 @@ void move_char(CHAR_DATA *ch, int door, bool automatic, bool fcharm)
 		{
 			if (raf.type == gsn_riptide && raf.location == APPLY_ROOM_NONE && raf.modifier == 1)
 			{
-				if (is_safe_new(Deref(raf.owner), ch, false) || Deref(raf.owner) == ch)
+				CHAR_DATA *rafOwner = Deref(raf.owner);
+
+				if (is_safe_new(rafOwner, ch, false) || rafOwner == ch)
 					break;
 
 				ROOM_INDEX_DATA *riptideroom = nullptr;
@@ -775,10 +785,12 @@ void move_char(CHAR_DATA *ch, int door, bool automatic, bool fcharm)
 		if (is_affected_by(ch, AFF_FLYING))
 			break;
 
-		if (is_same_cabal(ch, Deref(raf->owner)) || is_same_group(ch, Deref(raf->owner)))
+		CHAR_DATA *rafOwner = Deref(raf->owner);
+
+		if (is_same_cabal(ch, rafOwner) || is_same_group(ch, rafOwner))
 			break;
 
-		if (is_safe(ch, Deref(raf->owner)))
+		if (is_safe(ch, rafOwner))
 			break;
 
 		if (number_percent() <= (5 * (get_curr_stat(ch, STAT_DEX) - 15)))
@@ -808,7 +820,9 @@ void move_char(CHAR_DATA *ch, int door, bool automatic, bool fcharm)
 
 		auto raf = affect_find_room(to_room->affected, gsn_quicksand);
 
-		if (is_safe_new(Deref(raf->owner), ch, false) || is_same_group(Deref(raf->owner), ch) || is_same_cabal(Deref(raf->owner), ch))
+		CHAR_DATA *rafOwner = Deref(raf->owner);
+
+		if (is_safe_new(rafOwner, ch, false) || is_same_group(rafOwner, ch) || is_same_cabal(rafOwner, ch))
 			break;
 
 		if (is_affected(ch, gsn_ultradiffusion))
@@ -845,7 +859,9 @@ void move_char(CHAR_DATA *ch, int door, bool automatic, bool fcharm)
 	{
 		auto raf = affect_find_room(to_room->affected, gsn_stalactites);
 
-		if (is_safe_new(Deref(raf->owner), ch, false) || is_same_group(Deref(raf->owner), ch) || is_same_cabal(Deref(raf->owner), ch))
+		CHAR_DATA *rafOwner = Deref(raf->owner);
+
+		if (is_safe_new(rafOwner, ch, false) || is_same_group(rafOwner, ch) || is_same_cabal(rafOwner, ch))
 			break;
 
 		if (is_affected(ch, gsn_ultradiffusion))
@@ -1028,11 +1044,13 @@ void move_char(CHAR_DATA *ch, int door, bool automatic, bool fcharm)
 				CALL_IEVENT(obj, TRAP_IGREET, ch, obj);
 		}
 
-		if (is_npc(fch) && Deref(fch->last_fought) == ch && number_percent() > 60)
+		CHAR_DATA *lastFought = Deref(fch->last_fought);
+
+		if (is_npc(fch) && lastFought == ch && number_percent() > 60)
 		{
 			track_attack(fch, ch);
 		}
-		else if (is_npc(fch) && Deref(fch->last_fought) == ch)
+		else if (is_npc(fch) && lastFought == ch)
 		{
 			RS.Queue.AddToQueue((number_percent() > 25) ? 1 : 2, "move_char", "track_attack", track_attack, fch, ch);
 		}

--- a/code/act_move.c
+++ b/code/act_move.c
@@ -597,7 +597,7 @@ void move_char(CHAR_DATA *ch, int door, bool automatic, bool fcharm)
 	{
 		for (auto d = descriptor_list; d; d = d->next)
 		{
-			auto victim = d->character;
+			auto victim = Deref(d->character);
 			if (d->connected == CON_PLAYING
 				&& victim != nullptr
 				&& !is_npc(victim)

--- a/code/act_move.c
+++ b/code/act_move.c
@@ -2522,7 +2522,7 @@ void do_sleep(CHAR_DATA *ch, char *argument)
 		case POS_RESTING:
 		case POS_SITTING:
 		case POS_STANDING:
-			if (argument[0] == '\0' && ch->on == nullptr)
+			if (argument[0] == '\0' && Deref(ch->on) == nullptr)
 			{
 				send_to_char("You go to sleep.\n\r", ch);
 				act("$n goes to sleep.", ch, nullptr, nullptr, TO_ROOM);

--- a/code/act_move.c
+++ b/code/act_move.c
@@ -211,7 +211,7 @@ void move_char(CHAR_DATA *ch, int door, bool automatic, bool fcharm)
 	auto to_room = pexit->u1.to_room;
 
 	/*
-		if(pexit->has_rune == true)
+		if (pexit->rune != nullptr)
 		{
 			while((rune = find_rune(pexit, RUNE_TO_PORTAL, RUNE_TRIGGER_EXIT, rune)))
 			{
@@ -995,7 +995,7 @@ void move_char(CHAR_DATA *ch, int door, bool automatic, bool fcharm)
 		}
 	}
 
-	if (to_room->has_rune == true && to_room == ch->in_room)
+	if (to_room->rune != nullptr && to_room == ch->in_room)
 	{
 		auto rune = find_rune(to_room, RUNE_TO_ROOM, RUNE_TRIGGER_ENTRY, nullptr);
 		while (rune != nullptr)

--- a/code/act_move.c
+++ b/code/act_move.c
@@ -587,7 +587,7 @@ void move_char(CHAR_DATA *ch, int door, bool automatic, bool fcharm)
 		add_tracks(in_room, ch, door);
 	}
 
-	if (ch->fighting)
+	if (Deref(ch->fighting))
 		stop_fighting(ch, true);
 
 	char_from_room(ch);
@@ -3235,7 +3235,7 @@ void do_recall(CHAR_DATA *ch, char *argument)
 		return;
 	}
 
-	auto victim = ch->fighting;
+	auto victim = Deref(ch->fighting);
 	if (victim != nullptr)
 	{
 		char buf[MAX_STRING_LENGTH];
@@ -3797,7 +3797,7 @@ void smart_track(CHAR_DATA *ch, CHAR_DATA *mob)
 	if (ch->in_room->area != mob->in_room->area)
 		return;
 
-	if (mob->fighting)
+	if (Deref(mob->fighting))
 		return;
 
 	mob->path = nullptr;
@@ -3875,7 +3875,7 @@ void walk_to_room(CHAR_DATA *mob, ROOM_INDEX_DATA *goal)
 	if (mob->in_room->area != goal->area)
 		return;
 
-	if (mob->fighting)
+	if (Deref(mob->fighting))
 		return;
 
 	mob->path = nullptr;

--- a/code/act_move.h
+++ b/code/act_move.h
@@ -5,7 +5,6 @@
 
 extern char *const dir_name[];
 extern const short rev_dir[];
-extern PATHFIND_DATA *best_path;
 extern int iterations;
 
 // TODO: add to race.h
@@ -66,7 +65,11 @@ void do_animal_call (CHAR_DATA *ch,char *argument);
 void track_char (CHAR_DATA *ch, CHAR_DATA *mob);
 void smart_track (CHAR_DATA *ch, CHAR_DATA *mob);
 void walk_to_room (CHAR_DATA *mob, ROOM_INDEX_DATA *goal);
-void find_path (PATHFIND_DATA *path, ROOM_INDEX_DATA *goal);
+/// The direction a mob standing in `from` should move to make progress towards
+/// `goal`, or -1 if the area graph has no route. The search owns everything it
+/// allocates and leaves nothing behind it, so it is safe to call again -- and
+/// safe to move the mob afterwards.
+int find_first_step(ROOM_INDEX_DATA *from, ROOM_INDEX_DATA *goal);
 void do_aura_of_sustenance (CHAR_DATA *ch,char *argument);
 void do_vanish (CHAR_DATA *ch,char *argument);
 void do_door_bash (CHAR_DATA *ch,char *argument);

--- a/code/act_obj.c
+++ b/code/act_obj.c
@@ -3853,7 +3853,7 @@ void do_buy(CHAR_DATA *ch, char *argument)
 			if (count < number)
 			{
 				act("$n tells you 'I don't have that many in stock.", keeper, nullptr, ch, TO_VICT);
-				ch->reply = keeper;
+				ch->reply = keeper->self;
 				return;
 			}
 		}
@@ -3865,14 +3865,14 @@ void do_buy(CHAR_DATA *ch, char *argument)
 			else
 				act("$n tells you 'You can't afford to buy $p'.", keeper, obj, ch, TO_VICT);
 
-			ch->reply = keeper;
+			ch->reply = keeper->self;
 			return;
 		}
 
 		if (obj->level > ch->level)
 		{
 			act("$n tells you 'You can't use $p yet'.", keeper, obj, ch, TO_VICT);
-			ch->reply = keeper;
+			ch->reply = keeper->self;
 			return;
 		}
 
@@ -4195,7 +4195,7 @@ void do_value(CHAR_DATA *ch, char *argument)
 	if (obj == nullptr)
 	{
 		act("$n tells you 'You don't have that item'.", keeper, nullptr, ch, TO_VICT);
-		ch->reply = keeper;
+		ch->reply = keeper->self;
 		return;
 	}
 
@@ -4222,7 +4222,7 @@ void do_value(CHAR_DATA *ch, char *argument)
 	sprintf(buf, "$n tells you 'I'll give you %d gold coins for $p.'", cost / 100);
 	act(buf, keeper, obj, ch, TO_VICT);
 
-	ch->reply = keeper;
+	ch->reply = keeper->self;
 }
 
 void do_request(CHAR_DATA *ch, char *argument)

--- a/code/act_obj.c
+++ b/code/act_obj.c
@@ -89,7 +89,7 @@ bool check_arms(CHAR_DATA *ch, OBJ_DATA *obj)
 					|| paf.type == gsn_arms_of_wrath
 					|| paf.type == gsn_arms_of_purity
 					|| paf.type == gsn_arms_of_judgement)
-				&& paf.owner != ch)
+				&& Deref(paf.owner) != ch)
 			{
 				act("$p shocks you, falling from your numb hands.", ch, obj, 0, TO_CHAR);
 				act("$n drops $p.", ch, obj, 0, TO_ROOM);
@@ -1592,7 +1592,7 @@ void do_pour(CHAR_DATA *ch, char *argument)
 			oaf.location = 0;
 			oaf.modifier = 0;
 			oaf.duration = 4;
-			oaf.owner = ch;
+			oaf.owner = ch->self;
 			oaf.end_fun = puddle_evaporate;
 			oaf.tick_fun = 0;
 			affect_to_obj(puddle, &oaf);
@@ -1759,7 +1759,7 @@ void do_drink(CHAR_DATA *ch, char *argument)
 
 			SET_BIT(af.bitvector, AFF_POISON);
 
-			af.owner = ch;
+			af.owner = ch->self;
 			af.tick_fun = poison_tick;
 			affect_join(ch, &af);
 		}
@@ -1848,7 +1848,7 @@ void do_eat(CHAR_DATA *ch, char *argument)
 					af.location = APPLY_STR;
 					af.modifier = -5;
 					SET_BIT(af.bitvector, AFF_POISON);
-					af.owner = ch;
+					af.owner = ch->self;
 					af.tick_fun = poison_tick;
 					affect_join(ch, &af);
 				}

--- a/code/act_obj.c
+++ b/code/act_obj.c
@@ -1677,7 +1677,7 @@ void do_drink(CHAR_DATA *ch, char *argument)
 		}
 	}
 
-	if (ch->fighting != nullptr)
+	if (Deref(ch->fighting) != nullptr)
 	{
 		send_to_char("You're too busy fighting to drink anything.\n\r", ch);
 		return;
@@ -1789,7 +1789,7 @@ void do_eat(CHAR_DATA *ch, char *argument)
 		return;
 	}
 
-	if (ch->fighting != nullptr)
+	if (Deref(ch->fighting) != nullptr)
 	{
 		send_to_char("You're too busy fighting to worry about food.\n\r", ch);
 		return;
@@ -2225,7 +2225,7 @@ void wear_obj(CHAR_DATA *ch, OBJ_DATA *obj, bool fReplace)
 			return;
 		}
 
-		if (obj->item_type == ITEM_POTION && ch->fighting != nullptr)
+		if (obj->item_type == ITEM_POTION && Deref(ch->fighting) != nullptr)
 		{
 			send_to_char("You can't handle a potion in the heat of combat!\n\r", ch);
 			return;
@@ -2943,7 +2943,7 @@ void do_quaff(CHAR_DATA *ch, char *argument)
 		return;
 	}
 
-	if (ch->fighting != nullptr)
+	if (Deref(ch->fighting) != nullptr)
 	{
 		send_to_char("You're too busy fighting to quaff.\n\r", ch);
 		return;
@@ -3008,7 +3008,7 @@ void do_recite(CHAR_DATA *ch, char *argument)
 		return;
 	}
 
-	if (ch->fighting != nullptr)
+	if (Deref(ch->fighting) != nullptr)
 	{
 		send_to_char("You're too busy fighting to recite.\n\r", ch);
 		return;
@@ -3172,7 +3172,7 @@ void do_zap(CHAR_DATA *ch, char *argument)
 
 	one_argument(argument, arg);
 
-	if (arg[0] == '\0' && ch->fighting == nullptr)
+	if (arg[0] == '\0' && Deref(ch->fighting) == nullptr)
 	{
 		send_to_char("Zap whom or what?\n\r", ch);
 		return;
@@ -3196,9 +3196,9 @@ void do_zap(CHAR_DATA *ch, char *argument)
 
 	if (arg[0] == '\0')
 	{
-		if (ch->fighting != nullptr)
+		if (Deref(ch->fighting) != nullptr)
 		{
-			victim = ch->fighting;
+			victim = Deref(ch->fighting);
 		}
 		else
 		{
@@ -3304,7 +3304,7 @@ void do_steal(CHAR_DATA *ch, char *argument)
 	if (is_safe(ch, victim))
 		return;
 
-	if (victim->fighting != nullptr)
+	if (Deref(victim->fighting) != nullptr)
 	{
 		send_to_char("You can't get close enough in the fray!\n\r", ch);
 		return;
@@ -4991,7 +4991,7 @@ void do_roll(CHAR_DATA *ch, char *argument)
 		return;
 	}
 
-	if (ch->fighting)
+	if (Deref(ch->fighting))
 	{
 		send_to_char("You really have more important things to worry about right now!\n\r", ch);
 		return;
@@ -5050,7 +5050,7 @@ void do_flip(CHAR_DATA *ch, char *argument)
 	char buf[MSL];
 	OBJ_DATA *coin;
 
-	if (ch->fighting)
+	if (Deref(ch->fighting))
 	{
 		send_to_char("You really have more important things to worry about right now!\n\r", ch);
 		return;

--- a/code/act_obj.c
+++ b/code/act_obj.c
@@ -200,7 +200,7 @@ void get_obj(CHAR_DATA *ch, OBJ_DATA *obj, OBJ_DATA *container, bool pcheck)
 	{
 		for (gch = obj->in_room->people; gch != nullptr; gch = gch->next_in_room)
 		{
-			if (gch->on == obj)
+			if (gch->on == obj->self)
 			{
 				act("$N appears to be using $p.", ch, obj, gch, TO_CHAR);
 				return;
@@ -2814,7 +2814,7 @@ void do_sacrifice(CHAR_DATA *ch, char *argument)
 	{
 		for (gch = obj->in_room->people; gch != nullptr; gch = gch->next_in_room)
 		{
-			if (gch->on == obj)
+			if (gch->on == obj->self)
 			{
 				act("$N appears to be using $p.", ch, obj, gch, TO_CHAR);
 				return;

--- a/code/act_obj.c
+++ b/code/act_obj.c
@@ -110,7 +110,7 @@ bool can_loot(CHAR_DATA *ch, OBJ_DATA *obj)
 	{
 		RS.Logger.Info("{} looting {}.",
 			is_npc(ch)
-				? ((ch->master == nullptr) ? "Unknown mob" : ch->master->name)
+				? ((Deref(ch->master) == nullptr) ? "Unknown mob" : Deref(ch->master)->name)
 				: ch->name,
 			obj->short_descr);
 		ch->pause = 5;
@@ -3720,7 +3720,7 @@ void do_buy(CHAR_DATA *ch, char *argument)
 			return;
 		}
 
-		if (ch->pet != nullptr)
+		if (Deref(ch->pet) != nullptr)
 		{
 			send_to_char("You already own a pet.\n\r", ch);
 			return;
@@ -3791,8 +3791,8 @@ void do_buy(CHAR_DATA *ch, char *argument)
 		char_to_room(pet, ch->in_room);
 		add_follower(pet, ch);
 
-		pet->leader = ch;
-		ch->pet = pet;
+		pet->leader = ch->self;
+		ch->pet = pet->self;
 
 		send_to_char("Enjoy your pet.\n\r", ch);
 		act("$n bought $N as a pet.", ch, nullptr, pet, TO_ROOM);

--- a/code/act_obj.c
+++ b/code/act_obj.c
@@ -187,7 +187,7 @@ void get_obj(CHAR_DATA *ch, OBJ_DATA *obj, OBJ_DATA *container, bool pcheck)
 	// Distinct from the `container` parameter above: that is where the object is
 	// being taken from, this is where the object currently reports itself to be.
 	OBJ_DATA *heldIn = Deref(obj->in_obj);
-	if ((!heldIn || heldIn->carried_by != ch)
+	if ((!heldIn || heldIn->carried_by != ch->self)
 		&& (get_carry_weight(ch) + get_obj_weight(obj) > can_carry_w(ch)))
 	{
 		act("$p: you can't carry that much weight.", ch, obj, 0, TO_CHAR);
@@ -3617,7 +3617,7 @@ void obj_to_keeper(OBJ_DATA *obj, CHAR_DATA *ch)
 		t_obj->next_content = obj;
 	}
 
-	obj->carried_by = ch;
+	obj->carried_by = ch->self;
 	obj->in_room = nullptr;
 	obj->in_obj = nullptr;
 	ch->carry_number += get_obj_number(obj);
@@ -4521,10 +4521,12 @@ bool cabal_down_new(CHAR_DATA *ch, int cabal, bool show)
 			break;
 	}
 
-	if (!obj || !obj->carried_by || !is_npc(obj->carried_by))
+	CHAR_DATA *carrier = obj != nullptr ? Deref(obj->carried_by) : nullptr;
+
+	if (!obj || !carrier || !is_npc(carrier))
 		return false;
 
-	if (obj->carried_by->cabal && obj->carried_by->cabal != cabal)
+	if (carrier->cabal && carrier->cabal != cabal)
 		is_down = true;
 
 	if (is_down)
@@ -4939,10 +4941,12 @@ void save_cabal_items(void)
 		{
 			if (obj->pIndexData->vnum == vnum)
 			{
+				CHAR_DATA *carrier = Deref(obj->carried_by);
+
 				fprintf(fp, "%i %i\n",
 					i,
-					(obj->carried_by && is_npc(obj->carried_by) && is_cabal_guard(obj->carried_by))
-						? obj->carried_by->pIndexData->vnum
+					(carrier && is_npc(carrier) && is_cabal_guard(carrier))
+						? carrier->pIndexData->vnum
 						: 0);
 			}
 		}

--- a/code/act_obj.c
+++ b/code/act_obj.c
@@ -39,6 +39,7 @@
 #include <algorithm>
 #include "merc.h"
 #include "act_obj.h"
+#include "entity/handles.h"
 #include "rift.h"
 #include "handler.h"
 #include "magic.h"
@@ -183,7 +184,10 @@ void get_obj(CHAR_DATA *ch, OBJ_DATA *obj, OBJ_DATA *container, bool pcheck)
 		return;
 	}
 
-	if ((!obj->in_obj || obj->in_obj->carried_by != ch)
+	// Distinct from the `container` parameter above: that is where the object is
+	// being taken from, this is where the object currently reports itself to be.
+	OBJ_DATA *heldIn = Deref(obj->in_obj);
+	if ((!heldIn || heldIn->carried_by != ch)
 		&& (get_carry_weight(ch) + get_obj_weight(obj) > can_carry_w(ch)))
 	{
 		act("$p: you can't carry that much weight.", ch, obj, 0, TO_CHAR);

--- a/code/act_wiz.c
+++ b/code/act_wiz.c
@@ -2742,7 +2742,7 @@ void do_mstat(CHAR_DATA *ch, char *argument)
 		sprintf(buf, "Trust: %s%s%s\n\r",
 			IS_SET(victim->pcdata->trust, TRUST_GROUP) ? "group " : "",
 			IS_SET(victim->pcdata->trust, TRUST_CABAL) ? "cabal " : "",
-			ch->pcdata->trusting ? ch->pcdata->trusting->true_name : "");
+			Deref(ch->pcdata->trusting) ? Deref(ch->pcdata->trusting)->true_name : "");
 		send_to_char(buf, ch);
 	}
 

--- a/code/act_wiz.c
+++ b/code/act_wiz.c
@@ -843,7 +843,7 @@ void do_smote(CHAR_DATA *ch, char *argument)
 
 	for (vch = ch->in_room->people; vch != nullptr; vch = vch->next_in_room)
 	{
-		if (vch->desc == nullptr || vch == ch)
+		if (Deref(vch->desc) == nullptr || vch == ch)
 			continue;
 
 		letter = strstr(argument, vch->name);
@@ -1015,10 +1015,10 @@ void do_deny(CHAR_DATA *ch, char *argument)
 	victim->pause = 0;
 
 	// add to denial #
-	if (victim->desc)
+	if (Deref(victim->desc))
 	{
 		auto sites = SiteTrackerRepository(RS.DbRift);
-		sites.IncrementDenialsByHost(victim->desc->host);
+		sites.IncrementDenialsByHost(Deref(victim->desc)->host);
 	}
 
 	sprintf(buf, "AUTO: Denied by %s.\n\r", ch->true_name);
@@ -1072,7 +1072,7 @@ void do_disconnect(CHAR_DATA *ch, char *argument)
 		return;
 	}
 
-	if (victim->desc == nullptr)
+	if (Deref(victim->desc) == nullptr)
 	{
 		act("$N doesn't have a descriptor.", ch, nullptr, victim, TO_CHAR);
 		return;
@@ -1080,7 +1080,7 @@ void do_disconnect(CHAR_DATA *ch, char *argument)
 
 	for (d = descriptor_list; d != nullptr; d = d->next)
 	{
-		if (d == victim->desc)
+		if (d == Deref(victim->desc))
 		{
 			close_socket(d);
 			send_to_char("Ok.\n\r", ch);
@@ -3589,7 +3589,7 @@ void do_snoop(CHAR_DATA *ch, char *argument)
 		return;
 	}
 
-	if (victim->desc == nullptr)
+	if (Deref(victim->desc) == nullptr)
 	{
 		send_to_char("No descriptor to snoop.\n\r", ch);
 		return;
@@ -3602,14 +3602,14 @@ void do_snoop(CHAR_DATA *ch, char *argument)
 
 		for (d = descriptor_list; d != nullptr; d = d->next)
 		{
-			if (d->snoop_by == ch->desc)
+			if (d->snoop_by == Deref(ch->desc))
 				d->snoop_by = nullptr;
 		}
 
 		return;
 	}
 
-	if (victim->desc->snoop_by != nullptr)
+	if (Deref(victim->desc)->snoop_by != nullptr)
 	{
 		send_to_char("Busy already.\n\r", ch);
 		return;
@@ -3636,9 +3636,9 @@ void do_snoop(CHAR_DATA *ch, char *argument)
 		return;
 	}
 
-	if (ch->desc != nullptr)
+	if (Deref(ch->desc) != nullptr)
 	{
-		for (d = ch->desc->snoop_by; d != nullptr; d = d->snoop_by)
+		for (d = Deref(ch->desc)->snoop_by; d != nullptr; d = d->snoop_by)
 		{
 			if (Deref(d->character) == victim || Deref(d->original) == victim)
 			{
@@ -3648,7 +3648,7 @@ void do_snoop(CHAR_DATA *ch, char *argument)
 		}
 	}
 
-	victim->desc->snoop_by = ch->desc;
+	Deref(victim->desc)->snoop_by = Deref(ch->desc);
 
 	sprintf(buf, "$N starts snooping on %s", (is_npc(ch) ? victim->short_descr : victim->name));
 	wiznet(buf, ch, nullptr, WIZ_SNOOPS, WIZ_SECURE, get_trust(ch));
@@ -3669,10 +3669,12 @@ void do_switch(CHAR_DATA *ch, char *argument)
 		return;
 	}
 
-	if (ch->desc == nullptr)
+	DESCRIPTOR_DATA *connection = Deref(ch->desc);
+
+	if (connection == nullptr)
 		return;
 
-	if (Deref(ch->desc->original) != nullptr)
+	if (Deref(connection->original) != nullptr)
 	{
 		send_to_char("You are already switched.\n\r", ch);
 		return;
@@ -3707,7 +3709,7 @@ void do_switch(CHAR_DATA *ch, char *argument)
 		return;
 	}
 
-	if (victim->desc != nullptr)
+	if (Deref(victim->desc) != nullptr)
 	{
 		send_to_char("Character in use.\n\r", ch);
 		return;
@@ -3716,8 +3718,8 @@ void do_switch(CHAR_DATA *ch, char *argument)
 	sprintf(buf, "$N switches into %s.", victim->short_descr);
 	wiznet(buf, ch, nullptr, WIZ_SWITCHES, WIZ_SECURE, get_trust(ch));
 
-	ch->desc->character = victim->self;
-	ch->desc->original = ch->self;
+	Deref(ch->desc)->character = victim->self;
+	Deref(ch->desc)->original = ch->self;
 	victim->desc = ch->desc;
 	// The possessed mob borrows the immortal's pcdata (it's an NPC, so its own
 	// pcdata is null). Ownership stays with the original body; do_return calls
@@ -3740,10 +3742,12 @@ void do_return(CHAR_DATA *ch, char *argument)
 {
 	char buf[MAX_STRING_LENGTH];
 
-	if (ch->desc == nullptr)
+	DESCRIPTOR_DATA *connection = Deref(ch->desc);
+
+	if (connection == nullptr)
 		return;
 
-	if (Deref(ch->desc->original) == nullptr)
+	if (Deref(connection->original) == nullptr)
 	{
 		send_to_char("You aren't switched.\n\r", ch);
 		return;
@@ -3759,12 +3763,12 @@ void do_return(CHAR_DATA *ch, char *argument)
 
 	sprintf(buf, "$N returns from %s.", ch->short_descr);
 
-	wiznet(buf, Deref(ch->desc->original), 0, WIZ_SWITCHES, WIZ_SECURE, get_trust(ch));
+	wiznet(buf, Deref(connection->original), 0, WIZ_SWITCHES, WIZ_SECURE, get_trust(ch));
 
 	ch->pcdata.release();		// relinquish the borrowed pcdata WITHOUT freeing it
-	ch->desc->character = ch->desc->original;
-	ch->desc->original = nullptr;
-	Deref(ch->desc->character)->desc = ch->desc;
+	connection->character = connection->original;
+	connection->original = nullptr;
+	Deref(connection->character)->desc = ch->desc;
 	ch->desc = nullptr;
 }
 
@@ -4109,7 +4113,7 @@ void do_purge(CHAR_DATA *ch, char *argument)
 		if (victim->level > 1)
 			save_char_obj(victim);
 
-		d = victim->desc;
+		d = Deref(victim->desc);
 		extract_char(victim, true);
 
 		if (d != nullptr)
@@ -6117,7 +6121,7 @@ void do_force(CHAR_DATA *ch, char *argument)
 		}
 
 		/*
-		if(victim->desc == nullptr)
+		if(Deref(victim->desc) == nullptr)
 		{
 			send_to_char("They have no descriptor!\n\r",ch);
 			return;

--- a/code/act_wiz.c
+++ b/code/act_wiz.c
@@ -7212,9 +7212,13 @@ void do_raffects(CHAR_DATA *ch, char *argument)
 	{
 		for (rune = ch->in_room->rune; rune; rune = rune->next_content)
 		{
+			// A rune outlives its caster by design and nothing clears the
+			// back-reference, so "gone" is an ordinary answer here.
+			CHAR_DATA *caster = Deref(rune->owner);
+
 			sprintf(buf, "Rune '%s' placed in room by %s, level %d, duration %d hours.\n\r",
 				skill_table[rune->type].name,
-				!is_npc(rune->owner) ? rune->owner->true_name : rune->owner->name,
+				caster == nullptr ? "someone gone" : (!is_npc(caster) ? caster->true_name : caster->name),
 				rune->level,
 				rune->duration);
 			send_to_char(buf, ch);
@@ -7227,10 +7231,12 @@ void do_raffects(CHAR_DATA *ch, char *argument)
 		{
 			rune = ch->in_room->exit[i]->rune;
 
+			CHAR_DATA *caster = Deref(rune->owner);
+
 			sprintf(buf, "Rune '%s' placed on %s door by %s, level %d, duration %d hours.\n\r",
 				skill_table[rune->type].name,
 				direction_table[i].name,
-				!is_npc(rune->owner) ? rune->owner->true_name : rune->owner->name,
+				caster == nullptr ? "someone gone" : (!is_npc(caster) ? caster->true_name : caster->name),
 				rune->level, rune->duration);
 			send_to_char(buf, ch);
 

--- a/code/act_wiz.c
+++ b/code/act_wiz.c
@@ -5992,19 +5992,22 @@ void do_multicheck(CHAR_DATA *ch, char *argument)
 		if (!strcmp(CHARLIST[j].des->host, CHARLIST[j + 1].des->host)
 			|| (j != 0 && !strcmp(CHARLIST[j].des->host, CHARLIST[j - 1].des->host)))
 		{
+			CHAR_DATA *original = Deref(CHARLIST[j].des->original);
+			CHAR_DATA *player = Deref(CHARLIST[j].des->character);
+
 			count++;
 
 			sprintf(buf + strlen(buf), "[%3d %2d] %s@%s\n\r",
 				CHARLIST[j].des->descriptor,
 				CHARLIST[j].des->connected,
-				Deref(CHARLIST[j].des->original)
-					? Deref(CHARLIST[j].des->original)->true_name
-						? Deref(CHARLIST[j].des->original)->true_name
-						: Deref(CHARLIST[j].des->original)->name
-					: Deref(CHARLIST[j].des->character)
-						? Deref(CHARLIST[j].des->character)->true_name
-							? Deref(CHARLIST[j].des->character)->true_name
-							: Deref(CHARLIST[j].des->character)->name
+				original
+					? original->true_name
+						? original->true_name
+						: original->name
+					: player
+						? player->true_name
+							? player->true_name
+							: player->name
 						: "(none)",
 				(get_trust(ch) >= 55) ? CHARLIST[j].des->host : "unknown");
 		}
@@ -6016,14 +6019,17 @@ void do_multicheck(CHAR_DATA *ch, char *argument)
 	*/
 	if (!strcmp(CHARLIST[j].des->host, CHARLIST[j - 1].des->host))
 	{
+		CHAR_DATA *original = Deref(CHARLIST[j].des->original);
+		CHAR_DATA *player = Deref(CHARLIST[j].des->character);
+
 		count++;
 		sprintf(buf + strlen(buf), "[%3d %2d] %s@%s\n\r",
 			CHARLIST[j].des->descriptor,
 			CHARLIST[j].des->connected,
-			Deref(CHARLIST[j].des->original)
-				? Deref(CHARLIST[j].des->original)->name
-				: Deref(CHARLIST[j].des->character)
-					? Deref(CHARLIST[j].des->character)->name : "(none)",
+			original
+				? original->name
+				: player
+					? player->name : "(none)",
 			(get_trust(ch) >= 55) ? CHARLIST[j].des->host : "unknown");
 	}
 

--- a/code/act_wiz.c
+++ b/code/act_wiz.c
@@ -2784,8 +2784,10 @@ void do_mstat(CHAR_DATA *ch, char *argument)
 
 	if (!is_npc(victim))
 	{
+		CHAR_DATA *lastOpponent = Deref(victim->last_fight_opponent);
+
 		sprintf(buf, "Last PC fought: %s, %d seconds ago\n\r",
-			victim->last_fight_name != nullptr ? victim->last_fight_name : "(none)",
+			lastOpponent != nullptr ? lastOpponent->true_name : "(none)",
 			victim->last_fight_time ? (int)(current_time - victim->last_fight_time) : -1);
 		send_to_char(buf, ch);
 	}

--- a/code/act_wiz.c
+++ b/code/act_wiz.c
@@ -2515,6 +2515,7 @@ void do_mstat(CHAR_DATA *ch, char *argument)
 	char arg[MAX_INPUT_LENGTH];
 	CHAR_DATA *victim;
 	CHAR_DATA *opponent;
+	CHAR_DATA *replyTo;
 	ROOM_INDEX_DATA *barred;
 	int i, x;
 
@@ -2611,9 +2612,11 @@ void do_mstat(CHAR_DATA *ch, char *argument)
 		!opponent ? "(none)" : opponent->name);
 	send_to_char(buf, ch);
 
+	replyTo = Deref(victim->reply);
+
 	sprintf(buf, "Master: %-11s Leader: %-10s  Pet:    %-10s Reply: %s\n\r",
 		victim->master ? victim->master->name : "(none)", victim->leader ? victim->leader->name : "(none)",
-		victim->pet ? victim->pet->name : "(none)", victim->reply ? victim->reply->name : "(none)");
+		victim->pet ? victim->pet->name : "(none)", replyTo ? replyTo->name : "(none)");
 	send_to_char(buf, ch);
 
 	sprintf(buf, "Pierce: %-10d  Bash:   %-8d    Slash:  %-8d   Exotic: %-10d\n\r",

--- a/code/act_wiz.c
+++ b/code/act_wiz.c
@@ -40,6 +40,7 @@
 #include <iterator>
 #include "merc.h"
 #include "act_wiz.h"
+#include "entity/handles.h"
 #include "rift.h"
 #include "prof.h"
 #include "weather_enums.h"
@@ -1891,9 +1892,10 @@ void do_ostat(CHAR_DATA *ch, char *argument)
 		obj->timer);
 	send_to_char(buf, ch);
 
+	OBJ_DATA *container = Deref(obj->in_obj);
 	sprintf(buf, "In room: %d  In object: %s  Carried by: %s  Wear_loc: %d\n\r",
 		obj->in_room == nullptr ? 0 : obj->in_room->vnum,
-		obj->in_obj == nullptr ? "(none)" : obj->in_obj->short_descr,
+		container == nullptr ? "(none)" : container->short_descr,
 		obj->carried_by == nullptr ? "(none)" : can_see(ch, obj->carried_by) ? obj->carried_by->name : "someone",
 		obj->wear_loc);
 	send_to_char(buf, ch);
@@ -3246,8 +3248,9 @@ void do_owhere(CHAR_DATA *ch, char *argument)
 
 		number++;
 
-		for (in_obj = obj; in_obj->in_obj != nullptr; in_obj = in_obj->in_obj)
-			;
+		in_obj = obj;
+		while (OBJ_DATA *outer = Deref(in_obj->in_obj))
+			in_obj = outer;
 
 		if (in_obj->carried_by != nullptr && can_see(ch, in_obj->carried_by) && in_obj->carried_by->in_room != nullptr)
 		{

--- a/code/act_wiz.c
+++ b/code/act_wiz.c
@@ -1196,11 +1196,13 @@ void do_immecho(CHAR_DATA *ch, char *argument)
 
 	for (d = descriptor_list; d; d = d->next)
 	{
-		if (d->connected == CON_PLAYING && (Deref(d->character)->level > 51))
+		CHAR_DATA *wch = Deref(d->character);
+
+		if (d->connected == CON_PLAYING && (wch->level > 51))
 		{
-			colorconv(buffer, argument, Deref(d->character));
-			send_to_char(buffer, Deref(d->character));
-			send_to_char("\n\r", Deref(d->character));
+			colorconv(buffer, argument, wch);
+			send_to_char(buffer, wch);
+			send_to_char("\n\r", wch);
 		}
 	}
 }
@@ -1341,12 +1343,14 @@ void do_transfer(CHAR_DATA *ch, char *argument)
 	{
 		for (d = descriptor_list; d != nullptr; d = d->next)
 		{
+			CHAR_DATA *wch = Deref(d->character);
+
 			if (d->connected == CON_PLAYING
-				&& Deref(d->character) != ch
-				&& Deref(d->character)->in_room != nullptr
-				&& can_see(ch, Deref(d->character)))
+				&& wch != ch
+				&& wch->in_room != nullptr
+				&& can_see(ch, wch))
 			{
-				auto buffer = fmt::format("{} {}", Deref(d->character)->name, arg2);
+				auto buffer = fmt::format("{} {}", wch->name, arg2);
 				do_transfer(ch, buffer.data());
 			}
 		}
@@ -3334,20 +3338,23 @@ void do_mwhere(CHAR_DATA *ch, char *argument)
 
 		for (d = descriptor_list; d != nullptr; d = d->next)
 		{
-			if (Deref(d->character) != nullptr
+			victim = Deref(d->character);
+
+			if (victim != nullptr
 				&& d->connected == CON_PLAYING
-				&& Deref(d->character)->in_room != nullptr
-				&& can_see(ch, Deref(d->character))
-				&& can_see_room(ch, Deref(d->character)->in_room))
+				&& victim->in_room != nullptr
+				&& can_see(ch, victim)
+				&& can_see_room(ch, victim->in_room))
 			{
-				victim = Deref(d->character);
+				CHAR_DATA *original = Deref(d->original);
+
 				count++;
 
-				if (Deref(d->original) != nullptr)
+				if (original != nullptr)
 				{
 					sprintf(buf, "%3d) %s (in the body of %s) is in %s [%d]\n\r",
 						count,
-						Deref(d->original)->true_name,
+						original->true_name,
 						victim->short_descr,
 						get_room_name(victim->in_room),
 						victim->in_room->vnum);
@@ -3447,7 +3454,9 @@ void reboot_now(CHAR_DATA *ch)
 	for (d = descriptor_list; d != nullptr; d = d_next)
 	{
 		d_next = d->next;
-		vch = Deref(d->original) ? Deref(d->original) : Deref(d->character);
+		CHAR_DATA *original = Deref(d->original);
+
+		vch = original ? original : Deref(d->character);
 
 		if (vch != nullptr && d->connected == 0)
 		{
@@ -5855,11 +5864,14 @@ void do_sockets(CHAR_DATA *ch, char *argument)
 
 	for (d = descriptor_list; d != nullptr; d = d->next)
 	{
-		if (Deref(d->character) != nullptr
-			&& ((!Deref(d->original) && can_see(ch, Deref(d->character)))
-				|| (Deref(d->original) && can_see(ch, Deref(d->original))))
-			&& (!IS_SET(Deref(d->character)->comm, COMM_NOSOCKET) || get_trust(ch) == MAX_LEVEL)
-			&& (arg[0] == '\0' || is_name(arg, Deref(d->character)->true_name) || bDis))
+		CHAR_DATA *wch = Deref(d->character);
+		CHAR_DATA *original = Deref(d->original);
+
+		if (wch != nullptr
+			&& ((!original && can_see(ch, wch))
+				|| (original && can_see(ch, original)))
+			&& (!IS_SET(wch->comm, COMM_NOSOCKET) || get_trust(ch) == MAX_LEVEL)
+			&& (arg[0] == '\0' || is_name(arg, wch->true_name) || bDis))
 		{
 			count++;
 
@@ -5887,15 +5899,15 @@ void do_sockets(CHAR_DATA *ch, char *argument)
 				d->connected == (CON_READ_MOTD) ? "Getting motd" :
 				d->connected == (CON_CHOOSE_WEAPON) ? "Choosing weapon" :
 				d->connected == (CON_GET_CABAL) ? "Getting cabal" : "null",
-				(int)((current_time - Deref(d->character)->logon) / 60),
-				Deref(d->original)
-					? (Deref(d->original)->true_name)
-						? Deref(d->original)->true_name
-						: Deref(d->original)->name
-					: Deref(d->character)
-						? (Deref(d->character)->true_name)
-							? Deref(d->character)->true_name
-							: Deref(d->character)->name
+				(int)((current_time - wch->logon) / 60),
+				original
+					? (original->true_name)
+						? original->true_name
+						: original->name
+					: wch
+						? (wch->true_name)
+							? wch->true_name
+							: wch->name
 						: "(none)",
 				bDis && get_trust(ch) > 58 ? d->host : "unknown");
 		}
@@ -5946,7 +5958,9 @@ void do_multicheck(CHAR_DATA *ch, char *argument)
 
 	for (d = descriptor_list; d != nullptr; d = d->next)
 	{
-		if (Deref(d->character) != nullptr && can_see(ch, Deref(d->character)))
+		CHAR_DATA *wch = Deref(d->character);
+
+		if (wch != nullptr && can_see(ch, wch))
 		{
 			CHARLIST[i].des = d;
 			i++;

--- a/code/act_wiz.c
+++ b/code/act_wiz.c
@@ -1396,7 +1396,7 @@ void do_transfer(CHAR_DATA *ch, char *argument)
 		return;
 	}
 
-	if (victim->fighting != nullptr)
+	if (Deref(victim->fighting) != nullptr)
 		stop_fighting(victim, true);
 
 	act("$n disappears in a mushroom cloud.", victim, nullptr, nullptr, TO_ROOM);
@@ -1515,7 +1515,7 @@ void do_goto(CHAR_DATA *ch, char *argument)
 		return;
 	}
 
-	if (ch->fighting != nullptr)
+	if (Deref(ch->fighting) != nullptr)
 		stop_fighting(ch, true);
 
 	for (rch = ch->in_room->people; rch != nullptr; rch = rch->next_in_room)
@@ -1577,7 +1577,7 @@ void do_violate(CHAR_DATA *ch, char *argument)
 		return;
 	}
 
-	if (ch->fighting != nullptr)
+	if (Deref(ch->fighting) != nullptr)
 		stop_fighting(ch, true);
 
 	for (rch = ch->in_room->people; rch != nullptr; rch = rch->next_in_room)
@@ -2514,6 +2514,7 @@ void do_mstat(CHAR_DATA *ch, char *argument)
 	char cred[MSL], tbuf[MSL];
 	char arg[MAX_INPUT_LENGTH];
 	CHAR_DATA *victim;
+	CHAR_DATA *opponent;
 	ROOM_INDEX_DATA *barred;
 	int i, x;
 
@@ -2601,11 +2602,13 @@ void do_mstat(CHAR_DATA *ch, char *argument)
 		position_table[victim->position].name);
 	send_to_char(buf, ch);
 
+	opponent = Deref(victim->fighting);
+
 	sprintf(buf, "Saves:  %-11d Dammod: %-8.4f%%   Hunt:   %-10s Fight: %-11s\n\r",
 		victim->saving_throw,
 		victim->dam_mod,
 		!victim->hunting ? "(none)" : victim->hunting->name,
-		!victim->fighting ? "(none)" : victim->fighting->name);
+		!opponent ? "(none)" : opponent->name);
 	send_to_char(buf, ch);
 
 	sprintf(buf, "Master: %-11s Leader: %-10s  Pet:    %-10s Reply: %s\n\r",
@@ -4623,7 +4626,7 @@ void do_peace(CHAR_DATA *ch, char *argument)
 {
 	for (CHAR_DATA *rch = ch->in_room->people; rch != nullptr; rch = rch->next_in_room)
 	{
-		if (rch->fighting != nullptr)
+		if (Deref(rch->fighting) != nullptr)
 			stop_fighting(rch, true);
 
 		if (is_npc(rch) && IS_SET(rch->act, ACT_AGGRESSIVE))

--- a/code/act_wiz.c
+++ b/code/act_wiz.c
@@ -194,20 +194,22 @@ void wiznet(char *string, CHAR_DATA *ch, OBJ_DATA *obj, long flag, long flag_ski
 
 	for (DESCRIPTOR_DATA *d = descriptor_list; d != nullptr; d = d->next)
 	{
-		if (d->connected == CON_PLAYING
-			&& Deref(d->character)
-			&& is_immortal(Deref(d->character))
-			&& IS_SET(Deref(d->character)->wiznet, WIZ_ON)
-			&& (!flag || IS_SET(Deref(d->character)->wiznet, flag))
-			&& (!flag_skip || !IS_SET(Deref(d->character)->wiznet, flag_skip))
-			&& get_trust(Deref(d->character)) >= min_level
-			&& Deref(d->character) != ch)
-		{
-			if (IS_SET(Deref(d->character)->wiznet, WIZ_PREFIX))
-				send_to_char("--> ", Deref(d->character));
+		CHAR_DATA *wch = Deref(d->character);
 
-			sprintf(str, "%s%s%s", get_char_color(Deref(d->character), "wiznet"), string, END_COLOR(Deref(d->character)));
-			act_new(str, Deref(d->character), obj, ch, TO_CHAR, POS_DEAD);
+		if (d->connected == CON_PLAYING
+			&& wch
+			&& is_immortal(wch)
+			&& IS_SET(wch->wiznet, WIZ_ON)
+			&& (!flag || IS_SET(wch->wiznet, flag))
+			&& (!flag_skip || !IS_SET(wch->wiznet, flag_skip))
+			&& get_trust(wch) >= min_level
+			&& wch != ch)
+		{
+			if (IS_SET(wch->wiznet, WIZ_PREFIX))
+				send_to_char("--> ", wch);
+
+			sprintf(str, "%s%s%s", get_char_color(wch, "wiznet"), string, END_COLOR(wch));
+			act_new(str, wch, obj, ch, TO_CHAR, POS_DEAD);
 		}
 	}
 }
@@ -1163,18 +1165,20 @@ void do_echo(CHAR_DATA *ch, char *argument)
 
 	for (d = descriptor_list; d; d = d->next)
 	{
+		CHAR_DATA *wch = Deref(d->character);
+
 		if (d->connected == CON_PLAYING)
 		{
-			colorconv(buffer, argument, Deref(d->character));
+			colorconv(buffer, argument, wch);
 
-			if (get_trust(Deref(d->character)) >= get_trust(ch))
+			if (get_trust(wch) >= get_trust(ch))
 			{
-				send_to_char(ch->name, Deref(d->character));
-				send_to_char(" globals: ", Deref(d->character));
+				send_to_char(ch->name, wch);
+				send_to_char(" globals: ", wch);
 			}
 
-			send_to_char(buffer, Deref(d->character));
-			send_to_char("\n\r", Deref(d->character));
+			send_to_char(buffer, wch);
+			send_to_char("\n\r", wch);
 		}
 	}
 }
@@ -1214,15 +1218,17 @@ void do_recho(CHAR_DATA *ch, char *argument)
 
 	for (d = descriptor_list; d; d = d->next)
 	{
-		if (d->connected == CON_PLAYING && Deref(d->character)->in_room == ch->in_room)
+		CHAR_DATA *wch = Deref(d->character);
+
+		if (d->connected == CON_PLAYING && wch->in_room == ch->in_room)
 		{
-			colorconv(buffer, argument, Deref(d->character));
+			colorconv(buffer, argument, wch);
 
-			if (get_trust(Deref(d->character)) >= get_trust(ch) && !is_npc(ch))
-				send_to_char("local> ", Deref(d->character));
+			if (get_trust(wch) >= get_trust(ch) && !is_npc(ch))
+				send_to_char("local> ", wch);
 
-			send_to_char(buffer, Deref(d->character));
-			send_to_char("\n\r", Deref(d->character));
+			send_to_char(buffer, wch);
+			send_to_char("\n\r", wch);
 		}
 	}
 }
@@ -1240,18 +1246,20 @@ void do_zecho(CHAR_DATA *ch, char *argument)
 
 	for (d = descriptor_list; d; d = d->next)
 	{
+		CHAR_DATA *wch = Deref(d->character);
+
 		if (d->connected == CON_PLAYING
-			&& Deref(d->character)->in_room != nullptr
+			&& wch->in_room != nullptr
 			&& ch->in_room != nullptr
-			&& Deref(d->character)->in_room->area == ch->in_room->area)
+			&& wch->in_room->area == ch->in_room->area)
 		{
-			colorconv(buffer, argument, Deref(d->character));
+			colorconv(buffer, argument, wch);
 
-			if (get_trust(Deref(d->character)) >= get_trust(ch) && !is_npc(ch))
-				send_to_char("zone> ", Deref(d->character));
+			if (get_trust(wch) >= get_trust(ch) && !is_npc(ch))
+				send_to_char("zone> ", wch);
 
-			send_to_char(buffer, Deref(d->character));
-			send_to_char("\n\r", Deref(d->character));
+			send_to_char(buffer, wch);
+			send_to_char("\n\r", wch);
 		}
 	}
 }

--- a/code/act_wiz.c
+++ b/code/act_wiz.c
@@ -3856,7 +3856,7 @@ void do_clone(CHAR_DATA *ch, char *argument)
 		clone = create_object(obj->pIndexData, 0);
 		clone_object(obj, clone);
 
-		if (obj->carried_by != nullptr)
+		if (Deref(obj->carried_by) != nullptr)
 			obj_to_char(clone, ch);
 		else
 			obj_to_room(clone, ch->in_room);

--- a/code/act_wiz.c
+++ b/code/act_wiz.c
@@ -2615,8 +2615,8 @@ void do_mstat(CHAR_DATA *ch, char *argument)
 	replyTo = Deref(victim->reply);
 
 	sprintf(buf, "Master: %-11s Leader: %-10s  Pet:    %-10s Reply: %s\n\r",
-		victim->master ? victim->master->name : "(none)", victim->leader ? victim->leader->name : "(none)",
-		victim->pet ? victim->pet->name : "(none)", replyTo ? replyTo->name : "(none)");
+		Deref(victim->master) ? Deref(victim->master)->name : "(none)", Deref(victim->leader) ? Deref(victim->leader)->name : "(none)",
+		Deref(victim->pet) ? Deref(victim->pet)->name : "(none)", replyTo ? replyTo->name : "(none)");
 	send_to_char(buf, ch);
 
 	sprintf(buf, "Pierce: %-10d  Bash:   %-8d    Slash:  %-8d   Exotic: %-10d\n\r",

--- a/code/act_wiz.c
+++ b/code/act_wiz.c
@@ -2303,6 +2303,8 @@ void do_ostat(CHAR_DATA *ch, char *argument)
 
 	for (auto &paf : obj->affected)
 	{
+		CHAR_DATA *owner = Deref(paf.owner);
+
 		if (paf.aftype == AFT_SKILL)
 			sprintf(buf2, "Skill");
 		else if (paf.aftype == AFT_POWER)
@@ -2329,7 +2331,7 @@ void do_ostat(CHAR_DATA *ch, char *argument)
 			(paf.duration == 0) ? "" : (paf.duration == -1) ? "" : ".5",
 			(paf.where == TO_OBJ_AFFECTS) ? "aff" : (paf.where == TO_OBJ_APPLY) ? "apply" : "?",
 			oaffect_bit_name(paf.bitvector),
-			(paf.owner) ? paf.owner->name : "none", paf.level);
+			owner ? owner->name : "none", paf.level);
 		send_to_char(buffer.c_str(), ch);
 	}
 }
@@ -2478,6 +2480,8 @@ void do_astat(CHAR_DATA *ch, char *argument)
 
 		for (auto &paf : area->affected)
 		{
+			CHAR_DATA *owner = Deref(paf.owner);
+
 			if (paf.aftype == AFT_SKILL)
 				sprintf(buf, "Skill: '%s' ", skill_table[paf.type].name);
 			else if (paf.aftype == AFT_POWER)
@@ -2495,7 +2499,7 @@ void do_astat(CHAR_DATA *ch, char *argument)
 				(paf.duration == -1) ? paf.duration : paf.duration / 2,
 				"flag",
 				"nullptr",
-				paf.owner != nullptr ? paf.owner->name : "none",
+				owner ? owner->name : "none",
 				paf.level);
 			send_to_char(buf, ch);
 		}
@@ -3046,6 +3050,8 @@ void do_mstat(CHAR_DATA *ch, char *argument)
 
 	for (auto &paf : victim->affected)
 	{
+		CHAR_DATA *owner = Deref(paf.owner);
+
 		if (paf.aftype == AFT_SPELL)
 			sprintf(buf2, "Spell");
 		else if (paf.aftype == AFT_SKILL)
@@ -3080,7 +3086,7 @@ void do_mstat(CHAR_DATA *ch, char *argument)
 			paf.where == TO_IMMUNE || paf.where == TO_RESIST || paf.where == TO_VULN
 				? imm_bit_name(paf.bitvector)
 				: affect_bit_name(paf.bitvector),
-			paf.owner != nullptr ? paf.owner->true_name : "none", paf.level);
+			owner ? owner->true_name : "none", paf.level);
 		send_to_char(buffer.c_str(), ch);
 	}
 
@@ -7171,6 +7177,8 @@ void do_raffects(CHAR_DATA *ch, char *argument)
 
 		for (auto &paf : ch->in_room->affected)
 		{
+			CHAR_DATA *owner = Deref(paf.owner);
+
 			if (paf.aftype == AFT_SPELL)
 				sprintf(buf, "Spell: '%s' ", skill_table[paf.type].name);
 
@@ -7194,7 +7202,7 @@ void do_raffects(CHAR_DATA *ch, char *argument)
 				paf.duration / 2,
 				paf.where == TO_ROOM_FLAGS ? "flag" : paf.where == TO_ROOM_CONST ? "const" : "aff",
 				"nullptr",
-				paf.owner != nullptr ? paf.owner->name : "none",
+				owner ? owner->name : "none",
 				paf.level);
 			send_to_char(buf, ch);
 		}

--- a/code/act_wiz.c
+++ b/code/act_wiz.c
@@ -7208,7 +7208,7 @@ void do_raffects(CHAR_DATA *ch, char *argument)
 		}
 	}
 
-	if (ch->in_room->has_rune)
+	if (ch->in_room->rune != nullptr)
 	{
 		for (rune = ch->in_room->rune; rune; rune = rune->next_content)
 		{
@@ -7227,7 +7227,7 @@ void do_raffects(CHAR_DATA *ch, char *argument)
 
 	for (i = 0; i < 6; i++)
 	{
-		if (ch->in_room->exit[i] && ch->in_room->exit[i]->has_rune == true)
+		if (ch->in_room->exit[i] && ch->in_room->exit[i]->rune != nullptr)
 		{
 			rune = ch->in_room->exit[i]->rune;
 

--- a/code/act_wiz.c
+++ b/code/act_wiz.c
@@ -1418,7 +1418,10 @@ void do_at(CHAR_DATA *ch, char *argument)
 	char arg[MAX_INPUT_LENGTH];
 	ROOM_INDEX_DATA *location;
 	ROOM_INDEX_DATA *original;
-	OBJ_DATA *on;
+	// Held across interpret() below, which can run any command at all -- including
+	// one that destroys this object. A handle that outlives what it names simply
+	// stops resolving, where the pointer this replaced would have dangled.
+	Handle<OBJ_DATA> on;
 	CHAR_DATA *wch;
 
 	argument = one_argument(argument, arg);

--- a/code/act_wiz.c
+++ b/code/act_wiz.c
@@ -195,19 +195,19 @@ void wiznet(char *string, CHAR_DATA *ch, OBJ_DATA *obj, long flag, long flag_ski
 	for (DESCRIPTOR_DATA *d = descriptor_list; d != nullptr; d = d->next)
 	{
 		if (d->connected == CON_PLAYING
-			&& d->character
-			&& is_immortal(d->character)
-			&& IS_SET(d->character->wiznet, WIZ_ON)
-			&& (!flag || IS_SET(d->character->wiznet, flag))
-			&& (!flag_skip || !IS_SET(d->character->wiznet, flag_skip))
-			&& get_trust(d->character) >= min_level
-			&& d->character != ch)
+			&& Deref(d->character)
+			&& is_immortal(Deref(d->character))
+			&& IS_SET(Deref(d->character)->wiznet, WIZ_ON)
+			&& (!flag || IS_SET(Deref(d->character)->wiznet, flag))
+			&& (!flag_skip || !IS_SET(Deref(d->character)->wiznet, flag_skip))
+			&& get_trust(Deref(d->character)) >= min_level
+			&& Deref(d->character) != ch)
 		{
-			if (IS_SET(d->character->wiznet, WIZ_PREFIX))
-				send_to_char("--> ", d->character);
+			if (IS_SET(Deref(d->character)->wiznet, WIZ_PREFIX))
+				send_to_char("--> ", Deref(d->character));
 
-			sprintf(str, "%s%s%s", get_char_color(d->character, "wiznet"), string, END_COLOR(d->character));
-			act_new(str, d->character, obj, ch, TO_CHAR, POS_DEAD);
+			sprintf(str, "%s%s%s", get_char_color(Deref(d->character), "wiznet"), string, END_COLOR(Deref(d->character)));
+			act_new(str, Deref(d->character), obj, ch, TO_CHAR, POS_DEAD);
 		}
 	}
 }
@@ -1165,16 +1165,16 @@ void do_echo(CHAR_DATA *ch, char *argument)
 	{
 		if (d->connected == CON_PLAYING)
 		{
-			colorconv(buffer, argument, d->character);
+			colorconv(buffer, argument, Deref(d->character));
 
-			if (get_trust(d->character) >= get_trust(ch))
+			if (get_trust(Deref(d->character)) >= get_trust(ch))
 			{
-				send_to_char(ch->name, d->character);
-				send_to_char(" globals: ", d->character);
+				send_to_char(ch->name, Deref(d->character));
+				send_to_char(" globals: ", Deref(d->character));
 			}
 
-			send_to_char(buffer, d->character);
-			send_to_char("\n\r", d->character);
+			send_to_char(buffer, Deref(d->character));
+			send_to_char("\n\r", Deref(d->character));
 		}
 	}
 }
@@ -1192,11 +1192,11 @@ void do_immecho(CHAR_DATA *ch, char *argument)
 
 	for (d = descriptor_list; d; d = d->next)
 	{
-		if (d->connected == CON_PLAYING && (d->character->level > 51))
+		if (d->connected == CON_PLAYING && (Deref(d->character)->level > 51))
 		{
-			colorconv(buffer, argument, d->character);
-			send_to_char(buffer, d->character);
-			send_to_char("\n\r", d->character);
+			colorconv(buffer, argument, Deref(d->character));
+			send_to_char(buffer, Deref(d->character));
+			send_to_char("\n\r", Deref(d->character));
 		}
 	}
 }
@@ -1214,15 +1214,15 @@ void do_recho(CHAR_DATA *ch, char *argument)
 
 	for (d = descriptor_list; d; d = d->next)
 	{
-		if (d->connected == CON_PLAYING && d->character->in_room == ch->in_room)
+		if (d->connected == CON_PLAYING && Deref(d->character)->in_room == ch->in_room)
 		{
-			colorconv(buffer, argument, d->character);
+			colorconv(buffer, argument, Deref(d->character));
 
-			if (get_trust(d->character) >= get_trust(ch) && !is_npc(ch))
-				send_to_char("local> ", d->character);
+			if (get_trust(Deref(d->character)) >= get_trust(ch) && !is_npc(ch))
+				send_to_char("local> ", Deref(d->character));
 
-			send_to_char(buffer, d->character);
-			send_to_char("\n\r", d->character);
+			send_to_char(buffer, Deref(d->character));
+			send_to_char("\n\r", Deref(d->character));
 		}
 	}
 }
@@ -1241,17 +1241,17 @@ void do_zecho(CHAR_DATA *ch, char *argument)
 	for (d = descriptor_list; d; d = d->next)
 	{
 		if (d->connected == CON_PLAYING
-			&& d->character->in_room != nullptr
+			&& Deref(d->character)->in_room != nullptr
 			&& ch->in_room != nullptr
-			&& d->character->in_room->area == ch->in_room->area)
+			&& Deref(d->character)->in_room->area == ch->in_room->area)
 		{
-			colorconv(buffer, argument, d->character);
+			colorconv(buffer, argument, Deref(d->character));
 
-			if (get_trust(d->character) >= get_trust(ch) && !is_npc(ch))
-				send_to_char("zone> ", d->character);
+			if (get_trust(Deref(d->character)) >= get_trust(ch) && !is_npc(ch))
+				send_to_char("zone> ", Deref(d->character));
 
-			send_to_char(buffer, d->character);
-			send_to_char("\n\r", d->character);
+			send_to_char(buffer, Deref(d->character));
+			send_to_char("\n\r", Deref(d->character));
 		}
 	}
 }
@@ -1334,11 +1334,11 @@ void do_transfer(CHAR_DATA *ch, char *argument)
 		for (d = descriptor_list; d != nullptr; d = d->next)
 		{
 			if (d->connected == CON_PLAYING
-				&& d->character != ch
-				&& d->character->in_room != nullptr
-				&& can_see(ch, d->character))
+				&& Deref(d->character) != ch
+				&& Deref(d->character)->in_room != nullptr
+				&& can_see(ch, Deref(d->character)))
 			{
-				auto buffer = fmt::format("{} {}", d->character->name, arg2);
+				auto buffer = fmt::format("{} {}", Deref(d->character)->name, arg2);
 				do_transfer(ch, buffer.data());
 			}
 		}
@@ -3318,20 +3318,20 @@ void do_mwhere(CHAR_DATA *ch, char *argument)
 
 		for (d = descriptor_list; d != nullptr; d = d->next)
 		{
-			if (d->character != nullptr
+			if (Deref(d->character) != nullptr
 				&& d->connected == CON_PLAYING
-				&& d->character->in_room != nullptr
-				&& can_see(ch, d->character)
-				&& can_see_room(ch, d->character->in_room))
+				&& Deref(d->character)->in_room != nullptr
+				&& can_see(ch, Deref(d->character))
+				&& can_see_room(ch, Deref(d->character)->in_room))
 			{
-				victim = d->character;
+				victim = Deref(d->character);
 				count++;
 
-				if (d->original != nullptr)
+				if (Deref(d->original) != nullptr)
 				{
 					sprintf(buf, "%3d) %s (in the body of %s) is in %s [%d]\n\r",
 						count,
-						d->original->true_name,
+						Deref(d->original)->true_name,
 						victim->short_descr,
 						get_room_name(victim->in_room),
 						victim->in_room->vnum);
@@ -3431,7 +3431,7 @@ void reboot_now(CHAR_DATA *ch)
 	for (d = descriptor_list; d != nullptr; d = d_next)
 	{
 		d_next = d->next;
-		vch = d->original ? d->original : d->character;
+		vch = Deref(d->original) ? Deref(d->original) : Deref(d->character);
 
 		if (vch != nullptr && d->connected == 0)
 		{
@@ -3640,7 +3640,7 @@ void do_snoop(CHAR_DATA *ch, char *argument)
 	{
 		for (d = ch->desc->snoop_by; d != nullptr; d = d->snoop_by)
 		{
-			if (d->character == victim || d->original == victim)
+			if (Deref(d->character) == victim || Deref(d->original) == victim)
 			{
 				send_to_char("No snoop loops.\n\r", ch);
 				return;
@@ -3672,7 +3672,7 @@ void do_switch(CHAR_DATA *ch, char *argument)
 	if (ch->desc == nullptr)
 		return;
 
-	if (ch->desc->original != nullptr)
+	if (Deref(ch->desc->original) != nullptr)
 	{
 		send_to_char("You are already switched.\n\r", ch);
 		return;
@@ -3716,8 +3716,8 @@ void do_switch(CHAR_DATA *ch, char *argument)
 	sprintf(buf, "$N switches into %s.", victim->short_descr);
 	wiznet(buf, ch, nullptr, WIZ_SWITCHES, WIZ_SECURE, get_trust(ch));
 
-	ch->desc->character = victim;
-	ch->desc->original = ch;
+	ch->desc->character = victim->self;
+	ch->desc->original = ch->self;
 	victim->desc = ch->desc;
 	// The possessed mob borrows the immortal's pcdata (it's an NPC, so its own
 	// pcdata is null). Ownership stays with the original body; do_return calls
@@ -3743,7 +3743,7 @@ void do_return(CHAR_DATA *ch, char *argument)
 	if (ch->desc == nullptr)
 		return;
 
-	if (ch->desc->original == nullptr)
+	if (Deref(ch->desc->original) == nullptr)
 	{
 		send_to_char("You aren't switched.\n\r", ch);
 		return;
@@ -3759,12 +3759,12 @@ void do_return(CHAR_DATA *ch, char *argument)
 
 	sprintf(buf, "$N returns from %s.", ch->short_descr);
 
-	wiznet(buf, ch->desc->original, 0, WIZ_SWITCHES, WIZ_SECURE, get_trust(ch));
+	wiznet(buf, Deref(ch->desc->original), 0, WIZ_SWITCHES, WIZ_SECURE, get_trust(ch));
 
 	ch->pcdata.release();		// relinquish the borrowed pcdata WITHOUT freeing it
 	ch->desc->character = ch->desc->original;
 	ch->desc->original = nullptr;
-	ch->desc->character->desc = ch->desc;
+	Deref(ch->desc->character)->desc = ch->desc;
 	ch->desc = nullptr;
 }
 
@@ -4309,7 +4309,7 @@ void do_restore(CHAR_DATA *ch, char *argument)
 
 		for (d = descriptor_list; d != nullptr; d = d->next)
 		{
-			victim = d->character;
+			victim = Deref(d->character);
 
 			if (victim == nullptr || is_npc(victim))
 				continue;
@@ -5824,11 +5824,11 @@ void do_sockets(CHAR_DATA *ch, char *argument)
 
 	for (d = descriptor_list; d != nullptr; d = d->next)
 	{
-		if (d->character != nullptr
-			&& ((!d->original && can_see(ch, d->character))
-				|| (d->original && can_see(ch, d->original)))
-			&& (!IS_SET(d->character->comm, COMM_NOSOCKET) || get_trust(ch) == MAX_LEVEL)
-			&& (arg[0] == '\0' || is_name(arg, d->character->true_name) || bDis))
+		if (Deref(d->character) != nullptr
+			&& ((!Deref(d->original) && can_see(ch, Deref(d->character)))
+				|| (Deref(d->original) && can_see(ch, Deref(d->original))))
+			&& (!IS_SET(Deref(d->character)->comm, COMM_NOSOCKET) || get_trust(ch) == MAX_LEVEL)
+			&& (arg[0] == '\0' || is_name(arg, Deref(d->character)->true_name) || bDis))
 		{
 			count++;
 
@@ -5856,15 +5856,15 @@ void do_sockets(CHAR_DATA *ch, char *argument)
 				d->connected == (CON_READ_MOTD) ? "Getting motd" :
 				d->connected == (CON_CHOOSE_WEAPON) ? "Choosing weapon" :
 				d->connected == (CON_GET_CABAL) ? "Getting cabal" : "null",
-				(int)((current_time - d->character->logon) / 60),
-				d->original
-					? (d->original->true_name)
-						? d->original->true_name
-						: d->original->name
-					: d->character
-						? (d->character->true_name)
-							? d->character->true_name
-							: d->character->name
+				(int)((current_time - Deref(d->character)->logon) / 60),
+				Deref(d->original)
+					? (Deref(d->original)->true_name)
+						? Deref(d->original)->true_name
+						: Deref(d->original)->name
+					: Deref(d->character)
+						? (Deref(d->character)->true_name)
+							? Deref(d->character)->true_name
+							: Deref(d->character)->name
 						: "(none)",
 				bDis && get_trust(ch) > 58 ? d->host : "unknown");
 		}
@@ -5915,7 +5915,7 @@ void do_multicheck(CHAR_DATA *ch, char *argument)
 
 	for (d = descriptor_list; d != nullptr; d = d->next)
 	{
-		if (d->character != nullptr && can_see(ch, d->character))
+		if (Deref(d->character) != nullptr && can_see(ch, Deref(d->character)))
 		{
 			CHARLIST[i].des = d;
 			i++;
@@ -5952,14 +5952,14 @@ void do_multicheck(CHAR_DATA *ch, char *argument)
 			sprintf(buf + strlen(buf), "[%3d %2d] %s@%s\n\r",
 				CHARLIST[j].des->descriptor,
 				CHARLIST[j].des->connected,
-				CHARLIST[j].des->original
-					? CHARLIST[j].des->original->true_name
-						? CHARLIST[j].des->original->true_name
-						: CHARLIST[j].des->original->name
-					: CHARLIST[j].des->character
-						? CHARLIST[j].des->character->true_name
-							? CHARLIST[j].des->character->true_name
-							: CHARLIST[j].des->character->name
+				Deref(CHARLIST[j].des->original)
+					? Deref(CHARLIST[j].des->original)->true_name
+						? Deref(CHARLIST[j].des->original)->true_name
+						: Deref(CHARLIST[j].des->original)->name
+					: Deref(CHARLIST[j].des->character)
+						? Deref(CHARLIST[j].des->character)->true_name
+							? Deref(CHARLIST[j].des->character)->true_name
+							: Deref(CHARLIST[j].des->character)->name
 						: "(none)",
 				(get_trust(ch) >= 55) ? CHARLIST[j].des->host : "unknown");
 		}
@@ -5975,10 +5975,10 @@ void do_multicheck(CHAR_DATA *ch, char *argument)
 		sprintf(buf + strlen(buf), "[%3d %2d] %s@%s\n\r",
 			CHARLIST[j].des->descriptor,
 			CHARLIST[j].des->connected,
-			CHARLIST[j].des->original
-				? CHARLIST[j].des->original->name
-				: CHARLIST[j].des->character
-					? CHARLIST[j].des->character->name : "(none)",
+			Deref(CHARLIST[j].des->original)
+				? Deref(CHARLIST[j].des->original)->name
+				: Deref(CHARLIST[j].des->character)
+					? Deref(CHARLIST[j].des->character)->name : "(none)",
 			(get_trust(ch) >= 55) ? CHARLIST[j].des->host : "unknown");
 	}
 

--- a/code/act_wiz.c
+++ b/code/act_wiz.c
@@ -3608,16 +3608,20 @@ void do_snoop(CHAR_DATA *ch, char *argument)
 		send_to_char("Cancelling all snoops.\n\r", ch);
 		wiznet("$N stops being such a snoop.", ch, nullptr, WIZ_SNOOPS, WIZ_SECURE, get_trust(ch));
 
+		// A game rule, not lifetime: "snoop self" means "drop every snoop I am
+		// running", and nobody is leaving the world.
 		for (d = descriptor_list; d != nullptr; d = d->next)
 		{
-			if (d->snoop_by == Deref(ch->desc))
+			if (Deref(d->snoop_by) == Deref(ch->desc))
 				d->snoop_by = nullptr;
 		}
 
 		return;
 	}
 
-	if (Deref(victim->desc)->snoop_by != nullptr)
+	DESCRIPTOR_DATA *watched = Deref(victim->desc);
+
+	if (Deref(watched->snoop_by) != nullptr)
 	{
 		send_to_char("Busy already.\n\r", ch);
 		return;
@@ -3644,19 +3648,26 @@ void do_snoop(CHAR_DATA *ch, char *argument)
 		return;
 	}
 
-	if (Deref(ch->desc) != nullptr)
+	DESCRIPTOR_DATA *watcher = Deref(ch->desc);
+
+	if (watcher == nullptr)
 	{
-		for (d = Deref(ch->desc)->snoop_by; d != nullptr; d = d->snoop_by)
+		// Assigning the field used to be harmless when there was no connection
+		// to assign; taking a handle off one is not.
+		send_to_char("You have no connection to snoop with.\n\r", ch);
+		return;
+	}
+
+	for (d = Deref(watcher->snoop_by); d != nullptr; d = Deref(d->snoop_by))
+	{
+		if (Deref(d->character) == victim || Deref(d->original) == victim)
 		{
-			if (Deref(d->character) == victim || Deref(d->original) == victim)
-			{
-				send_to_char("No snoop loops.\n\r", ch);
-				return;
-			}
+			send_to_char("No snoop loops.\n\r", ch);
+			return;
 		}
 	}
 
-	Deref(victim->desc)->snoop_by = Deref(ch->desc);
+	watched->snoop_by = watcher->self;
 
 	sprintf(buf, "$N starts snooping on %s", (is_npc(ch) ? victim->short_descr : victim->name));
 	wiznet(buf, ch, nullptr, WIZ_SNOOPS, WIZ_SECURE, get_trust(ch));

--- a/code/act_wiz.c
+++ b/code/act_wiz.c
@@ -2640,10 +2640,12 @@ void do_mstat(CHAR_DATA *ch, char *argument)
 		sprintf(buf, "Short:  %-30s  ", victim->short_descr);
 		send_to_char(buf, ch);
 
-		if (victim->last_fought != nullptr)
+		CHAR_DATA *quarry = Deref(victim->last_fought);
+
+		if (quarry != nullptr)
 		{
 			sprintf(buf, "Tracking: Player %s.  Remaining Timer: %d\n\r",
-				victim->last_fought->name,
+				quarry->name,
 				victim->tracktimer);
 			send_to_char(buf, ch);
 		}

--- a/code/act_wiz.c
+++ b/code/act_wiz.c
@@ -2515,6 +2515,7 @@ void do_mstat(CHAR_DATA *ch, char *argument)
 	char arg[MAX_INPUT_LENGTH];
 	CHAR_DATA *victim;
 	CHAR_DATA *opponent;
+	CHAR_DATA *quarry;
 	CHAR_DATA *replyTo;
 	ROOM_INDEX_DATA *barred;
 	int i, x;
@@ -2604,11 +2605,12 @@ void do_mstat(CHAR_DATA *ch, char *argument)
 	send_to_char(buf, ch);
 
 	opponent = Deref(victim->fighting);
+	quarry = Deref(victim->hunting);
 
 	sprintf(buf, "Saves:  %-11d Dammod: %-8.4f%%   Hunt:   %-10s Fight: %-11s\n\r",
 		victim->saving_throw,
 		victim->dam_mod,
-		!victim->hunting ? "(none)" : victim->hunting->name,
+		!quarry ? "(none)" : quarry->name,
 		!opponent ? "(none)" : opponent->name);
 	send_to_char(buf, ch);
 

--- a/code/act_wiz.c
+++ b/code/act_wiz.c
@@ -1845,7 +1845,9 @@ void do_ostat(CHAR_DATA *ch, char *argument)
 
 	obj = get_obj_world(ch, argument);
 
-	if (obj == nullptr || (obj && obj->carried_by && !can_see(ch, obj->carried_by)))
+	CHAR_DATA *objCarrier = obj != nullptr ? Deref(obj->carried_by) : nullptr;
+
+	if (obj == nullptr || (objCarrier && !can_see(ch, objCarrier)))
 	{
 		send_to_char("Nothing like that in hell, earth, or heaven.\n\r", ch);
 		return;
@@ -1896,7 +1898,7 @@ void do_ostat(CHAR_DATA *ch, char *argument)
 	sprintf(buf, "In room: %d  In object: %s  Carried by: %s  Wear_loc: %d\n\r",
 		obj->in_room == nullptr ? 0 : obj->in_room->vnum,
 		container == nullptr ? "(none)" : container->short_descr,
-		obj->carried_by == nullptr ? "(none)" : can_see(ch, obj->carried_by) ? obj->carried_by->name : "someone",
+		objCarrier == nullptr ? "(none)" : can_see(ch, objCarrier) ? objCarrier->name : "someone",
 		obj->wear_loc);
 	send_to_char(buf, ch);
 
@@ -3252,12 +3254,14 @@ void do_owhere(CHAR_DATA *ch, char *argument)
 		while (OBJ_DATA *outer = Deref(in_obj->in_obj))
 			in_obj = outer;
 
-		if (in_obj->carried_by != nullptr && can_see(ch, in_obj->carried_by) && in_obj->carried_by->in_room != nullptr)
+		CHAR_DATA *carrier = Deref(in_obj->carried_by);
+
+		if (carrier != nullptr && can_see(ch, carrier) && carrier->in_room != nullptr)
 		{
 			sprintf(buf, "%3d) %s is carried by %s [Room %d]\n\r",
 				number, obj->short_descr,
-				pers(in_obj->carried_by, ch),
-				in_obj->carried_by->in_room->vnum);
+				pers(carrier, ch),
+				carrier->in_room->vnum);
 		}
 		else if (in_obj->in_room != nullptr && can_see_room(ch, in_obj->in_room))
 		{

--- a/code/alias.c
+++ b/code/alias.c
@@ -110,10 +110,12 @@ void do_alias(CHAR_DATA *ch, char *argument)
 	int pos;
 	smash_tilde(argument);
 
-	if (ch->desc == nullptr)
+	DESCRIPTOR_DATA *connection = Deref(ch->desc);
+
+	if (connection == nullptr)
 		rch = ch;
 	else
-		rch = Deref(ch->desc->original) ? Deref(ch->desc->original) : ch;
+		rch = Deref(connection->original) ? Deref(connection->original) : ch;
 
 	if (is_npc(rch))
 		return;
@@ -210,10 +212,12 @@ void do_unalias(CHAR_DATA *ch, char *argument)
 	int pos;
 	bool found = false;
 
-	if (ch->desc == nullptr)
+	DESCRIPTOR_DATA *connection = Deref(ch->desc);
+
+	if (connection == nullptr)
 		rch = ch;
 	else
-		rch = Deref(ch->desc->original) ? Deref(ch->desc->original) : ch;
+		rch = Deref(connection->original) ? Deref(connection->original) : ch;
 
 	if (is_npc(rch))
 		return;

--- a/code/alias.c
+++ b/code/alias.c
@@ -53,7 +53,7 @@ void substitute_alias(DESCRIPTOR_DATA *d, char *argument)
 	char *point;
 	int alias;
 
-	ch = d->original ? d->original : d->character;
+	ch = Deref(d->original) ? Deref(d->original) : Deref(d->character);
 
 	if (is_npc(ch)
 		|| ch->pcdata->alias[0] == nullptr
@@ -61,7 +61,7 @@ void substitute_alias(DESCRIPTOR_DATA *d, char *argument)
 		|| !str_prefix("una", argument)
 		|| !str_prefix("prefix", argument))
 	{
-		interpret(d->character, argument);
+		interpret(Deref(d->character), argument);
 		return;
 	}
 
@@ -94,7 +94,7 @@ void substitute_alias(DESCRIPTOR_DATA *d, char *argument)
 		}
 	}
 
-	interpret(d->character, buf);
+	interpret(Deref(d->character), buf);
 }
 
 void do_alia(CHAR_DATA *ch, char *argument)
@@ -113,7 +113,7 @@ void do_alias(CHAR_DATA *ch, char *argument)
 	if (ch->desc == nullptr)
 		rch = ch;
 	else
-		rch = ch->desc->original ? ch->desc->original : ch;
+		rch = Deref(ch->desc->original) ? Deref(ch->desc->original) : ch;
 
 	if (is_npc(rch))
 		return;
@@ -213,7 +213,7 @@ void do_unalias(CHAR_DATA *ch, char *argument)
 	if (ch->desc == nullptr)
 		rch = ch;
 	else
-		rch = ch->desc->original ? ch->desc->original : ch;
+		rch = Deref(ch->desc->original) ? Deref(ch->desc->original) : ch;
 
 	if (is_npc(rch))
 		return;

--- a/code/aprog.c
+++ b/code/aprog.c
@@ -6,6 +6,7 @@
 #include <string.h>
 #include <time.h>
 #include "merc.h"
+#include "entity/handles.h"
 #include "aprog.h"
 #include "weather_enums.h"
 #include "comm.h"
@@ -167,7 +168,7 @@ void tick_prog_academy_reset(AREA_DATA *area)
 
 	for (ch = char_list; ch; ch = ch->next)
 	{
-		if (!is_npc(ch) && ch->in_room->area == area && ch->level > 10 && !ch->fighting && !is_immortal(ch))
+		if (!is_npc(ch) && ch->in_room->area == area && ch->level > 10 && !Deref(ch->fighting) && !is_immortal(ch))
 		{
 			char buf[MSL];
 
@@ -372,7 +373,7 @@ void pulse_prog_ruins_shark(AREA_DATA *area)
 
 		if (shark->pIndexData->vnum == 20111)
 		{
-			if (!shark->fighting && !shark->last_fought && number_percent() > 50 && shark->in_room)
+			if (!Deref(shark->fighting) && !shark->last_fought && number_percent() > 50 && shark->in_room)
 				extract_char(shark, true);
 			else
 				count++;

--- a/code/aprog.c
+++ b/code/aprog.c
@@ -373,7 +373,7 @@ void pulse_prog_ruins_shark(AREA_DATA *area)
 
 		if (shark->pIndexData->vnum == 20111)
 		{
-			if (!Deref(shark->fighting) && !shark->last_fought && number_percent() > 50 && shark->in_room)
+			if (!Deref(shark->fighting) && !Deref(shark->last_fought) && number_percent() > 50 && shark->in_room)
 				extract_char(shark, true);
 			else
 				count++;

--- a/code/aprog.c
+++ b/code/aprog.c
@@ -386,18 +386,18 @@ void pulse_prog_ruins_shark(AREA_DATA *area)
 	for (d = descriptor_list; d; d = d->next)
 	{
 		if (d->connected == CON_PLAYING
-			&& d->character->in_room != nullptr
-			&& d->character->in_room->area == area
+			&& Deref(d->character)->in_room != nullptr
+			&& Deref(d->character)->in_room->area == area
 			&& number_percent() > 90)
 		{
-			ch = d->character;
+			ch = Deref(d->character);
 
-			if ((d->character->hit * 2) > d->character->max_hit)
+			if ((Deref(d->character)->hit * 2) > Deref(d->character)->max_hit)
 				continue;
 
-			if (d->character->in_room->vnum < 20100
-				|| (d->character->in_room->vnum > 20150 && d->character->in_room->vnum < 20181)
-				|| d->character->in_room->vnum > 20219)
+			if (Deref(d->character)->in_room->vnum < 20100
+				|| (Deref(d->character)->in_room->vnum > 20150 && Deref(d->character)->in_room->vnum < 20181)
+				|| Deref(d->character)->in_room->vnum > 20219)
 			{
 				continue;
 			}

--- a/code/cabal.c
+++ b/code/cabal.c
@@ -717,7 +717,7 @@ void spell_hire_mercenary(int sn, int level, CHAR_DATA *ch, void *vo, int target
 		if (is_npc(merc)
 			&& merc->pIndexData->vnum >= MOB_VNUM_WARRIOR_MERCENARY
 			&& merc->pIndexData->vnum <= MOB_VNUM_SHAMAN_MERCENARY
-			&& merc->master == ch)
+			&& Deref(merc->master) == ch)
 		{
 			break;
 		}
@@ -786,7 +786,7 @@ void spell_hire_mercenary(int sn, int level, CHAR_DATA *ch, void *vo, int target
 	merc->damage[DICE_BONUS] = ch->level / 2;
 
 	if (merc_vnum != MOB_VNUM_SHAMAN_MERCENARY)
-		merc->leader = ch;
+		merc->leader = ch->self;
 
 	SET_BIT(merc->affected_by, AFF_CHARM);
 	do_gtell(merc, "Reporting for duty.");

--- a/code/cabal.c
+++ b/code/cabal.c
@@ -34,6 +34,7 @@
 #include <iterator>
 #include <algorithm>
 #include "merc.h"
+#include "entity/handles.h"
 #include "cabal.h"
 #include "recycle.h"
 #include "tables.h"
@@ -631,7 +632,7 @@ void spell_scourge(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 		if (is_same_group(vch, ch) || is_safe(ch, vch) || is_same_cabal(ch, vch))
 			continue;
 
-		if (!is_npc(ch) && !is_npc(vch) && (ch->fighting == nullptr || vch->fighting == nullptr))
+		if (!is_npc(ch) && !is_npc(vch) && (Deref(ch->fighting) == nullptr || Deref(vch->fighting) == nullptr))
 		{
 			sprintf(buf, "Die, %s you scourging dog!", pers(ch, vch));
 			do_myell(vch, buf, ch);
@@ -1018,7 +1019,7 @@ void do_howl(CHAR_DATA *ch, char *argument)
 		ch->mana -= 30;
 	}
 
-	if (!ch->fighting)
+	if (!Deref(ch->fighting))
 	{
 		send_to_char("You must be fighting to howl!\n\r", ch);
 		return;
@@ -1048,7 +1049,7 @@ void do_howl(CHAR_DATA *ch, char *argument)
 			vch_next = vch->next_in_room;
 			if (vch != ch
 				&& !check_leadership_save(vch, gsn_howl)
-				&& vch->fighting == ch
+				&& Deref(vch->fighting) == ch
 				&& (!is_npc(vch) || (is_npc(vch) && !IS_SET(vch->act, ACT_SENTINEL))))
 			{
 				act("$n looks frightened and tries to run!", vch, 0, 0, TO_ROOM);
@@ -1575,7 +1576,7 @@ void spell_shroud_of_light(int sn, int level, CHAR_DATA *ch, void *vo, int targe
 		return;
 	}
 
-	if (ch->fighting)
+	if (Deref(ch->fighting))
 	{
 		send_to_char("You are not able to shroud yourself while you fight.\n\r", ch);
 		return;
@@ -1598,7 +1599,7 @@ void spell_shroud_of_light(int sn, int level, CHAR_DATA *ch, void *vo, int targe
 
 void spell_crimson_martyr(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 {
-	CHAR_DATA *victim = ch->fighting, *vch, *vch_next;
+	CHAR_DATA *victim = Deref(ch->fighting), *vch, *vch_next;
 	AFFECT_DATA af;
 
 	for (vch = ch->in_room->people; vch; vch = vch->next_in_room)

--- a/code/cabal.c
+++ b/code/cabal.c
@@ -1192,7 +1192,7 @@ void spell_deny_magic(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 	af.type = gsn_deny_magic;
 	af.level = level;
 	af.aftype = AFT_POWER;
-	af.owner = ch;
+	af.owner = ch->self;
 	new_affect_to_char(victim, &af);
 }
 
@@ -1269,7 +1269,7 @@ void spell_medicine(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 		af.aftype = AFT_POWER;
 		af.type = gsn_medicine;
 		af.duration = 4;
-		af.owner = ch;
+		af.owner = ch->self;
 		af.level = level;
 		new_affect_to_char(vch, &af);
 
@@ -1367,7 +1367,7 @@ void spell_horde_communion(int sn, int level, CHAR_DATA *ch, void *vo, int targe
 	af.location = 0;
 	af.modifier = 0;
 	af.duration = -1;
-	af.owner = ch;
+	af.owner = ch->self;
 	af.level = level;
 	af.tick_fun = communion_tick;
 	new_affect_to_char(victim, &af);
@@ -1671,13 +1671,13 @@ void spell_crimson_martyr(int sn, int level, CHAR_DATA *ch, void *vo, int target
 
 void retribution_tick(CHAR_DATA *ch, AFFECT_DATA *af)
 {
-	if (af->modifier == 0 || !af->owner || is_safe(af->owner, ch))
+	if (af->modifier == 0 || !Deref(af->owner) || is_safe(Deref(af->owner), ch))
 		return;
 
 	float dam = af->modifier / (af->duration == 0 ? 1 : af->duration);
 
 	send_to_char("Pain courses through your body as zealous retribution is extracted upon you!\n\r", ch);
-	damage_new(af->owner, ch, (int)dam, gsn_retribution, DAM_HOLY, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "the retribution of the Phalanx*");
+	damage_new(Deref(af->owner), ch, (int)dam, gsn_retribution, DAM_HOLY, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "the retribution of the Phalanx*");
 	af->modifier -= (int)dam;
 }
 
@@ -1706,7 +1706,7 @@ void spell_retribution(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 	af.level = level;
 	af.type = sn;
 	af.tick_fun = retribution_tick;
-	af.owner = ch;
+	af.owner = ch->self;
 	affect_to_char(victim, &af);
 
 	act("You unleash the vengeance of the Phalanx upon $N!", ch, 0, victim, TO_CHAR);

--- a/code/cabal.c
+++ b/code/cabal.c
@@ -1292,11 +1292,11 @@ void spell_horde_communion(int sn, int level, CHAR_DATA *ch, void *vo, int targe
 	CHAR_DATA *victim = (CHAR_DATA *)vo;
 	AFFECT_DATA af;
 
-	if (is_npc(ch) && (!ch->desc || !ch->desc->original))
+	if (is_npc(ch) && (!ch->desc || !Deref(ch->desc->original)))
 		return;
 
 	if (is_npc(ch))
-		ch = ch->desc->original;
+		ch = Deref(ch->desc->original);
 
 	if (is_affected(victim, gsn_horde_communion))
 	{

--- a/code/cabal.c
+++ b/code/cabal.c
@@ -1292,11 +1292,13 @@ void spell_horde_communion(int sn, int level, CHAR_DATA *ch, void *vo, int targe
 	CHAR_DATA *victim = (CHAR_DATA *)vo;
 	AFFECT_DATA af;
 
-	if (is_npc(ch) && (!ch->desc || !Deref(ch->desc->original)))
+	DESCRIPTOR_DATA *connection = Deref(ch->desc);
+
+	if (is_npc(ch) && (!connection || !Deref(connection->original)))
 		return;
 
 	if (is_npc(ch))
-		ch = Deref(ch->desc->original);
+		ch = Deref(connection->original);
 
 	if (is_affected(victim, gsn_horde_communion))
 	{

--- a/code/characterClasses/ap.c
+++ b/code/characterClasses/ap.c
@@ -311,7 +311,7 @@ void lust_pulse(CHAR_DATA *ch, AFFECT_DATA *af)
 	char buf[MSL];
 	int skill;
 
-	if (ch->fighting || !is_awake(ch))
+	if (Deref(ch->fighting) || !is_awake(ch))
 		return;
 
 	skill = (int)(get_skill(ch, skill_lookup("steal")) * 0.8);
@@ -509,7 +509,7 @@ void check_baals_mastery(CHAR_DATA *ch, CHAR_DATA *victim)
 	if (!is_affected(ch, gsn_baals_mastery))
 		return;
 
-	if (victim != ch->fighting)
+	if (victim != Deref(ch->fighting))
 		return;
 
 	if (!(af = affect_find(ch->affected, gsn_baals_mastery)))
@@ -840,7 +840,7 @@ void living_blade_pulse(OBJ_DATA *obj, OBJ_AFFECT_DATA *af)
 		return;
 	}
 
-	if (!ch->fighting && af->modifier == 0)
+	if (!Deref(ch->fighting) && af->modifier == 0)
 	{
 		if (number_percent() < 4 && af->location == APPLY_DAMROLL)
 		{
@@ -874,7 +874,7 @@ void living_blade_pulse(OBJ_DATA *obj, OBJ_AFFECT_DATA *af)
 		}
 	}
 
-	if (!ch->fighting && number_percent() <= 33)
+	if (!Deref(ch->fighting) && number_percent() <= 33)
 	{
 		OBJ_AFFECT_DATA af2;
 		af2.where = af->where;
@@ -895,7 +895,7 @@ void living_blade_pulse(OBJ_DATA *obj, OBJ_AFFECT_DATA *af)
 
 		return;
 	}
-	else if (!ch->fighting)
+	else if (!Deref(ch->fighting))
 	{
 		return;
 	}
@@ -903,7 +903,7 @@ void living_blade_pulse(OBJ_DATA *obj, OBJ_AFFECT_DATA *af)
 	if (!(obj->wear_loc == WEAR_WIELD || obj->wear_loc == WEAR_DUAL_WIELD))
 		return;
 
-	if (is_npc(ch->fighting) && number_percent() > 5)
+	if (is_npc(Deref(ch->fighting)) && number_percent() > 5)
 		return;
 
 	OBJ_AFFECT_DATA af2;
@@ -919,12 +919,12 @@ void living_blade_pulse(OBJ_DATA *obj, OBJ_AFFECT_DATA *af)
 	af2.pulse_fun = af->pulse_fun;
 	affect_remove_obj(obj, af, false);
 
-	if (is_npc(ch->fighting) && af2.modifier <= 15)
+	if (is_npc(Deref(ch->fighting)) && af2.modifier <= 15)
 	{
 		af2.modifier++;
 		af2.modifier = std::min((int)af2.modifier, 15);
 	}
-	else if (is_npc(ch->fighting))
+	else if (is_npc(Deref(ch->fighting)))
 	{
 		af2.modifier -= 2;
 	}
@@ -1795,7 +1795,7 @@ void insanity_pulse(CHAR_DATA *ch, AFFECT_DATA *af)
 	if (number_percent() < 5)
 		return;
 
-	if (ch->fighting != nullptr)
+	if (Deref(ch->fighting) != nullptr)
 	{
 		insanity_fight(ch);
 		return;
@@ -1807,7 +1807,7 @@ void insanity_pulse(CHAR_DATA *ch, AFFECT_DATA *af)
 
 	for (victim = ch->in_room->people; victim != nullptr; victim = victim->next_in_room)
 	{
-		if (ch->fighting != nullptr)
+		if (Deref(ch->fighting) != nullptr)
 			return;
 
 		if ((victim == ch) || (is_safe_new(ch, victim, false)) || (number_percent() > 95))
@@ -1944,7 +1944,7 @@ void insanity_end(CHAR_DATA *ch, AFFECT_DATA *af)
 
 void insanity_fight(CHAR_DATA *ch)
 {
-	CHAR_DATA *victim = ch->fighting;
+	CHAR_DATA *victim = Deref(ch->fighting);
 
 	if (victim == nullptr)
 		return;
@@ -2122,9 +2122,9 @@ void do_breath_mephisto(CHAR_DATA *ch, char *argument)
 
 	if (argument[0] == '\0')
 	{
-		if (ch->fighting)
+		if (Deref(ch->fighting))
 		{
-			victim = ch->fighting;
+			victim = Deref(ch->fighting);
 		}
 		else
 		{
@@ -2160,7 +2160,7 @@ void mephisto_two(CHAR_DATA *ch, CHAR_DATA *victim, char *argument)
 {
 	AFFECT_DATA af;
 
-	if (!(ch->fighting) && !(get_char_room(ch, argument)))
+	if (!(Deref(ch->fighting)) && !(get_char_room(ch, argument)))
 	{
 		act("You let the intense cold dissipate, your target having escaped.", ch, 0, 0, TO_CHAR);
 		return;
@@ -2196,9 +2196,9 @@ void do_touch(CHAR_DATA *ch, char *argument)
 
 	if (argument[0] == '\0')
 	{
-		if (ch->fighting)
+		if (Deref(ch->fighting))
 		{
-			victim = ch->fighting;
+			victim = Deref(ch->fighting);
 		}
 		else
 		{
@@ -2228,7 +2228,7 @@ void do_touch(CHAR_DATA *ch, char *argument)
 	if (is_safe_new(ch, victim, true))
 		return;
 
-	if (ch->fighting)
+	if (Deref(ch->fighting))
 		chance -= 20;
 
 	if (victim->position == POS_SLEEPING)

--- a/code/characterClasses/ap.c
+++ b/code/characterClasses/ap.c
@@ -7,6 +7,7 @@
 #include <time.h>
 #include <math.h>
 #include "../merc.h"
+#include "../entity/handles.h"
 #include "ap.h"
 #include "../interp.h"
 #include "../tables.h"
@@ -815,7 +816,7 @@ void living_blade_pulse(OBJ_DATA *obj, OBJ_AFFECT_DATA *af)
 	char buf[MSL];
 	CHAR_DATA *ch;
 
-	if ((ch = obj->carried_by) == nullptr)
+	if ((ch = Deref(obj->carried_by)) == nullptr)
 		return;
 
 	if (ch != af->owner)
@@ -957,10 +958,12 @@ void living_blade_end(OBJ_DATA *obj, OBJ_AFFECT_DATA *af)
 	if (af->location == APPLY_HITROLL)
 		return;
 
-	if (!obj->carried_by)
+	CHAR_DATA *carrier = Deref(obj->carried_by);
+
+	if (carrier == nullptr)
 		return;
 
-	act("$p ceases its slight writhing and seems less animated.", obj->carried_by, obj, 0, TO_CHAR);
+	act("$p ceases its slight writhing and seems less animated.", carrier, obj, 0, TO_CHAR);
 }
 
 void traitor_pulse(CHAR_DATA *ch, AFFECT_DATA *af)

--- a/code/characterClasses/ap.c
+++ b/code/characterClasses/ap.c
@@ -1213,10 +1213,10 @@ void check_unholy_communion(CHAR_DATA *ch, char *argument)
 	for (d = descriptor_list; d; d = d->next)
 	{
 		if (d->connected == CON_PLAYING 
-			&& !is_immortal(d->character)
-			&& !is_npc(d->character)
-			&& d->character->in_room->area == ch->in_room->area
-			&& d->character != ch)
+			&& !is_immortal(Deref(d->character))
+			&& !is_npc(Deref(d->character))
+			&& Deref(d->character)->in_room->area == ch->in_room->area
+			&& Deref(d->character) != ch)
 		{
 			send_to_char("A voice hisses in your mind: 'Ssssolitude, mortal.  There are othersss near...'\n\r", ch);
 			return;

--- a/code/characterClasses/ap.c
+++ b/code/characterClasses/ap.c
@@ -994,7 +994,7 @@ void spell_dark_familiar(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 
 	for (check = char_list; check != nullptr; check = check->next)
 	{
-		if (is_npc(check) && check->leader == ch)
+		if (is_npc(check) && Deref(check->leader) == ch)
 		{
 			found = true;
 			break;
@@ -1071,7 +1071,7 @@ void spell_dark_familiar(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 
 	add_follower(fam, ch);
 
-	fam->leader = ch;
+	fam->leader = ch->self;
 
 	SET_BIT(fam->affected_by, AFF_CHARM);
 

--- a/code/characterClasses/ap.c
+++ b/code/characterClasses/ap.c
@@ -56,7 +56,7 @@ void check_bloodlust(CHAR_DATA *ch, CHAR_DATA *victim)
 		af.where = TO_AFFECTS;
 		af.aftype = AFT_SKILL;
 		af.type = gsn_bloodlust;
-		af.owner = ch;
+		af.owner = ch->self;
 		af.level = level;
 		af.duration = 96;
 		af.modifier = level * 2;
@@ -109,7 +109,7 @@ void spell_indomitability(int sn, int level, CHAR_DATA *ch, void *vo, int target
 	af.where = TO_AFFECTS;
 	af.aftype = AFT_SPELL;
 	af.type = gsn_indom;
-	af.owner = ch;
+	af.owner = ch->self;
 	af.level = level;
 	af.duration = level / 5;
 	af.modifier = 0;
@@ -188,7 +188,7 @@ void spell_wrack(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 	af.level = level;
 	af.location = APPLY_DAM_MOD;
 	af.modifier = 20;
-	af.owner = ch;
+	af.owner = ch->self;
 	affect_to_char(victim, &af);
 
 	af.aftype = AFT_MALADY;
@@ -218,7 +218,7 @@ void spell_radiance(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 
 	init_affect(&af);
 	af.where = TO_AFFECTS;
-	af.owner = ch;
+	af.owner = ch->self;
 	af.level = level;
 	af.location = 0;
 	af.modifier = 3;
@@ -265,7 +265,7 @@ void spell_inspire_lust(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 		af.level = level;
 		af.location = 0;
 		af.modifier = 0;
-		af.owner = ch;
+		af.owner = ch->self;
 		af.pulse_fun = lust_pulse;
 		af.type = sn;
 		af.duration = level / 6;
@@ -296,7 +296,7 @@ void spell_inspire_lust(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 		af.level = level;
 		af.location = 0;
 		af.modifier = 0;
-		af.owner = ch;
+		af.owner = ch->self;
 		af.pulse_fun = lust_pulse;
 		af.type = sn;
 		af.duration = level / 6;
@@ -484,7 +484,7 @@ void spell_baals_mastery(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 	af.where = TO_AFFECTS;
 	af.aftype = AFT_INVIS;
 	af.type = gsn_baals_mastery;
-	af.owner = ch;
+	af.owner = ch->self;
 	af.level = MAX_LEVEL;
 	af.location = 0;
 	af.modifier = weapon;
@@ -562,7 +562,7 @@ void check_baals_mastery(CHAR_DATA *ch, CHAR_DATA *victim)
 				af2.where = TO_AFFECTS;
 				af2.aftype = AFT_MALADY;
 				af2.type = gsn_bleeding;
-				af2.owner = ch;
+				af2.owner = ch->self;
 				af2.level = ch->level;
 				af2.location = APPLY_STR;
 				af2.modifier = -4;
@@ -687,7 +687,7 @@ void spell_word_of_command(int sn, int level, CHAR_DATA *ch, void *vo, int targe
 	af.where = TO_AFFECTS;
 	af.aftype = AFT_INVIS;
 	af.type = gsn_word_of_command;
-	af.owner = ch;
+	af.owner = ch->self;
 	af.level = level;
 	af.location = 0;
 	af.duration = -1;
@@ -760,7 +760,7 @@ void spell_mark_of_wrath(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 	af.where = TO_AFFECTS;
 	af.aftype = AFT_INVIS;
 	af.type = gsn_mark_of_wrath;
-	af.owner = victim;
+	af.owner = victim->self;
 	af.level = level;
 
 	if (is_good(victim))
@@ -795,7 +795,7 @@ void spell_living_blade(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 	oaf.where = TO_OBJ_APPLY;
 	oaf.type = gsn_living_blade;
 	oaf.aftype = AFT_SPELL;
-	oaf.owner = ch;
+	oaf.owner = ch->self;
 	oaf.level = level;
 	oaf.duration = level;
 	oaf.location = APPLY_DAMROLL;
@@ -819,7 +819,7 @@ void living_blade_pulse(OBJ_DATA *obj, OBJ_AFFECT_DATA *af)
 	if ((ch = Deref(obj->carried_by)) == nullptr)
 		return;
 
-	if (ch != af->owner)
+	if (ch != Deref(af->owner))
 	{
 		if (number_percent() < 7 && af->location == APPLY_DAMROLL)
 		{
@@ -968,13 +968,13 @@ void living_blade_end(OBJ_DATA *obj, OBJ_AFFECT_DATA *af)
 
 void traitor_pulse(CHAR_DATA *ch, AFFECT_DATA *af)
 {
-	if (!af->owner)
+	if (!Deref(af->owner))
 	{
 		affect_remove(ch, af);
 		return;
 	}
 
-	if (!is_same_group(ch, af->owner) && af->duration == -1)
+	if (!is_same_group(ch, Deref(af->owner)) && af->duration == -1)
 	{
 		af->duration = 10;
 		return;
@@ -1088,7 +1088,7 @@ void spell_dark_familiar(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 	af.type = gsn_dark_familiar;
 	af.aftype = AFT_TIMER;
 	af.level = ch->level;
-	af.owner = ch;
+	af.owner = ch->self;
 	af.duration = 64;
 	affect_to_char(ch, &af);
 }
@@ -1130,7 +1130,7 @@ void spell_unholy_communion(int sn, int level, CHAR_DATA *ch, void *vo, int targ
 	af.type = gsn_unholy_communion;
 	af.aftype = AFT_SPELL;
 	af.level = level;
-	af.owner = ch;
+	af.owner = ch->self;
 	af.duration = 12;
 	af.end_fun = communion_end;
 	affect_to_char(ch, &af);
@@ -1148,7 +1148,7 @@ void communion_end(CHAR_DATA *ch, AFFECT_DATA *af)
 	timer.type = gsn_unholy_communion;
 	timer.aftype = AFT_TIMER;
 	timer.level = ch->level;
-	timer.owner = ch;
+	timer.owner = ch->self;
 	timer.duration = 96;
 	affect_to_char(ch, &timer);
 }
@@ -1379,7 +1379,7 @@ void demon_appear(CHAR_DATA *ch, int *demonptr, int *typeptr)
 		af.where = TO_AFFECTS;
 		af.aftype = AFT_INVIS;
 		af.type = gsn_lesser_demon;
-		af.owner = ch;
+		af.owner = ch->self;
 		af.level = 60;
 		af.tick_fun = lesser_demon_tick;
 
@@ -1454,7 +1454,7 @@ void demon_appear(CHAR_DATA *ch, int *demonptr, int *typeptr)
 		af.where = TO_AFFECTS;
 		af.aftype = AFT_INVIS;
 		af.type = gsn_greater_demon;
-		af.owner = ch;
+		af.owner = ch->self;
 		af.level = 60;
 		af.tick_fun = greater_demon_tick;
 		switch (demon)
@@ -1533,7 +1533,7 @@ void lesser_demon_tick(CHAR_DATA *mob, AFFECT_DATA *af)
 {
 	char buf[MSL];
 
-	if (!is_npc(mob) || !af->owner)
+	if (!is_npc(mob) || !Deref(af->owner))
 		return;
 
 	switch (mob->pIndexData->vnum)
@@ -1541,21 +1541,21 @@ void lesser_demon_tick(CHAR_DATA *mob, AFFECT_DATA *af)
 		case MOB_VNUM_BARBAS:
 			break;
 		case MOB_VNUM_FURCAS:
-			if (af->owner && af->duration == 12)
+			if (Deref(af->owner) && af->duration == 12)
 			{
-				sprintf(buf, "%s Does it want a hint?  Does it?  We might not be in the same area as we were before, we might not... but always somewhere near, yes....", af->owner->name);
+				sprintf(buf, "%s Does it want a hint?  Does it?  We might not be in the same area as we were before, we might not... but always somewhere near, yes....", Deref(af->owner)->name);
 				do_tell(mob, buf);
 				break;
 			}
 
-			if (af->owner && af->duration == 1)
+			if (Deref(af->owner) && af->duration == 1)
 			{
-				sprintf(buf, "%s We give up... it cannnot find us... a pity, yes.  Goodbye, it.", af->owner->name);
+				sprintf(buf, "%s We give up... it cannnot find us... a pity, yes.  Goodbye, it.", Deref(af->owner)->name);
 				do_tell(mob, buf);
 
 				act("$n vanishes in a crimson flash!", mob, 0, 0, TO_ROOM);
 
-				af->owner->pcdata->lesserdata[LESSER_FURCAS] = FAVOR_FAILED;
+				Deref(af->owner)->pcdata->lesserdata[LESSER_FURCAS] = FAVOR_FAILED;
 				extract_char(mob, true);
 			}
 
@@ -1587,7 +1587,7 @@ void lesser_demon_tick(CHAR_DATA *mob, AFFECT_DATA *af)
 				do_say(mob, "My friend, I have better things to do with my time.  A pity.");
 				act("$n vanishes in a crimson flash!", mob, 0, 0, TO_ROOM);
 
-				af->owner->pcdata->lesserdata[LESSER_MALAPHAR] = FAVOR_FAILED;
+				Deref(af->owner)->pcdata->lesserdata[LESSER_MALAPHAR] = FAVOR_FAILED;
 				extract_char(mob, true);
 			}
 			break;
@@ -1597,7 +1597,7 @@ void lesser_demon_tick(CHAR_DATA *mob, AFFECT_DATA *af)
 				do_say(mob, "I've better things to do with my time, than wait for you to mumble a rhyme!");
 				act("$n vanishes in a crimson flash!", mob, 0, 0, TO_ROOM);
 
-				af->owner->pcdata->lesserdata[LESSER_IPOS] = FAVOR_FAILED;
+				Deref(af->owner)->pcdata->lesserdata[LESSER_IPOS] = FAVOR_FAILED;
 				extract_char(mob, true);
 			}
 			break;
@@ -1610,7 +1610,7 @@ void greater_demon_tick(CHAR_DATA *mob, AFFECT_DATA *af)
 {
 	char buf[MSL];
 
-	if (!is_npc(mob) || !af->owner)
+	if (!is_npc(mob) || !Deref(af->owner))
 		return;
 
 	switch (mob->pIndexData->vnum)
@@ -1630,11 +1630,11 @@ void greater_demon_tick(CHAR_DATA *mob, AFFECT_DATA *af)
 
 			if (af->duration == 1)
 			{
-				sprintf(buf, "The abyss will not forget this treachery, %s.", af->owner->name);
+				sprintf(buf, "The abyss will not forget this treachery, %s.", Deref(af->owner)->name);
 				do_whisper(mob, buf);
 
 				act("The puddle of gore before you which was once a greater demon seeps downward.", mob, 0, 0, TO_ROOM);
-				af->owner->pcdata->greaterdata[GREATER_OZE] = FAVOR_FAILED;
+				Deref(af->owner)->pcdata->greaterdata[GREATER_OZE] = FAVOR_FAILED;
 
 				extract_char(mob, true);
 				break;
@@ -1644,7 +1644,7 @@ void greater_demon_tick(CHAR_DATA *mob, AFFECT_DATA *af)
 		case MOB_VNUM_GAMYGYN:
 			if (af->duration == 1)
 			{
-				sprintf(buf, "%s You fool.  You utter fool.  You know not what power you have squandered.", af->owner->name);
+				sprintf(buf, "%s You fool.  You utter fool.  You know not what power you have squandered.", Deref(af->owner)->name);
 				do_tell(mob, buf);
 
 				act("Flashing a great dark light, $n vanishes from sight.", mob, 0, 0, TO_ROOM);
@@ -1656,7 +1656,7 @@ void greater_demon_tick(CHAR_DATA *mob, AFFECT_DATA *af)
 		case MOB_VNUM_OROBAS:
 			if (af->duration == 1)
 			{
-				sprintf(buf, "%s, you fool.  You utter fool.  You know not what power you have squandered!", af->owner->name);
+				sprintf(buf, "%s, you fool.  You utter fool.  You know not what power you have squandered!", Deref(af->owner)->name);
 				do_say(mob, buf);
 
 				act("With a fierce snarl, and many assorted whispers, Orobas streaks into the sky.", mob, 0, 0, TO_ROOM);
@@ -1697,7 +1697,7 @@ void greater_demon_tick(CHAR_DATA *mob, AFFECT_DATA *af)
 
 				act("Turning coldly and melting into a cool mist, $n wafts away on a breeze.", mob, 0, 0, TO_ALL);
 
-				af->owner->pcdata->greaterdata[GREATER_GERYON] = FAVOR_FAILED;
+				Deref(af->owner)->pcdata->greaterdata[GREATER_GERYON] = FAVOR_FAILED;
 
 				extract_char(mob, true);
 				break;
@@ -1712,7 +1712,7 @@ void greater_demon_tick(CHAR_DATA *mob, AFFECT_DATA *af)
 
 			if (af->duration == 2)
 			{
-				act("As blood trickles down your neck, your mind races to decide:  ear or nose?", mob, 0, af->owner,
+				act("As blood trickles down your neck, your mind races to decide:  ear or nose?", mob, 0, Deref(af->owner),
 					TO_VICT);
 				break;
 
@@ -1722,7 +1722,7 @@ void greater_demon_tick(CHAR_DATA *mob, AFFECT_DATA *af)
 				act("In disgust, $n rips his claws free and moves his massive frame back.", mob, 0, 0, TO_ROOM);
 				act("Slowly, the monstrous demon fades into shadows and dissipates.", mob, 0, 0, TO_ROOM);
 
-				af->owner->pcdata->greaterdata[GREATER_CIMERIES] = FAVOR_FAILED;
+				Deref(af->owner)->pcdata->greaterdata[GREATER_CIMERIES] = FAVOR_FAILED;
 				extract_char(mob, true);
 			}
 			break;
@@ -1777,7 +1777,7 @@ void spell_insanity(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 	af.location = APPLY_DAMROLL;
 	af.pulse_fun = insanity_pulse;
 	af.end_fun = insanity_end;
-	af.owner = ch;
+	af.owner = ch->self;
 	affect_to_char(ch, &af);
 
 	af.pulse_fun = nullptr;
@@ -2181,7 +2181,7 @@ void mephisto_two(CHAR_DATA *ch, CHAR_DATA *victim, char *argument)
 	af.where = TO_AFFECTS;
 	af.aftype = AFT_TIMER;
 	af.type = skill_lookup("breath of mephisto");
-	af.owner = ch;
+	af.owner = ch->self;
 	af.duration = 4;
 	af.modifier = 0;
 	af.location = 0;
@@ -2254,7 +2254,7 @@ void do_touch(CHAR_DATA *ch, char *argument)
 		af.where = TO_AFFECTS;
 		af.location = 0;
 		af.modifier = 0;
-		af.owner = ch;
+		af.owner = ch->self;
 		af.type = skill_lookup("burning touch");
 		af.aftype = AFT_MALADY;
 		af.end_fun = nullptr;
@@ -2326,7 +2326,7 @@ void check_orobas_gamygyn(CHAR_DATA *ch, CHAR_DATA *victim)
 
 void burning_pulse(CHAR_DATA *ch, AFFECT_DATA *af)
 {
-	CHAR_DATA *owner = af->owner;
+	CHAR_DATA *owner = Deref(af->owner);
 	if (number_percent() > 50)
 		return;
 
@@ -2381,7 +2381,7 @@ void do_darksight(CHAR_DATA *ch, char *argument)
 	init_affect(&af);
 	af.where = TO_AFFECTS;
 	af.type = gsn_darksight;
-	af.owner = ch;
+	af.owner = ch->self;
 	af.aftype = AFT_SKILL;
 	af.duration = 12;
 	af.location = 0;
@@ -2402,7 +2402,7 @@ void darksight_end(CHAR_DATA *ch, AFFECT_DATA *af)
 	init_affect(&af2);
 	af2.where = TO_AFFECTS;
 	af2.type = gsn_darksight;
-	af2.owner = ch;
+	af2.owner = ch->self;
 	af2.aftype = AFT_TIMER;
 	af2.duration = 36;
 	af2.modifier = 0;

--- a/code/characterClasses/chrono.c
+++ b/code/characterClasses/chrono.c
@@ -177,7 +177,7 @@ void do_rune(CHAR_DATA *ch, char *argument)
 	void *vo;
 	int mana, where, sn, target = 0;
 
-	if (is_npc(ch) && ch->desc == nullptr)
+	if (is_npc(ch) && Deref(ch->desc) == nullptr)
 		return;
 
 	if (ch->Class()->ctype != CLASS_CASTER && !is_immortal(ch))

--- a/code/characterClasses/chrono.c
+++ b/code/characterClasses/chrono.c
@@ -61,7 +61,7 @@ void spell_stasis_wall(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 		rune->level = level;
 		rune->placed_on = pexit;
 		rune->target_type = RUNE_TO_PORTAL; // grep for this too
-		rune->owner = ch;
+		rune->owner = ch->self;
 		rune->trigger_type = RUNE_TRIGGER_EXIT; // grep for rune trigger types if you need to
 		rune->type = sn;
 		rune->duration = level / 10;
@@ -77,7 +77,7 @@ void spell_stasis_wall(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 	rune->level = level;
 	rune->placed_on = (ROOM_INDEX_DATA *)ch->in_room;
 	rune->target_type = RUNE_TO_ROOM;
-	rune->owner = ch;
+	rune->owner = ch->self;
 	rune->trigger_type = RUNE_TRIGGER_ENTRY;
 	rune->type = sn;
 	rune->duration = level / 10;
@@ -91,16 +91,16 @@ void spell_stasis_wall(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 		usually make sure the lag on the rune
 		is at least as long as the lag on the draw_rune queue
 	*/
-	RS.Queue.AddToQueue(9, "spell_stasis_wall", "draw_rune_queue", draw_rune_queue, rune, rune->owner); 
+	RS.Queue.AddToQueue(9, "spell_stasis_wall", "draw_rune_queue", draw_rune_queue, rune, Deref(rune->owner));
 }
 
 bool trigger_stasis_wall(void *vo, void *vo2, void *vo3, void *vo4)
 {
 	RUNE_DATA *rune = (RUNE_DATA *)vo;
-	CHAR_DATA *victim = (CHAR_DATA *)vo2, *ch = rune->owner;
+	CHAR_DATA *victim = (CHAR_DATA *)vo2, *ch = Deref(rune->owner);
 	int dir = (int)*(int *)vo3;
 
-	if (!rune->owner)
+	if (ch == nullptr)
 		return false;
 
 	if (is_safe_new(ch, victim, false))
@@ -115,11 +115,18 @@ bool trigger_stasis_wall(void *vo, void *vo2, void *vo3, void *vo4)
 bool activate_stasis_wall(void *vo, void *vo2, void *vo3, void *vo4)
 {
 	RUNE_DATA *rune = (RUNE_DATA *)vo, new_rune;
-	CHAR_DATA *victim = (CHAR_DATA *)vo2, *ch = rune->owner;
+	CHAR_DATA *victim = (CHAR_DATA *)vo2, *ch = Deref(rune->owner);
 	int dir = reverse_d((int)*(int *)vo3);
+
+	// The owner check has to come first: it used to sit below a line that
+	// already read ch->in_room, so a rune outliving its caster dereferenced
+	// null before ever reaching the guard written for exactly that case.
+	if (ch == nullptr || ch == victim || dir != rune->extra)
+		return false;
+
 	EXIT_DATA *pexit = ch->in_room->exit[dir];
 
-	if (!rune->owner || rune->owner == victim || dir != rune->extra || !pexit)
+	if (pexit == nullptr)
 		return false;
 
 	if (is_safe_new(ch, victim, false))
@@ -145,7 +152,14 @@ bool activate_stasis_wall(void *vo, void *vo2, void *vo3, void *vo4)
 void draw_rune(void *vo, void *vo2)
 {
 	RUNE_DATA *rune = (RUNE_DATA *)vo;
-	CHAR_DATA *ch = rune->owner;
+	CHAR_DATA *ch = Deref(rune->owner);
+
+	// Nine ticks pass between the queue entry being made and this running, and
+	// extract_char only cancels pending events for NPCs -- so the caster may
+	// simply be gone by now.
+	if (ch == nullptr)
+		return;
+
 	if (ch->in_room->vnum != rune->drawn_in)
 	{
 		send_to_char("A backlash of energy whips through you as your uncompleted rune overloads!\n\r", ch);

--- a/code/characterClasses/chrono.c
+++ b/code/characterClasses/chrono.c
@@ -380,49 +380,72 @@ RUNE_DATA *find_rune(void *vo, int target_type, int trigger_type, RUNE_DATA *run
 	return nullptr;
 }
 
-void extract_rune(RUNE_DATA *rune)
+/*
+ * The head of the per-container rune chain, as a pointer to the field itself so
+ * a caller can rewrite it. `placed_on` is a void * discriminated by
+ * target_type, and this is the only place that has to know that.
+ */
+static RUNE_DATA **rune_container_head(RUNE_DATA *rune)
 {
-	OBJ_DATA *obj;
-	EXIT_DATA *exit;
-	ROOM_INDEX_DATA *room;
-	RUNE_DATA *rune_prev;
-
 	switch (rune->target_type)
 	{
 		case RUNE_TO_WEAPON:
 		case RUNE_TO_ARMOR:
-			obj = (OBJ_DATA *)rune->placed_on;
-
-			if (obj->has_rune && rune->next_content)
-			{
-				obj->rune = rune->next_content;
-				break;
-			}
-
-			obj->has_rune = false;
-			break;
+			return &((OBJ_DATA *)rune->placed_on)->rune;
 		case RUNE_TO_PORTAL:
-			exit = (EXIT_DATA *)rune->placed_on;
-
-			if (exit->has_rune && rune->next_content)
-			{
-				exit->rune = rune->next_content;
-				break;
-			}
-
-			exit->has_rune = false;
-			break;
+			return &((EXIT_DATA *)rune->placed_on)->rune;
 		case RUNE_TO_ROOM:
-			room = (ROOM_INDEX_DATA *)rune->placed_on;
+			return &((ROOM_INDEX_DATA *)rune->placed_on)->rune;
+	}
 
-			if (room->has_rune && rune->next_content)
+	return nullptr;
+}
+
+static bool *rune_container_flag(RUNE_DATA *rune)
+{
+	switch (rune->target_type)
+	{
+		case RUNE_TO_WEAPON:
+		case RUNE_TO_ARMOR:
+			return &((OBJ_DATA *)rune->placed_on)->has_rune;
+		case RUNE_TO_PORTAL:
+			return &((EXIT_DATA *)rune->placed_on)->has_rune;
+		case RUNE_TO_ROOM:
+			return &((ROOM_INDEX_DATA *)rune->placed_on)->has_rune;
+	}
+
+	return nullptr;
+}
+
+void extract_rune(RUNE_DATA *rune)
+{
+	RUNE_DATA *rune_prev;
+
+	// Unlink from the container's chain. Every rune is on two lists and this is
+	// the one keyed by what it was placed on, so a rune that stays linked here
+	// after free_rune has recycled it is a chain find_rune will walk into.
+	RUNE_DATA **head = rune_container_head(rune);
+	bool *flag = rune_container_flag(rune);
+
+	if (head != nullptr)
+	{
+		if (*head == rune)
+		{
+			*head = rune->next_content;
+		}
+		else
+		{
+			for (rune_prev = *head; rune_prev != nullptr; rune_prev = rune_prev->next_content)
 			{
-				room->rune = rune->next_content;
-				break;
+				if (rune_prev->next_content == rune)
+				{
+					rune_prev->next_content = rune->next_content;
+					break;
+				}
 			}
+		}
 
-			room->has_rune = false;
-			break;
+		*flag = (*head != nullptr);
 	}
 
 	if (rune_list == rune)

--- a/code/characterClasses/chrono.c
+++ b/code/characterClasses/chrono.c
@@ -25,7 +25,6 @@ void spell_stasis_wall(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 {
 	int dir = 0;
 	EXIT_DATA *pexit = nullptr;
-	RUNE_DATA *rune;
 
 	 // it's been casted, so we don't get the dir handed straight to us (this is pre TAR_DIR)
 	if (target != RUNE_DOOR)
@@ -50,29 +49,43 @@ void spell_stasis_wall(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 		return;
 	}
 
-	// allocate temporary rune, it'll be discarded after apply_rune anyway
-	// (sizeof(*rune), not sizeof(rune): the latter is the pointer's 8 bytes, which
-	// left every field write below running off the end of the allocation)
-	rune = (RUNE_DATA *)talloc_struct(sizeof(*rune));
-
 	// if it's not RUNE_DOOR then it's been casted, not runed, so it's immediate
 	if (target != RUNE_DOOR)
 	{
-		rune->level = level;
-		rune->placed_on = pexit;
-		rune->target_type = RUNE_TO_PORTAL; // grep for this too
-		rune->owner = ch->self;
-		rune->trigger_type = RUNE_TRIGGER_EXIT; // grep for rune trigger types if you need to
-		rune->type = sn;
-		rune->duration = level / 10;
-		rune->end_fun = nullptr;
-		rune->function = trigger_stasis_wall; // this is what's called when the rune is triggered
-		apply_rune(rune);					  // this will create a new copy of the talloced rune
+		// apply_rune copies this into a rune of its own, so the template only
+		// has to outlive the call.
+		RUNE_DATA rune = {};
+
+		rune.level = level;
+		rune.placed_on = pexit;
+		rune.target_type = RUNE_TO_PORTAL; // grep for this too
+		rune.owner = ch->self;
+		rune.trigger_type = RUNE_TRIGGER_EXIT; // grep for rune trigger types if you need to
+		rune.type = sn;
+		rune.duration = level / 10;
+		rune.end_fun = nullptr;
+		rune.function = trigger_stasis_wall; // this is what's called when the rune is triggered
+		apply_rune(&rune);
 
 		act("$n gestures and an immovable barrier snaps into existence to the $t!", ch, direction_table[dir].name, 0, TO_ROOM);
 		act("You gesture and a stasis wall forms to the $t!", ch, direction_table[dir].name, 0, TO_CHAR);
 		return;
 	}
+
+	// The drawn rune has to survive nine ticks on the queue before draw_rune
+	// finalises it, so it cannot live in the temp-struct pool: talloc_struct
+	// bumps a pointer through a fixed buffer and wraps back to the start
+	// without regard for anything still holding what it hands out. Nine ticks
+	// is ample for another caller -- act_info.c allocates from that pool on a
+	// plain `look` -- to come round and write over the rune while the queue
+	// entry still names it.
+	//
+	// new_rune gives it a lifetime instead, and draw_rune ends that lifetime on
+	// every path out. The one hole left is a queue entry cancelled rather than
+	// run (DeleteQueuedEventsInvolving, which extract_char calls for NPCs):
+	// that leaks the struct, because the queue cancels with a tombstone and has
+	// no hook to run on the way. A leaked rune is the better failure.
+	RUNE_DATA *rune = new_rune();
 
 	rune->level = level;
 	rune->placed_on = (ROOM_INDEX_DATA *)ch->in_room;
@@ -91,7 +104,7 @@ void spell_stasis_wall(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 		usually make sure the lag on the rune
 		is at least as long as the lag on the draw_rune queue
 	*/
-	RS.Queue.AddToQueue(9, "spell_stasis_wall", "draw_rune_queue", draw_rune_queue, rune, Deref(rune->owner));
+	RS.Queue.AddToQueue(9, "spell_stasis_wall", "draw_rune_queue", draw_rune_queue, rune, ch);
 }
 
 bool trigger_stasis_wall(void *vo, void *vo2, void *vo3, void *vo4)
@@ -149,6 +162,9 @@ bool activate_stasis_wall(void *vo, void *vo2, void *vo3, void *vo4)
 	return false;
 }
 
+// Consumes the rune spell_stasis_wall queued. Every path out of here frees it,
+// including the ones that decide the draw failed: the queue held the only
+// reference, and apply_rune takes a copy rather than the struct itself.
 void draw_rune(void *vo, void *vo2)
 {
 	RUNE_DATA *rune = (RUNE_DATA *)vo;
@@ -158,12 +174,16 @@ void draw_rune(void *vo, void *vo2)
 	// extract_char only cancels pending events for NPCs -- so the caster may
 	// simply be gone by now.
 	if (ch == nullptr)
+	{
+		free_rune(rune);
 		return;
+	}
 
 	if (ch->in_room->vnum != rune->drawn_in)
 	{
 		send_to_char("A backlash of energy whips through you as your uncompleted rune overloads!\n\r", ch);
 		damage_new(ch, ch, dice(rune->level, 4), TYPE_UNDEFINED, DAM_ENERGY, true, HIT_UNBLOCKABLE, 0, 1, "mana surge");
+		free_rune(rune);
 		return;
 	}
 
@@ -171,11 +191,13 @@ void draw_rune(void *vo, void *vo2)
 	{
 		act("The rune flares brightly before vanishing!", ch, 0, 0, TO_ROOM);
 		send_to_char("The improperly scribed rune flares brightly before vanishing!\n\r", ch);
+		free_rune(rune);
 		return;
 	}
 
 	act("The rune flares $t!", ch, skill_table[rune->type].msg_off, 0, TO_ALL);
 	apply_rune(rune);
+	free_rune(rune);
 }
 
 void draw_rune_queue(RUNE_DATA *rune, CHAR_DATA *ch)

--- a/code/characterClasses/chrono.c
+++ b/code/characterClasses/chrono.c
@@ -415,22 +415,6 @@ static RUNE_DATA **rune_container_head(RUNE_DATA *rune)
 	return nullptr;
 }
 
-static bool *rune_container_flag(RUNE_DATA *rune)
-{
-	switch (rune->target_type)
-	{
-		case RUNE_TO_WEAPON:
-		case RUNE_TO_ARMOR:
-			return &((OBJ_DATA *)rune->placed_on)->has_rune;
-		case RUNE_TO_PORTAL:
-			return &((EXIT_DATA *)rune->placed_on)->has_rune;
-		case RUNE_TO_ROOM:
-			return &((ROOM_INDEX_DATA *)rune->placed_on)->has_rune;
-	}
-
-	return nullptr;
-}
-
 void extract_rune(RUNE_DATA *rune)
 {
 	RUNE_DATA *rune_prev;
@@ -439,7 +423,6 @@ void extract_rune(RUNE_DATA *rune)
 	// the one keyed by what it was placed on, so a rune that stays linked here
 	// after free_rune has recycled it is a chain find_rune will walk into.
 	RUNE_DATA **head = rune_container_head(rune);
-	bool *flag = rune_container_flag(rune);
 
 	if (head != nullptr)
 	{
@@ -458,8 +441,6 @@ void extract_rune(RUNE_DATA *rune)
 				}
 			}
 		}
-
-		*flag = (*head != nullptr);
 	}
 
 	if (rune_list == rune)
@@ -497,30 +478,18 @@ void apply_rune(RUNE_DATA *rune)
 		case RUNE_TO_WEAPON:
 		case RUNE_TO_ARMOR:
 			obj = (OBJ_DATA *)rune_new->placed_on;
-
-			if (obj->has_rune)
-				rune_new->next_content = obj->rune;
-
+			rune_new->next_content = obj->rune;
 			obj->rune = rune_new;
-			obj->has_rune = true;
 			break;
 		case RUNE_TO_PORTAL:
 			pexit = (EXIT_DATA *)rune_new->placed_on;
-
-			if (pexit->has_rune)
-				rune_new->next_content = pexit->rune;
-
+			rune_new->next_content = pexit->rune;
 			pexit->rune = rune_new;
-			pexit->has_rune = true;
 			break;
 		case RUNE_TO_ROOM:
 			room = (ROOM_INDEX_DATA *)rune_new->placed_on;
-
-			if (room->has_rune)
-				rune_new->next_content = room->rune;
-
+			rune_new->next_content = room->rune;
 			room->rune = rune_new;
-			room->has_rune = true;
 			break;
 	}
 }

--- a/code/characterClasses/healer.c
+++ b/code/characterClasses/healer.c
@@ -55,7 +55,7 @@ void spell_healing_sleep(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 	af.type = sn;
 	af.level = level;
 	af.duration = 4;
-	af.owner = ch;
+	af.owner = ch->self;
 
 	SET_BIT(af.bitvector, AFF_SLEEP);
 

--- a/code/characterClasses/necro.c
+++ b/code/characterClasses/necro.c
@@ -6,6 +6,7 @@
 #include <stdlib.h>
 #include <algorithm>
 #include "../merc.h"
+#include "../entity/handles.h"
 #include "necro.h"
 #include "../comm.h"
 #include "../act_comm.h"
@@ -417,7 +418,7 @@ void animate_two(CHAR_DATA *ch, OBJ_DATA *corpse)
 		return;
 	}
 
-	if (ch->fighting)
+	if (Deref(ch->fighting))
 	{
 		act("The interruption disrupts your concentration, and $p crumbles to dust.", ch, corpse, nullptr, TO_CHAR);
 		act("$n is unable to continue the animation process, and $p crumbles to dust.", ch, corpse, nullptr, TO_ROOM);
@@ -447,7 +448,7 @@ void animate_three(CHAR_DATA *ch, OBJ_DATA *corpse)
 		return;
 	}
 
-	if (ch->fighting)
+	if (Deref(ch->fighting))
 	{
 		act("The interruption disrupts your concentration, and $p crumbles to dust.", ch, corpse, nullptr, TO_CHAR);
 		act("$n is unable to continue the animation process, and $p crumbles to dust.", ch, corpse, nullptr, TO_ROOM);
@@ -687,7 +688,7 @@ void spell_visceral(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 
 void visceral_two(CHAR_DATA *ch)
 {
-	if (ch->fighting)
+	if (Deref(ch->fighting))
 	{
 		send_to_char("The profane ritual disrupted, the magicks dissipate harmlessly.\n\r", ch);
 		ch->disrupted = true;
@@ -705,7 +706,7 @@ void visceral_three(CHAR_DATA *ch)
 	if (ch->disrupted)
 		return;
 
-	if (ch->fighting)
+	if (Deref(ch->fighting))
 	{
 		send_to_char("The dark powers are furious at the disruption of the unholy orgy!\n\r", ch);
 
@@ -731,7 +732,7 @@ void visceral_four(CHAR_DATA *ch)
 	if (ch->disrupted)
 		return;
 
-	if (ch->fighting)
+	if (Deref(ch->fighting))
 	{
 		send_to_char("The unseen dark powers howl in fury at the disruption!\n\r", ch);
 		send_to_char("Invisible claws rend at your flesh as they seek to sate their bloodthirst!\n\r", ch);
@@ -811,7 +812,7 @@ void ritual_two(CHAR_DATA *ch, CHAR_DATA *victim)
 	if (ch->disrupted)
 		return;
 
-	if (ch->fighting)
+	if (Deref(ch->fighting))
 	{
 		send_to_char("The unholy ritual disrupted, the harnessed energy dissipates harmlessly.\n\r", ch);
 
@@ -830,7 +831,7 @@ void ritual_three(CHAR_DATA *ch, CHAR_DATA *victim)
 	if (ch->disrupted)
 		return;
 
-	if (ch->fighting)
+	if (Deref(ch->fighting))
 	{
 		send_to_char("The unholy ritual disrupted, the harnessed energy dissipates harmlessly.\n\r", ch);
 
@@ -856,7 +857,7 @@ void ritual_four(CHAR_DATA *ch, CHAR_DATA *victim)
 	if (ch->disrupted)
 		return;
 
-	if (ch->fighting)
+	if (Deref(ch->fighting))
 	{
 		send_to_char("The Dark Gods are angered at the disruption, and unleash their fury upon you!\n\r", ch);
 		act("A swirling black cloud coalesces above and lashes out at $n!", ch, nullptr, nullptr, TO_ROOM);
@@ -936,7 +937,7 @@ void spell_ritual_flesh(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 
 void flesh_two(CHAR_DATA *ch, CHAR_DATA *victim)
 {
-	if (ch->fighting)
+	if (Deref(ch->fighting))
 	{
 		send_to_char("The unholy ritual disrupted, the harnessed energy dissipates harmlessly.\n\r", ch);
 		ch->disrupted = true;
@@ -954,7 +955,7 @@ void flesh_three(CHAR_DATA *ch, CHAR_DATA *victim)
 	if (ch->disrupted)
 		return;
 
-	if (ch->fighting)
+	if (Deref(ch->fighting))
 	{
 		send_to_char("The unholy ritual disrupted, the harnessed energy dissipates harmlessly.\n\r", ch);
 		ch->disrupted = true;
@@ -978,7 +979,7 @@ void flesh_four(CHAR_DATA *ch, CHAR_DATA *victim)
 	if (ch->disrupted)
 		return;
 
-	if (ch->fighting)
+	if (Deref(ch->fighting))
 	{
 		send_to_char("The Dark Gods are angered at the disruption, and unleash their fury upon you!\n\r", ch);
 		act("A swirling black cloud coalesces above and lashes out at $n!", ch, nullptr, nullptr, TO_ROOM);
@@ -1129,7 +1130,7 @@ void spell_corrupt_flesh(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 		do_myell(victim, buf, ch);
 		obj_from_char(obj);
 
-		if (ch->fighting == nullptr)
+		if (Deref(ch->fighting) == nullptr)
 			one_hit(victim, ch, TYPE_HIT);
 	}
 

--- a/code/characterClasses/necro.c
+++ b/code/characterClasses/necro.c
@@ -260,7 +260,7 @@ void spell_hex(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 	hex.aftype = AFT_MALADY;
 	hex.type = sn;
 	hex.level = level;
-	hex.owner = ch;
+	hex.owner = ch->self;
 	hex.location = APPLY_SAVING_SPELL;
 	hex.modifier = 30;
 	hex.duration = level / 6;
@@ -752,7 +752,7 @@ void visceral_four(CHAR_DATA *ch)
 	af.aftype = AFT_SPELL;
 	af.level = ch->level;
 	af.duration = 60;
-	af.owner = ch;
+	af.owner = ch->self;
 	af.end_fun = nullptr;
 	af.location = APPLY_HIT;
 	af.modifier = ch->level * 8;
@@ -1657,7 +1657,7 @@ bool check_bond(CHAR_DATA *ch, CHAR_DATA *mob)
 		init_affect(&af);
 		af.where = TO_AFFECTS;
 		af.duration = -1;
-		af.owner = ch;
+		af.owner = ch->self;
 		af.type = gsn_unholy_bond;
 		af.aftype = AFT_SKILL;
 		affect_to_char(mob, &af);

--- a/code/characterClasses/necro.c
+++ b/code/characterClasses/necro.c
@@ -348,7 +348,7 @@ void spell_animate_dead(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 	for (search = char_list; search != nullptr; search = search->next)
 	{
 		if (is_npc(search)
-			&& search->master == ch
+			&& Deref(search->master) == ch
 			&& (search->pIndexData->vnum == MOB_VNUM_ZOMBIE
 				|| (search->pIndexData->vnum >= 2940 && search->pIndexData->vnum <= 2947)))
 		{
@@ -564,7 +564,7 @@ void animate_four(CHAR_DATA *ch, OBJ_DATA *corpse)
 	std::snprintf(buf1, static_cast<size_t>(MAX_STRING_LENGTH), "%s", name);
 	add_follower(zombie, ch);
 
-	zombie->leader = ch;
+	zombie->leader = ch->self;
 
 	SET_BIT(zombie->affected_by, AFF_CHARM);
 
@@ -607,7 +607,7 @@ void spell_black_circle(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 
 	for (pet = char_list; pet != nullptr; pet = pet->next)
 	{
-		if (is_npc(pet) && is_affected_by(pet, AFF_CHARM) && pet->master && pet->master == ch)
+		if (is_npc(pet) && is_affected_by(pet, AFF_CHARM) && Deref(pet->master) && Deref(pet->master) == ch)
 		{
 			stop_fighting(pet, true);
 
@@ -764,7 +764,7 @@ void visceral_four(CHAR_DATA *ch)
 
 	for (mob = ch->in_room->people; mob != nullptr; mob = mob->next_in_room)
 	{
-		if (is_npc(mob) && is_affected_by(mob, AFF_CHARM) && mob->master && mob->master == ch)
+		if (is_npc(mob) && is_affected_by(mob, AFF_CHARM) && Deref(mob->master) && Deref(mob->master) == ch)
 		{
 			af.location = APPLY_DAMROLL;
 			af.modifier = (ch->level / 2) - 5;
@@ -781,7 +781,7 @@ void spell_ritual_soul(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 	for (search = char_list; search != nullptr; search = search->next)
 	{
 		if (is_npc(search)
-			&& search->master == ch
+			&& Deref(search->master) == ch
 			&& search->pIndexData->vnum > 2939
 			&& search->pIndexData->vnum < 2945)
 		{
@@ -790,7 +790,7 @@ void spell_ritual_soul(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 		}
 	}
 
-	if (!is_npc(victim) || victim->pIndexData->vnum != MOB_VNUM_ZOMBIE || victim->master != ch)
+	if (!is_npc(victim) || victim->pIndexData->vnum != MOB_VNUM_ZOMBIE || Deref(victim->master) != ch)
 	{
 		send_to_char("You must cast the ritual upon a zombie you control.\n\r", ch);
 		return;
@@ -892,7 +892,7 @@ void ritual_four(CHAR_DATA *ch, CHAR_DATA *victim)
 
 	add_follower(mob, ch);
 
-	mob->leader = ch;
+	mob->leader = ch->self;
 
 	SET_BIT(mob->affected_by, AFF_CHARM);
 
@@ -911,7 +911,7 @@ void spell_ritual_flesh(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 	for (search = char_list; search != nullptr; search = search->next)
 	{
 		if (is_npc(search)
-			&& search->master == ch
+			&& Deref(search->master) == ch
 			&& search->pIndexData->vnum > 2944
 			&& search->pIndexData->vnum < 2948)
 		{
@@ -920,7 +920,7 @@ void spell_ritual_flesh(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 		}
 	}
 
-	if (!is_npc(victim) || victim->pIndexData->vnum != MOB_VNUM_ZOMBIE || victim->master != ch)
+	if (!is_npc(victim) || victim->pIndexData->vnum != MOB_VNUM_ZOMBIE || Deref(victim->master) != ch)
 	{
 		send_to_char("You must cast the ritual upon a zombie you control.\n\r", ch);
 		return;
@@ -1018,7 +1018,7 @@ void flesh_four(CHAR_DATA *ch, CHAR_DATA *victim)
 
 	add_follower(mob, ch);
 
-	mob->leader = ch;
+	mob->leader = ch->self;
 
 	SET_BIT(mob->affected_by, AFF_CHARM);
 
@@ -1242,7 +1242,7 @@ void spell_corrupt_flesh(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 		extract_obj(obj);
 
 		mob->level = 1;
-		mob->leader = ch;
+		mob->leader = ch->self;
 	}
 }
 
@@ -1376,7 +1376,7 @@ void spell_lesser_golem(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 	for (check = char_list; check != nullptr; check = check->next)
 	{
 		if (is_npc(check)
-			&& check->master == ch
+			&& Deref(check->master) == ch
 			&& (check->pIndexData->vnum == 2955 || check->pIndexData->vnum == 2956 || check->pIndexData->vnum == 2957))
 		{
 			send_to_char("You already have a golem under your command.\n\r", ch);
@@ -1430,7 +1430,7 @@ void spell_lesser_golem(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 
 	add_follower(mob, ch);
 
-	mob->leader = ch;
+	mob->leader = ch->self;
 
 	SET_BIT(mob->affected_by, AFF_CHARM);
 
@@ -1467,7 +1467,7 @@ void spell_greater_golem(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 	for (check = char_list; check != nullptr; check = check->next)
 	{
 		if (is_npc(check)
-			&& check->master == ch
+			&& Deref(check->master) == ch
 			&& (check->pIndexData->vnum == 2959 || check->pIndexData->vnum == 2960 || check->pIndexData->vnum == 2961))
 		{
 			send_to_char("You already have a golem under your command.\n\r", ch);
@@ -1560,7 +1560,7 @@ void spell_greater_golem(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 
 	add_follower(mob, ch);
 
-	mob->leader = ch;
+	mob->leader = ch->self;
 
 	SET_BIT(mob->affected_by, AFF_CHARM);
 
@@ -1685,8 +1685,8 @@ bool check_zombie_summon(CHAR_DATA *ch)
 	{
 		if (is_npc(mob)
 			&& is_affected_by(mob, AFF_CHARM)
-			&& mob->master
-			&& mob->master == ch
+			&& Deref(mob->master)
+			&& Deref(mob->master) == ch
 			&& is_affected(mob, gsn_unholy_bond))
 		{
 			if (number_percent() > 75)

--- a/code/characterClasses/paladin.c
+++ b/code/characterClasses/paladin.c
@@ -511,7 +511,7 @@ void spell_arms_of_light(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 	oaf.modifier = 0;
 	oaf.duration = level;
 	oaf.level = ch->level;
-	oaf.owner = ch;
+	oaf.owner = ch->self;
 	affect_to_obj(weapon, &oaf);
 
 	act("A bright glow begins to emanate from $n's $p.", ch, weapon, 0, TO_ROOM);
@@ -572,7 +572,7 @@ void spell_arms_of_purity(int sn, int level, CHAR_DATA *ch, void *vo, int target
 	oaf.duration = level;
 	oaf.location = APPLY_NONE;
 	oaf.modifier = 0;
-	oaf.owner = ch;
+	oaf.owner = ch->self;
 	affect_to_obj(weapon, &oaf);
 
 	act("Rippling waves of warm energy play up and down $n's $p.", ch, weapon, 0, TO_ROOM);
@@ -635,7 +635,7 @@ void spell_arms_of_wrath(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 	oaf.modifier = 0;
 	oaf.duration = level;
 	oaf.level = ch->level;
-	oaf.owner = ch;
+	oaf.owner = ch->self;
 	affect_to_obj(weapon, &oaf);
 
 	act("$n's $p is set ablaze with white flames!", ch, weapon, 0, TO_ROOM);
@@ -697,7 +697,7 @@ void spell_arms_of_judgement(int sn, int level, CHAR_DATA *ch, void *vo, int tar
 	oaf.modifier = 0;
 	oaf.duration = level;
 	oaf.level = ch->level;
-	oaf.owner = ch;
+	oaf.owner = ch->self;
 	affect_to_obj(weapon, &oaf);
 
 	act("Bright golden light radiates from $n's $p!", ch, weapon, 0, TO_ROOM);
@@ -1171,7 +1171,7 @@ void spell_empathy(int level, int sn, CHAR_DATA *ch, void *vo, int target)
 	act("$n touches $N on $S forehead forming a spiritual link.", ch, 0, vict, TO_ROOM);
 
 	init_affect(&af);
-	af.owner = ch;
+	af.owner = ch->self;
 	af.level = ch->level;
 	af.type = gsn_empathy;
 	af.where = TO_AFFECTS;
@@ -1186,8 +1186,8 @@ void spell_empathy(int level, int sn, CHAR_DATA *ch, void *vo, int target)
 void empathy_end(CHAR_DATA *ch, AFFECT_DATA *af)
 {
 	// ch=char with empathy, af->owner = paladin
-	if (af->owner)
-		act("You feel pained as your spiritual link with $n is severed!", af->owner, 0, ch, TO_VICT);
+	if (Deref(af->owner))
+		act("You feel pained as your spiritual link with $n is severed!", Deref(af->owner), 0, ch, TO_VICT);
 }
 
 void spell_tower_of_fortitude(int level, int sn, CHAR_DATA *ch, void *vo, int target)
@@ -1205,7 +1205,7 @@ void spell_tower_of_fortitude(int level, int sn, CHAR_DATA *ch, void *vo, int ta
 	act("$n centers $mself and readies for combat.", ch, 0, 0, TO_ROOM);
 
 	init_affect(&af);
-	af.owner = ch;
+	af.owner = ch->self;
 	af.level = ch->level;
 	af.type = gsn_tower_of_fortitude;
 	af.where = TO_AFFECTS;
@@ -1232,7 +1232,7 @@ void spell_indomitable_spirit(int level, int sn, CHAR_DATA *ch, void *vo, int ta
 	act("$n calls up on $s deity to raise his spirit.", ch, 0, 0, TO_ROOM);
 
 	init_affect(&af);
-	af.owner = ch;
+	af.owner = ch->self;
 	af.level = ch->level;
 	af.type = gsn_indomitable_spirit;
 	af.where = TO_AFFECTS;

--- a/code/characterClasses/paladin.c
+++ b/code/characterClasses/paladin.c
@@ -5,6 +5,7 @@
 #include <time.h>
 #include <math.h>
 #include "../merc.h"
+#include "../entity/handles.h"
 #include "paladin.h"
 #include "../interp.h"
 #include "../tables.h"
@@ -255,7 +256,7 @@ bool check_intercept(CHAR_DATA *ch, CHAR_DATA *victim, CHAR_DATA *paladin, int d
 	if (!is_awake(paladin))
 		return false;
 
-	if (paladin->fighting != ch)
+	if (Deref(paladin->fighting) != ch)
 		return false;
 
 	if (!is_npc(ch) && (!can_pk(ch, paladin) || !can_pk(paladin, ch)))
@@ -370,7 +371,7 @@ void spell_blinding_orb(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 		char buf2[MSL];
 		sprintf(buf2, "Die, %s, you sorcerous dog!", pers(ch, victim));
 
-		if (!victim->fighting && !is_npc(victim))
+		if (!Deref(victim->fighting) && !is_npc(victim))
 			do_myell(victim, buf2, ch);
 
 		damage_new(ch, victim, dam, sn, DAM_LIGHT, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, nullptr);
@@ -718,7 +719,7 @@ void spell_arms_of_judgement(int sn, int level, CHAR_DATA *ch, void *vo, int tar
 void do_strike_of_virtue(CHAR_DATA *ch, char *argument)
 {
 	OBJ_DATA *weapon;
-	CHAR_DATA *victim = ch->fighting;
+	CHAR_DATA *victim = Deref(ch->fighting);
 
 	weapon = get_eq_char(ch, WEAR_WIELD);
 
@@ -787,7 +788,7 @@ void do_group_retreat(CHAR_DATA *ch, char *argument)
 	char arg[MAX_INPUT_LENGTH];
 	CHAR_DATA *to = nullptr;
 	CHAR_DATA *vch, *vch_next;
-	CHAR_DATA *victim = ch->fighting;
+	CHAR_DATA *victim = Deref(ch->fighting);
 	ROOM_INDEX_DATA *to_room = nullptr;
 	char buf[MAX_INPUT_LENGTH];
 	EXIT_DATA *pexit;
@@ -797,7 +798,7 @@ void do_group_retreat(CHAR_DATA *ch, char *argument)
 
 	one_argument(argument, arg);
 
-	if (!ch->fighting)
+	if (!Deref(ch->fighting))
 	{
 		send_to_char("You aren't fighting!\n\r", ch);
 		return;
@@ -1069,7 +1070,7 @@ void spell_holy_shroud(int level, int sn, CHAR_DATA *ch, void *vo, int target)
 
 int check_arms(CHAR_DATA *ch, OBJ_DATA *wield, bool bOncePerRound)
 {
-	CHAR_DATA *victim = ch->fighting;
+	CHAR_DATA *victim = Deref(ch->fighting);
 	AFFECT_DATA af;
 
 	if (is_affected_obj(wield, gsn_arms_of_light))
@@ -1262,8 +1263,8 @@ void ispirit_beat(CHAR_DATA *ch, AFFECT_DATA *af)
 			act("$n's body collapses under the strain of $s spiritual exertion!", ch, 0, 0, TO_ROOM);
 			act("$n is DEAD!!", ch, 0, 0, TO_ROOM);
 
-			if (ch->fighting)
-				raw_kill(ch->fighting, ch);
+			if (Deref(ch->fighting))
+				raw_kill(Deref(ch->fighting), ch);
 			else
 				raw_kill(ch, ch);
 		}

--- a/code/characterClasses/sorcerer.c
+++ b/code/characterClasses/sorcerer.c
@@ -1482,7 +1482,7 @@ void spell_scathing(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 		if (is_same_group(vch, ch) || is_safe(ch, vch) || is_same_cabal(ch, vch))
 			continue;
 
-		if (!is_npc(ch) && !is_npc(vch) && (ch->fighting == nullptr || vch->fighting == nullptr))
+		if (!is_npc(ch) && !is_npc(vch) && (Deref(ch->fighting) == nullptr || Deref(vch->fighting) == nullptr))
 		{
 			std::snprintf(buf, static_cast<int>(MSL), "Die, %s you sorcerous dog!", pers(ch, vch));
 			do_myell(vch, buf, ch);
@@ -3260,9 +3260,9 @@ void spell_coagulate(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 
 	if (!str_cmp(target_name, ""))
 	{
-		if (ch->fighting != nullptr)
+		if (Deref(ch->fighting) != nullptr)
 		{
-			victim = ch->fighting;
+			victim = Deref(ch->fighting);
 		}
 		else
 		{
@@ -3589,10 +3589,10 @@ void spell_enervate_agitate_helper(int sn, int level, CHAR_DATA *ch, void *vo, i
 
 	if (trusts(ch, victim) && abs(es) < 2)
 	{
-		if (ch->fighting == victim)
+		if (Deref(ch->fighting) == victim)
 			stop_fighting(ch, false);
 
-		if (victim->fighting == ch)
+		if (Deref(victim->fighting) == ch)
 			stop_fighting(victim, false);
 	}
 }
@@ -4492,7 +4492,7 @@ void spell_thunderclap(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 		if (is_same_group(vch, ch) || is_safe(ch, vch) || is_same_cabal(ch, vch))
 			continue;
 
-		if (!is_npc(ch) && !is_npc(vch) && (ch->fighting == nullptr || vch->fighting == nullptr))
+		if (!is_npc(ch) && !is_npc(vch) && (Deref(ch->fighting) == nullptr || Deref(vch->fighting) == nullptr))
 		{
 			std::snprintf(buf,static_cast<int>(MSL), "Die, %s you sorcerous dog!", pers(ch, vch));
 			do_myell(vch, buf, ch);
@@ -4871,7 +4871,7 @@ void spell_heat_earth(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 		if (is_same_group(vch, ch) || is_safe(ch, vch) || is_same_cabal(ch, vch))
 			continue;
 
-		if (!is_npc(ch) && !is_npc(vch) && (!ch->fighting || !vch->fighting))
+		if (!is_npc(ch) && !is_npc(vch) && (!Deref(ch->fighting) || !Deref(vch->fighting)))
 		{
 			std::snprintf(buf, static_cast<int>(MSL), "Die, %s you sorcerous dog!", pers(ch, vch));
 			do_myell(vch, buf, ch);
@@ -5143,7 +5143,7 @@ void concave_shell_move(CHAR_DATA *ch, int *dirptr, ROOM_INDEX_DATA *oldroom)
 				&& ((IS_SET(wch->act, ACT_AGGRESSIVE) && wch->level >= ch->level + 5)
 					|| IS_SET(wch->off_flags, SPAM_MURDER))
 				&& is_awake(wch)
-				&& wch->fighting != nullptr
+				&& Deref(wch->fighting) != nullptr
 				&& can_see(wch, ch)
 				&& !is_affected_by(wch, AFF_CALM)
 				&& !IS_SET(ch->in_room->room_flags, ROOM_SAFE))
@@ -5745,7 +5745,7 @@ void spell_hailstorm(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 		if (is_same_group(vch, ch) || is_safe(ch, vch) || is_same_cabal(ch, vch))
 			continue;
 
-		if (!is_npc(ch) && !is_npc(vch) && (!ch->fighting || !vch->fighting))
+		if (!is_npc(ch) && !is_npc(vch) && (!Deref(ch->fighting) || !Deref(vch->fighting)))
 		{
 			std::snprintf(buf, static_cast<size_t>(MSL), "Die, %s you sorcerous dog!", pers(ch, vch));
 			do_myell(vch, buf, ch);
@@ -7208,16 +7208,16 @@ void sphere_of_plasma_end(CHAR_DATA *ch, AFFECT_DATA *paf)
 
 void sphere_of_plasma_pulse(CHAR_DATA *ch, AFFECT_DATA *af)
 {
-	if (!ch->fighting)
+	if (!Deref(ch->fighting))
 		return;
 
 	if (number_percent() > 60)
 		return;
 
-	act("A tendril of plasma from the sphere encircling you lashes out at $N!", ch, 0, ch->fighting, TO_CHAR);
+	act("A tendril of plasma from the sphere encircling you lashes out at $N!", ch, 0, Deref(ch->fighting), TO_CHAR);
 	act("A writhing, pulsating tendril of plasma lashes out from $n's body!", ch, 0, 0, TO_ROOM);
 
-	damage_new(ch, ch->fighting, af->level, gsn_sphere_of_plasma, DAM_TRUESTRIKE, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, nullptr);
+	damage_new(ch, Deref(ch->fighting), af->level, gsn_sphere_of_plasma, DAM_TRUESTRIKE, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, nullptr);
 
 	if (--af->modifier <= 0)
 		affect_remove(ch, af);
@@ -7360,7 +7360,7 @@ void essence_of_plasma_pulse(ROOM_INDEX_DATA *room, ROOM_AFFECT_DATA *af)
 		}
 	}
 
-	if (victim->fighting)
+	if (Deref(victim->fighting))
 		fighting = true;
 
 	if (af->modifier == 0)

--- a/code/characterClasses/sorcerer.c
+++ b/code/characterClasses/sorcerer.c
@@ -2804,7 +2804,7 @@ void spell_anchor(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 	{
 		wch_next = wch->next;
 
-		if (is_npc(wch) && wch->pIndexData->vnum == MOB_VNUM_ANCHOR && wch->hunting == ch)
+		if (is_npc(wch) && wch->pIndexData->vnum == MOB_VNUM_ANCHOR && Deref(wch->hunting) == ch)
 		{
 			oldanchor = wch;
 			break;
@@ -2820,7 +2820,7 @@ void spell_anchor(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 	anchor = create_mobile(get_mob_index(MOB_VNUM_ANCHOR));
 	char_to_room(anchor, ch->in_room);
 	anchor->level = level;
-	anchor->hunting = ch;
+	anchor->hunting = ch->self;
 
 	act("You harness the energy in the surrounding air to anchor your essence to this spot.", ch, 0, 0, TO_CHAR);
 	act("$n concentrates intently, and a small funnel cloud begins to spin in place beside $m.", ch, 0, 0, TO_ROOM);
@@ -2849,7 +2849,7 @@ void spell_aerial_transferrence(int sn, int level, CHAR_DATA *ch, void *vo, int 
 	{
 		wch_next = wch->next;
 
-		if (is_npc(wch) && wch->pIndexData->vnum == MOB_VNUM_ANCHOR && wch->hunting == ch)
+		if (is_npc(wch) && wch->pIndexData->vnum == MOB_VNUM_ANCHOR && Deref(wch->hunting) == ch)
 		{
 			anchor = wch;
 			break;

--- a/code/characterClasses/sorcerer.c
+++ b/code/characterClasses/sorcerer.c
@@ -10,6 +10,7 @@
 #include <iterator>
 #include <algorithm>
 #include "../merc.h"
+#include "../entity/handles.h"
 #include "sorcerer.h"
 #include "../weather_enums.h"
 #include "../act_info.h"
@@ -4069,8 +4070,8 @@ void acid_end(OBJ_DATA *obj, OBJ_AFFECT_DATA *af)
 	if (obj->in_room && obj->in_room->people)
 		act("$p is dissolved by the acid coating it.", obj->in_room->people, obj, 0, TO_ALL);
 
-	if (obj->in_obj && obj->in_obj->carried_by)
-		act("You hear a faint hissing sound coming from $p.", obj->in_obj->carried_by, obj->in_obj, 0, TO_CHAR);
+	if (OBJ_DATA *container = Deref(obj->in_obj); container && container->carried_by)
+		act("You hear a faint hissing sound coming from $p.", container->carried_by, container, 0, TO_CHAR);
 
 	extract_obj(obj);
 }

--- a/code/characterClasses/sorcerer.c
+++ b/code/characterClasses/sorcerer.c
@@ -1446,8 +1446,8 @@ void spell_immolate(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 
 void immolate_end(OBJ_DATA *obj, OBJ_AFFECT_DATA *af)
 {
-	if (obj->carried_by)
-		act("$p stops burning.", obj->carried_by, obj, 0, TO_CHAR);
+	if (CHAR_DATA *carrier = Deref(obj->carried_by))
+		act("$p stops burning.", carrier, obj, 0, TO_CHAR);
 
 	if (obj->in_room && obj->in_room->people)
 		act("$p stops burning.", obj->in_room->people, obj, 0, TO_ALL);
@@ -4064,14 +4064,17 @@ void spell_acid_vein(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 
 void acid_end(OBJ_DATA *obj, OBJ_AFFECT_DATA *af)
 {
-	if (obj->carried_by)
-		act("$p is dissolved by the acid coating it.", obj->carried_by, obj, 0, TO_CHAR);
+	if (CHAR_DATA *carrier = Deref(obj->carried_by))
+		act("$p is dissolved by the acid coating it.", carrier, obj, 0, TO_CHAR);
 
 	if (obj->in_room && obj->in_room->people)
 		act("$p is dissolved by the acid coating it.", obj->in_room->people, obj, 0, TO_ALL);
 
-	if (OBJ_DATA *container = Deref(obj->in_obj); container && container->carried_by)
-		act("You hear a faint hissing sound coming from $p.", container->carried_by, container, 0, TO_CHAR);
+	OBJ_DATA *container = Deref(obj->in_obj);
+	CHAR_DATA *containerCarrier = container != nullptr ? Deref(container->carried_by) : nullptr;
+
+	if (containerCarrier != nullptr)
+		act("You hear a faint hissing sound coming from $p.", containerCarrier, container, 0, TO_CHAR);
 
 	extract_obj(obj);
 }
@@ -5849,8 +5852,8 @@ void spell_ice_blast(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 
 void container_defrost(OBJ_DATA *obj, OBJ_AFFECT_DATA *af)
 {
-	if (obj->carried_by)
-		act("The ice sealing $p melts.", obj->carried_by, obj, 0, TO_CHAR);
+	if (CHAR_DATA *carrier = Deref(obj->carried_by))
+		act("The ice sealing $p melts.", carrier, obj, 0, TO_CHAR);
 }
 
 void spell_icy_carapace(int sn, int level, CHAR_DATA *ch, void *vo, int target)
@@ -5982,8 +5985,8 @@ void spell_sheath_of_ice(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 
 void ice_sheath_melt(OBJ_DATA *obj, OBJ_AFFECT_DATA *af)
 {
-	if (obj->carried_by)
-		act("The ice surrounding $p melts.", obj->carried_by, obj, 0, TO_CHAR);
+	if (CHAR_DATA *carrier = Deref(obj->carried_by))
+		act("The ice surrounding $p melts.", carrier, obj, 0, TO_CHAR);
 }
 
 void spell_ironskin(int sn, int level, CHAR_DATA *ch, void *vo, int target)
@@ -7742,8 +7745,8 @@ void crystal_tick(OBJ_DATA *obj, OBJ_AFFECT_DATA *af)
 
 	if (af->modifier <= 0)
 	{
-		if (obj->carried_by)
-			act("$p crumbles to dust as the energy contained within dissipates.", obj->carried_by, obj, 0, TO_CHAR);
+		if (CHAR_DATA *carrier = Deref(obj->carried_by))
+			act("$p crumbles to dust as the energy contained within dissipates.", carrier, obj, 0, TO_CHAR);
 
 		extract_obj(obj);
 	}

--- a/code/characterClasses/sorcerer.c
+++ b/code/characterClasses/sorcerer.c
@@ -189,7 +189,7 @@ void spell_gravity_well(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 	raf.duration = level / 6;
 	raf.location = 0;
 	raf.modifier = 0;
-	raf.owner = ch;
+	raf.owner = ch->self;
 	raf.tick_fun = nullptr;
 	raf.end_fun = gravity_well_explode;
 	new_affect_to_room(ch->in_room, &raf);
@@ -212,7 +212,7 @@ void spell_gravity_well(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 	aaf.duration = -1;
 	aaf.location = 0;
 	aaf.modifier = 0;
-	aaf.owner = ch;
+	aaf.owner = ch->self;
 	aaf.tick_fun = nullptr;
 	aaf.end_fun = nullptr;
 	affect_to_area(ch->in_room->area, &aaf);
@@ -220,7 +220,7 @@ void spell_gravity_well(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 
 void gravity_well_explode(ROOM_INDEX_DATA *room, ROOM_AFFECT_DATA *af)
 {
-	CHAR_DATA *victim, *v_next, *ch = af->owner;
+	CHAR_DATA *victim, *v_next, *ch = Deref(af->owner);
 	OBJ_DATA *well;
 	int dam;
 	bool wasinroom = true;
@@ -305,7 +305,7 @@ void spell_cyclone(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 	aaf.duration = 6;
 	aaf.location = 0;
 	aaf.modifier = 0;
-	aaf.owner = ch;
+	aaf.owner = ch->self;
 	aaf.tick_fun = cyclone_begin_tick;
 	aaf.end_fun = cyclone_begin;
 	affect_to_area(ch->in_room->area, &aaf);
@@ -372,7 +372,7 @@ void spell_chill(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 		af.aftype = AFT_MALADY;
 		af.type = sn;
 		af.location = APPLY_STR;
-		af.owner = ch;
+		af.owner = ch->self;
 		af.duration = 10;
 		af.level = level;
 		af.modifier = -2;
@@ -505,7 +505,7 @@ void spell_conflagration(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 	raf.duration = 20;
 	raf.location = APPLY_ROOM_SECT;
 	raf.modifier = SECT_CONFLAGRATION - ch->in_room->sector_type;
-	raf.owner = ch;
+	raf.owner = ch->self;
 	raf.end_fun = conflag_burnout;
 	raf.pulse_fun = conflagration_pulse;
 	raf.tick_fun = nullptr;
@@ -607,7 +607,7 @@ void conflagration_pulse(ROOM_INDEX_DATA *room, ROOM_AFFECT_DATA *af)
 			if (dam <= 1)
 				continue;
 
-			damage_new(af->owner, vch, dam, TYPE_UNDEFINED, DAM_FIRE, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "the raging wildfire*");
+			damage_new(Deref(af->owner), vch, dam, TYPE_UNDEFINED, DAM_FIRE, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "the raging wildfire*");
 		}
 	}
 
@@ -1036,7 +1036,7 @@ void spell_vacuum(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 	raf.duration = -1;
 	raf.location = 0;
 	raf.modifier = 0;
-	raf.owner = ch;
+	raf.owner = ch->self;
 	raf.end_fun = vacuum_end_fun;
 	raf.tick_fun = nullptr;
 	new_affect_to_room(ch->in_room, &raf);
@@ -1116,12 +1116,12 @@ void vacuum_end_fun(ROOM_INDEX_DATA *room, ROOM_AFFECT_DATA *af)
 	{
 		vch_next = vch->next_in_room;
 
-		if (is_safe(af->owner, vch))
+		if (is_safe(Deref(af->owner), vch))
 			continue;
 
 		WAIT_STATE(vch, PULSE_VIOLENCE);
 
-		damage_new(af->owner, vch, (3 * af->level) / roomcount, TYPE_HIT + attack_lookup("asphyxiation"), DAM_ENERGY, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "the vacuum*");
+		damage_new(Deref(af->owner), vch, (3 * af->level) / roomcount, TYPE_HIT + attack_lookup("asphyxiation"), DAM_ENERGY, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "the vacuum*");
 
 		if (vch)
 			pplcount++;
@@ -1163,7 +1163,7 @@ void vacuum_end_fun(ROOM_INDEX_DATA *room, ROOM_AFFECT_DATA *af)
 							{
 								vch_next = vch->next_in_room;
 
-								if (j == randperson && !is_safe_new(af->owner, vch, false))
+								if (j == randperson && !is_safe_new(Deref(af->owner), vch, false))
 									smacked = vch;
 								j++;
 							}
@@ -1174,7 +1174,7 @@ void vacuum_end_fun(ROOM_INDEX_DATA *room, ROOM_AFFECT_DATA *af)
 
 						act("$p is sucked into the room, striking $n!", smacked, obj, 0, TO_ROOM);
 						act("$p is sucked into the room, striking you!", smacked, obj, 0, TO_CHAR);
-						damage_new(af->owner, smacked, dice(get_true_weight(obj) + 1, 9), TYPE_UNDEFINED, DAM_BASH, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "the flying debris*");
+						damage_new(Deref(af->owner), smacked, dice(get_true_weight(obj) + 1, 9), TYPE_UNDEFINED, DAM_BASH, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "the flying debris*");
 						objcount++;
 					}
 				}
@@ -1202,7 +1202,7 @@ void vacuum_end_fun(ROOM_INDEX_DATA *room, ROOM_AFFECT_DATA *af)
 					if (is_npc(vch) && IS_SET(vch->act, ACT_SENTINEL))
 						continue;
 
-					if (!is_npc(vch) && is_safe_new(af->owner, vch, false))
+					if (!is_npc(vch) && is_safe_new(Deref(af->owner), vch, false))
 						continue;
 
 					direction = flag_name_lookup(reverse_d(i), direction_table);
@@ -1421,7 +1421,7 @@ void spell_immolate(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 			oaf.where = TO_OBJ_AFFECTS;
 			oaf.aftype = AFT_SPELL;
 			oaf.type = gsn_immolate;
-			oaf.owner = ch;
+			oaf.owner = ch->self;
 			oaf.level = level;
 			oaf.location = 0;
 			oaf.modifier = 0;
@@ -1613,7 +1613,7 @@ void spell_earthquake(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 			raf.duration = 1;
 			raf.location = 0;
 			raf.modifier = 0;
-			raf.owner = ch;
+			raf.owner = ch->self;
 			raf.end_fun = nullptr;
 			raf.tick_fun = nullptr;
 			new_affect_to_room(ch->in_room, &raf);
@@ -1973,7 +1973,7 @@ void spell_interference(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 	aaf.duration = dice(2, 3) + 5;
 	aaf.location = 0;
 	aaf.modifier = 0;
-	aaf.owner = ch;
+	aaf.owner = ch->self;
 	aaf.tick_fun = nullptr;
 	aaf.end_fun = interference_end;
 	affect_to_area(area, &aaf);
@@ -1985,7 +1985,7 @@ void spell_interference(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 	af.duration = 48;
 	af.location = 0;
 	af.modifier = 0;
-	af.owner = ch;
+	af.owner = ch->self;
 	affect_to_char(ch, &af);
 
 	send_to_char("You blanket the area with a veil of electrical interference.\n\r", ch);
@@ -2326,7 +2326,7 @@ void spell_flood(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 		raf.duration = duration;
 		raf.location = APPLY_ROOM_SECT;
 		raf.modifier = SECT_WATER - to_room->sector_type;
-		raf.owner = ch;
+		raf.owner = ch->self;
 		raf.end_fun = flood_recede;
 		raf.tick_fun = nullptr;
 		new_affect_to_room(to_room, &raf);
@@ -2403,7 +2403,7 @@ void spell_tidalwave(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 				raf.duration = -1;
 				raf.location = APPLY_ROOM_NONE;
 				raf.modifier = std::max((i * 2) - 1, 2);
-				raf.owner = ch;
+				raf.owner = ch->self;
 				raf.end_fun = nullptr;
 				raf.tick_fun = nullptr;
 				new_affect_to_room(to_room, &raf);
@@ -2437,7 +2437,7 @@ void spell_tidalwave(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 				raf.duration = -1;
 				raf.location = APPLY_ROOM_NONE;
 				raf.modifier = std::max((i * 2) - 1, 2);
-				raf.owner = ch;
+				raf.owner = ch->self;
 				raf.end_fun = nullptr;
 				raf.tick_fun = nullptr;
 				new_affect_to_room(to_room, &raf);
@@ -2530,12 +2530,12 @@ void spell_riptide(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 		{
 			for (auto &raf : room->affected)
 			{
-				if (raf.type == sn && raf.owner == ch && raf.location == APPLY_ROOM_NONE && raf.modifier == 1)
+				if (raf.type == sn && Deref(raf.owner) == ch && raf.location == APPLY_ROOM_NONE && raf.modifier == 1)
 				{
 					first_room = room;
 					fraf = &raf;
 				}
-				else if (raf.type == sn && raf.owner == ch && raf.location == APPLY_ROOM_NONE && raf.modifier == 2)
+				else if (raf.type == sn && Deref(raf.owner) == ch && raf.location == APPLY_ROOM_NONE && raf.modifier == 2)
 				{
 					second_room = room;
 				}
@@ -2583,7 +2583,7 @@ void spell_riptide(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 		nraf.duration = 24;
 		nraf.location = APPLY_ROOM_NONE;
 		nraf.modifier = 2;
-		nraf.owner = ch;
+		nraf.owner = ch->self;
 		nraf.end_fun = riptide_two_end;
 		nraf.tick_fun = nullptr;
 		new_affect_to_room(ch->in_room, &nraf);
@@ -2613,7 +2613,7 @@ void spell_riptide(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 		nraf.duration = 4;
 		nraf.location = APPLY_ROOM_NONE;
 		nraf.modifier = 1;
-		nraf.owner = ch;
+		nraf.owner = ch->self;
 		nraf.end_fun = riptide_one_end;
 		nraf.tick_fun = nullptr;
 		new_affect_to_room(ch->in_room, &nraf);
@@ -2622,7 +2622,7 @@ void spell_riptide(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 
 void riptide_one_end(ROOM_INDEX_DATA *room, ROOM_AFFECT_DATA *af)
 {
-	act("Your control over your riptide's water currents wanes.", af->owner, nullptr, nullptr, TO_CHAR);
+	act("Your control over your riptide's water currents wanes.", Deref(af->owner), nullptr, nullptr, TO_CHAR);
 
 	if (room->people)
 		act("The ripples in the water cease.", room->people, nullptr, nullptr, TO_ALL);
@@ -3553,7 +3553,7 @@ void spell_enervate_agitate_helper(int sn, int level, CHAR_DATA *ch, void *vo, i
 		else
 			af.tick_fun = nullptr;
 
-		af.owner = ch;
+		af.owner = ch->self;
 
 		if (victim->pcdata->energy_state == 1)
 			SET_BIT(af.bitvector, AFF_HASTE);
@@ -3572,7 +3572,7 @@ void spell_enervate_agitate_helper(int sn, int level, CHAR_DATA *ch, void *vo, i
 		af.location = APPLY_DEX;
 		af.modifier = -4 + (es + 2) * 2;
 		af.end_fun = nullptr;
-		af.owner = ch;
+		af.owner = ch->self;
 		new_affect_to_char(victim, &af);
 	}
 
@@ -3619,8 +3619,8 @@ void agitate_tick(CHAR_DATA *ch, AFFECT_DATA *af)
 		act("$n collapses in a heap, wisps of smoke rising from $s charred corpse.", ch, 0, 0, TO_ROOM);
 		send_to_char("You crumple to the ground, your consciousness fading away, as your body collapses under the heat.\n\r", ch);
 
-		if (af->owner)
-			raw_kill(af->owner, ch);
+		if (Deref(af->owner))
+			raw_kill(Deref(af->owner), ch);
 		else
 			raw_kill(ch, ch);
 
@@ -3631,13 +3631,13 @@ void agitate_tick(CHAR_DATA *ch, AFFECT_DATA *af)
 	{
 		send_to_char("Your body is wracked by searing pains!\n\r", ch);
 
-		if (!af->owner)
-			af->owner = ch;
+		if (!Deref(af->owner))
+			af->owner = ch->self;
 
 		dam = ch->pcdata->energy_state;
 		dam = dice(dam == 2 ? 5 : dam == 3 ? 10 : dam == 4 ? 20 : 5, 10);
 
-		damage_new(af->owner, ch, dam, gsn_agitate, DAM_FIRE, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "agitation");
+		damage_new(Deref(af->owner), ch, dam, gsn_agitate, DAM_FIRE, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "agitation");
 	}
 }
 
@@ -3953,7 +3953,7 @@ void spell_acid_stream(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 	af.where = TO_AFFECTS;
 	af.type = gsn_acid_stream;
 	af.level = level;
-	af.owner = ch;
+	af.owner = ch->self;
 
 	switch (location)
 	{
@@ -4055,7 +4055,7 @@ void spell_acid_vein(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 	oaf.duration = level * 3;
 	oaf.end_fun = acid_end;
 	oaf.level = level;
-	oaf.owner = ch;
+	oaf.owner = ch->self;
 	affect_to_obj(weapon, &oaf);
 
 	act("You coat $p with acid.", ch, weapon, 0, TO_CHAR);
@@ -4247,7 +4247,7 @@ void spell_attract(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 	af.type = sn;
 	af.level = level;
 	af.location = 0;
-	af.owner = ch;
+	af.owner = ch->self;
 	af.modifier = 0;
 	af.duration = dice(4, 2) + level / 5;
 	af.tick_fun = attract_tick;
@@ -4267,10 +4267,10 @@ void attract_tick(CHAR_DATA *ch, AFFECT_DATA *af)
 	act("Your skin tingles briefly, and a bolt arcs down from the dark skies above!", ch, nullptr, ch, TO_CHAR);
 	act("The skies light up as lightning arcs like quicksilver towards $N!", ch, nullptr, ch, TO_ROOM);
 
-	if (!af->owner)
-		af->owner = ch;
+	if (!Deref(af->owner))
+		af->owner = ch->self;
 
-	damage_new(af->owner, ch, dice(af->level, 4), gsn_attract, DAM_LIGHTNING, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "the lightning strike*");
+	damage_new(Deref(af->owner), ch, dice(af->level, 4), gsn_attract, DAM_LIGHTNING, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "the lightning strike*");
 
 	if (!is_awake(ch))
 		ch->position = POS_STANDING;
@@ -4587,7 +4587,7 @@ void spell_caustic_vapor(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 	raf.duration = 20;
 	raf.location = 0;
 	raf.modifier = 0;
-	raf.owner = ch;
+	raf.owner = ch->self;
 	raf.end_fun = caustic_vapor_burnout;
 	raf.tick_fun = nullptr;
 	new_affect_to_room(ch->in_room, &raf);
@@ -4639,7 +4639,7 @@ void spell_smokescreen(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 	raf.duration = level / 5;
 	raf.location = 0;
 	raf.modifier = 0;
-	raf.owner = ch;
+	raf.owner = ch->self;
 	raf.end_fun = smokescreen_end;
 	raf.tick_fun = nullptr;
 	new_affect_to_room(ch->in_room, &raf);
@@ -4684,7 +4684,7 @@ void spell_smother(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 		SET_BIT(af.bitvector, AFF_BLIND);
 
 		af.mod_name = MOD_VISION;
-		af.owner = ch;
+		af.owner = ch->self;
 		affect_to_char(victim, &af);
 	}
 
@@ -4936,7 +4936,7 @@ void spell_blanket(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 	raf.duration = 24;
 	raf.location = APPLY_ROOM_SECT;
 	raf.modifier = SECT_SNOW - ch->in_room->sector_type;
-	raf.owner = ch;
+	raf.owner = ch->self;
 	raf.end_fun = blanket_melt;
 	raf.tick_fun = nullptr;
 	new_affect_to_room(ch->in_room, &raf);
@@ -5275,7 +5275,7 @@ void spell_unbreakable(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 	af.where = TO_AFFECTS;
 	af.type = gsn_unbreakable;
 	af.aftype = AFT_SPELL;
-	af.owner = ch;
+	af.owner = ch->self;
 	af.modifier = 0;
 	af.duration = level / 4;
 	af.location = 0;
@@ -5362,7 +5362,7 @@ void spell_whiteout(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 	aaf.duration = 2;
 	aaf.location = APPLY_AREA_TEMP;
 	aaf.modifier = Temperature::Cold - area->temp;
-	aaf.owner = ch;
+	aaf.owner = ch->self;
 	aaf.end_fun = whiteout_end;
 	aaf.tick_fun = nullptr;
 	affect_to_area(area, &aaf);
@@ -5384,7 +5384,7 @@ void spell_whiteout(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 	af.duration = 36;
 	af.location = 0;
 	af.modifier = 0;
-	af.owner = ch;
+	af.owner = ch->self;
 	affect_to_char(ch, &af);
 }
 
@@ -5536,7 +5536,7 @@ void spell_icelance(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 		af.aftype = AFT_MALADY;
 		af.tick_fun = bleeding_tick;
 		af.end_fun = nullptr;
-		af.owner = ch;
+		af.owner = ch->self;
 		new_affect_to_char(victim, &af);
 
 		act("Blood spills forth from your gaping wound!", victim, 0, 0, TO_CHAR);
@@ -5584,7 +5584,7 @@ void spell_freeze_door(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 	raf.aftype = AFT_SPELL;
 	raf.level = level;
 	raf.duration = 8;
-	raf.owner = ch;
+	raf.owner = ch->self;
 	raf.modifier = door;
 	raf.end_fun = door_unfreeze;
 	new_affect_to_room(ch->in_room, &raf);
@@ -5636,7 +5636,7 @@ void spell_frost_growth(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 	raf.aftype = AFT_SPELL;
 	raf.level = level;
 	raf.duration = level / 3;
-	raf.owner = ch;
+	raf.owner = ch->self;
 	raf.end_fun = ground_thaw;
 	new_affect_to_room(ch->in_room, &raf);
 }
@@ -5681,7 +5681,7 @@ void spell_bind_feet(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 	af.aftype = AFT_SPELL;
 	af.level = level;
 	af.duration = level / 10;
-	af.owner = ch;
+	af.owner = ch->self;
 	affect_to_char(victim, &af);
 }
 
@@ -5710,7 +5710,7 @@ void spell_glaciate(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 	raf.duration = 3 + level / 7;
 	raf.location = APPLY_ROOM_SECT;
 	raf.modifier = SECT_ICE - ch->in_room->sector_type;
-	raf.owner = ch;
+	raf.owner = ch->self;
 	raf.end_fun = glaciate_melt;
 	raf.tick_fun = nullptr;
 	new_affect_to_room(room, &raf);
@@ -5785,7 +5785,7 @@ void spell_stalactites(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 	raf.location = 0;
 	raf.modifier = dice(1, 6);
 	raf.duration = level / 5;
-	raf.owner = ch;
+	raf.owner = ch->self;
 	raf.end_fun = nullptr;
 	raf.tick_fun = nullptr;
 	new_affect_to_room(ch->in_room, &raf);
@@ -5837,7 +5837,7 @@ void spell_ice_blast(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 					oaf.location = 0;
 					oaf.modifier = 0;
 					oaf.duration = level / 6;
-					oaf.owner = ch;
+					oaf.owner = ch->self;
 					oaf.end_fun = container_defrost;
 					oaf.tick_fun = nullptr;
 					affect_to_obj(obj, &oaf);
@@ -5913,7 +5913,7 @@ void spell_icy_carapace(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 	af.level = level;
 	af.duration = (int)((float)level * 0.7);
 	af.modifier = (int)((float)level * 0.82);
-	af.owner = ch;
+	af.owner = ch->self;
 	affect_to_char(ch, &af);
 
 	af.location = APPLY_DEX;
@@ -5967,7 +5967,7 @@ void spell_sheath_of_ice(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 	oaf.modifier = std::max(5, wield->weight * (level / 50));
 	oaf.duration = level / 5;
 	oaf.level = level;
-	oaf.owner = ch;
+	oaf.owner = ch->self;
 	oaf.end_fun = ice_sheath_melt;
 	oaf.tick_fun = nullptr;
 	oaf.pulse_fun = nullptr;
@@ -6006,7 +6006,7 @@ void spell_ironskin(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 	af.where = TO_AFFECTS;
 	af.aftype = AFT_SPELL;
 	af.type = gsn_ironskin;
-	af.owner = ch;
+	af.owner = ch->self;
 	af.level = level;
 	af.location = APPLY_AC;
 	af.modifier = level / 3;
@@ -6099,7 +6099,7 @@ void spell_burden(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 	af.where = TO_AFFECTS;
 	af.aftype = AFT_SPELL;
 	af.type = gsn_burden;
-	af.owner = ch;
+	af.owner = ch->self;
 	af.level = level;
 	af.location = APPLY_CARRY_WEIGHT;
 	af.modifier = (level * victim->carry_weight) / 50;
@@ -6480,7 +6480,7 @@ void spell_cloak_of_mist(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 	af.type = gsn_cloak_of_mist;
 	af.aftype = AFT_SPELL;
 	af.level = level;
-	af.owner = ch;
+	af.owner = ch->self;
 	af.location = 0;
 	af.modifier = 0;
 	af.duration = level / 4;
@@ -6543,7 +6543,7 @@ void spell_creeping_tomb(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 
 	init_affect(&af);
 	af.where = TO_AFFECTS;
-	af.owner = ch;
+	af.owner = ch->self;
 	af.aftype = AFT_SPELL;
 	af.type = gsn_creeping_tomb;
 	af.level = level + 15;
@@ -6600,7 +6600,7 @@ void spell_pass_without_trace(int sn, int level, CHAR_DATA *ch, void *vo, int ta
 	af.where = TO_AFFECTS;
 	af.aftype = AFT_SPELL;
 	af.type = gsn_pass_without_trace;
-	af.owner = ch;
+	af.owner = ch->self;
 	af.level = level;
 	af.duration = level / 6;
 	af.location = 0;
@@ -6633,7 +6633,7 @@ void spell_quicksand(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 	raf.where = TO_ROOM_AFFECTS;
 	raf.aftype = AFT_SPELL;
 	raf.type = gsn_quicksand;
-	raf.owner = ch;
+	raf.owner = ch->self;
 	raf.level = level;
 	raf.location = 0;
 	raf.duration = 24;
@@ -6646,7 +6646,7 @@ void spell_quicksand(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 	af.where = TO_AFFECTS;
 	af.aftype = AFT_TIMER;
 	af.type = gsn_quicksand;
-	af.owner = ch;
+	af.owner = ch->self;
 	af.level = level;
 	af.duration = 48;
 	affect_to_char(ch, &af);
@@ -6736,7 +6736,7 @@ void spell_rust(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 	oaf.where = TO_OBJ_APPLY;
 	oaf.type = gsn_rust;
 	oaf.aftype = AFT_SPELL;
-	oaf.owner = ch;
+	oaf.owner = ch->self;
 	oaf.level = level;
 	oaf.duration = level / 4;
 	oaf.location = APPLY_DEX;
@@ -6819,7 +6819,7 @@ void spell_airy_water(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 	raf.where = TO_ROOM_AFFECTS;
 	raf.type = gsn_airy_water;
 	raf.aftype = AFT_SPELL;
-	raf.owner = ch;
+	raf.owner = ch->self;
 	raf.level = level;
 	raf.duration = 12;
 	raf.location = 0;
@@ -6850,7 +6850,7 @@ void spell_cooling_mist(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 	af.where = TO_RESIST;
 	af.aftype = AFT_SPELL;
 	af.type = gsn_cooling_mist;
-	af.owner = ch;
+	af.owner = ch->self;
 	af.level = level;
 	af.location = 0;
 	af.modifier = 0;
@@ -6967,7 +6967,7 @@ void spell_prismatic_spray(int sn, int level, CHAR_DATA *ch, void *vo, int targe
 		af.where = TO_AFFECTS;
 		af.type = gsn_poison;
 		af.aftype = AFT_MALADY;
-		af.owner = ch;
+		af.owner = ch->self;
 		af.level = level;
 		af.location = APPLY_STR;
 		af.modifier = -5;
@@ -6989,7 +6989,7 @@ void spell_prismatic_spray(int sn, int level, CHAR_DATA *ch, void *vo, int targe
 		af.where = TO_AFFECTS;
 		af.type = gsn_blindness;
 		af.aftype = AFT_SPELL;
-		af.owner = ch;
+		af.owner = ch->self;
 		af.level = level;
 		af.location = APPLY_HITROLL;
 		af.modifier = -4;
@@ -7059,7 +7059,7 @@ void spell_earthfade(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 	af.aftype = AFT_SPELL;
 	af.type = gsn_earthfade;
 	af.level = level;
-	af.owner = ch;
+	af.owner = ch->self;
 	af.modifier = 0;
 	af.location = 0;
 	af.duration = level / 5;
@@ -7241,7 +7241,7 @@ void spell_sphere_of_plasma(int sn, int level, CHAR_DATA *ch, void *vo, int targ
 	af.aftype = AFT_SPELL;
 	af.type = sn;
 	af.level = level;
-	af.owner = ch;
+	af.owner = ch->self;
 	af.location = 0;
 	af.modifier = dice(level / 13, 2);
 	af.duration = level / 5;
@@ -7270,7 +7270,7 @@ void spell_plasma_cube(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 	raf.where = TO_ROOM_AFFECTS;
 	raf.type = sn;
 	raf.aftype = AFT_SPELL;
-	raf.owner = ch;
+	raf.owner = ch->self;
 	raf.level = level;
 	raf.duration = 12;
 	raf.location = 0;
@@ -7306,7 +7306,7 @@ void spell_essence_of_plasma(int sn, int level, CHAR_DATA *ch, void *vo, int tar
 	raf.where = TO_ROOM_AFFECTS;
 	raf.aftype = AFT_SPELL;
 	raf.type = gsn_essence_of_plasma;
-	raf.owner = ch;
+	raf.owner = ch->self;
 	raf.level = level;
 	raf.location = 0;
 	raf.duration = 12;
@@ -7319,7 +7319,7 @@ void spell_essence_of_plasma(int sn, int level, CHAR_DATA *ch, void *vo, int tar
 	af.where = TO_AFFECTS;
 	af.aftype = AFT_TIMER;
 	af.type = gsn_essence_of_plasma;
-	af.owner = ch;
+	af.owner = ch->self;
 	af.level = level;
 	af.location = 0;
 	af.duration = 12;
@@ -7338,7 +7338,7 @@ void essence_of_plasma_pulse(ROOM_INDEX_DATA *room, ROOM_AFFECT_DATA *af)
 
 	for (victim = room->people; victim; victim = victim->next_in_room)
 	{
-		if (!is_safe_new(af->owner, victim, false))
+		if (!is_safe_new(Deref(af->owner), victim, false))
 			valid_target = true;
 	}
 
@@ -7349,7 +7349,7 @@ void essence_of_plasma_pulse(ROOM_INDEX_DATA *room, ROOM_AFFECT_DATA *af)
 	{
 		for (victim = room->people; victim; victim = victim->next_in_room)
 		{
-			if (is_safe_new(af->owner, victim, false))
+			if (is_safe_new(Deref(af->owner), victim, false))
 				continue;
 
 			if (number_percent() < 80)
@@ -7371,7 +7371,7 @@ void essence_of_plasma_pulse(ROOM_INDEX_DATA *room, ROOM_AFFECT_DATA *af)
 	act("The ball of plasma hurtles about wildly, discharging pure energy into you!", victim, 0, 0, TO_CHAR);
 	act("The ball of plasma hurtles about wildly, discharging pure energy into $n!", victim, 0, 0, TO_ROOM);
 
-	damage_new(af->owner, victim, dam, gsn_essence_of_plasma, DAM_ENERGY, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "the essence of plasma*");
+	damage_new(Deref(af->owner), victim, dam, gsn_essence_of_plasma, DAM_ENERGY, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "the essence of plasma*");
 
 	if (!fighting && !is_npc(victim))
 		stop_fighting(victim, true);
@@ -7392,8 +7392,8 @@ void essence_of_plasma_end(ROOM_INDEX_DATA *room, ROOM_AFFECT_DATA *af)
 
 void plasma_thread_end(CHAR_DATA *ch, AFFECT_DATA *paf)
 {
-	if (paf->owner)
-		act("The thread of plasma no longer connects you to $N.", ch, nullptr, paf->owner, TO_CHAR);
+	if (Deref(paf->owner))
+		act("The thread of plasma no longer connects you to $N.", ch, nullptr, Deref(paf->owner), TO_CHAR);
 }
 
 void spell_plasma_thread(int sn, int level, CHAR_DATA *ch, void *vo, int target)
@@ -7448,7 +7448,7 @@ void spell_plasma_thread(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 	af.where = TO_AFFECTS;
 	af.aftype = AFT_SPELL;
 	af.type = sn;
-	af.owner = ch;
+	af.owner = ch->self;
 	af.level = level;
 	af.location = 0;
 	af.duration = 2;
@@ -7460,7 +7460,7 @@ void spell_plasma_thread(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 	af.where = TO_AFFECTS;
 	af.aftype = AFT_SPELL;
 	af.type = sn;
-	af.owner = victim;
+	af.owner = victim->self;
 	af.level = level;
 	af.location = 0;
 	af.duration = 2;
@@ -7481,7 +7481,7 @@ void check_plasma_thread(CHAR_DATA *ch, int direction)
 
 	if (af != nullptr)
 	{
-		victim = af->owner;
+		victim = Deref(af->owner);
 
 		if (victim == nullptr)
 		{
@@ -7730,7 +7730,7 @@ void spell_fashion_crystal(int sn, int level, CHAR_DATA *ch, void *vo, int targe
 	oaf.where = TO_OBJ_AFFECTS;
 	oaf.type = gsn_fashion_crystal;
 	oaf.aftype = AFT_SPELL;
-	oaf.owner = ch;
+	oaf.owner = ch->self;
 	oaf.level = level;
 	oaf.location = 0;
 	oaf.modifier = mana;
@@ -7769,7 +7769,7 @@ void spell_farsee(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 	af.aftype = AFT_SPELL;
 	af.type = gsn_farsee;
 	af.level = level;
-	af.owner = ch;
+	af.owner = ch->self;
 	af.location = 0;
 	af.modifier = 0;
 	af.duration = level / 4;
@@ -7923,7 +7923,7 @@ void spell_rotating_ward(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 	af.where = TO_AFFECTS;
 	af.type = gsn_rotating_ward;
 	af.aftype = AFT_SPELL;
-	af.owner = ch;
+	af.owner = ch->self;
 	af.level = level;
 	af.modifier = charges;
 	af.duration = level / 2;
@@ -7981,7 +7981,7 @@ void mana_infusion_helper(CHAR_DATA *ch, CHAR_DATA *victim)
 	af.location = 0;
 	af.duration = number_range(1, 3);
 	af.modifier = 0;
-	af.owner = ch;
+	af.owner = ch->self;
 	af.tick_fun = infusion_tick;
 	affect_to_char(victim, &af);
 }
@@ -8014,7 +8014,7 @@ void spell_mana_infusion(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 	af1.type = gsn_mana_infusion;
 	af1.aftype = AFT_INVIS;
 	af1.duration = 2;
-	af1.owner = ch;
+	af1.owner = ch->self;
 	new_affect_to_char(victim, &af1);
 
 	RS.Queue.AddToQueue(2, "spell_mana_infusion", "damage_queued", damage_queued, ch, victim, level, DAM_OTHER, HIT_UNBLOCKABLE, HIT_NOADD, dammod, "the escaping mana*");
@@ -8031,5 +8031,9 @@ void infusion_tick(CHAR_DATA *ch, AFFECT_DATA *af)
 	act("You writhe in pain as the mana continues to flow out of you.", ch, 0, 0, TO_CHAR);
 	act("$n writhes in pain as the mana continues to flow out of $m.", ch, 0, 0, TO_ROOM);
 
-	damage_new(af->owner ? af->owner : ch, ch, af->owner ? af->owner->level / 2 : ch->level / 2, gsn_mana_sickness, true, DAM_OTHER, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "the escaping mana*");
+	// One read: both uses are arguments to the same call, so nothing runs
+	// between them.
+	CHAR_DATA *owner = Deref(af->owner);
+
+	damage_new(owner ? owner : ch, ch, owner ? owner->level / 2 : ch->level / 2, gsn_mana_sickness, true, DAM_OTHER, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "the escaping mana*");
 }

--- a/code/characterClasses/thief.c
+++ b/code/characterClasses/thief.c
@@ -1800,7 +1800,7 @@ bool check_stealth(CHAR_DATA *ch, CHAR_DATA *mob)
 	if (!is_affected_by(ch, AFF_SNEAK))
 		return false;
 
-	if (mob->last_fought == ch)
+	if (Deref(mob->last_fought) == ch)
 		return false;
 
 	skill = get_skill(ch, gsn_stealth);

--- a/code/characterClasses/thief.c
+++ b/code/characterClasses/thief.c
@@ -61,7 +61,7 @@ void do_backstab(CHAR_DATA *ch, char *argument)
 		return;
 	}
 
-	if (ch->fighting != nullptr || victim->fighting)
+	if (Deref(ch->fighting) != nullptr || Deref(victim->fighting))
 	{
 		send_to_char("You're facing the wrong end.\n\r", ch);
 		return;
@@ -110,7 +110,7 @@ void do_backstab(CHAR_DATA *ch, char *argument)
 	{
 		check_improve(ch, gsn_backstab, true, 1);
 
-		if (!is_npc(ch) && !is_npc(victim) && victim->fighting == nullptr)
+		if (!is_npc(ch) && !is_npc(victim) && Deref(victim->fighting) == nullptr)
 		{
 			switch (number_range(0, 1))
 			{
@@ -131,7 +131,7 @@ void do_backstab(CHAR_DATA *ch, char *argument)
 	{
 		check_improve(ch, gsn_backstab, false, 1);
 
-		if (!is_npc(ch) && !is_npc(victim) && victim->fighting == nullptr)
+		if (!is_npc(ch) && !is_npc(victim) && Deref(victim->fighting) == nullptr)
 		{
 			switch (number_range(0, 1))
 			{
@@ -210,7 +210,7 @@ void do_circle_stab(CHAR_DATA *ch, char *argument)
 
 	if (arg[0] == '\0')
 	{
-		victim = ch->fighting;
+		victim = Deref(ch->fighting);
 
 		if (victim == nullptr)
 		{
@@ -224,7 +224,7 @@ void do_circle_stab(CHAR_DATA *ch, char *argument)
 		return;
 	}
 
-	if (ch->fighting == nullptr)
+	if (Deref(ch->fighting) == nullptr)
 	{
 		send_to_char("You can't circle someone like that.\n\r", ch);
 		return;
@@ -234,7 +234,7 @@ void do_circle_stab(CHAR_DATA *ch, char *argument)
 	{
 		v_next = v_check->next_in_room;
 
-		if (v_check->fighting == ch)
+		if (Deref(v_check->fighting) == ch)
 		{
 			send_to_char("Not while you're defending yourself!\n\r", ch);
 			return;
@@ -636,7 +636,7 @@ void do_plant(CHAR_DATA *ch, char *argument)
 	if (is_safe(ch, victim))
 		return;
 
-	if (victim->fighting != nullptr)
+	if (Deref(victim->fighting) != nullptr)
 	{
 		send_to_char("Can't plant while that person is fighting.\n\r", ch);
 		return;
@@ -953,7 +953,7 @@ void do_drag(CHAR_DATA *ch, char *argument)
 		}
 	}
 
-	if (ch->fighting)
+	if (Deref(ch->fighting))
 	{
 		send_to_char("You can't drag anyone while you are fighting!\n\r", ch);
 		return;
@@ -996,7 +996,7 @@ void do_drag(CHAR_DATA *ch, char *argument)
 		return;
 	}
 
-	if (!is_npc(ch) && !is_npc(victim) && (ch->fighting == nullptr || victim->fighting == nullptr))
+	if (!is_npc(ch) && !is_npc(victim) && (Deref(ch->fighting) == nullptr || Deref(victim->fighting) == nullptr))
 	{
 		sprintf(store, "Help! %s is dragging me around!", pers(ch, victim));
 		do_myell(victim, store, ch);
@@ -1236,7 +1236,7 @@ void do_slash(CHAR_DATA *ch, char *argument)
 	if (is_safe(ch, victim))
 		return;
 
-	if (victim->fighting != nullptr)
+	if (Deref(victim->fighting) != nullptr)
 	{
 		send_to_char("You can't do that while they are fighting.\n\r", ch);
 		return;
@@ -1522,7 +1522,7 @@ void disguise_end(CHAR_DATA *ch, AFFECT_DATA *af)
 
 void disguise_pulse(CHAR_DATA *ch, AFFECT_DATA *af)
 {
-	if (ch->fighting && number_percent() < 25)
+	if (Deref(ch->fighting) && number_percent() < 25)
 	{
 		act("Your shoddy disguise comes apart, the tatters falling away and revealing you!", ch, 0, 0, TO_CHAR);
 		act("$n's garb falls to tatters around $m...  revealing $t beneath the disguise!", ch, ch->pcdata->old->name, 0, TO_ROOM);
@@ -2314,7 +2314,7 @@ void do_knife(CHAR_DATA *ch, char *argument)
 		return;
 	}
 
-	if (ch->fighting != nullptr)
+	if (Deref(ch->fighting) != nullptr)
 	{
 		send_to_char("No way! You're still fighting!\n\r", ch);
 		return;

--- a/code/characterClasses/thief.c
+++ b/code/characterClasses/thief.c
@@ -403,7 +403,7 @@ void do_blackjack(CHAR_DATA *ch, char *argument)
 	init_affect(&af);
 	af.where = TO_AFFECTS;
 	af.level = ch->level;
-	af.owner = ch;
+	af.owner = ch->self;
 	af.location = 0;
 	af.type = gsn_blackjack;
 	af.modifier = 0;
@@ -1092,7 +1092,7 @@ void do_tripwire(CHAR_DATA *ch, char *argument)
 		raf.aftype = AFT_SKILL;
 		raf.level = ch->level;
 		raf.duration = 5;
-		raf.owner = ch;
+		raf.owner = ch->self;
 		raf.modifier = door;
 		new_affect_to_room(ch->in_room, &raf);
 
@@ -1387,7 +1387,7 @@ void do_stash(CHAR_DATA *ch, char *argument)
 		oaf.aftype = AFT_SKILL;
 		oaf.level = ch->level;
 		oaf.duration = -1;
-		oaf.owner = ch;
+		oaf.owner = ch->self;
 		affect_to_obj(obj, &oaf);
 
 		check_improve(ch, gsn_stash, true, 1);
@@ -1469,7 +1469,7 @@ void do_disguise(CHAR_DATA *ch, char *argument)
 	oaf.aftype = AFT_SKILL;
 	oaf.level = ch->level;
 	oaf.duration = -1;
-	oaf.owner = ch;
+	oaf.owner = ch->self;
 	affect_to_obj(corpse, &oaf);
 
 	if (number_percent() < skill)
@@ -1495,7 +1495,7 @@ void do_disguise(CHAR_DATA *ch, char *argument)
 		init_affect(&af);
 		af.where = TO_AFFECTS;
 		af.type = gsn_disguise;
-		af.owner = ch;
+		af.owner = ch->self;
 		af.level = ch->level;
 		af.aftype = AFT_INVIS;
 		af.duration = ch->level;
@@ -1603,7 +1603,7 @@ void do_search(CHAR_DATA *ch, char *argument)
 				if (ch->Class()->GetIndex() == CLASS_THIEF)
 					chance += (ch->level / 2);
 
-				if (oaf.owner != ch && (number_percent() < chance))
+				if (Deref(oaf.owner) != ch && (number_percent() < chance))
 				{
 					affect_strip_obj(obj, gsn_stash);
 					act("You stumble across $p which seemed to be hidden from your eye.", ch, obj, 0, TO_CHAR);
@@ -1706,7 +1706,7 @@ void do_counterfeit(CHAR_DATA *ch, char *argument)
 	oaf.aftype = AFT_SKILL;
 	oaf.level = ch->level;
 	oaf.duration = ch->level;
-	oaf.owner = ch;
+	oaf.owner = ch->self;
 	oaf.end_fun = counterfeit_end;
 	affect_to_obj(copy, &oaf);
 
@@ -2385,7 +2385,7 @@ void do_knife(CHAR_DATA *ch, char *argument)
 			af.modifier = 0;
 			af.aftype = AFT_INVIS;
 			af.tick_fun = bleeding_tick;
-			af.owner = ch;
+			af.owner = ch->self;
 			new_affect_to_char(victim, &af);
 		}
 	}
@@ -2474,7 +2474,7 @@ void do_bluff(CHAR_DATA *ch, char *argument)
 		}
 
 		af.aftype = AFT_SKILL;
-		af.owner = ch;
+		af.owner = ch->self;
 		af.mod_name = MOD_APPEARANCE;
 		new_affect_to_char(ch, &af);
 

--- a/code/characterClasses/thief.c
+++ b/code/characterClasses/thief.c
@@ -5,6 +5,7 @@
 #include <time.h>
 #include <math.h>
 #include "../merc.h"
+#include "../entity/handles.h"
 #include "thief.h"
 #include "../comm.h"
 #include "../devextra.h"
@@ -1715,10 +1716,10 @@ void do_counterfeit(CHAR_DATA *ch, char *argument)
 void counterfeit_end(OBJ_DATA *obj, OBJ_AFFECT_DATA *af)
 {
 
-	if (obj->carried_by)
+	if (CHAR_DATA *carrier = Deref(obj->carried_by))
 	{
 		act("You suddenly realize that $p is counterfeit, and really $T!",
-			obj->carried_by,
+			carrier,
 			obj,
 			obj->pIndexData->short_descr,
 			TO_CHAR);
@@ -1727,7 +1728,7 @@ void counterfeit_end(OBJ_DATA *obj, OBJ_AFFECT_DATA *af)
 	if (obj->in_room && obj->in_room->people)
 	{
 		act("You suddenly realize that $p is counterfeit, and really $T!",
-			obj->carried_by,
+			Deref(obj->carried_by),
 			obj,
 			obj->pIndexData->short_descr,
 			TO_ALL);

--- a/code/characterClasses/warrior.c
+++ b/code/characterClasses/warrior.c
@@ -9,6 +9,7 @@
 #include <math.h>
 #include <iterator>
 #include "../merc.h"
+#include "../entity/handles.h"
 #include "warrior.h"
 #include "sorcerer.h"
 #include "../act_comm.h"
@@ -152,7 +153,7 @@ void do_style(CHAR_DATA *ch, char *argument)
 		return;
 	}
 
-	if (ch->fighting)
+	if (Deref(ch->fighting))
 	{
 		skill = get_skill(ch, gsn_integrate);
 
@@ -197,7 +198,7 @@ void do_entrap(CHAR_DATA *ch, char *argument)
 		return;
 	}
 
-	victim = ch->fighting;
+	victim = Deref(ch->fighting);
 
 	if (victim == nullptr)
 	{
@@ -424,7 +425,7 @@ void do_hobble(CHAR_DATA *ch, char *argument)
 		return;
 	}
 
-	victim = ch->fighting;
+	victim = Deref(ch->fighting);
 
 	if (victim == nullptr)
 	{
@@ -705,7 +706,7 @@ void do_crippling_blow(CHAR_DATA *ch, char *argument)
 		return;
 	}
 
-	victim = ch->fighting;
+	victim = Deref(ch->fighting);
 
 	if (victim == nullptr)
 	{
@@ -968,7 +969,7 @@ void do_gouge(CHAR_DATA *ch, char *argument)
 		return;
 	}
 
-	victim = ch->fighting;
+	victim = Deref(ch->fighting);
 
 	if (victim == nullptr)
 	{
@@ -1135,7 +1136,7 @@ void do_bleed(CHAR_DATA *ch, char *argument)
 		return;
 	}
 
-	victim = ch->fighting;
+	victim = Deref(ch->fighting);
 
 	if (victim == nullptr)
 	{
@@ -1368,7 +1369,7 @@ void do_unbalance(CHAR_DATA *ch, char *argument)
 		return;
 	}
 
-	victim = ch->fighting;
+	victim = Deref(ch->fighting);
 
 	if (victim == nullptr)
 	{
@@ -1428,7 +1429,7 @@ void do_unbalance(CHAR_DATA *ch, char *argument)
 void do_uppercut(CHAR_DATA *ch, char *argument)
 {
 	int success = 0, skill, special = 100, duration = ch->level;
-	CHAR_DATA *victim = ch->fighting;
+	CHAR_DATA *victim = Deref(ch->fighting);
 	AFFECT_DATA af;
 	OBJ_DATA *weapon;
 	char ch1[MSL], chspecial[MSL], vict1[MSL], victspecial[MSL], nv1[MSL], nvspecial[MSL];
@@ -1581,7 +1582,7 @@ void do_dart(CHAR_DATA *ch, char *argument)
 {
 	OBJ_DATA *weapon;
 	AFFECT_DATA af;
-	CHAR_DATA *victim = ch->fighting;
+	CHAR_DATA *victim = Deref(ch->fighting);
 	char cha[MSL], vict[MSL], nv[MSL];
 	int skill = get_skill(ch, gsn_dart);
 
@@ -1703,7 +1704,7 @@ void do_impale(CHAR_DATA *ch, char *argument)
 		return;
 	}
 
-	victim = ch->fighting;
+	victim = Deref(ch->fighting);
 
 	if (victim == nullptr)
 	{
@@ -1760,7 +1761,7 @@ void do_impale(CHAR_DATA *ch, char *argument)
 			break;
 	}
 
-	if (!is_npc(victim) && !is_npc(ch) && (!ch->fighting || !victim->fighting))
+	if (!is_npc(victim) && !is_npc(ch) && (!Deref(ch->fighting) || !Deref(victim->fighting)))
 	{
 		sprintf(buf, "Help! %s is impaling me!", pers(ch, victim));
 		do_myell(victim, buf, ch);
@@ -1977,7 +1978,7 @@ void do_hurl(CHAR_DATA *ch, char *argument)
 		sprintf(buf, "A %s comes hurtling in from the %s, flipping end over end!", weapon_name_lookup(weapon->value[0]), dirname);
 		act(buf, victim, 0, 0, TO_ALL);
 
-		if (!is_npc(victim) && victim->fighting == nullptr)
+		if (!is_npc(victim) && Deref(victim->fighting) == nullptr)
 		{
 			sprintf(buf, "Help! %s is hurling a weapon at me!", pers(ch, victim));
 			do_myell(victim, buf, ch);
@@ -2012,7 +2013,7 @@ void do_hurl(CHAR_DATA *ch, char *argument)
 		act("With a flick of $s wrist, $n hurls $S $t at you!", ch, weapon_name_lookup(weapon->value[0]), victim, TO_VICT);
 		act("With a flick of $s wrist, $n hurls $S $t at $N!", ch, weapon_name_lookup(weapon->value[0]), victim, TO_NOTVICT);
 
-		if (!is_npc(victim) && victim->fighting == nullptr)
+		if (!is_npc(victim) && Deref(victim->fighting) == nullptr)
 		{
 			sprintf(buf, "Help! %s is hurling a weapon at me!", pers(ch, victim));
 			do_myell(victim, buf, ch);
@@ -2080,7 +2081,7 @@ void do_overhead(CHAR_DATA *ch, char *argument)
 
 	if (argument[0] == '\0')
 	{
-		victim = ch->fighting;
+		victim = Deref(ch->fighting);
 		if (victim == nullptr)
 		{
 			send_to_char("Overhead who?\n\r", ch);
@@ -2127,7 +2128,7 @@ void do_overhead(CHAR_DATA *ch, char *argument)
 		return;
 	}
 
-	if (ch->fighting == nullptr && is_affected(victim, gsn_overhead))
+	if (Deref(ch->fighting) == nullptr && is_affected(victim, gsn_overhead))
 	{
 		send_to_char("They are guarding their head too well right now.\n\r", ch);
 		return;
@@ -2169,7 +2170,7 @@ void do_overhead(CHAR_DATA *ch, char *argument)
 
 	if (number_percent() < .7 * skill)
 	{
-		if (ch->fighting == nullptr)
+		if (Deref(ch->fighting) == nullptr)
 		{
 			if (number_percent() < .3 * special)
 			{
@@ -2297,7 +2298,7 @@ void do_overhead(CHAR_DATA *ch, char *argument)
 			}
 		}
 
-		if (!is_npc(victim) && (ch->fighting == nullptr || victim->fighting == nullptr))
+		if (!is_npc(victim) && (Deref(ch->fighting) == nullptr || Deref(victim->fighting) == nullptr))
 		{
 			if (!can_see(victim, ch))
 			{
@@ -2361,7 +2362,7 @@ void do_exchange(CHAR_DATA *ch, char *argument)
 		return;
 	}
 
-	if (!ch->fighting)
+	if (!Deref(ch->fighting))
 	{
 		send_to_char("You must be fighting to exchange blows!\n\r", ch);
 		return;
@@ -2375,7 +2376,7 @@ void do_exchange(CHAR_DATA *ch, char *argument)
 		return;
 	}
 
-	victim = ch->fighting;
+	victim = Deref(ch->fighting);
 
 	if (victim == nullptr)
 	{
@@ -2454,7 +2455,7 @@ void do_charge(CHAR_DATA *ch, char *argument)
 		return;
 	}
 
-	if (ch->fighting)
+	if (Deref(ch->fighting))
 	{
 		send_to_char("You can't charge while in combat.\n\r", ch);
 		return;
@@ -2588,7 +2589,7 @@ void do_shieldbash(CHAR_DATA *ch, char *argument)
 		return;
 	}
 
-	victim = ch->fighting;
+	victim = Deref(ch->fighting);
 
 	if (victim == nullptr)
 	{
@@ -2670,7 +2671,7 @@ void do_brace(CHAR_DATA *ch, char *arg)
 		return;
 	}
 
-	victim = ch->fighting;
+	victim = Deref(ch->fighting);
 
 	if (victim == nullptr)
 	{
@@ -2725,7 +2726,7 @@ void do_shatter(CHAR_DATA *ch, char *argument)
 {
 	float skill;
 	float chance = 100;
-	CHAR_DATA *victim = ch->fighting;
+	CHAR_DATA *victim = Deref(ch->fighting);
 	OBJ_DATA *weapon, *wield, *handone, *handtwo, *secondary;
 	char chsuc[MSL], chfail[MSL], victsuc[MSL], victfail[MSL], nvictsuc[MSL], nvictfail[MSL];
 	bool isprimary = false;
@@ -3200,7 +3201,7 @@ void do_whirlwind(CHAR_DATA *ch, char *argument)
 
 	if (argument[0] == '\0')
 	{
-		victim = ch->fighting;
+		victim = Deref(ch->fighting);
 		if (victim == nullptr)
 		{
 			send_to_char("Who are you trying to whirlwind?\n\r", ch);
@@ -3243,7 +3244,7 @@ void do_whirlwind(CHAR_DATA *ch, char *argument)
 		return;
 	}
 
-	if (!is_npc(victim) && ((ch->fighting == nullptr) || (victim->fighting == nullptr)))
+	if (!is_npc(victim) && ((Deref(ch->fighting) == nullptr) || (Deref(victim->fighting) == nullptr)))
 	{
 		sprintf(buf, "Help! %s is whirling into me!", pers(ch, victim));
 		do_myell(victim, buf, ch);
@@ -3264,7 +3265,7 @@ void do_whirlwind(CHAR_DATA *ch, char *argument)
 		vch_next = vch->next_in_room;
 		if (number_percent() < skill)
 		{
-			if ((vch != ch && is_same_group(vch, victim) && ((can_see(ch, vch) || vch->fighting != nullptr))))
+			if ((vch != ch && is_same_group(vch, victim) && ((can_see(ch, vch) || Deref(vch->fighting) != nullptr))))
 			{
 				one_hit_new(ch, vch, TYPE_UNDEFINED, HIT_NOSPECIALS, HIT_UNBLOCKABLE, HIT_NOADD, 100, nullptr);
 			}
@@ -3281,7 +3282,7 @@ void do_whirlwind(CHAR_DATA *ch, char *argument)
 		}
 		else
 		{
-			if ((vch != ch && is_same_group(vch, victim) && ((can_see(ch, vch) || vch->fighting != nullptr))))
+			if ((vch != ch && is_same_group(vch, victim) && ((can_see(ch, vch) || Deref(vch->fighting) != nullptr))))
 			{
 				one_hit_new(ch, vch, TYPE_UNDEFINED, HIT_NOSPECIALS, HIT_UNBLOCKABLE, HIT_NOADD, 100, nullptr);
 			}
@@ -3363,7 +3364,7 @@ void do_entwine(CHAR_DATA *ch, char *argument)
 
 	argument = one_argument(argument, arg1);
 
-	victim = ch->fighting;
+	victim = Deref(ch->fighting);
 	if (victim == nullptr)
 	{
 		if (arg1[0] == '\0')
@@ -3456,7 +3457,7 @@ void do_entwine(CHAR_DATA *ch, char *argument)
 		return;
 	}
 
-	if (!is_npc(victim) && (ch->fighting == nullptr || victim->fighting == nullptr))
+	if (!is_npc(victim) && (Deref(ch->fighting) == nullptr || Deref(victim->fighting) == nullptr))
 	{
 		sprintf(buf, "Help! %s is entwining me!", pers(ch, victim));
 		do_myell(victim, buf, ch);
@@ -3511,7 +3512,7 @@ void do_entwine(CHAR_DATA *ch, char *argument)
 		check_improve(ch, gsn_entwine, false, 1);
 	}
 
-	if (!ch->fighting && !victim->fighting)
+	if (!Deref(ch->fighting) && !Deref(victim->fighting))
 	{
 		set_fighting(ch, victim);
 		multi_hit(victim, ch, TYPE_UNDEFINED);
@@ -3745,7 +3746,7 @@ void do_pull(CHAR_DATA *ch, char *argument)
 				direction = flag_name_lookup(reverse_d(dir), direction_table);
 				act("$n enters from $t, pulling along a tightly-entwined $N with him!", ch, direction, guy, TO_NOTVICT);
 
-				if (guy->in_room == ch->in_room && !ch->fighting && !guy->fighting)
+				if (guy->in_room == ch->in_room && !Deref(ch->fighting) && !Deref(guy->fighting))
 				{
 					set_fighting(ch, guy);
 					multi_hit(guy, ch, TYPE_UNDEFINED);
@@ -3824,7 +3825,7 @@ void do_assess(CHAR_DATA *ch, char *argument)
 		return;
 	}
 
-	victim = ch->fighting;
+	victim = Deref(ch->fighting);
 	if (argument[0] == '\0' && !victim)
 	{
 		send_to_char("Assess who?\n\r", ch);
@@ -3988,7 +3989,7 @@ void do_exploit(CHAR_DATA *ch, char *argument)
 		return;
 	}
 
-	victim = ch->fighting;
+	victim = Deref(ch->fighting);
 	if (victim == nullptr)
 	{
 		send_to_char("You aren't fighting anyone.\n\r", ch);
@@ -4187,7 +4188,7 @@ void do_offhand(CHAR_DATA *ch, char *arg)
 	int chance;
 	OBJ_DATA *wield, *offhand;
 	bool found;
-	CHAR_DATA *victim = ch->fighting;
+	CHAR_DATA *victim = Deref(ch->fighting);
 
 	chance = get_skill(ch, skill_lookup("offhand disarm"));
 
@@ -4312,7 +4313,7 @@ void do_drive(CHAR_DATA *ch, char *argument)
 	}
 
 	/* Check to see if they are fighting */
-	if (ch->fighting)
+	if (Deref(ch->fighting))
 	{
 		where = direction_lookup(argument);
 		if (where == -1)
@@ -4341,7 +4342,7 @@ void do_drive(CHAR_DATA *ch, char *argument)
 		else
 		{
 			sprintf(dir, "%s", argument);
-			victim = ch->fighting;
+			victim = Deref(ch->fighting);
 		}
 	}
 	else
@@ -4404,7 +4405,7 @@ void do_drive(CHAR_DATA *ch, char *argument)
 		return;
 	}
 
-	if (!is_npc(ch) && !is_npc(victim) && (ch->fighting == nullptr || victim->fighting == nullptr))
+	if (!is_npc(ch) && !is_npc(victim) && (Deref(ch->fighting) == nullptr || Deref(victim->fighting) == nullptr))
 	{
 		sprintf(store, "Help! %s is pushing me around!", pers(ch, victim));
 		do_myell(victim, store, ch);
@@ -4454,7 +4455,7 @@ void do_drive(CHAR_DATA *ch, char *argument)
 		check_improve(ch, gsn_drive, false, 1);
 	}
 
-	if (victim->in_room == ch->in_room && !ch->fighting && !victim->fighting)
+	if (victim->in_room == ch->in_room && !Deref(ch->fighting) && !Deref(victim->fighting))
 		set_fighting(ch, victim);
 
 	one_hit(victim, ch, TYPE_HIT);
@@ -4485,7 +4486,7 @@ void do_dash(CHAR_DATA *ch, char *argument)
 	}
 
 	/* Check to see if they are fighting */
-	if (ch->fighting)
+	if (Deref(ch->fighting))
 	{
 		send_to_char("You can't dash while you are fighting!\n\r", ch);
 		return;
@@ -4588,13 +4589,13 @@ void do_concuss(CHAR_DATA *ch, char *argument)
 		return;
 	}
 
-	if (!ch->fighting)
+	if (!Deref(ch->fighting))
 	{
 		send_to_char("You must in combat to do that!\n\r", ch);
 		return;
 	}
 
-	victim = ch->fighting;
+	victim = Deref(ch->fighting);
 
 	if (is_wielded(ch, WEAPON_AXE, WIELD_ONE)
 		|| is_wielded(ch, WEAPON_WHIP, WIELD_ONE)
@@ -4706,7 +4707,7 @@ void do_retreat(CHAR_DATA *ch, char *arg)
 		return;
 	}
 
-	if (!ch->fighting)
+	if (!Deref(ch->fighting))
 	{
 		send_to_char("You must be fighting to retreat!\n\r", ch);
 		return;
@@ -4772,7 +4773,7 @@ void do_disrupt_formation(CHAR_DATA *ch, char *arg)
 
 	if (arg[0] == '\0')
 	{
-		victim = ch->fighting;
+		victim = Deref(ch->fighting);
 		if (victim == nullptr)
 		{
 			send_to_char("But you aren't fighting anyone!\n\r", ch);
@@ -4796,7 +4797,7 @@ void do_disrupt_formation(CHAR_DATA *ch, char *arg)
 		return;
 	}
 
-	if (ch->fighting && !is_npc(ch))
+	if (Deref(ch->fighting) && !is_npc(ch))
 	{
 		send_to_char("You have other things to worry about at the moment.\n\r", ch);
 		return;

--- a/code/characterClasses/warrior.c
+++ b/code/characterClasses/warrior.c
@@ -549,7 +549,7 @@ void do_hobble(CHAR_DATA *ch, char *argument)
 					af2.aftype = AFT_INVIS;
 					af2.tick_fun = bleeding_tick;
 					af2.end_fun = nullptr;
-					af2.owner = ch;
+					af2.owner = ch->self;
 					new_affect_to_char(victim, &af2);
 					break;
 				case WEAPON_SWORD:
@@ -572,7 +572,7 @@ void do_hobble(CHAR_DATA *ch, char *argument)
 					af2.aftype = AFT_INVIS;
 					af2.tick_fun = bleeding_tick;
 					af2.end_fun = nullptr;
-					af2.owner = ch;
+					af2.owner = ch->self;
 					new_affect_to_char(victim, &af2);
 					break;
 				case WEAPON_FLAIL:
@@ -834,7 +834,7 @@ void do_crippling_blow(CHAR_DATA *ch, char *argument)
 					af2.aftype = AFT_INVIS;
 					af2.tick_fun = bleeding_tick;
 					af2.end_fun = nullptr;
-					af2.owner = ch;
+					af2.owner = ch->self;
 					new_affect_to_char(victim, &af2);
 					break;
 				case WEAPON_SWORD:
@@ -857,7 +857,7 @@ void do_crippling_blow(CHAR_DATA *ch, char *argument)
 					af2.aftype = AFT_INVIS;
 					af2.tick_fun = bleeding_tick;
 					af2.end_fun = nullptr;
-					af2.owner = ch;
+					af2.owner = ch->self;
 					new_affect_to_char(victim, &af2);
 					break;
 				case WEAPON_FLAIL:
@@ -1224,7 +1224,7 @@ void do_bleed(CHAR_DATA *ch, char *argument)
 			af.aftype = AFT_MALADY;
 			af.end_fun = nullptr;
 			af.tick_fun = bleeding_tick;
-			af.owner = ch;
+			af.owner = ch->self;
 			new_affect_to_char(victim, &af);
 		}
 
@@ -1534,7 +1534,7 @@ void do_uppercut(CHAR_DATA *ch, char *argument)
 				af.where = TO_AFFECTS;
 				af.level = ch->level;
 				af.duration = duration;
-				af.owner = ch;
+				af.owner = ch->self;
 				af.type = gsn_uppercut;
 				af.aftype = AFT_MALADY;
 				af.mod_name = MOD_SPEECH;
@@ -1670,7 +1670,7 @@ void do_dart(CHAR_DATA *ch, char *argument)
 
 		af.where = TO_AFFECTS;
 		af.level = ch->level;
-		af.owner = ch;
+		af.owner = ch->self;
 		af.end_fun = nullptr;
 
 		if (!is_affected(victim, af.type))
@@ -1795,7 +1795,7 @@ void do_impale(CHAR_DATA *ch, char *argument)
 				af.duration = ch->level / 9;
 				af.location = APPLY_STR;
 				af.modifier = -ch->level / 8;
-				af.owner = ch;
+				af.owner = ch->self;
 				new_affect_to_char(victim, &af);
 
 				af.location = APPLY_DEX;
@@ -1809,7 +1809,7 @@ void do_impale(CHAR_DATA *ch, char *argument)
 			iaf.aftype = AFT_INVIS;
 			iaf.duration = -1;
 			iaf.level = ch->level;
-			iaf.owner = ch;
+			iaf.owner = ch->self;
 			new_affect_to_char(victim, &iaf);
 
 			extract_obj(weapon);
@@ -1831,7 +1831,7 @@ void do_impale(CHAR_DATA *ch, char *argument)
 				af.duration = ch->level / 8;
 				af.location = APPLY_STR;
 				af.modifier = -ch->level / 8;
-				af.owner = ch;
+				af.owner = ch->self;
 				new_affect_to_char(victim, &af);
 
 				af.location = APPLY_DEX;
@@ -1998,7 +1998,7 @@ void do_hurl(CHAR_DATA *ch, char *argument)
 				af.duration = 2;
 				af.location = APPLY_NONE;
 				af.modifier = 0;
-				af.owner = ch;
+				af.owner = ch->self;
 				affect_to_char(victim, &af);
 			}
 		}
@@ -2033,7 +2033,7 @@ void do_hurl(CHAR_DATA *ch, char *argument)
 				af.duration = 2;
 				af.location = APPLY_NONE;
 				af.modifier = 0;
-				af.owner = ch;
+				af.owner = ch->self;
 				affect_to_char(victim, &af);
 			}
 		}
@@ -2242,7 +2242,7 @@ void do_overhead(CHAR_DATA *ch, char *argument)
 			af.aftype = AFT_INVIS;
 			af.tick_fun = bleeding_tick;
 			af.end_fun = nullptr;
-			af.owner = ch;
+			af.owner = ch->self;
 			af.level = ch->level;
 
 			switch (weapon->value[0])
@@ -2343,8 +2343,8 @@ void do_extract(CHAR_DATA *ch, char *argument)
 	owner = ch;
 	af = affect_find(ch->affected, gsn_impale);
 
-	if (af && af->owner)
-		owner = af->owner;
+	if (af && Deref(af->owner))
+		owner = Deref(af->owner);
 
 	damage_new(owner, ch, dam, gsn_impale, DAM_OTHER, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "the extraction*");
 	affect_strip(ch, gsn_impale);
@@ -3485,7 +3485,7 @@ void do_entwine(CHAR_DATA *ch, char *argument)
 		}
 
 		af.aftype = AFT_SKILL;
-		af.owner = ch;
+		af.owner = ch->self;
 		affect_to_char(victim, &af);
 
 		init_affect(&af);
@@ -3496,7 +3496,7 @@ void do_entwine(CHAR_DATA *ch, char *argument)
 		af.location = APPLY_NONE;
 		af.modifier = 0;
 		af.aftype = AFT_INVIS;
-		af.owner = victim;
+		af.owner = victim->self;
 		affect_to_char(ch, &af);
 
 		act("You crack your whip, deftly coiling it about $N's $t and pulling it taut!", ch, arm ? "arm" : leg ? "leg" : "", victim, TO_CHAR);
@@ -3564,14 +3564,14 @@ void do_uncoil(CHAR_DATA *ch, char *argument)
 		}
 	}
 
-	guy = af->owner;
+	guy = Deref(af->owner);
 
 	if (guy != nullptr)
 	{
 		af2 = nullptr;
 		for (auto &af2_elem : guy->affected)
 		{
-			if (af2_elem.type == gsn_entwine && af2_elem.owner == ch)
+			if (af2_elem.type == gsn_entwine && Deref(af2_elem.owner) == ch)
 			{
 				af2 = &af2_elem;
 				break;
@@ -3670,12 +3670,12 @@ void do_pull(CHAR_DATA *ch, char *argument)
 			}
 		}
 
-		guy = af->owner;
+		guy = Deref(af->owner);
 
 		af2 = nullptr;
 		for (auto &af2_elem : guy->affected)
 		{
-			if (af2_elem.type == gsn_entwine && af2_elem.owner == ch)
+			if (af2_elem.type == gsn_entwine && Deref(af2_elem.owner) == ch)
 			{
 				af2 = &af2_elem;
 				break;

--- a/code/characterClasses/warrior.c
+++ b/code/characterClasses/warrior.c
@@ -4803,7 +4803,7 @@ void do_disrupt_formation(CHAR_DATA *ch, char *arg)
 		return;
 	}
 
-	if (ch->leader)
+	if (Deref(ch->leader))
 		grouped = true;
 
 	if (is_npc(victim))
@@ -4978,7 +4978,7 @@ void do_leadership(CHAR_DATA *ch, char *argument)
 
 bool check_leadership_save(CHAR_DATA *ch, int skill)
 {
-	if (ch->leader == nullptr || ch->leader == ch)
+	if (Deref(ch->leader) == nullptr || Deref(ch->leader) == ch)
 		return false;
 
 	if (skill == gsn_howl || skill == gsn_disrupt_formation)

--- a/code/characterClasses/zealot.c
+++ b/code/characterClasses/zealot.c
@@ -5,6 +5,7 @@
 #include <time.h>
 #include <math.h>
 #include "../merc.h"
+#include "../entity/handles.h"
 #include "zealot.h"
 #include "../comm.h"
 #include "../handler.h"
@@ -167,7 +168,7 @@ void spell_divine_malison(int sn, int level, CHAR_DATA *ch, void *vo, int target
 		return;
 	}
 
-	if (ch->fighting && saves_spell(level + 9, victim, DAM_HOLY))
+	if (Deref(ch->fighting) && saves_spell(level + 9, victim, DAM_HOLY))
 	{
 		act("A nimbus flickers briefly around $n, but dissipates.", victim, 0, 0, TO_ROOM);
 		act("A haze surrounds you briefly, but dissipates.", victim, 0, 0, TO_CHAR);

--- a/code/characterClasses/zealot.c
+++ b/code/characterClasses/zealot.c
@@ -42,7 +42,7 @@ void spell_infidels_weight(int sn, int level, CHAR_DATA *ch, void *vo, int targe
 	af.duration = level / 4;
 	af.location = APPLY_CARRY_WEIGHT;
 	af.modifier = mod;
-	af.owner = ch;
+	af.owner = ch->self;
 	new_affect_to_char(victim, &af);
 
 	act("You burden $N with the weight of a thousand infidels!", ch, 0, victim, TO_CHAR);
@@ -115,7 +115,7 @@ void spell_burning_vision(int sn, int level, CHAR_DATA *ch, void *vo, int target
 		af.level = level;
 		af.duration = 20;
 		af.modifier = 4;
-		af.owner = ch;
+		af.owner = ch->self;
 		af.tick_fun = burning_vision_tick;
 		af.mod_name = MOD_VISION;
 		new_affect_to_char(victim, &af);
@@ -162,7 +162,7 @@ void spell_divine_malison(int sn, int level, CHAR_DATA *ch, void *vo, int target
 		return;
 	}
 
-	if (victim && (paf = affect_find(victim->affected, gsn_divine_ward)) != nullptr && paf->owner == ch)
+	if (victim && (paf = affect_find(victim->affected, gsn_divine_ward)) != nullptr && Deref(paf->owner) == ch)
 	{
 		act("Your deity already protects you from $N!", ch, 0, victim, TO_CHAR);
 		return;
@@ -199,6 +199,6 @@ void spell_divine_malison(int sn, int level, CHAR_DATA *ch, void *vo, int target
 	af.level = level;
 	af.duration = level / 4;
 	af.modifier = reduction;
-	af.owner = ch;
+	af.owner = ch->self;
 	affect_to_char(victim, &af);
 }

--- a/code/comm.c
+++ b/code/comm.c
@@ -602,8 +602,10 @@ void close_socket(DESCRIPTOR_DATA *dclose)
 			if (ch->invis_level < 51)
 				act("$n has lost $s link.", ch, nullptr, nullptr, TO_ROOM);
 
+			CHAR_DATA *lastOpponent = Deref(ch->last_fight_opponent);
+
 			sprintf(buf, "$N has lost $S link (Last fought %s %d %s ago).",
-				ch->last_fight_name != nullptr ? ch->last_fight_name : "nobody",
+				lastOpponent != nullptr ? lastOpponent->true_name : "nobody",
 				ch->last_fight_time ? ftime > 600 ? (int)(ftime / 60) : ftime : -1,
 				ftime > 600 ? "minutes" : "seconds");
 			wiznet(buf, ch, nullptr, WIZ_LINKS, 0, get_trust(ch));

--- a/code/comm.c
+++ b/code/comm.c
@@ -246,8 +246,10 @@ void game_loop_unix(int control)
 				FD_CLR(d->descriptor, &in_set);
 				FD_CLR(d->descriptor, &out_set);
 
-				if (Deref(d->character) && Deref(d->character)->level > 1)
-					save_char_obj(Deref(d->character));
+				CHAR_DATA *player = Deref(d->character);
+
+				if (player && player->level > 1)
+					save_char_obj(player);
 
 				d->outtop = 0;
 				close_socket(d);
@@ -262,17 +264,22 @@ void game_loop_unix(int control)
 			d_next = d->next;
 			d->fcommand= false;
 
+			// Nothing between here and the interpret() below can free the
+			// character: read_from_descriptor only touches the socket, and the
+			// branch that does close the connection continues out of the loop.
+			CHAR_DATA *player = Deref(d->character);
+
 			if (FD_ISSET(d->descriptor, &in_set))
 			{
-				if (Deref(d->character) != nullptr)
-					Deref(d->character)->timer = 0;
+				if (player != nullptr)
+					player->timer = 0;
 
 				if (!read_from_descriptor(d))
 				{
 					FD_CLR(d->descriptor, &out_set);
 
-					if (Deref(d->character) != nullptr && Deref(d->character)->level > 1)
-						save_char_obj(Deref(d->character));
+					if (player != nullptr && player->level > 1)
+						save_char_obj(player);
 
 					d->outtop = 0;
 					close_socket(d);
@@ -280,15 +287,14 @@ void game_loop_unix(int control)
 				}
 			}
 
-			if (Deref(d->character) != nullptr && Deref(d->character)->wait > 0)
-				--Deref(d->character)->wait;
+			if (player != nullptr && player->wait > 0)
+				--player->wait;
 
-			if (Deref(d->character) != nullptr && Deref(d->character)->wait <= 0 && Deref(d->character)->pcdata->pending)
+			if (player != nullptr && player->wait <= 0 && player->pcdata->pending)
 			{
-				CHAR_DATA *player;
 				int i = 0;
 
-				interpret(Deref(d->character), Deref(d->character)->pcdata->queue[0]);
+				interpret(player, player->pcdata->queue[0]);
 
 				// The queued command can be "quit", which extracts the
 				// character out from under us -- so read the connection again
@@ -332,7 +338,12 @@ void game_loop_unix(int control)
 			if (d->incomm[0] != '\0')
 			{
 				d->fcommand = true;
-				stop_idling(Deref(d->character));
+				stop_idling(player);
+
+				// stop_idling moves the character back out of limbo and fires a
+				// room act, so read the connection again rather than carrying
+				// the value above across it.
+				player = Deref(d->character);
 
 				/* OLC */
 				if (d->showstr_point)
@@ -341,11 +352,11 @@ void game_loop_unix(int control)
 				}
 				else if (d->pString)
 				{
-					string_add(Deref(d->character), d->incomm);
+					string_add(player, d->incomm);
 				}
-				else if (d->connected == CON_PLAYING && Deref(d->character)->pcdata && Deref(d->character)->pcdata->entering_text)
+				else if (d->connected == CON_PLAYING && player->pcdata && player->pcdata->entering_text)
 				{
-					process_text(Deref(d->character), d->incomm);
+					process_text(player, d->incomm);
 				}
 				else
 				{
@@ -386,8 +397,12 @@ void game_loop_unix(int control)
 			{
 				if (!process_output(d, true))
 				{
-					if (Deref(d->character) != nullptr && Deref(d->character)->level > 1)
-						save_char_obj(Deref(d->character));
+					// Read after process_output, not before: its write path can
+					// overflow the output buffer and close the connection.
+					CHAR_DATA *player = Deref(d->character);
+
+					if (player != nullptr && player->level > 1)
+						save_char_obj(player);
 
 					d->outtop = 0;
 					close_socket(d);

--- a/code/comm.c
+++ b/code/comm.c
@@ -607,8 +607,6 @@ void close_socket(DESCRIPTOR_DATA *dclose)
 				ch->last_fight_time ? ftime > 600 ? (int)(ftime / 60) : ftime : -1,
 				ftime > 600 ? "minutes" : "seconds");
 			wiznet(buf, ch, nullptr, WIZ_LINKS, 0, get_trust(ch));
-
-			ch->desc = nullptr;
 		}
 		else
 		{
@@ -1194,7 +1192,7 @@ void bust_a_prompt(CHAR_DATA *ch)
 	// therefore need to terminate it here so we avoid stack garabage.
 	*point = '\0';
 
-	write_to_buffer(ch->desc, buf, point - buf);
+	write_to_buffer(Deref(ch->desc), buf, point - buf);
 	//   free_pstring(orig);
 }
 
@@ -2800,7 +2798,7 @@ void nanny(DESCRIPTOR_DATA *d, char *argument)
 				char_to_room(ch, get_room_index(24525));
 			}
 
-			ch->pcdata->host = palloc_string(ch->desc->host);
+			ch->pcdata->host = palloc_string(Deref(ch->desc)->host);
 
 			if (!is_immortal(ch))
 				act("$n awakens into the world of Shalar.", ch, nullptr, nullptr, TO_ROOM);
@@ -2981,7 +2979,7 @@ bool check_reconnect(DESCRIPTOR_DATA *d, char *name, bool fConn)
 	for (ch = char_list; ch != nullptr; ch = ch->next)
 	{
 		if (!is_npc(ch)
-			&& (!fConn || ch->desc == nullptr)
+			&& (!fConn || Deref(ch->desc) == nullptr)
 			&& !str_cmp((pending->true_name ? pending->true_name : pending->name), (ch->true_name ? ch->true_name : ch->name)))
 		{
 			if (fConn == false)
@@ -3005,7 +3003,7 @@ bool check_reconnect(DESCRIPTOR_DATA *d, char *name, bool fConn)
 				free_char(pending);
 				d->character = ch->self;
 
-				ch->desc = d;
+				ch->desc = d->self;
 				ch->timer = 0;
 
 				send_to_char("Reconnecting. Type replay to see missed tells.\n\r", ch);
@@ -3013,7 +3011,7 @@ bool check_reconnect(DESCRIPTOR_DATA *d, char *name, bool fConn)
 				if (ch->invis_level < 51)
 					act("$n has reconnected.", ch, nullptr, nullptr, TO_ROOM);
 
-				ch->pcdata->host = palloc_string(ch->desc->host);
+				ch->pcdata->host = palloc_string(Deref(ch->desc)->host);
 				/* Limit crap to balance reconnect objects from extracted link object */
 				for (obj = ch->carrying; obj != nullptr; obj = obj->next_content)
 				{
@@ -3069,8 +3067,8 @@ bool check_playing(DESCRIPTOR_DATA *d, char *name)
 void stop_idling(CHAR_DATA *ch)
 {
 	if (ch == nullptr
-		|| ch->desc == nullptr
-		|| ch->desc->connected != CON_PLAYING
+		|| Deref(ch->desc) == nullptr
+		|| Deref(ch->desc)->connected != CON_PLAYING
 		|| ch->was_in_room == nullptr
 		|| ch->in_room != get_room_index(ROOM_VNUM_LIMBO))
 		return;
@@ -3092,8 +3090,8 @@ void stop_idling(CHAR_DATA *ch)
 ///
 void send_to_char(const char *txt, CHAR_DATA *ch)
 {
-	if (txt != nullptr && ch->desc != nullptr)
-		write_to_buffer(ch->desc, txt, strlen(txt));
+	if (txt != nullptr && Deref(ch->desc) != nullptr)
+		write_to_buffer(Deref(ch->desc), txt, strlen(txt));
 }
 
 void send_to_char_queue (std::string txt, CHAR_DATA *ch)
@@ -3103,8 +3101,8 @@ void send_to_char_queue (std::string txt, CHAR_DATA *ch)
 
 void send_to_chars(const char *txt, CHAR_DATA *ch, int min, ...)
 {
-	if (txt != nullptr && ch->desc != nullptr)
-		write_to_buffer(ch->desc, txt, strlen(txt));
+	if (txt != nullptr && Deref(ch->desc) != nullptr)
+		write_to_buffer(Deref(ch->desc), txt, strlen(txt));
 }
 
 /*
@@ -3112,7 +3110,9 @@ void send_to_chars(const char *txt, CHAR_DATA *ch, int min, ...)
  */
 void page_to_char(const char *txt, CHAR_DATA *ch)
 {
-	if (txt == nullptr || ch->desc == nullptr)
+	DESCRIPTOR_DATA *connection = Deref(ch->desc);
+
+	if (txt == nullptr || connection == nullptr)
 		return;
 
 	if (ch->lines == 0)
@@ -3121,11 +3121,11 @@ void page_to_char(const char *txt, CHAR_DATA *ch)
 		return;
 	}
 
-	ch->desc->showstr_head = new char[strlen(txt) + 1];
-	strcpy(ch->desc->showstr_head, txt);
+	connection->showstr_head = new char[strlen(txt) + 1];
+	strcpy(connection->showstr_head, txt);
 
-	ch->desc->showstr_point = ch->desc->showstr_head;
-	show_string(ch->desc, "");
+	connection->showstr_point = connection->showstr_head;
+	show_string(connection, "");
 }
 
 /* string pager */
@@ -3239,7 +3239,7 @@ void act_area(const char *format, CHAR_DATA *ch, CHAR_DATA *victim)
 
 			to = Deref(d->character);
 
-			if ((!is_npc(to) && to->desc == nullptr))
+			if ((!is_npc(to) && Deref(to->desc) == nullptr))
 				continue;
 
 			point = buf;
@@ -3294,13 +3294,13 @@ void act_area(const char *format, CHAR_DATA *ch, CHAR_DATA *victim)
 
 			*point = '\0';
 
-			if (to->desc != nullptr)
+			if (Deref(to->desc) != nullptr)
 			{
 				sprintf(buf2, "%s yells '%s", ch->short_descr, get_char_color(to, "yells"));
 				buf2[0] = UPPER(buf2[0]);
 				send_to_char(buf2, to);
 
-				write_to_buffer(to->desc, buf, point - buf);
+				write_to_buffer(Deref(to->desc), buf, point - buf);
 
 				sprintf(buf2, "%s'\n\r", END_COLOR(to));
 				send_to_char(buf2, to);
@@ -3363,7 +3363,7 @@ void act_new(const char *format, CHAR_DATA *ch, const void *arg1, const void *ar
 
 	for (; to != nullptr; to = to->next_in_room)
 	{
-		if ((!is_npc(to) && to->desc == nullptr) || to->position < min_pos)
+		if ((!is_npc(to) && Deref(to->desc) == nullptr) || to->position < min_pos)
 			continue;
 
 		if ((type == TO_CHAR) && to != ch)
@@ -3519,8 +3519,8 @@ void act_new(const char *format, CHAR_DATA *ch, const void *arg1, const void *ar
 		else
 			buf[0] = UPPER(buf[0]);
 
-		if (to->desc != nullptr)
-			write_to_buffer(to->desc, buf, point - buf);
+		if (Deref(to->desc) != nullptr)
+			write_to_buffer(Deref(to->desc), buf, point - buf);
 	}
 }
 
@@ -3604,7 +3604,7 @@ void do_rename(CHAR_DATA *ch, char *argument)
 		return;
 	}
 
-	if (!victim->desc || (victim->desc->connected != CON_PLAYING))
+	if (!Deref(victim->desc) || Deref(victim->desc)->connected != CON_PLAYING)
 	{
 		send_to_char("They are link-dead.\n\r", ch);
 		return;
@@ -3822,14 +3822,14 @@ void show_allocate(CHAR_DATA *ch, int finish)
 
 	if (!finish)
 	{
-		write_to_buffer(ch->desc, "Type '<str/int/wis/dex/con> <amount>' to modify a particular stat.\n\r", 0);
-		write_to_buffer(ch->desc, "The default amount is 1, use negative numbers to deallocate points.\n\r", 0);
-		write_to_buffer(ch->desc, "Type 'finish' when you're done.\n\r", 0);
-		write_to_buffer(ch->desc, "\n\rTime to allocate points to your stats.\n\r", 0);
+		write_to_buffer(Deref(ch->desc), "Type '<str/int/wis/dex/con> <amount>' to modify a particular stat.\n\r", 0);
+		write_to_buffer(Deref(ch->desc), "The default amount is 1, use negative numbers to deallocate points.\n\r", 0);
+		write_to_buffer(Deref(ch->desc), "Type 'finish' when you're done.\n\r", 0);
+		write_to_buffer(Deref(ch->desc), "\n\rTime to allocate points to your stats.\n\r", 0);
 	}
 
 	sprintf(buf, "You have %d points to allocate.\n\r", ch->train);
-	write_to_buffer(ch->desc, buf, 0);
+	write_to_buffer(Deref(ch->desc), buf, 0);
 
 	sprintf(buf, "Your stats: Str: %d (Max %d)  Int: %d (Max %d)  Wis: %d (Max %d)  Dex: %d (Max %d)  Con: %d (Max %d)\n\r",
 		ch->perm_stat[STAT_STR],
@@ -3844,7 +3844,7 @@ void show_allocate(CHAR_DATA *ch, int finish)
 		pc_race_table[ch->race].max_stats[STAT_CON]);
 	send_to_char(buf, ch);
 
-	write_to_buffer(ch->desc, "> ", 0);
+	write_to_buffer(Deref(ch->desc), "> ", 0);
 }
 
 void process_text(CHAR_DATA *ch, char *text)

--- a/code/comm.c
+++ b/code/comm.c
@@ -246,8 +246,8 @@ void game_loop_unix(int control)
 				FD_CLR(d->descriptor, &in_set);
 				FD_CLR(d->descriptor, &out_set);
 
-				if (d->character && d->character->level > 1)
-					save_char_obj(d->character);
+				if (Deref(d->character) && Deref(d->character)->level > 1)
+					save_char_obj(Deref(d->character));
 
 				d->outtop = 0;
 				close_socket(d);
@@ -264,15 +264,15 @@ void game_loop_unix(int control)
 
 			if (FD_ISSET(d->descriptor, &in_set))
 			{
-				if (d->character != nullptr)
-					d->character->timer = 0;
+				if (Deref(d->character) != nullptr)
+					Deref(d->character)->timer = 0;
 
 				if (!read_from_descriptor(d))
 				{
 					FD_CLR(d->descriptor, &out_set);
 
-					if (d->character != nullptr && d->character->level > 1)
-						save_char_obj(d->character);
+					if (Deref(d->character) != nullptr && Deref(d->character)->level > 1)
+						save_char_obj(Deref(d->character));
 
 					d->outtop = 0;
 					close_socket(d);
@@ -280,42 +280,51 @@ void game_loop_unix(int control)
 				}
 			}
 
-			if (d->character != nullptr && d->character->wait > 0)
-				--d->character->wait;
+			if (Deref(d->character) != nullptr && Deref(d->character)->wait > 0)
+				--Deref(d->character)->wait;
 
-			if (d->character != nullptr && d->character->wait <= 0 && d->character->pcdata->pending)
+			if (Deref(d->character) != nullptr && Deref(d->character)->wait <= 0 && Deref(d->character)->pcdata->pending)
 			{
+				CHAR_DATA *player;
 				int i = 0;
-				interpret(d->character, d->character->pcdata->queue[0]);
 
-				if (!d->character) // Cal: Silly Morglum.  But what if we just interpreted a "quit"?
-					continue;	   // then d->character is null and we just crashed. :(
+				interpret(Deref(d->character), Deref(d->character)->pcdata->queue[0]);
 
-				for (i = 1; i < d->character->pcdata->write_next; i++)
+				// The queued command can be "quit", which extracts the
+				// character out from under us -- so read the connection again
+				// here rather than before the call. Everything below this point
+				// only shuffles the command queue and cannot free anything, so
+				// the one read covers all of it.
+				player = Deref(d->character);
+
+				if (!player)
+					continue;
+
+				for (i = 1; i < player->pcdata->write_next; i++)
 				{
 					if (i > MAX_QUEUE - 1) break;
-					strcpy(d->character->pcdata->queue[(i - 1)], d->character->pcdata->queue[i]);
+					strcpy(player->pcdata->queue[(i - 1)], player->pcdata->queue[i]);
 				}
 
-				d->character->pcdata->write_next--;
+				player->pcdata->write_next--;
 
-				for (i = d->character->pcdata->write_next; i < MAX_QUEUE; i++)
+				for (i = player->pcdata->write_next; i < MAX_QUEUE; i++)
 				{
-					d->character->pcdata->queue[i][0] = '\0';
+					player->pcdata->queue[i][0] = '\0';
 				}
 
-				if (d->character->pcdata->write_next == 0)
-					d->character->pcdata->pending= false;
+				if (player->pcdata->write_next == 0)
+					player->pcdata->pending = false;
 
 				continue;
 				/*
-					d->character->pcdata->queue[d->character->pcdata->read_next][0] = '\0';
-					d->character->pcdata->read_next++;
+					Deref(d->character)->pcdata->queue[Deref(d->character)->pcdata->read_next][0] = '\0';
+					Deref(d->character)->pcdata->read_next++;
 
-					if (d->character->pcdata->read_next > 19)
-						d->character->pcdata->read_next = 0;
-					if (d->character->pcdata->queue[d->character->pcdata->read_next][0] == '\0')
-						d->character->pcdata->pending= false;
+					if (Deref(d->character)->pcdata->read_next > 19)
+						Deref(d->character)->pcdata->read_next = 0;
+					if (Deref(d->character)->pcdata->queue[Deref(d->character)->pcdata->read_next][0] == '\0')
+						Deref(d->character)->pcdata->pending= false;
 				*/
 			}
 
@@ -323,7 +332,7 @@ void game_loop_unix(int control)
 			if (d->incomm[0] != '\0')
 			{
 				d->fcommand = true;
-				stop_idling(d->character);
+				stop_idling(Deref(d->character));
 
 				/* OLC */
 				if (d->showstr_point)
@@ -332,11 +341,11 @@ void game_loop_unix(int control)
 				}
 				else if (d->pString)
 				{
-					string_add(d->character, d->incomm);
+					string_add(Deref(d->character), d->incomm);
 				}
-				else if (d->connected == CON_PLAYING && d->character->pcdata && d->character->pcdata->entering_text)
+				else if (d->connected == CON_PLAYING && Deref(d->character)->pcdata && Deref(d->character)->pcdata->entering_text)
 				{
-					process_text(d->character, d->incomm);
+					process_text(Deref(d->character), d->incomm);
 				}
 				else
 				{
@@ -353,8 +362,8 @@ void game_loop_unix(int control)
 				}
 				/*		if (d->showstr_point)
 							show_string(d,d->incomm);
-						else if ( d->connected == CON_PLAYING && d->character->pcdata &&
-				   d->character->pcdata->entering_text ) process_text(d->character, d->incomm); else if ( d->connected
+						else if ( d->connected == CON_PLAYING && Deref(d->character)->pcdata &&
+				   Deref(d->character)->pcdata->entering_text ) process_text(Deref(d->character), d->incomm); else if ( d->connected
 				   == CON_PLAYING ) substitute_alias( d, d->incomm ); else nanny( d, d->incomm );
 				*/
 				d->incomm[0] = '\0';
@@ -377,8 +386,8 @@ void game_loop_unix(int control)
 			{
 				if (!process_output(d, true))
 				{
-					if (d->character != nullptr && d->character->level > 1)
-						save_char_obj(d->character);
+					if (Deref(d->character) != nullptr && Deref(d->character)->level > 1)
+						save_char_obj(Deref(d->character));
 
 					d->outtop = 0;
 					close_socket(d);
@@ -582,7 +591,7 @@ void close_socket(DESCRIPTOR_DATA *dclose)
 		}
 	}
 
-	if ((ch = dclose->character) != nullptr)
+	if ((ch = Deref(dclose->character)) != nullptr)
 	{
 		RS.Logger.Info("Closing link to {}.", ch->name);
 
@@ -603,7 +612,7 @@ void close_socket(DESCRIPTOR_DATA *dclose)
 		}
 		else
 		{
-			free_char(dclose->original ? dclose->original : dclose->character);
+			free_char(Deref(dclose->original) ? Deref(dclose->original) : Deref(dclose->character));
 		}
 	}
 
@@ -813,7 +822,7 @@ bool process_output(DESCRIPTOR_DATA *d, bool fPrompt)
 		CHAR_DATA *ch;
 		CHAR_DATA *victim;
 
-		ch = d->character;
+		ch = Deref(d->character);
 
 		/* battle prompt */
 		if ((victim = Deref(ch->fighting)) != nullptr)
@@ -842,13 +851,13 @@ bool process_output(DESCRIPTOR_DATA *d, bool fPrompt)
 			}
 		}
 
-		ch = d->original ? d->original : d->character;
+		ch = Deref(d->original) ? Deref(d->original) : Deref(d->character);
 		if (!IS_SET(ch->comm, COMM_COMPACT))
 			write_to_buffer(d, "\n\r", 2);
 		if (!is_npc(ch) && ch->pcdata->entering_text)
 			write_to_buffer(d, ": ", 2);
 		else if (IS_SET(ch->comm, COMM_PROMPT))
-			bust_a_prompt(d->character);
+			bust_a_prompt(Deref(d->character));
 
 		if (IS_SET(ch->comm, COMM_TELNET_GA))
 			write_to_buffer(d, go_ahead_str, 0);
@@ -865,8 +874,8 @@ bool process_output(DESCRIPTOR_DATA *d, bool fPrompt)
 	 */
 	if (d->snoop_by != nullptr)
 	{
-		if (d->character != nullptr)
-			write_to_buffer(d->snoop_by, d->character->name, 0);
+		if (Deref(d->character) != nullptr)
+			write_to_buffer(d->snoop_by, Deref(d->character)->name, 0);
 
 		write_to_buffer(d->snoop_by, "> ", 2);
 		write_to_buffer(d->snoop_by, d->outbuf, d->outtop);
@@ -1083,9 +1092,9 @@ void bust_a_prompt(CHAR_DATA *ch)
 					for (d = descriptor_list; d != nullptr; d = d->next)
 					{
 						if (d->connected == CON_PLAYING
-							&& d->character->in_room != nullptr
-							&& d->character->in_room->area == ch->in_room->area
-							&& !is_immortal(d->character))
+							&& Deref(d->character)->in_room != nullptr
+							&& Deref(d->character)->in_room->area == ch->in_room->area
+							&& !is_immortal(Deref(d->character)))
 						{
 							number_people++;
 						}
@@ -1107,9 +1116,9 @@ void bust_a_prompt(CHAR_DATA *ch)
 					for (d = descriptor_list; d != nullptr; d = d->next)
 					{
 						if (d->connected == CON_PLAYING
-							&& d->character->in_room != nullptr
-							&& d->character->in_room->area == ch->in_room->area
-							&& can_see(ch, d->character))
+							&& Deref(d->character)->in_room != nullptr
+							&& Deref(d->character)->in_room->area == ch->in_room->area
+							&& can_see(ch, Deref(d->character)))
 						{
 							number_people++;
 						}
@@ -1131,7 +1140,7 @@ void bust_a_prompt(CHAR_DATA *ch)
 
 					for (d = descriptor_list; d != nullptr; d = d->next)
 					{
-						if (d->connected == CON_PLAYING && can_see(ch, d->character))
+						if (d->connected == CON_PLAYING && can_see(ch, Deref(d->character)))
 							number_people++;
 					}
 
@@ -1319,7 +1328,7 @@ bool output_buffer(DESCRIPTOR_DATA *d)
 				act = true;
 				break;
 			case 'n':
-				if (d->character && is_ansi(d->character))
+				if (Deref(d->character) && is_ansi(Deref(d->character)))
 					sprintf(buf2, "%s", ANSI_NORMAL);
 				else
 					buf2[0] = '\0';
@@ -1335,7 +1344,7 @@ bool output_buffer(DESCRIPTOR_DATA *d)
 
 		if (act)
 		{
-			if (d->character && is_ansi(d->character))
+			if (Deref(d->character) && is_ansi(Deref(d->character)))
 			{
 				sprintf(buf2, "%s", color_value_string(color, bold, flash));
 				color_code = true;
@@ -1467,7 +1476,7 @@ void nanny(DESCRIPTOR_DATA *d, char *argument)
 		argument++;
 	}
 
-	ch = d->character;
+	ch = Deref(d->character);
 
 	switch (d->connected)
 	{
@@ -1503,7 +1512,7 @@ void nanny(DESCRIPTOR_DATA *d, char *argument)
 			}
 
 			fOld = load_char_obj(d, argument);
-			ch = d->character;
+			ch = Deref(d->character);
 
 			if (IS_SET(ch->act, PLR_DENY))
 			{
@@ -1578,8 +1587,7 @@ void nanny(DESCRIPTOR_DATA *d, char *argument)
 				case 'n':
 					write_to_buffer(d, "Thank you.  Please select a more suitable name: ", 0);
 
-					free_char(d->character);
-					d->character = nullptr;
+					free_char(Deref(d->character));
 					d->connected = CON_GET_NAME;
 					return;
 				default:
@@ -1667,15 +1675,21 @@ void nanny(DESCRIPTOR_DATA *d, char *argument)
 					for (d_old = descriptor_list; d_old != nullptr; d_old = d_next)
 					{
 						d_next = d_old->next;
-						if (d_old == d || d_old->character == nullptr)
+						CHAR_DATA *oldDriving = Deref(d_old->character);
+						CHAR_DATA *oldSwitchedFrom = Deref(d_old->original);
+						char *oldName;
+
+						if (d_old == d || oldDriving == nullptr)
 							continue;
 
-						if (str_cmp((ch->true_name ? ch->true_name : ch->name), d_old->original
-							? d_old->original->name
-							: (d_old->character->true_name ? d_old->character->true_name : d_old->character->name)))
-						{
+						oldName = oldSwitchedFrom
+							? oldSwitchedFrom->name
+							: (oldDriving->true_name ? oldDriving->true_name : oldDriving->name);
+
+						// str_cmp is true when the names DIFFER, so this skips
+						// every connection that is not the same player.
+						if (str_cmp((ch->true_name ? ch->true_name : ch->name), oldName))
 							continue;
-						}
 
 						close_socket(d_old);
 					}
@@ -1685,10 +1699,9 @@ void nanny(DESCRIPTOR_DATA *d, char *argument)
 
 					write_to_buffer(d, "Reconnect attempt failed.\n\rName: ", 0);
 
-					if (d->character != nullptr)
+					if (Deref(d->character) != nullptr)
 					{
-						free_char(d->character);
-						d->character = nullptr;
+						free_char(Deref(d->character));
 					}
 
 					d->connected = CON_GET_NAME;
@@ -1697,10 +1710,9 @@ void nanny(DESCRIPTOR_DATA *d, char *argument)
 				case 'N':
 					write_to_buffer(d, "Name: ", 0);
 
-					if (d->character != nullptr)
+					if (Deref(d->character) != nullptr)
 					{
-						free_char(d->character);
-						d->character = nullptr;
+						free_char(Deref(d->character));
 					}
 
 					d->connected = CON_GET_NAME;
@@ -1745,8 +1757,7 @@ void nanny(DESCRIPTOR_DATA *d, char *argument)
 				case 'n':
 				case 'N':
 					write_to_buffer(d, "Ok, what IS it, then? ", 0);
-					free_char(d->character);
-					d->character = nullptr;
+					free_char(Deref(d->character));
 					d->connected = CON_GET_NAME;
 					break;
 				default:
@@ -2961,16 +2972,22 @@ bool check_reconnect(DESCRIPTOR_DATA *d, char *name, bool fConn)
 	CHAR_DATA *ch, *fch, *fch_next;
 	OBJ_DATA *obj;
 
+	// The half-built character sitting on the login screen, which this function
+	// either copies a password out of or replaces with the reconnected body.
+	// Read once -- nothing below frees it until the free_char that ends its
+	// life, and nothing reads it after that.
+	CHAR_DATA *pending = Deref(d->character);
+
 	for (ch = char_list; ch != nullptr; ch = ch->next)
 	{
 		if (!is_npc(ch)
 			&& (!fConn || ch->desc == nullptr)
-			&& !str_cmp((d->character->true_name ? d->character->true_name : d->character->name), (ch->true_name ? ch->true_name : ch->name)))
+			&& !str_cmp((pending->true_name ? pending->true_name : pending->name), (ch->true_name ? ch->true_name : ch->name)))
 		{
 			if (fConn == false)
 			{
-				free_pstring(d->character->pcdata->pwd);
-				d->character->pcdata->pwd = palloc_string(ch->pcdata->pwd);
+				free_pstring(pending->pcdata->pwd);
+				pending->pcdata->pwd = palloc_string(ch->pcdata->pwd);
 			}
 			else
 			{
@@ -2979,14 +2996,14 @@ bool check_reconnect(DESCRIPTOR_DATA *d, char *name, bool fConn)
 					fch_next = fch->next;
 					if (is_npc(fch)
 						&& (is_affected(fch, gsn_animate_dead) || is_affected_by(fch, AFF_CHARM))
-						&& Deref(fch->master) == d->character)
+						&& Deref(fch->master) == pending)
 					{
 						extract_char(fch, true);
 					}
 				}
 
-				free_char(d->character);
-				d->character = ch;
+				free_char(pending);
+				d->character = ch->self;
 
 				ch->desc = d;
 				ch->timer = 0;
@@ -3025,11 +3042,18 @@ bool check_playing(DESCRIPTOR_DATA *d, char *name)
 
 	for (dold = descriptor_list; dold; dold = dold->next)
 	{
+		// A switched immortal answers to the name of their own body, not the
+		// mob they are driving -- hence the original-first pick. The guard
+		// stays on `character`, as it always has: this loop is looking for
+		// connections that are driving somebody.
+		CHAR_DATA *driving = Deref(dold->character);
+		CHAR_DATA *switchedFrom = Deref(dold->original);
+
 		if (dold != d
-			&& dold->character != nullptr
+			&& driving != nullptr
 			&& dold->connected != CON_GET_NAME
 			&& dold->connected != CON_GET_OLD_PASSWORD
-			&& !str_cmp(name, dold->original ? dold->original->true_name : dold->character->true_name))
+			&& !str_cmp(name, switchedFrom ? switchedFrom->true_name : driving->true_name))
 		{
 			write_to_buffer(d, "That character is already playing.\n\r", 0);
 			write_to_buffer(d, "Do you wish to connect anyway (Y/N)?", 0);
@@ -3126,8 +3150,8 @@ void show_string(struct descriptor_data *d, char *input)
 		return;
 	}
 
-	if (d->character)
-		show_lines = d->character->lines;
+	if (Deref(d->character))
+		show_lines = Deref(d->character)->lines;
 	else
 		show_lines = 0;
 
@@ -3202,18 +3226,18 @@ void act_area(const char *format, CHAR_DATA *ch, CHAR_DATA *victim)
 	for (d = descriptor_list; d != nullptr; d = d->next)
 	{
 		if (d->connected == CON_PLAYING
-			&& d->character
-			&& d->character->in_room != nullptr
-			&& d->character->in_room->area == ch->in_room->area
-			&& !IS_SET(d->character->comm, COMM_QUIET))
+			&& Deref(d->character)
+			&& Deref(d->character)->in_room != nullptr
+			&& Deref(d->character)->in_room->area == ch->in_room->area
+			&& !IS_SET(Deref(d->character)->comm, COMM_QUIET))
 		{
-			if (IS_SET(d->character->in_room->room_flags, ROOM_SILENCE))
+			if (IS_SET(Deref(d->character)->in_room->room_flags, ROOM_SILENCE))
 				continue;
 
-			if (!is_awake(d->character))
+			if (!is_awake(Deref(d->character)))
 				continue;
 
-			to = d->character;
+			to = Deref(d->character);
 
 			if ((!is_npc(to) && to->desc == nullptr))
 				continue;

--- a/code/comm.c
+++ b/code/comm.c
@@ -2846,10 +2846,10 @@ void nanny(DESCRIPTOR_DATA *d, char *argument)
 					RS.Logger.Warn("Failed to record login for [{}]", ch->true_name);
 			}
 
-			if (ch->pet != nullptr)
+			if (Deref(ch->pet) != nullptr)
 			{
-				char_to_room(ch->pet, ch->in_room);
-				act("$n awakens into the world of Shalar.", ch->pet, nullptr, nullptr, TO_ROOM);
+				char_to_room(Deref(ch->pet), ch->in_room);
+				act("$n awakens into the world of Shalar.", Deref(ch->pet), nullptr, nullptr, TO_ROOM);
 			}
 
 			if (ch->cabal != 0)
@@ -2979,7 +2979,7 @@ bool check_reconnect(DESCRIPTOR_DATA *d, char *name, bool fConn)
 					fch_next = fch->next;
 					if (is_npc(fch)
 						&& (is_affected(fch, gsn_animate_dead) || is_affected_by(fch, AFF_CHARM))
-						&& fch->master == d->character)
+						&& Deref(fch->master) == d->character)
 					{
 						extract_char(fch, true);
 					}

--- a/code/comm.c
+++ b/code/comm.c
@@ -843,7 +843,13 @@ bool process_output(DESCRIPTOR_DATA *d, bool fPrompt)
 			}
 		}
 
-		ch = Deref(d->original) ? Deref(d->original) : Deref(d->character);
+		CHAR_DATA *original = Deref(d->original);
+
+		// Re-read rather than reusing the local above: the write_to_buffer calls
+		// in the battle prompt can overflow the output buffer, and that closes
+		// the socket and frees the character.
+		ch = original ? original : Deref(d->character);
+
 		if (!IS_SET(ch->comm, COMM_COMPACT))
 			write_to_buffer(d, "\n\r", 2);
 		if (!is_npc(ch) && ch->pcdata->entering_text)
@@ -868,8 +874,10 @@ bool process_output(DESCRIPTOR_DATA *d, bool fPrompt)
 
 	if (snooper != nullptr)
 	{
-		if (Deref(d->character) != nullptr)
-			write_to_buffer(snooper, Deref(d->character)->name, 0);
+		CHAR_DATA *snooped = Deref(d->character);
+
+		if (snooped != nullptr)
+			write_to_buffer(snooper, snooped->name, 0);
 
 		write_to_buffer(snooper, "> ", 2);
 		write_to_buffer(snooper, d->outbuf, d->outtop);
@@ -1085,10 +1093,12 @@ void bust_a_prompt(CHAR_DATA *ch)
 
 					for (d = descriptor_list; d != nullptr; d = d->next)
 					{
+						CHAR_DATA *wch = Deref(d->character);
+
 						if (d->connected == CON_PLAYING
-							&& Deref(d->character)->in_room != nullptr
-							&& Deref(d->character)->in_room->area == ch->in_room->area
-							&& !is_immortal(Deref(d->character)))
+							&& wch->in_room != nullptr
+							&& wch->in_room->area == ch->in_room->area
+							&& !is_immortal(wch))
 						{
 							number_people++;
 						}
@@ -1109,10 +1119,12 @@ void bust_a_prompt(CHAR_DATA *ch)
 					number_people = 0;
 					for (d = descriptor_list; d != nullptr; d = d->next)
 					{
+						CHAR_DATA *wch = Deref(d->character);
+
 						if (d->connected == CON_PLAYING
-							&& Deref(d->character)->in_room != nullptr
-							&& Deref(d->character)->in_room->area == ch->in_room->area
-							&& can_see(ch, Deref(d->character)))
+							&& wch->in_room != nullptr
+							&& wch->in_room->area == ch->in_room->area
+							&& can_see(ch, wch))
 						{
 							number_people++;
 						}
@@ -1220,6 +1232,10 @@ bool output_buffer(DESCRIPTOR_DATA *d)
 	if (d == nullptr)
 		return false;
 
+	// Safe to hold across the whole rewrite: this function only transforms the
+	// buffer, it never writes to one, so nothing here can close the connection.
+	CHAR_DATA *ch = Deref(d->character);
+
 	memset(buf, '\0', MAX_STRING_LENGTH);
 	point = buf;
 	str = d->outbuf;
@@ -1322,7 +1338,7 @@ bool output_buffer(DESCRIPTOR_DATA *d)
 				act = true;
 				break;
 			case 'n':
-				if (Deref(d->character) && is_ansi(Deref(d->character)))
+				if (ch && is_ansi(ch))
 					sprintf(buf2, "%s", ANSI_NORMAL);
 				else
 					buf2[0] = '\0';
@@ -1338,7 +1354,7 @@ bool output_buffer(DESCRIPTOR_DATA *d)
 
 		if (act)
 		{
-			if (Deref(d->character) && is_ansi(Deref(d->character)))
+			if (ch && is_ansi(ch))
 			{
 				sprintf(buf2, "%s", color_value_string(color, bold, flash));
 				color_code = true;
@@ -1666,6 +1682,7 @@ void nanny(DESCRIPTOR_DATA *d, char *argument)
 			{
 				case 'y':
 				case 'Y':
+				{
 					for (d_old = descriptor_list; d_old != nullptr; d_old = d_next)
 					{
 						d_next = d_old->next;
@@ -1693,24 +1710,31 @@ void nanny(DESCRIPTOR_DATA *d, char *argument)
 
 					write_to_buffer(d, "Reconnect attempt failed.\n\rName: ", 0);
 
-					if (Deref(d->character) != nullptr)
+					CHAR_DATA *failed = Deref(d->character);
+
+					if (failed != nullptr)
 					{
-						free_char(Deref(d->character));
+						free_char(failed);
 					}
 
 					d->connected = CON_GET_NAME;
 					break;
+				}
 				case 'n':
 				case 'N':
+				{
 					write_to_buffer(d, "Name: ", 0);
 
-					if (Deref(d->character) != nullptr)
+					CHAR_DATA *declined = Deref(d->character);
+
+					if (declined != nullptr)
 					{
-						free_char(Deref(d->character));
+						free_char(declined);
 					}
 
 					d->connected = CON_GET_NAME;
 					break;
+				}
 				default:
 					write_to_buffer(d, "Please type Y or N? ", 0);
 					break;

--- a/code/comm.c
+++ b/code/comm.c
@@ -3221,19 +3221,19 @@ void act_area(const char *format, CHAR_DATA *ch, CHAR_DATA *victim)
 	/*colorconv(format, format, ch);*/
 	for (d = descriptor_list; d != nullptr; d = d->next)
 	{
+		to = Deref(d->character);
+
 		if (d->connected == CON_PLAYING
-			&& Deref(d->character)
-			&& Deref(d->character)->in_room != nullptr
-			&& Deref(d->character)->in_room->area == ch->in_room->area
-			&& !IS_SET(Deref(d->character)->comm, COMM_QUIET))
+			&& to
+			&& to->in_room != nullptr
+			&& to->in_room->area == ch->in_room->area
+			&& !IS_SET(to->comm, COMM_QUIET))
 		{
-			if (IS_SET(Deref(d->character)->in_room->room_flags, ROOM_SILENCE))
+			if (IS_SET(to->in_room->room_flags, ROOM_SILENCE))
 				continue;
 
-			if (!is_awake(Deref(d->character)))
+			if (!is_awake(to))
 				continue;
-
-			to = Deref(d->character);
 
 			if ((!is_npc(to) && Deref(to->desc) == nullptr))
 				continue;

--- a/code/comm.c
+++ b/code/comm.c
@@ -2809,7 +2809,7 @@ void nanny(DESCRIPTOR_DATA *d, char *argument)
 				for (obj = object_list; obj != nullptr; obj = obj_next)
 				{
 					obj_next = obj->next;
-					if (obj->carried_by == ch)
+					if (obj->carried_by == ch->self)
 					{
 						if (isCabalItem(obj))
 						{

--- a/code/comm.c
+++ b/code/comm.c
@@ -57,6 +57,7 @@
 #include <stdlib.h>
 #include <algorithm>
 #include "merc.h"
+#include "entity/handles.h"
 #include "comm.h"
 #include "recycle.h"
 #include "tables.h"
@@ -815,7 +816,7 @@ bool process_output(DESCRIPTOR_DATA *d, bool fPrompt)
 		ch = d->character;
 
 		/* battle prompt */
-		if ((victim = ch->fighting) != nullptr)
+		if ((victim = Deref(ch->fighting)) != nullptr)
 		{
 			int percent;
 			char wound[100];

--- a/code/comm.c
+++ b/code/comm.c
@@ -576,19 +576,11 @@ void close_socket(DESCRIPTOR_DATA *dclose)
 	if (dclose->outtop > 0)
 		process_output(dclose, false);
 
-	if (dclose->snoop_by != nullptr)
-	{
-		write_to_buffer(dclose->snoop_by, "Your victim has left the game.\n\r", 0);
-	}
+	DESCRIPTOR_DATA *snooper = Deref(dclose->snoop_by);
 
+	if (snooper != nullptr)
 	{
-		DESCRIPTOR_DATA *d;
-
-		for (d = descriptor_list; d != nullptr; d = d->next)
-		{
-			if (d->snoop_by == dclose)
-				d->snoop_by = nullptr;
-		}
+		write_to_buffer(snooper, "Your victim has left the game.\n\r", 0);
 	}
 
 	if ((ch = Deref(dclose->character)) != nullptr)
@@ -872,13 +864,15 @@ bool process_output(DESCRIPTOR_DATA *d, bool fPrompt)
 	/*
 	 * Snoop-o-rama.
 	 */
-	if (d->snoop_by != nullptr)
+	DESCRIPTOR_DATA *snooper = Deref(d->snoop_by);
+
+	if (snooper != nullptr)
 	{
 		if (Deref(d->character) != nullptr)
-			write_to_buffer(d->snoop_by, Deref(d->character)->name, 0);
+			write_to_buffer(snooper, Deref(d->character)->name, 0);
 
-		write_to_buffer(d->snoop_by, "> ", 2);
-		write_to_buffer(d->snoop_by, d->outbuf, d->outtop);
+		write_to_buffer(snooper, "> ", 2);
+		write_to_buffer(snooper, d->outbuf, d->outtop);
 	}
 
 	/*

--- a/code/db.c
+++ b/code/db.c
@@ -3944,7 +3944,10 @@ void load_rooms(FILE *fp)
 
 		fBootDb = true;
 
-		pRoomIndex = new ROOM_INDEX_DATA;
+		// Value-init, not default-init: the scalar members are read before
+		// anything assigns them -- `rune` in particular, which is now the only
+		// record of whether this room carries one.
+		pRoomIndex = new ROOM_INDEX_DATA();
 		pRoomIndex->reset_first = nullptr;
 		pRoomIndex->reset_last = nullptr;
 		pRoomIndex->owner = palloc_string("");
@@ -3973,7 +3976,6 @@ void load_rooms(FILE *fp)
 		pRoomIndex->rprogs = nullptr;
 		zero_vector(pRoomIndex->progtypes);
 		pRoomIndex->cabal = 0;
-		pRoomIndex->has_rune= false;
 
 		zero_vector(pRoomIndex->affected_by);
 		if (pRoomIndex->area->area_type == ARE_SHRINE)
@@ -4032,7 +4034,11 @@ void load_rooms(FILE *fp)
 					exit(1);
 				}
 
-				pexit = new EXIT_DATA;
+				// Value-init for the same reason as the room above. This one
+				// was the worse of the two: nothing zeroed the exit's rune
+				// fields at all, so every exit in the world booted with an
+				// indeterminate rune pointer behind an indeterminate flag.
+				pexit = new EXIT_DATA();
 				pexit->u1.vnum = fread_number(fp);
 				fread_flag_new(pexit->exit_info, fp);
 				pexit->key = fread_number(fp);

--- a/code/db.c
+++ b/code/db.c
@@ -1745,7 +1745,7 @@ void reset_room(ROOM_INDEX_DATA *pRoom)
 					break;
 
 				add_follower(LastMob, rch);
-				LastMob->leader = rch;
+				LastMob->leader = rch->self;
 				break;
 			case 'D':
 				pRoomIndex = get_room_index(pReset->arg1);

--- a/code/db.c
+++ b/code/db.c
@@ -2414,46 +2414,6 @@ void clone_object(OBJ_DATA *parent, OBJ_DATA *clone)
 }
 
 /*
- * Clear a new character.
- */
-void clear_char(CHAR_DATA *ch)
-{
-	int i;
-
-	*ch = CHAR_DATA();
-	ch->name = &str_empty[0];
-	ch->short_descr = &str_empty[0];
-	ch->long_descr = &str_empty[0];
-	ch->description = &str_empty[0];
-	ch->prompt = &str_empty[0];
-	ch->logon = current_time;
-	ch->lines = PAGELEN;
-
-	for (i = 0; i < 4; i++)
-	{
-		ch->armor[i] = 0;
-	}
-
-	ch->position = POS_STANDING;
-	ch->hit = 20;
-	ch->max_hit = 20;
-	ch->mana = 100;
-	ch->max_mana = 100;
-	ch->move = 100;
-	ch->max_move = 100;
-	ch->last_fought = nullptr;
-	ch->last_fight_time = 0;
-	ch->last_fight_name = nullptr;
-	ch->on = nullptr;
-	ch->hometown = 0;
-	ch->arms = 2;
-	ch->legs = 2;
-	ch->balance = 0;
-	ch->regen_rate = 0;
-	ch->ghost = 0;
-}
-
-/*
  * Get an extra description from a list.
  */
 char *get_extra_descr(const char *name, const std::list<EXTRA_DESCR_DATA> &eds)

--- a/code/db.c
+++ b/code/db.c
@@ -3823,7 +3823,7 @@ void do_llimit(CHAR_DATA *ch, char *argument)
 
 	for (obj = object_list; obj != nullptr; obj = obj->next)
 	{
-		carrier = obj->carried_by;
+		carrier = Deref(obj->carried_by);
 
 		if (carrier != nullptr && !is_npc(carrier))
 			continue;

--- a/code/db.c
+++ b/code/db.c
@@ -45,6 +45,7 @@
 #include "merc.h"
 #include "db.h"
 #include "db2.h"
+#include "entity/handles.h"
 #include "rift.h"
 #include "recycle.h"
 #include "lookup.h"
@@ -85,6 +86,10 @@ SHOP_DATA *shop_last;
 
 char bug_buf[2 * MAX_INPUT_LENGTH];
 CHAR_DATA *char_list;
+// The same entities as char_list/object_list, indexed so a cross-reference can
+// be checked for liveness instead of trusted. See entity/handles.h.
+SlotMap<CHAR_DATA> charHandles;
+SlotMap<OBJ_DATA> objectHandles;
 char *help_greeting;
 char log_buf[2 * MAX_INPUT_LENGTH];
 KILL_DATA kill_table[MAX_LEVEL];

--- a/code/db.c
+++ b/code/db.c
@@ -90,6 +90,7 @@ CHAR_DATA *char_list;
 // be checked for liveness instead of trusted. See entity/handles.h.
 SlotMap<CHAR_DATA> charHandles;
 SlotMap<OBJ_DATA> objectHandles;
+SlotMap<DESCRIPTOR_DATA> descriptorHandles;
 char *help_greeting;
 char log_buf[2 * MAX_INPUT_LENGTH];
 KILL_DATA kill_table[MAX_LEVEL];

--- a/code/db.h
+++ b/code/db.h
@@ -679,7 +679,6 @@ CHAR_DATA *create_mobile (MOB_INDEX_DATA *pMobIndex);
 void clone_mobile (CHAR_DATA *parent, CHAR_DATA *clone);
 OBJ_DATA *create_object (OBJ_INDEX_DATA *pObjIndex, int level);
 void clone_object (OBJ_DATA *parent, OBJ_DATA *clone);
-void clear_char(CHAR_DATA *ch);
 char *get_extra_descr (const char *name, const std::list<EXTRA_DESCR_DATA> &eds);
 MOB_INDEX_DATA *get_mob_index (int vnum);
 OBJ_INDEX_DATA *get_obj_index(int vnum);

--- a/code/devextra.c
+++ b/code/devextra.c
@@ -9,6 +9,7 @@
 #include <algorithm>
 #include <iterator>
 #include "merc.h"
+#include "entity/handles.h"
 #include "devextra.h"
 #include "rift.h"
 #include "stdlibs/cfilesystem.h"
@@ -1124,7 +1125,7 @@ bool check_volley(CHAR_DATA *ch, CHAR_DATA *victim)
 
 	skill = get_skill(victim, gsn_volley);
 
-	if (!skill || victim->fighting || !is_awake(victim) || victim == ch)
+	if (!skill || Deref(victim->fighting) || !is_awake(victim) || victim == ch)
 		return false;
 
 	if (get_trust(victim) == MAX_LEVEL)
@@ -2246,7 +2247,7 @@ void do_commune(CHAR_DATA *ch, char *argument)
 		case TAR_CHAR_OFFENSIVE:
 			if (arg2[0] == '\0')
 			{
-				victim = ch->fighting;
+				victim = Deref(ch->fighting);
 
 				if (victim == nullptr)
 				{
@@ -2332,7 +2333,7 @@ void do_commune(CHAR_DATA *ch, char *argument)
 		case TAR_OBJ_CHAR_OFF:
 			if (arg2[0] == '\0')
 			{
-				victim = ch->fighting;
+				victim = Deref(ch->fighting);
 
 				if (victim == nullptr)
 				{
@@ -2442,7 +2443,7 @@ void do_commune(CHAR_DATA *ch, char *argument)
 
 		if (skill_table[sn].target == TAR_CHAR_OFFENSIVE)
 		{
-			if (!is_npc(ch) && !is_npc(victim) && (ch->fighting == nullptr || victim->fighting == nullptr))
+			if (!is_npc(ch) && !is_npc(victim) && (Deref(ch->fighting) == nullptr || Deref(victim->fighting) == nullptr))
 			{
 				switch (number_range(0, 2))
 				{
@@ -2524,7 +2525,7 @@ void do_commune(CHAR_DATA *ch, char *argument)
 		for (vch = ch->in_room->people; vch; vch = vch_next)
 		{
 			vch_next = vch->next_in_room;
-			if (victim == vch && victim->fighting == nullptr)
+			if (victim == vch && Deref(victim->fighting) == nullptr)
 			{
 				multi_hit(victim, ch, TYPE_UNDEFINED);
 				break;
@@ -2606,7 +2607,7 @@ void do_call(CHAR_DATA *ch, char *argument)
 		case TAR_CHAR_OFFENSIVE:
 			if (arg2[0] == '\0')
 			{
-				victim = ch->fighting;
+				victim = Deref(ch->fighting);
 
 				if (victim == nullptr)
 				{
@@ -2682,7 +2683,7 @@ void do_call(CHAR_DATA *ch, char *argument)
 		case TAR_OBJ_CHAR_OFF:
 			if (arg2[0] == '\0')
 			{
-				victim = ch->fighting;
+				victim = Deref(ch->fighting);
 
 				if (victim == nullptr)
 				{
@@ -2789,7 +2790,7 @@ void do_call(CHAR_DATA *ch, char *argument)
 
 		if (skill_table[sn].target == TAR_CHAR_OFFENSIVE)
 		{
-			if (!is_npc(ch) && !is_npc(victim) && (ch->fighting == nullptr || victim->fighting == nullptr))
+			if (!is_npc(ch) && !is_npc(victim) && (Deref(ch->fighting) == nullptr || Deref(victim->fighting) == nullptr))
 			{
 				switch (number_range(0, 2))
 				{
@@ -2833,7 +2834,7 @@ void do_call(CHAR_DATA *ch, char *argument)
 		{
 			vch_next = vch->next_in_room;
 
-			if (victim == vch && victim->fighting == nullptr)
+			if (victim == vch && Deref(victim->fighting) == nullptr)
 			{
 				multi_hit(victim, ch, TYPE_UNDEFINED);
 				break;

--- a/code/devextra.c
+++ b/code/devextra.c
@@ -108,16 +108,16 @@ void do_pswitch(CHAR_DATA *ch, char *argument)
 	if (!CFileSystem::Copy(ploadSource, ploadDest))
 		RS.Logger.Warn("Failed to copy [{}] to [{}]", ploadSource, ploadDest);
 
-	d->character->desc = nullptr;
-	d->character->next = char_list;
-	char_list = d->character;
+	Deref(d->character)->desc = nullptr;
+	Deref(d->character)->next = char_list;
+	char_list = Deref(d->character);
 	d->outsize = 2000;
 	d->outbuf = new char[d->outsize];
 	d->connected = CON_PLAYING;
-	reset_char(d->character);
+	reset_char(Deref(d->character));
 
-	victim = d->character;
-	d->character->pcdata->host = palloc_string("PLOAD");
+	victim = Deref(d->character);
+	Deref(d->character)->pcdata->host = palloc_string("PLOAD");
 }
 
 void do_gold(CHAR_DATA *ch, char *argument)
@@ -218,16 +218,16 @@ void clean_mud()
 
 			if (!load_char_obj(d, tbuf))
 			{
-				free_char(d->character);
+				free_char(Deref(d->character));
 				continue;
 			}
 
-			d->character->desc = nullptr;
+			Deref(d->character)->desc = nullptr;
 
-			if (d->character->level >= 30)
-				perm_death_log(d->character, 4);
+			if (Deref(d->character)->level >= 30)
+				perm_death_log(Deref(d->character), 4);
 
-			delete_char(d->character->true_name, true);
+			delete_char(Deref(d->character)->true_name, true);
 		}
 
 		free_descriptor(d);
@@ -250,7 +250,7 @@ void clean_mud()
 				RS.Logger.Info("Deleting player...");
 			}
 
-			free_char(d->character);
+			free_char(Deref(d->character));
 		}
 
 		free_descriptor(d);
@@ -1043,15 +1043,15 @@ void mob_recho(CHAR_DATA *ch, char *argument)
 	for (DESCRIPTOR_DATA *d = descriptor_list; d; d = d->next)
 	{
 		if (d->connected == CON_PLAYING
-			&& d->character->in_room == ch->in_room
-			&& is_awake(d->character)
-			&& d->character != ch)
+			&& Deref(d->character)->in_room == ch->in_room
+			&& is_awake(Deref(d->character))
+			&& Deref(d->character) != ch)
 		{
-			if (get_trust(d->character) >= 55)
-				send_to_char("local mob> ", d->character);
+			if (get_trust(Deref(d->character)) >= 55)
+				send_to_char("local mob> ", Deref(d->character));
 
-			send_to_char(argument, d->character);
-			send_to_char("\n\r", d->character);
+			send_to_char(argument, Deref(d->character));
+			send_to_char("\n\r", Deref(d->character));
 		}
 	}
 }
@@ -1063,13 +1063,13 @@ void area_echo(CHAR_DATA *ch, char *echo)
 	for (DESCRIPTOR_DATA *d = descriptor_list; d; d = d->next)
 	{
 		if (d->connected == CON_PLAYING
-			&& d->character->in_room != nullptr
+			&& Deref(d->character)->in_room != nullptr
 			&& ch->in_room != nullptr
-			&& d->character->in_room->area == ch->in_room->area)
+			&& Deref(d->character)->in_room->area == ch->in_room->area)
 		{
-			colorconv(buffer, echo, d->character);
-			send_to_char(buffer, d->character);
-			send_to_char("\n\r", d->character);
+			colorconv(buffer, echo, Deref(d->character));
+			send_to_char(buffer, Deref(d->character));
+			send_to_char("\n\r", Deref(d->character));
 		}
 	}
 }
@@ -1081,13 +1081,13 @@ void rarea_echo(ROOM_INDEX_DATA *room, char *echo)
 	for (DESCRIPTOR_DATA *d = descriptor_list; d; d = d->next)
 	{
 		if (d->connected == CON_PLAYING
-			&& d->character->in_room != nullptr
+			&& Deref(d->character)->in_room != nullptr
 			&& room != nullptr
-			&& d->character->in_room->area == room->area)
+			&& Deref(d->character)->in_room->area == room->area)
 		{
-			colorconv(buffer, echo, d->character);
-			send_to_char(buffer, d->character);
-			send_to_char("\n\r", d->character);
+			colorconv(buffer, echo, Deref(d->character));
+			send_to_char(buffer, Deref(d->character));
+			send_to_char("\n\r", Deref(d->character));
 		}
 	}
 }
@@ -1099,17 +1099,17 @@ void outdoors_echo(AREA_DATA *area, char *echo)
 	for (DESCRIPTOR_DATA *d = descriptor_list; d; d = d->next)
 	{
 		if (d->connected == CON_PLAYING
-			&& d->character->in_room != nullptr
+			&& Deref(d->character)->in_room != nullptr
 			&& area != nullptr
-			&& d->character->in_room->area == area
-			&& d->character->in_room->sector_type != SECT_INSIDE
-			&& d->character->in_room->sector_type != SECT_UNDERWATER
-			&& is_awake(d->character)
-			&& !IS_SET(d->character->in_room->room_flags, ROOM_INDOORS))
+			&& Deref(d->character)->in_room->area == area
+			&& Deref(d->character)->in_room->sector_type != SECT_INSIDE
+			&& Deref(d->character)->in_room->sector_type != SECT_UNDERWATER
+			&& is_awake(Deref(d->character))
+			&& !IS_SET(Deref(d->character)->in_room->room_flags, ROOM_INDOORS))
 		{
-			colorconv(buffer, echo, d->character);
-			send_to_char(buffer, d->character);
-			send_to_char("\n\r", d->character);
+			colorconv(buffer, echo, Deref(d->character));
+			send_to_char(buffer, Deref(d->character));
+			send_to_char("\n\r", Deref(d->character));
 		}
 	}
 }
@@ -1148,8 +1148,8 @@ char *get_char_color(CHAR_DATA *ch, char *event)
 	if (IS_SET(ch->comm, COMM_LOTS_O_COLOR))
 		return color_table[number_range(0, MAX_COLORS - 1)].color_ascii;
 
-	if (ch->desc != nullptr && ch->desc->original != nullptr)
-		ch = ch->desc->original;
+	if (ch->desc != nullptr && Deref(ch->desc->original) != nullptr)
+		ch = Deref(ch->desc->original);
 
 	if (is_npc(ch))
 		return "";
@@ -1214,9 +1214,9 @@ char *END_COLOR(CHAR_DATA *ch)
 	if (IS_SET(ch->comm, COMM_LOTS_O_COLOR))
 		return color_table[number_range(0, MAX_COLORS - 1)].color_ascii;
 
-	if (ch->desc != nullptr && ch->desc->original != nullptr)
+	if (ch->desc != nullptr && Deref(ch->desc->original) != nullptr)
 	{
-		if (IS_SET(ch->desc->original->comm, COMM_ANSI))
+		if (IS_SET(Deref(ch->desc->original)->comm, COMM_ANSI))
 			return "\x01B[0m";
 		else
 			return "";

--- a/code/devextra.c
+++ b/code/devextra.c
@@ -1042,16 +1042,18 @@ void mob_recho(CHAR_DATA *ch, char *argument)
 
 	for (DESCRIPTOR_DATA *d = descriptor_list; d; d = d->next)
 	{
-		if (d->connected == CON_PLAYING
-			&& Deref(d->character)->in_room == ch->in_room
-			&& is_awake(Deref(d->character))
-			&& Deref(d->character) != ch)
-		{
-			if (get_trust(Deref(d->character)) >= 55)
-				send_to_char("local mob> ", Deref(d->character));
+		CHAR_DATA *wch = Deref(d->character);
 
-			send_to_char(argument, Deref(d->character));
-			send_to_char("\n\r", Deref(d->character));
+		if (d->connected == CON_PLAYING
+			&& wch->in_room == ch->in_room
+			&& is_awake(wch)
+			&& wch != ch)
+		{
+			if (get_trust(wch) >= 55)
+				send_to_char("local mob> ", wch);
+
+			send_to_char(argument, wch);
+			send_to_char("\n\r", wch);
 		}
 	}
 }
@@ -1098,18 +1100,20 @@ void outdoors_echo(AREA_DATA *area, char *echo)
 
 	for (DESCRIPTOR_DATA *d = descriptor_list; d; d = d->next)
 	{
+		CHAR_DATA *wch = Deref(d->character);
+
 		if (d->connected == CON_PLAYING
-			&& Deref(d->character)->in_room != nullptr
+			&& wch->in_room != nullptr
 			&& area != nullptr
-			&& Deref(d->character)->in_room->area == area
-			&& Deref(d->character)->in_room->sector_type != SECT_INSIDE
-			&& Deref(d->character)->in_room->sector_type != SECT_UNDERWATER
-			&& is_awake(Deref(d->character))
-			&& !IS_SET(Deref(d->character)->in_room->room_flags, ROOM_INDOORS))
+			&& wch->in_room->area == area
+			&& wch->in_room->sector_type != SECT_INSIDE
+			&& wch->in_room->sector_type != SECT_UNDERWATER
+			&& is_awake(wch)
+			&& !IS_SET(wch->in_room->room_flags, ROOM_INDOORS))
 		{
-			colorconv(buffer, echo, Deref(d->character));
-			send_to_char(buffer, Deref(d->character));
-			send_to_char("\n\r", Deref(d->character));
+			colorconv(buffer, echo, wch);
+			send_to_char(buffer, wch);
+			send_to_char("\n\r", wch);
 		}
 	}
 }

--- a/code/devextra.c
+++ b/code/devextra.c
@@ -108,16 +108,17 @@ void do_pswitch(CHAR_DATA *ch, char *argument)
 	if (!CFileSystem::Copy(ploadSource, ploadDest))
 		RS.Logger.Warn("Failed to copy [{}] to [{}]", ploadSource, ploadDest);
 
-	Deref(d->character)->desc = nullptr;
-	Deref(d->character)->next = char_list;
-	char_list = Deref(d->character);
+	victim = Deref(d->character);
+
+	victim->desc = nullptr;
+	victim->next = char_list;
+	char_list = victim;
 	d->outsize = 2000;
 	d->outbuf = new char[d->outsize];
 	d->connected = CON_PLAYING;
-	reset_char(Deref(d->character));
+	reset_char(victim);
 
-	victim = Deref(d->character);
-	Deref(d->character)->pcdata->host = palloc_string("PLOAD");
+	victim->pcdata->host = palloc_string("PLOAD");
 }
 
 void do_gold(CHAR_DATA *ch, char *argument)
@@ -222,12 +223,14 @@ void clean_mud()
 				continue;
 			}
 
-			Deref(d->character)->desc = nullptr;
+			CHAR_DATA *victim = Deref(d->character);
 
-			if (Deref(d->character)->level >= 30)
-				perm_death_log(Deref(d->character), 4);
+			victim->desc = nullptr;
 
-			delete_char(Deref(d->character)->true_name, true);
+			if (victim->level >= 30)
+				perm_death_log(victim, 4);
+
+			delete_char(victim->true_name, true);
 		}
 
 		free_descriptor(d);
@@ -1064,14 +1067,16 @@ void area_echo(CHAR_DATA *ch, char *echo)
 
 	for (DESCRIPTOR_DATA *d = descriptor_list; d; d = d->next)
 	{
+		CHAR_DATA *wch = Deref(d->character);
+
 		if (d->connected == CON_PLAYING
-			&& Deref(d->character)->in_room != nullptr
+			&& wch->in_room != nullptr
 			&& ch->in_room != nullptr
-			&& Deref(d->character)->in_room->area == ch->in_room->area)
+			&& wch->in_room->area == ch->in_room->area)
 		{
-			colorconv(buffer, echo, Deref(d->character));
-			send_to_char(buffer, Deref(d->character));
-			send_to_char("\n\r", Deref(d->character));
+			colorconv(buffer, echo, wch);
+			send_to_char(buffer, wch);
+			send_to_char("\n\r", wch);
 		}
 	}
 }
@@ -1082,14 +1087,16 @@ void rarea_echo(ROOM_INDEX_DATA *room, char *echo)
 
 	for (DESCRIPTOR_DATA *d = descriptor_list; d; d = d->next)
 	{
+		CHAR_DATA *wch = Deref(d->character);
+
 		if (d->connected == CON_PLAYING
-			&& Deref(d->character)->in_room != nullptr
+			&& wch->in_room != nullptr
 			&& room != nullptr
-			&& Deref(d->character)->in_room->area == room->area)
+			&& wch->in_room->area == room->area)
 		{
-			colorconv(buffer, echo, Deref(d->character));
-			send_to_char(buffer, Deref(d->character));
-			send_to_char("\n\r", Deref(d->character));
+			colorconv(buffer, echo, wch);
+			send_to_char(buffer, wch);
+			send_to_char("\n\r", wch);
 		}
 	}
 }

--- a/code/devextra.c
+++ b/code/devextra.c
@@ -1260,7 +1260,7 @@ void WAIT_STATE(CHAR_DATA *ch, int npulse)
 	{
 		raf = affect_find_room(ch->in_room->affected, gsn_gravity_well);
 
-		if (ch == raf->owner)
+		if (ch == Deref(raf->owner))
 			wait += PULSE_VIOLENCE;
 	}
 
@@ -2890,7 +2890,7 @@ void do_snare(CHAR_DATA *ch, char *argument)
 	af.duration = 24;
 	af.location = APPLY_NONE;
 	af.modifier = 0;
-	af.owner = ch;
+	af.owner = ch->self;
 	af.end_fun = nullptr;
 	af.tick_fun = nullptr;
 	new_affect_to_room(ch->in_room, &af);

--- a/code/devextra.c
+++ b/code/devextra.c
@@ -1012,7 +1012,7 @@ bool trusts(CHAR_DATA *ch, CHAR_DATA *victim)
 
 	if (is_npc(victim))
 	{
-		if (is_affected_by(victim, AFF_CHARM) && victim->master == ch)
+		if (is_affected_by(victim, AFF_CHARM) && Deref(victim->master) == ch)
 			return true;
 		else
 			return false;
@@ -2266,7 +2266,7 @@ void do_commune(CHAR_DATA *ch, char *argument)
 				}
 			}
 
-			if (is_affected_by(ch, AFF_CHARM) && ch->master == victim)
+			if (is_affected_by(ch, AFF_CHARM) && Deref(ch->master) == victim)
 			{
 				send_to_char("You can't do that on your own master.\n\r", ch);
 				return;
@@ -2353,7 +2353,7 @@ void do_commune(CHAR_DATA *ch, char *argument)
 
 			if (target == TARGET_CHAR) /* check the sanity of the attack */
 			{
-				if (is_affected_by(ch, AFF_CHARM) && ch->master == victim)
+				if (is_affected_by(ch, AFF_CHARM) && Deref(ch->master) == victim)
 				{
 					send_to_char("You can't do that on your own follower.\n\r", ch);
 					return;
@@ -2516,7 +2516,7 @@ void do_commune(CHAR_DATA *ch, char *argument)
 	if ((skill_table[sn].target == TAR_CHAR_OFFENSIVE
 			|| (skill_table[sn].target == TAR_OBJ_CHAR_OFF
 			&& target == TARGET_CHAR))
-		&& victim != ch && victim->master != ch)
+		&& victim != ch && Deref(victim->master) != ch)
 	{
 		CHAR_DATA *vch;
 		CHAR_DATA *vch_next;
@@ -2626,7 +2626,7 @@ void do_call(CHAR_DATA *ch, char *argument)
 				}
 			}
 
-			if (is_affected_by(ch, AFF_CHARM) && ch->master == victim)
+			if (is_affected_by(ch, AFF_CHARM) && Deref(ch->master) == victim)
 			{
 				send_to_char("You can't do that on your own master.\n\r", ch);
 				return;
@@ -2703,7 +2703,7 @@ void do_call(CHAR_DATA *ch, char *argument)
 
 			if (target == TARGET_CHAR) /* check the sanity of the attack */
 			{
-				if (is_affected_by(ch, AFF_CHARM) && ch->master == victim)
+				if (is_affected_by(ch, AFF_CHARM) && Deref(ch->master) == victim)
 				{
 					send_to_char("You can't do that on your own follower.\n\r", ch);
 					return;
@@ -2824,7 +2824,7 @@ void do_call(CHAR_DATA *ch, char *argument)
 	if ((skill_table[sn].target == TAR_CHAR_OFFENSIVE
 			|| (skill_table[sn].target == TAR_OBJ_CHAR_OFF && target == TARGET_CHAR))
 		&& victim != ch
-		&& victim->master != ch)
+		&& Deref(victim->master) != ch)
 	{
 		CHAR_DATA *vch;
 		CHAR_DATA *vch_next;

--- a/code/devextra.c
+++ b/code/devextra.c
@@ -1148,8 +1148,10 @@ char *get_char_color(CHAR_DATA *ch, char *event)
 	if (IS_SET(ch->comm, COMM_LOTS_O_COLOR))
 		return color_table[number_range(0, MAX_COLORS - 1)].color_ascii;
 
-	if (ch->desc != nullptr && Deref(ch->desc->original) != nullptr)
-		ch = Deref(ch->desc->original);
+	DESCRIPTOR_DATA *connection = Deref(ch->desc);
+
+	if (connection != nullptr && Deref(connection->original) != nullptr)
+		ch = Deref(connection->original);
 
 	if (is_npc(ch))
 		return "";
@@ -1214,9 +1216,11 @@ char *END_COLOR(CHAR_DATA *ch)
 	if (IS_SET(ch->comm, COMM_LOTS_O_COLOR))
 		return color_table[number_range(0, MAX_COLORS - 1)].color_ascii;
 
-	if (ch->desc != nullptr && Deref(ch->desc->original) != nullptr)
+	DESCRIPTOR_DATA *connection = Deref(ch->desc);
+
+	if (connection != nullptr && Deref(connection->original) != nullptr)
 	{
-		if (IS_SET(Deref(ch->desc->original)->comm, COMM_ANSI))
+		if (IS_SET(Deref(connection->original)->comm, COMM_ANSI))
 			return "\x01B[0m";
 		else
 			return "";
@@ -2114,7 +2118,7 @@ void do_commune(CHAR_DATA *ch, char *argument)
 	AFFECT_DATA af, *paf;
 	int target;
 
-	if (is_npc(ch) && ch->desc == nullptr)
+	if (is_npc(ch) && Deref(ch->desc) == nullptr)
 		return;
 
 	target_name = one_argument(argument, arg1);
@@ -2547,7 +2551,7 @@ void do_call(CHAR_DATA *ch, char *argument)
 	int sn;
 	int target;
 
-	if (is_npc(ch) && ch->desc == nullptr)
+	if (is_npc(ch) && Deref(ch->desc) == nullptr)
 		return;
 
 	target_name = one_argument(argument, arg1);

--- a/code/devextra.c
+++ b/code/devextra.c
@@ -1027,7 +1027,7 @@ bool trusts(CHAR_DATA *ch, CHAR_DATA *victim)
 	if (IS_SET(victim->pcdata->trust, TRUST_GROUP) && is_same_group(ch, victim))
 		return true;
 
-	if (victim->pcdata->trusting == ch)
+	if (Deref(victim->pcdata->trusting) == ch)
 		return true;
 
 	return false;

--- a/code/dioextra.c
+++ b/code/dioextra.c
@@ -1713,10 +1713,10 @@ void do_damage(CHAR_DATA *ch, char *argument)
 
 	damage_new(ch, victim, dam, TYPE_UNDEFINED, DAM_OTHER, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, argument);
 
-	if (ch->fighting == victim)
+	if (Deref(ch->fighting) == victim)
 		stop_fighting(ch, false);
 
-	if (victim->fighting == ch)
+	if (Deref(victim->fighting) == ch)
 		stop_fighting(victim, false);
 }
 

--- a/code/dioextra.c
+++ b/code/dioextra.c
@@ -156,20 +156,20 @@ void do_ghost(CHAR_DATA *ch, char *argument)
 		for (d = descriptor_list; d; d = d->next)
 		{
 			if (d->connected == CON_PLAYING
-				&& d->character != ch
-				&& d->character->in_room != nullptr
-				&& can_see(ch, d->character))
+				&& Deref(d->character) != ch
+				&& Deref(d->character)->in_room != nullptr
+				&& can_see(ch, Deref(d->character)))
 			{
 				if (!str_cmp(arg2, "yes"))
 				{
-					d->character->ghost = 15;
-					send_to_char("You have turned into an invincible ghost for several minutes.\n\r", d->character);
+					Deref(d->character)->ghost = 15;
+					send_to_char("You have turned into an invincible ghost for several minutes.\n\r", Deref(d->character));
 				}
 
 				if (!str_cmp(arg2, "no"))
 				{
-					d->character->ghost = 0;
-					send_to_char("You are no longer an invincible ghost.\n\r", d->character);
+					Deref(d->character)->ghost = 0;
+					send_to_char("You are no longer an invincible ghost.\n\r", Deref(d->character));
 				}
 			}
 		}
@@ -182,21 +182,21 @@ void do_ghost(CHAR_DATA *ch, char *argument)
 		for (d = descriptor_list; d; d = d->next)
 		{
 			if (d->connected == CON_PLAYING 
-				&& d->character != ch
-				&& d->character->in_room != nullptr
-				&& can_see(ch, d->character)
-				&& d->character->in_room->area == ch->in_room->area)
+				&& Deref(d->character) != ch
+				&& Deref(d->character)->in_room != nullptr
+				&& can_see(ch, Deref(d->character))
+				&& Deref(d->character)->in_room->area == ch->in_room->area)
 			{
 				if (!str_cmp(arg2, "yes"))
 				{
-					d->character->ghost = 15;
-					send_to_char("You have turned into an invincible ghost for a several minutes.\n\r", d->character);
+					Deref(d->character)->ghost = 15;
+					send_to_char("You have turned into an invincible ghost for a several minutes.\n\r", Deref(d->character));
 				}
 
 				if (!str_cmp(arg2, "no"))
 				{
-					d->character->ghost = 0;
-					send_to_char("You are no longer an invincible ghost.\n\r", d->character);
+					Deref(d->character)->ghost = 0;
+					send_to_char("You are no longer an invincible ghost.\n\r", Deref(d->character));
 				}
 			}
 		}
@@ -536,20 +536,20 @@ void do_ccb(CHAR_DATA *ch, char *argument)
 	{
 		if (d->connected == CON_PLAYING)
 		{
-			if ((d->character != ch
-					&& !IS_SET(d->character->comm, COMM_NOCABAL)
-					&& d->character->cabal
-					&& d->character->cabal == cabal)
-				|| (IS_SET(d->character->comm, COMM_ALL_CABALS)
-					&& d->character != ch))
+			if ((Deref(d->character) != ch
+					&& !IS_SET(Deref(d->character)->comm, COMM_NOCABAL)
+					&& Deref(d->character)->cabal
+					&& Deref(d->character)->cabal == cabal)
+				|| (IS_SET(Deref(d->character)->comm, COMM_ALL_CABALS)
+					&& Deref(d->character) != ch))
 			{
 				buffer = fmt::format("{}{}: {}{}{}\n\r",
 					cabal_table[cabal].who_name,
-					pers(ch, d->character),
-					get_char_color(d->character, "channels"),
+					pers(ch, Deref(d->character)),
+					get_char_color(Deref(d->character), "channels"),
 					arg2,
 					END_COLOR(ch));
-				send_to_char(buffer.c_str(), d->character);
+				send_to_char(buffer.c_str(), Deref(d->character));
 			}
 		}
 	}
@@ -1607,7 +1607,7 @@ bool auto_check_multi(DESCRIPTOR_DATA *d_check, char *host)
 {
 	for (DESCRIPTOR_DATA *d = descriptor_list; d != nullptr; d = d->next)
 	{
-		if (d == d_check || d->character == nullptr)
+		if (d == d_check || Deref(d->character) == nullptr)
 			continue;
 
 		if (!str_cmp(host, d->host))
@@ -1653,20 +1653,20 @@ void do_pload(CHAR_DATA *ch, char *argument)
 	if (!CFileSystem::Copy(ploadSource, ploadDest))
 		RS.Logger.Warn("Failed to copy [{}] to [{}]", ploadSource, ploadDest);
 
-	d->character->desc = nullptr;
-	d->character->next = char_list;
+	Deref(d->character)->desc = nullptr;
+	Deref(d->character)->next = char_list;
 
-	char_list = d->character;
+	char_list = Deref(d->character);
 
 	d->outsize = 2000;
 	d->outbuf = new char[d->outsize];
 	d->connected = CON_PLAYING;
 
-	reset_char(d->character);
+	reset_char(Deref(d->character));
 
-	victim = d->character;
+	victim = Deref(d->character);
 
-	d->character->pcdata->host = palloc_string("PLOAD");
+	Deref(d->character)->pcdata->host = palloc_string("PLOAD");
 
 	interpret(ch, argument);
 
@@ -1726,11 +1726,11 @@ void zone_echo(AREA_DATA *area, char *echo)
 
 	for (DESCRIPTOR_DATA *d = descriptor_list; d; d = d->next)
 	{
-		if (d->connected == CON_PLAYING && d->character->in_room != nullptr && d->character->in_room->area == area)
+		if (d->connected == CON_PLAYING && Deref(d->character)->in_room != nullptr && Deref(d->character)->in_room->area == area)
 		{
-			colorconv(buffer, echo, d->character);
-			send_to_char(buffer, d->character);
-			send_to_char("\n\r", d->character);
+			colorconv(buffer, echo, Deref(d->character));
+			send_to_char(buffer, Deref(d->character));
+			send_to_char("\n\r", Deref(d->character));
 		}
 	}
 }

--- a/code/dioextra.c
+++ b/code/dioextra.c
@@ -40,6 +40,7 @@
 #include <iterator>
 #include <filesystem>
 #include "merc.h"
+#include "entity/handles.h"
 #include "dioextra.h"
 #include "handler.h"
 #include "stdlibs/cfilesystem.h"
@@ -894,11 +895,11 @@ void report_cabal_items(CHAR_DATA *ch, char *argument)
 			if (obj->pIndexData->cabal != guardian->cabal)
 				continue;
 
-			if (obj->carried_by != nullptr)
+			if (CHAR_DATA *carrier = Deref(obj->carried_by))
 			{
 				sprintf(pbuf, "%s is carried by %s.",
 					obj->short_descr,
-					is_npc(obj->carried_by) ? obj->carried_by->short_descr : obj->carried_by->name);
+					is_npc(carrier) ? carrier->short_descr : carrier->name);
 				break;
 			}
 		}

--- a/code/dioextra.c
+++ b/code/dioextra.c
@@ -1420,10 +1420,10 @@ void update_pc_last_fight(CHAR_DATA *ch, CHAR_DATA *ch2)
 		return;
 
 	ch->last_fight_time = current_time;
-	ch->last_fight_name = ch2->true_name;
+	ch->last_fight_opponent = ch2->self;
 
 	ch2->last_fight_time = current_time;
-	ch2->last_fight_name = ch->true_name;
+	ch2->last_fight_opponent = ch->self;
 }
 
 /// Displays a list of members in a specified cabal and their last login times.

--- a/code/dioextra.c
+++ b/code/dioextra.c
@@ -155,21 +155,23 @@ void do_ghost(CHAR_DATA *ch, char *argument)
 	{
 		for (d = descriptor_list; d; d = d->next)
 		{
+			CHAR_DATA *wch = Deref(d->character);
+
 			if (d->connected == CON_PLAYING
-				&& Deref(d->character) != ch
-				&& Deref(d->character)->in_room != nullptr
-				&& can_see(ch, Deref(d->character)))
+				&& wch != ch
+				&& wch->in_room != nullptr
+				&& can_see(ch, wch))
 			{
 				if (!str_cmp(arg2, "yes"))
 				{
-					Deref(d->character)->ghost = 15;
-					send_to_char("You have turned into an invincible ghost for several minutes.\n\r", Deref(d->character));
+					wch->ghost = 15;
+					send_to_char("You have turned into an invincible ghost for several minutes.\n\r", wch);
 				}
 
 				if (!str_cmp(arg2, "no"))
 				{
-					Deref(d->character)->ghost = 0;
-					send_to_char("You are no longer an invincible ghost.\n\r", Deref(d->character));
+					wch->ghost = 0;
+					send_to_char("You are no longer an invincible ghost.\n\r", wch);
 				}
 			}
 		}
@@ -181,22 +183,24 @@ void do_ghost(CHAR_DATA *ch, char *argument)
 	{
 		for (d = descriptor_list; d; d = d->next)
 		{
-			if (d->connected == CON_PLAYING 
-				&& Deref(d->character) != ch
-				&& Deref(d->character)->in_room != nullptr
-				&& can_see(ch, Deref(d->character))
-				&& Deref(d->character)->in_room->area == ch->in_room->area)
+			CHAR_DATA *wch = Deref(d->character);
+
+			if (d->connected == CON_PLAYING
+				&& wch != ch
+				&& wch->in_room != nullptr
+				&& can_see(ch, wch)
+				&& wch->in_room->area == ch->in_room->area)
 			{
 				if (!str_cmp(arg2, "yes"))
 				{
-					Deref(d->character)->ghost = 15;
-					send_to_char("You have turned into an invincible ghost for a several minutes.\n\r", Deref(d->character));
+					wch->ghost = 15;
+					send_to_char("You have turned into an invincible ghost for a several minutes.\n\r", wch);
 				}
 
 				if (!str_cmp(arg2, "no"))
 				{
-					Deref(d->character)->ghost = 0;
-					send_to_char("You are no longer an invincible ghost.\n\r", Deref(d->character));
+					wch->ghost = 0;
+					send_to_char("You are no longer an invincible ghost.\n\r", wch);
 				}
 			}
 		}
@@ -536,20 +540,22 @@ void do_ccb(CHAR_DATA *ch, char *argument)
 	{
 		if (d->connected == CON_PLAYING)
 		{
-			if ((Deref(d->character) != ch
-					&& !IS_SET(Deref(d->character)->comm, COMM_NOCABAL)
-					&& Deref(d->character)->cabal
-					&& Deref(d->character)->cabal == cabal)
-				|| (IS_SET(Deref(d->character)->comm, COMM_ALL_CABALS)
-					&& Deref(d->character) != ch))
+			CHAR_DATA *wch = Deref(d->character);
+
+			if ((wch != ch
+					&& !IS_SET(wch->comm, COMM_NOCABAL)
+					&& wch->cabal
+					&& wch->cabal == cabal)
+				|| (IS_SET(wch->comm, COMM_ALL_CABALS)
+					&& wch != ch))
 			{
 				buffer = fmt::format("{}{}: {}{}{}\n\r",
 					cabal_table[cabal].who_name,
-					pers(ch, Deref(d->character)),
-					get_char_color(Deref(d->character), "channels"),
+					pers(ch, wch),
+					get_char_color(wch, "channels"),
 					arg2,
 					END_COLOR(ch));
-				send_to_char(buffer.c_str(), Deref(d->character));
+				send_to_char(buffer.c_str(), wch);
 			}
 		}
 	}
@@ -1653,20 +1659,20 @@ void do_pload(CHAR_DATA *ch, char *argument)
 	if (!CFileSystem::Copy(ploadSource, ploadDest))
 		RS.Logger.Warn("Failed to copy [{}] to [{}]", ploadSource, ploadDest);
 
-	Deref(d->character)->desc = nullptr;
-	Deref(d->character)->next = char_list;
+	victim = Deref(d->character);
 
-	char_list = Deref(d->character);
+	victim->desc = nullptr;
+	victim->next = char_list;
+
+	char_list = victim;
 
 	d->outsize = 2000;
 	d->outbuf = new char[d->outsize];
 	d->connected = CON_PLAYING;
 
-	reset_char(Deref(d->character));
+	reset_char(victim);
 
-	victim = Deref(d->character);
-
-	Deref(d->character)->pcdata->host = palloc_string("PLOAD");
+	victim->pcdata->host = palloc_string("PLOAD");
 
 	interpret(ch, argument);
 
@@ -1726,11 +1732,13 @@ void zone_echo(AREA_DATA *area, char *echo)
 
 	for (DESCRIPTOR_DATA *d = descriptor_list; d; d = d->next)
 	{
-		if (d->connected == CON_PLAYING && Deref(d->character)->in_room != nullptr && Deref(d->character)->in_room->area == area)
+		CHAR_DATA *wch = Deref(d->character);
+
+		if (d->connected == CON_PLAYING && wch->in_room != nullptr && wch->in_room->area == area)
 		{
-			colorconv(buffer, echo, Deref(d->character));
-			send_to_char(buffer, Deref(d->character));
-			send_to_char("\n\r", Deref(d->character));
+			colorconv(buffer, echo, wch);
+			send_to_char(buffer, wch);
+			send_to_char("\n\r", wch);
 		}
 	}
 }

--- a/code/effects.c
+++ b/code/effects.c
@@ -37,6 +37,7 @@
 #include <string.h>
 #include <time.h>
 #include "merc.h"
+#include "entity/handles.h"
 #include "effects.h"
 #include "handler.h"
 #include "recycle.h"
@@ -131,8 +132,8 @@ void acid_effect(void *vo, int level, int dam, int target)
 		if (number_percent() > chance)
 			return;
 
-		if (obj->carried_by != nullptr)
-			act(msg, obj->carried_by, obj, nullptr, TO_ALL);
+		if (CHAR_DATA *carrier = Deref(obj->carried_by))
+			act(msg, carrier, obj, nullptr, TO_ALL);
 		else if (obj->in_room != nullptr && obj->in_room->people != nullptr)
 			act(msg, obj->in_room->people, obj, nullptr, TO_ALL);
 
@@ -166,11 +167,13 @@ void acid_effect(void *vo, int level, int dam, int target)
 				obj->affected.push_front(paf);
 			}
 
-			if (obj->carried_by != nullptr && obj->wear_loc != WEAR_NONE)
+			CHAR_DATA *carrier = Deref(obj->carried_by);
+
+			if (carrier != nullptr && obj->wear_loc != WEAR_NONE)
 			{
 				for (i = 0; i < 4; i++)
 				{
-					obj->carried_by->armor[i] += 1;
+					carrier->armor[i] += 1;
 				}
 			}
 
@@ -189,9 +192,9 @@ void acid_effect(void *vo, int level, int dam, int target)
 				{
 					obj_to_room(t_obj, obj->in_room);
 				}
-				else if (obj->carried_by != nullptr)
+				else if (CHAR_DATA *carrier = Deref(obj->carried_by))
 				{
-					obj_to_room(t_obj, obj->carried_by->in_room);
+					obj_to_room(t_obj, carrier->in_room);
 				}
 				else
 				{
@@ -300,8 +303,8 @@ void cold_effect(void *vo, int level, int dam, int target)
 		if (number_percent() > chance)
 			return;
 
-		if (obj->carried_by != nullptr)
-			act(msg, obj->carried_by, obj, nullptr, TO_ALL);
+		if (CHAR_DATA *carrier = Deref(obj->carried_by))
+			act(msg, carrier, obj, nullptr, TO_ALL);
 		else if (obj->in_room != nullptr && obj->in_room->people != nullptr)
 			act(msg, obj->in_room->people, obj, nullptr, TO_ALL);
 
@@ -421,8 +424,8 @@ void fire_effect(void *vo, int level, int dam, int target)
 		if (number_percent() > chance)
 			return;
 
-		if (obj->carried_by != nullptr)
-			act(msg, obj->carried_by, obj, nullptr, TO_ALL);
+		if (CHAR_DATA *carrier = Deref(obj->carried_by))
+			act(msg, carrier, obj, nullptr, TO_ALL);
 		else if (obj->in_room != nullptr && obj->in_room->people != nullptr)
 			act(msg, obj->in_room->people, obj, nullptr, TO_ALL);
 
@@ -439,9 +442,9 @@ void fire_effect(void *vo, int level, int dam, int target)
 				{
 					obj_to_room(t_obj, obj->in_room);
 				}
-				else if (obj->carried_by != nullptr)
+				else if (CHAR_DATA *carrier = Deref(obj->carried_by))
 				{
-					obj_to_room(t_obj, obj->carried_by->in_room);
+					obj_to_room(t_obj, carrier->in_room);
 				}
 				else
 				{
@@ -619,8 +622,8 @@ void shock_effect(void *vo, int level, int dam, int target)
 		if (number_percent() > chance)
 			return;
 
-		if (obj->carried_by != nullptr)
-			act(msg, obj->carried_by, obj, nullptr, TO_ALL);
+		if (CHAR_DATA *carrier = Deref(obj->carried_by))
+			act(msg, carrier, obj, nullptr, TO_ALL);
 		else if (obj->in_room != nullptr && obj->in_room->people != nullptr)
 			act(msg, obj->in_room->people, obj, nullptr, TO_ALL);
 

--- a/code/entity/affect_data.h
+++ b/code/entity/affect_data.h
@@ -3,6 +3,7 @@
 
 #include "fwd.h"
 #include "limits.h"
+#include "../stdlibs/handle.h"
 
 //
 // An affect.
@@ -12,12 +13,12 @@
 // rule-of-5 (bodies in recycle.c). Parents hold these by value in a
 // std::list<AFFECT_DATA> (ch->affected, obj->charaffs, and the two Tier-0
 // prototype lists obj_index->affected / obj_index->charaffs). `owner` is a
-// non-owning CHAR_DATA back-reference and stays a raw pointer (scrubbed on
-// extract_char). std::list, not vector: callers cache an element pointer
+// non-owning CHAR_DATA back-reference and expires on its own when that
+// character is freed. std::list, not vector: callers cache an element pointer
 // returned by affect_find across later list mutations.
 struct affect_data
 {
-	CHAR_DATA *owner = nullptr;
+	Handle<CHAR_DATA> owner;
 	char *name = nullptr;
 	short where = 0;
 	short type = 0;
@@ -49,10 +50,12 @@ struct affect_data
 
 // A room affect. Plain value type; a room owns these by value in a
 // std::list<ROOM_AFFECT_DATA> (room->affected). `owner` is a non-owning
-// CHAR_DATA back-reference and stays a raw pointer.
+// CHAR_DATA back-reference. Note extract_char still deletes a character's room
+// affects outright: the affect keeps damaging whoever walks in, so losing the
+// attribution is not the same as the effect ending.
 struct room_affect_data
 {
-	CHAR_DATA *owner = nullptr;
+	Handle<CHAR_DATA> owner;
 	short where = 0;
 	short type = 0;
 	short level = 0;
@@ -72,10 +75,12 @@ struct room_affect_data
 
 // An area affect. Plain value type; an area owns these by value in a
 // std::list<AREA_AFFECT_DATA> (area->affected). `owner` is a non-owning
-// CHAR_DATA back-reference and stays a raw pointer.
+// CHAR_DATA back-reference and expires on its own when that character is
+// freed; nothing has ever scrubbed it, and an area affect outlives the fight
+// that spawned it by design.
 struct area_affect_data
 {
-	CHAR_DATA *owner = nullptr;
+	Handle<CHAR_DATA> owner;
 	short where = 0;
 	short type = 0;
 	short level = 0;
@@ -94,7 +99,7 @@ struct area_affect_data
 // CHAR_DATA back-reference and stays a raw pointer.
 struct obj_affect_data
 {
-	CHAR_DATA *owner = nullptr;
+	Handle<CHAR_DATA> owner;
 	short where = 0;
 	short type = 0;
 	short level = 0;

--- a/code/entity/char_data.h
+++ b/code/entity/char_data.h
@@ -43,7 +43,11 @@ public:
 	Handle<CHAR_DATA> fighting;
 	CHAR_DATA *reply;
 	CHAR_DATA *pet;
-	CHAR_DATA *last_fought;
+	// The character this mob is hunting. Non-owning, and the quarry can be
+	// extracted independently, so it is a handle rather than a pointer. The
+	// clears outside extract_char are a mob giving up the hunt -- losing the
+	// trail, a peace command -- which is about intent, not lifetime.
+	Handle<CHAR_DATA> last_fought;
 	int tracktimer;
 	time_t last_fight_time;
 	char * last_fight_name;

--- a/code/entity/char_data.h
+++ b/code/entity/char_data.h
@@ -70,7 +70,12 @@ public:
 	time_t last_fight_time;
 	char * last_fight_name;
 	CHAR_DATA *hunting;
-	CHAR_DATA *defending;
+	// The character this one is guarding, and the one it is analyzing. Both
+	// non-owning, both able to outlive their target, so both are handles.
+	// Nothing scrubs either on extract -- `defending` is cleared only when a
+	// player quits or stops defending, `analyzePC` never -- so before these
+	// were handles they simply dangled on any other death.
+	Handle<CHAR_DATA> defending;
 	std::list<MEM_DATA> memory;
 	GAME_FUN *game_fun;
 	MOB_INDEX_DATA *pIndexData;
@@ -201,7 +206,7 @@ public:
 	short legs;
 	short balance;
 	short batter;
-	CHAR_DATA *analyzePC;
+	Handle<CHAR_DATA> analyzePC;
 	int analyze;
 	short pulseTimer;					// counter for racial combat pulse
 	char *backup_true_name;				// Dev's SUPAR CLEVAR CORRUPTION FIX!!!

--- a/code/entity/char_data.h
+++ b/code/entity/char_data.h
@@ -35,7 +35,12 @@ public:
 	CHAR_DATA *next_in_room;
 	CHAR_DATA *master;
 	CHAR_DATA *leader;
-	CHAR_DATA *fighting;
+	// The character this one is in combat with. Non-owning, and the opponent
+	// can be extracted independently, so it is a handle rather than a pointer.
+	// stop_fighting clears it for both sides -- that is about the fight
+	// ending, not about lifetime; almost every caller leaves both characters
+	// alive.
+	Handle<CHAR_DATA> fighting;
 	CHAR_DATA *reply;
 	CHAR_DATA *pet;
 	CHAR_DATA *last_fought;

--- a/code/entity/char_data.h
+++ b/code/entity/char_data.h
@@ -51,7 +51,11 @@ public:
 	std::list<AFFECT_DATA> affected;
 	NOTE_DATA *pnote;
 	OBJ_DATA *carrying;
-	OBJ_DATA *on;
+	// The furniture this character is sitting/resting/sleeping on. Non-owning,
+	// and the object can be destroyed independently, so it is a handle rather
+	// than a pointer. Cleared outright when the character or the object leaves
+	// the room -- that is about position, not lifetime.
+	Handle<OBJ_DATA> on;
 	ROOM_INDEX_DATA *in_room;
 	ROOM_INDEX_DATA *was_in_room;
 	AREA_DATA *zone;

--- a/code/entity/char_data.h
+++ b/code/entity/char_data.h
@@ -69,7 +69,12 @@ public:
 	int tracktimer;
 	time_t last_fight_time;
 	char * last_fight_name;
-	CHAR_DATA *hunting;
+	// The character this mob is stalking -- set by the face sucker's greet prog
+	// and by the sorcerer's aerial anchor. Non-owning, and the quarry can be
+	// extracted independently, so it is a handle rather than a pointer. Nothing
+	// clears it anywhere, on death or otherwise, so before it was a handle a
+	// dead quarry's stalker was inherited by whoever took its address next.
+	Handle<CHAR_DATA> hunting;
 	// The character this one is guarding, and the one it is analyzing. Both
 	// non-owning, both able to outlive their target, so both are handles.
 	// Nothing scrubs either on extract -- `defending` is cleared only when a

--- a/code/entity/char_data.h
+++ b/code/entity/char_data.h
@@ -68,7 +68,13 @@ public:
 	Handle<CHAR_DATA> last_fought;
 	int tracktimer;
 	time_t last_fight_time;
-	char * last_fight_name;
+	// The player this one last fought, for the lost-link wiznet and do_stat.
+	// This used to be a `char *` aliasing the opponent's own true_name buffer
+	// and compared by pointer identity, which meant it went stale whenever that
+	// buffer was released -- on death, but also on a rename, which no scrub
+	// could catch because the buffer was no longer anyone's name. Naming the
+	// character instead of their name allocation removes both problems.
+	Handle<CHAR_DATA> last_fight_opponent;
 	// The character this mob is stalking -- set by the face sucker's greet prog
 	// and by the sorcerer's aerial anchor. Non-owning, and the quarry can be
 	// extracted independently, so it is a handle rather than a pointer. Nothing

--- a/code/entity/char_data.h
+++ b/code/entity/char_data.h
@@ -114,7 +114,6 @@ public:
 	std::unique_ptr<GEN_DATA> gen_data;
 	PATHFIND_DATA *path;	// For smart pathfinding/tracking.  Mob only.
 	PATHFIND_DATA *best;	// Stores best direction thus far.  Mob only.
-	bool valid;
 	char *name;
 	char *true_name;
 	long id;

--- a/code/entity/char_data.h
+++ b/code/entity/char_data.h
@@ -33,8 +33,19 @@ public:
 	Handle<CHAR_DATA> self;
 	CHAR_DATA *next;
 	CHAR_DATA *next_in_room;
-	CHAR_DATA *master;
-	CHAR_DATA *leader;
+	// The follower graph. All non-owning, and any of the three can be
+	// extracted independently of the others, so they are handles rather than
+	// pointers. The sweeps in stop_follower/die_follower stay: they run mostly
+	// for reasons nobody died of -- setting nofollow, switching who you
+	// follow, a spell breaking a group -- so they are about who follows whom,
+	// not about lifetime.
+	//
+	// Two deliberate rules live here. A follower whose leader is shed becomes
+	// its OWN leader, so a handle to self is normal and must keep resolving.
+	// And a follower affected by gsn_trail is exempt from the sweep on
+	// purpose: the point of the skill is that the target cannot shake them.
+	Handle<CHAR_DATA> master;
+	Handle<CHAR_DATA> leader;
 	// The character this one is in combat with. Non-owning, and the opponent
 	// can be extracted independently, so it is a handle rather than a pointer.
 	// stop_fighting clears it for both sides -- that is about the fight
@@ -46,7 +57,10 @@ public:
 	// outside extract_char -- do_noreply, and cloaking with invis/incog -- are
 	// a player closing the channel, not a lifetime event.
 	Handle<CHAR_DATA> reply;
-	CHAR_DATA *pet;
+	// The charmed pet this character owns. Non-owning -- nuke_pets extracts it
+	// rather than this field doing so -- and cleared by stop_follower when the
+	// pet is dismissed, which leaves both alive.
+	Handle<CHAR_DATA> pet;
 	// The character this mob is hunting. Non-owning, and the quarry can be
 	// extracted independently, so it is a handle rather than a pointer. The
 	// clears outside extract_char are a mob giving up the hunt -- losing the

--- a/code/entity/char_data.h
+++ b/code/entity/char_data.h
@@ -14,6 +14,7 @@
 #include "gen_data.h"					// GEN_DATA held by unique_ptr in ch->gen_data
 #include "mem_data.h"					// MEM_DATA held by value in ch->memory
 #include "affect_data.h"				// AFFECT_DATA held by value in ch->affected
+#include "../stdlibs/handle.h"			// self, and the handle-typed cross-references
 
 //
 // One character (PC or NPC).
@@ -25,6 +26,11 @@ extern CProficiencies prof_none; //empty proficiencies for jackasses who are goi
 class	char_data
 {
 public:
+	// A handle naming this character, issued by new_char and retired by
+	// free_char. It is how another entity refers to this one without risking a
+	// pointer into a recycled slot; null for a character that never came from
+	// new_char.
+	Handle<CHAR_DATA> self;
 	CHAR_DATA *next;
 	CHAR_DATA *next_in_room;
 	CHAR_DATA *master;

--- a/code/entity/char_data.h
+++ b/code/entity/char_data.h
@@ -112,8 +112,6 @@ public:
 	AREA_DATA *zone;
 	std::unique_ptr<PC_DATA> pcdata;
 	std::unique_ptr<GEN_DATA> gen_data;
-	PATHFIND_DATA *path;	// For smart pathfinding/tracking.  Mob only.
-	PATHFIND_DATA *best;	// Stores best direction thus far.  Mob only.
 	char *name;
 	char *true_name;
 	long id;

--- a/code/entity/char_data.h
+++ b/code/entity/char_data.h
@@ -41,7 +41,11 @@ public:
 	// ending, not about lifetime; almost every caller leaves both characters
 	// alive.
 	Handle<CHAR_DATA> fighting;
-	CHAR_DATA *reply;
+	// Who `reply` answers. Non-owning, and the other party can be extracted
+	// independently, so it is a handle rather than a pointer. The clears
+	// outside extract_char -- do_noreply, and cloaking with invis/incog -- are
+	// a player closing the channel, not a lifetime event.
+	Handle<CHAR_DATA> reply;
 	CHAR_DATA *pet;
 	// The character this mob is hunting. Non-owning, and the quarry can be
 	// extracted independently, so it is a handle rather than a pointer. The

--- a/code/entity/char_data.h
+++ b/code/entity/char_data.h
@@ -84,7 +84,15 @@ public:
 	std::list<MEM_DATA> memory;
 	GAME_FUN *game_fun;
 	MOB_INDEX_DATA *pIndexData;
-	DESCRIPTOR_DATA *desc;
+	// The connection driving this character, if any -- null for a mob, and for
+	// a player who has gone link-dead. Non-owning, and the socket can be closed
+	// and its struct recycled while the body stays in the world, so it is a
+	// handle rather than a pointer. The only clear on a lifetime path is
+	// close_socket's, and it is guarded: when an immortal is switched at
+	// shutdown, close_socket frees the immortal and the descriptor but never
+	// touches the mob, which before this was a handle left the mob holding a
+	// descriptor the next connection would be handed.
+	Handle<DESCRIPTOR_DATA> desc;
 	std::list<AFFECT_DATA> affected;
 	NOTE_DATA *pnote;
 	OBJ_DATA *carrying;

--- a/code/entity/exit_data.h
+++ b/code/entity/exit_data.h
@@ -23,7 +23,6 @@ struct exit_data
 	EXIT_DATA *next;					// OLC
 	int orig_door;						// OLC
 	RUNE_DATA *rune;
-	bool has_rune;
 };
 
 #endif /* ENTITY_EXIT_DATA_H */

--- a/code/entity/handles.h
+++ b/code/entity/handles.h
@@ -17,6 +17,28 @@
 // null. Deref of a null handle is null, so unregistered entities are safe by
 // default rather than dangerous by default.
 //
+// CACHING A Deref RESULT
+//
+// Deref returns a raw pointer, and that pointer is only good until something
+// can free the entity. Reading the same handle several times in a row looks
+// redundant and is a standing temptation to hoist into one local -- but in
+// combat and prog code it is load-bearing, because damage_new, multi_hit,
+// one_hit, track_attack and anything that moves a character can end a fight or
+// kill outright, partway through the very block doing the reads. A cached
+// CHAR_DATA * survives that; the handle does not, which is the entire point of
+// it being a handle.
+//
+// The rule, and it is worth stating because the two cases look identical:
+//
+//   * Read once into a local ONLY when nothing between the read and its last
+//     use can invalidate the entity -- display code, predicate code, pure
+//     field assignment.
+//   * Otherwise re-read through the handle at each use. A Deref is an array
+//     index and an integer compare; a stale pointer is a use-after-free.
+//
+// Sites that follow the second rule are commented where they sit. Do not
+// "simplify" them without checking what the calls in between can do.
+//
 
 extern SlotMap<CHAR_DATA> charHandles;
 extern SlotMap<OBJ_DATA> objectHandles;

--- a/code/entity/handles.h
+++ b/code/entity/handles.h
@@ -42,6 +42,7 @@
 
 extern SlotMap<CHAR_DATA> charHandles;
 extern SlotMap<OBJ_DATA> objectHandles;
+extern SlotMap<DESCRIPTOR_DATA> descriptorHandles;
 
 /// The character this handle names, or null if it has been extracted.
 inline CHAR_DATA *Deref(Handle<CHAR_DATA> handle)
@@ -53,6 +54,12 @@ inline CHAR_DATA *Deref(Handle<CHAR_DATA> handle)
 inline OBJ_DATA *Deref(Handle<OBJ_DATA> handle)
 {
 	return objectHandles.Deref(handle);
+}
+
+/// The connection this handle names, or null if the socket has been closed.
+inline DESCRIPTOR_DATA *Deref(Handle<DESCRIPTOR_DATA> handle)
+{
+	return descriptorHandles.Deref(handle);
 }
 
 #endif /* ENTITY_HANDLES_H */

--- a/code/entity/handles.h
+++ b/code/entity/handles.h
@@ -1,0 +1,36 @@
+#ifndef ENTITY_HANDLES_H
+#define ENTITY_HANDLES_H
+
+#include "fwd.h"
+#include "../stdlibs/handle.h"
+
+//
+// The two entity slot maps, and the shorthand for reading through a handle.
+//
+// These sit beside char_list and object_list -- the same entities, indexed a
+// second way. Registration happens in new_char/new_obj and retirement in
+// free_char/free_obj, so an entity is registered for exactly the span during
+// which it is not on a free list. Nothing else should Add or Remove.
+//
+// An entity that was never handed out by new_char/new_obj -- one on the stack
+// in a test, say -- is simply not registered, and its `self` handle stays
+// null. Deref of a null handle is null, so unregistered entities are safe by
+// default rather than dangerous by default.
+//
+
+extern SlotMap<CHAR_DATA> charHandles;
+extern SlotMap<OBJ_DATA> objectHandles;
+
+/// The character this handle names, or null if it has been extracted.
+inline CHAR_DATA *Deref(Handle<CHAR_DATA> handle)
+{
+	return charHandles.Deref(handle);
+}
+
+/// The object this handle names, or null if it has been extracted.
+inline OBJ_DATA *Deref(Handle<OBJ_DATA> handle)
+{
+	return objectHandles.Deref(handle);
+}
+
+#endif /* ENTITY_HANDLES_H */

--- a/code/entity/obj_data.h
+++ b/code/entity/obj_data.h
@@ -22,7 +22,10 @@ struct obj_data
 	OBJ_DATA *next;
 	OBJ_DATA *next_content;
 	OBJ_DATA *contains;
-	OBJ_DATA *in_obj;
+	// The container this object sits inside, if any. Kept in step with in_room
+	// and carried_by by the obj_to_*/obj_from_* pair -- an object is in exactly
+	// one of the three at a time.
+	Handle<OBJ_DATA> in_obj;
 	CHAR_DATA *carried_by;
 	std::list<EXTRA_DESCR_DATA> extra_descr;
 	std::list<OBJ_APPLY_DATA> apply;

--- a/code/entity/obj_data.h
+++ b/code/entity/obj_data.h
@@ -35,7 +35,6 @@ struct obj_data
 	ROOM_INDEX_DATA *in_room;
 	RUNE_DATA *rune;
 	bool has_rune;
-	bool valid;
 	char *talked;
 	char *owner;
 	char *name;

--- a/code/entity/obj_data.h
+++ b/code/entity/obj_data.h
@@ -26,7 +26,7 @@ struct obj_data
 	// and carried_by by the obj_to_*/obj_from_* pair -- an object is in exactly
 	// one of the three at a time.
 	Handle<OBJ_DATA> in_obj;
-	CHAR_DATA *carried_by;
+	Handle<CHAR_DATA> carried_by;
 	std::list<EXTRA_DESCR_DATA> extra_descr;
 	std::list<OBJ_APPLY_DATA> apply;
 	std::list<OBJ_AFFECT_DATA> affected;

--- a/code/entity/obj_data.h
+++ b/code/entity/obj_data.h
@@ -7,6 +7,7 @@
 #include "limits.h"
 #include "extra_descr.h"
 #include "affect_data.h"		// OBJ_APPLY_DATA held by value
+#include "../stdlibs/handle.h"	// self, and the handle-typed cross-references
 
 //
 // One object.
@@ -14,6 +15,10 @@
 
 struct obj_data
 {
+	// A handle naming this object, issued by new_obj and retired by free_obj.
+	// It is how another entity refers to this one without risking a pointer
+	// into a recycled slot; null for an object that never came from new_obj.
+	Handle<OBJ_DATA> self;
 	OBJ_DATA *next;
 	OBJ_DATA *next_content;
 	OBJ_DATA *contains;

--- a/code/entity/obj_data.h
+++ b/code/entity/obj_data.h
@@ -23,7 +23,6 @@ struct obj_data
 	OBJ_DATA *next_content;
 	OBJ_DATA *contains;
 	OBJ_DATA *in_obj;
-	OBJ_DATA *on;
 	CHAR_DATA *carried_by;
 	std::list<EXTRA_DESCR_DATA> extra_descr;
 	std::list<OBJ_APPLY_DATA> apply;

--- a/code/entity/obj_data.h
+++ b/code/entity/obj_data.h
@@ -34,7 +34,6 @@ struct obj_data
 	OBJ_INDEX_DATA *pIndexData;
 	ROOM_INDEX_DATA *in_room;
 	RUNE_DATA *rune;
-	bool has_rune;
 	char *talked;
 	char *owner;
 	char *name;

--- a/code/entity/pc_data.h
+++ b/code/entity/pc_data.h
@@ -19,7 +19,6 @@ struct pc_data
 {
 	PC_DATA *next;
 	BUFFER *buffer;
-	bool valid;
 	bool newbie;
 	char *pwd;
 	char *bamfin;

--- a/code/entity/pc_data.h
+++ b/code/entity/pc_data.h
@@ -9,6 +9,7 @@
 #include "../enums.h"		// SECT_MAX
 #include "../prof.h"		// CProficiencies is embedded by value
 #include "trophy_data.h"	// TROPHY_DATA held by value in pcdata->trophy
+#include "../stdlibs/handle.h"	// trusting is a handle, not a pointer
 
 //
 // Data which only PC's have.
@@ -83,7 +84,11 @@ struct pc_data
 	char *entered_text;
 	DO_FUN *end_fun;
 	long trust[MAX_BITVECTOR];
-	CHAR_DATA *trusting;
+	// The player this one has authorised to take questionable actions against
+	// them. Non-owning, and the other player can leave the world independently,
+	// so it is a handle rather than a pointer. do_trust's own clear stays: that
+	// is a player withdrawing trust, not a lifetime event.
+	Handle<CHAR_DATA> trusting;
 	short energy_state;
 	char *host;
 	short quests[MAX_QUESTS];

--- a/code/entity/room_index_data.h
+++ b/code/entity/room_index_data.h
@@ -24,7 +24,8 @@ struct room_index_data
 	AREA_DATA *area;
 	EXIT_DATA *exit[6];
 	TRACK_DATA tracks[20];
-	PATHFIND_DATA *path;				// For smart tracking
+	PATHFIND_DATA *path;				// Visited marker for the one tracking
+										// search currently running; non-owning
 	char *name;
 	char *alt_name;
 	char *description;

--- a/code/entity/room_index_data.h
+++ b/code/entity/room_index_data.h
@@ -45,7 +45,6 @@ struct room_index_data
 	bool move_progs;
 	TRAP_DATA *trap;
 	RUNE_DATA *rune;
-	bool has_rune;
 	short light;
 	RESET_DATA *reset_first;			// OLC
 	RESET_DATA *reset_last; 			// OLC

--- a/code/fight.c
+++ b/code/fight.c
@@ -363,7 +363,7 @@ void multi_hit(CHAR_DATA *ch, CHAR_DATA *victim, int dt)
 	bool noprimary = false;
 
 	/* decrement the wait */
-	if (ch->desc == nullptr)
+	if (Deref(ch->desc) == nullptr)
 		ch->wait = std::max(0, ch->wait - PULSE_VIOLENCE);
 
 	if (ch->level == MAX_LEVEL)
@@ -1663,11 +1663,11 @@ bool is_safe_new(CHAR_DATA *ch, CHAR_DATA *victim, bool show)
 	if (is_npc(ch)
 		&& is_npc(victim)
 		&& !is_affected_by(ch,AFF_CHARM)
-		&& !is_affected_by(victim,AFF_CHARM) && !ch->desc
+		&& !is_affected_by(victim,AFF_CHARM) && !Deref(ch->desc)
 		&& !Deref(ch->hunting) && !Deref(victim->hunting) && victim!=ch
 		&& Deref(ch->fighting) != victim
 		&& Deref(victim->fighting) != ch
-		&& !ch->desc && !victim->desc)
+		&& !Deref(ch->desc) && !Deref(victim->desc))
 	{
 		return true;
 	}
@@ -1677,7 +1677,7 @@ bool is_safe_new(CHAR_DATA *ch, CHAR_DATA *victim, bool show)
 
 	/* Handle Link dead players , only saves from PKS, not mobs -Ceran */
 	if (!is_npc(victim)
-		&& victim->desc == nullptr
+		&& Deref(victim->desc) == nullptr
 		&& !is_npc(ch)
 		&& get_trust(ch) < 58
 		&& Deref(victim->fighting) != ch

--- a/code/fight.c
+++ b/code/fight.c
@@ -139,7 +139,7 @@ void violence_update(void)
 			&& !IS_SET(ch->act, ACT_IS_HEALER)
 			&& !IS_SET(ch->act, ACT_BANKER))
 		{
-			ch->last_fought = victim;
+			ch->last_fought = victim->self;
 			ch->tracktimer = 144;
 		}
 
@@ -1685,7 +1685,7 @@ bool is_safe_new(CHAR_DATA *ch, CHAR_DATA *victim, bool show)
 	if (Deref(victim->fighting) == ch || victim == ch)
 		return false;
 
-	if (is_npc(ch) && ch->last_fought == victim)
+	if (is_npc(ch) && Deref(ch->last_fought) == victim)
 		return false;
 
 	if ((victim->ghost > 0) || is_affected(victim, gsn_ultradiffusion))
@@ -6535,7 +6535,7 @@ void do_cleave(CHAR_DATA *ch, char *argument)
 	act("$n makes an attempt to cleave $N in half.", ch, 0, victim, TO_NOTVICT);
 
 	if (is_npc(victim))
-		victim->last_fought = ch;
+		victim->last_fought = ch->self;
 
 	if (number_percent() > chance)
 	{

--- a/code/fight.c
+++ b/code/fight.c
@@ -3513,7 +3513,7 @@ void raw_kill(CHAR_DATA *ch, CHAR_DATA *victim)
 	af.level = victim->level;
 	affect_to_char(victim, &af);
 
-	victim->last_fight_name = nullptr;
+	victim->last_fight_opponent = nullptr;
 	victim->last_fight_time = 0;
 
 	if (!is_npc(victim)) /* con loss */

--- a/code/fight.c
+++ b/code/fight.c
@@ -43,6 +43,7 @@
 #include <time.h>
 #include <algorithm>
 #include "merc.h"
+#include "entity/handles.h"
 #include "fight.h"
 #include "handler.h"
 #include "interp.h"
@@ -86,6 +87,7 @@ void violence_update(void)
 	CHAR_DATA *ch;
 	CHAR_DATA *ch_next;
 	CHAR_DATA *victim;
+	CHAR_DATA *opponent;
 	int regen = 0;
 	OBJ_DATA *obj;
 	AFFECT_DATA *af;
@@ -101,9 +103,11 @@ void violence_update(void)
 				ch->hit = std::min(ch->hit - number_range(1, ch->regen_rate), (int)ch->max_hit);
 		}
 
-		if (ch->fighting != nullptr)
+		opponent = Deref(ch->fighting);
+
+		if (opponent != nullptr)
 		{
-			check_analyze(ch, ch->fighting);
+			check_analyze(ch, opponent);
 
 			if (!is_npc(ch))
 				check_style_improve(ch, ch->pcdata->style, 6);
@@ -123,30 +127,30 @@ void violence_update(void)
 				affect_strip(ch, gsn_unbalance);
 		}
 
-		victim = ch->fighting;
+		victim = Deref(ch->fighting);
 
 		if (victim == nullptr || ch->in_room == nullptr)
 			continue;
 
 		if (is_npc(ch)
-			&& !is_npc(ch->fighting)
+			&& !is_npc(victim)
 			&& !IS_SET(ch->off_flags, NO_TRACK)
 			&& !is_affected_by(ch, AFF_CHARM)
 			&& !IS_SET(ch->act, ACT_IS_HEALER)
 			&& !IS_SET(ch->act, ACT_BANKER))
 		{
-			ch->last_fought = ch->fighting;
+			ch->last_fought = victim;
 			ch->tracktimer = 144;
 		}
 
-		update_pc_last_fight(ch, ch->fighting);
+		update_pc_last_fight(ch, victim);
 		/*
 		if (is_awake(ch) && ch->in_room == victim->in_room)
 			multi_hit(ch, victim, TYPE_UNDEFINED);
 		else
 			stop_fighting(ch, false);
 
-		if ((victim = ch->fighting) == nullptr)
+		if ((victim = Deref(ch->fighting)) == nullptr)
 			continue;
 		*/
 
@@ -191,7 +195,7 @@ void check_assist(CHAR_DATA *ch, CHAR_DATA *victim)
 		if (is_npc(rch) && rch->pIndexData->vnum == ACADEMY_PET && ch->ghost > 0)
 			continue;
 
-		if (is_awake(rch) && rch->fighting == nullptr)
+		if (is_awake(rch) && Deref(rch->fighting) == nullptr)
 		{
 			/* NPC assisting group (for charm, zombies, elementals..added by Ceran */
 			if (is_npc(rch) && (is_affected_by(rch, AFF_CHARM)) && is_same_group(rch, ch))
@@ -224,12 +228,12 @@ void check_assist(CHAR_DATA *ch, CHAR_DATA *victim)
 				{
 					CHAR_DATA *fch;
 
-					fch = ch->fighting;
+					fch = Deref(ch->fighting);
 
 					if (rch->defending != nullptr
 						&& rch->defending == ch
 						&& fch != nullptr
-						&& fch->fighting == ch
+						&& Deref(fch->fighting) == ch
 						&& number_percent() < get_skill(rch, gsn_defend)
 						&& number_percent() > 40
 						&& number_percent() < get_skill(rch, gsn_rescue))
@@ -420,7 +424,7 @@ void multi_hit(CHAR_DATA *ch, CHAR_DATA *victim, int dt)
 	if (!noprimary)
 		one_hit(ch, victim, dt);
 
-	if (ch->fighting != victim || dt == gsn_backstab || (dt == gsn_ambush))
+	if (Deref(ch->fighting) != victim || dt == gsn_backstab || (dt == gsn_ambush))
 		return;
 
 	if (is_affected_by(ch, AFF_HASTE) && (is_npc(ch) || get_skill(ch, gsn_third_attack) > 5))
@@ -465,7 +469,7 @@ void multi_hit(CHAR_DATA *ch, CHAR_DATA *victim, int dt)
 			one_hit(ch, victim, dt);
 			check_improve(ch, gsn_second_attack, true, 5);
 
-			if (ch->fighting != victim)
+			if (Deref(ch->fighting) != victim)
 				return;
 		}
 	}
@@ -477,7 +481,7 @@ void multi_hit(CHAR_DATA *ch, CHAR_DATA *victim, int dt)
 			one_hit(ch, victim, gsn_dual_wield);
 			check_improve(ch, gsn_dual_wield, true, 3);
 
-			if (ch->fighting != victim)
+			if (Deref(ch->fighting) != victim)
 				return;
 		}
 		else
@@ -503,7 +507,7 @@ void multi_hit(CHAR_DATA *ch, CHAR_DATA *victim, int dt)
 
 			check_improve(ch, gsn_third_attack, true, 6);
 
-			if (ch->fighting != victim)
+			if (Deref(ch->fighting) != victim)
 				return;
 		}
 
@@ -519,7 +523,7 @@ void multi_hit(CHAR_DATA *ch, CHAR_DATA *victim, int dt)
 				one_hit(ch, victim, gsn_dual_wield);
 				check_improve(ch, gsn_dual_wield, true, 3);
 
-				if (ch->fighting != victim)
+				if (Deref(ch->fighting) != victim)
 					return;
 			}
 			else
@@ -546,7 +550,7 @@ void multi_hit(CHAR_DATA *ch, CHAR_DATA *victim, int dt)
 
 			check_improve(ch, gsn_fourth_attack, true, 6);
 
-			if (ch->fighting != victim)
+			if (Deref(ch->fighting) != victim)
 				return;
 		}
 
@@ -561,7 +565,7 @@ void multi_hit(CHAR_DATA *ch, CHAR_DATA *victim, int dt)
 				one_hit(ch, victim, gsn_dual_wield);
 				check_improve(ch, gsn_dual_wield, true, 6);
 
-				if (ch->fighting != victim)
+				if (Deref(ch->fighting) != victim)
 					return;
 			}
 			else
@@ -590,7 +594,7 @@ void multi_hit(CHAR_DATA *ch, CHAR_DATA *victim, int dt)
 
 				check_improve(ch, gsn_fifth_attack, true, 6);
 
-				if (ch->fighting != victim)
+				if (Deref(ch->fighting) != victim)
 					return;
 			}
 
@@ -606,7 +610,7 @@ void multi_hit(CHAR_DATA *ch, CHAR_DATA *victim, int dt)
 					one_hit(ch, victim, gsn_dual_wield);
 					check_improve(ch, gsn_dual_wield, true, 6);
 
-					if (ch->fighting != victim)
+					if (Deref(ch->fighting) != victim)
 						return;
 				}
 				else
@@ -643,7 +647,7 @@ void mob_hit(CHAR_DATA *ch, CHAR_DATA *victim, int dt)
 
 	one_hit(ch, victim, dt);
 
-	if (ch->fighting != victim)
+	if (Deref(ch->fighting) != victim)
 		return;
 
 	/* Area attack -- BALLS nasty! */
@@ -653,7 +657,7 @@ void mob_hit(CHAR_DATA *ch, CHAR_DATA *victim, int dt)
 		{
 			vch_next = vch->next;
 
-			if (vch != victim && vch->fighting == ch)
+			if (vch != victim && Deref(vch->fighting) == ch)
 				one_hit(ch, vch, dt);
 		}
 	}
@@ -661,7 +665,7 @@ void mob_hit(CHAR_DATA *ch, CHAR_DATA *victim, int dt)
 	if (is_affected_by(ch, AFF_HASTE) || (IS_SET(ch->off_flags, OFF_FAST) && !is_affected_by(ch, AFF_SLOW)))
 		one_hit(ch, victim, dt);
 
-	if (ch->fighting != victim || dt == gsn_backstab)
+	if (Deref(ch->fighting) != victim || dt == gsn_backstab)
 		return;
 
 	chance = std::max(70, get_skill(ch, gsn_second_attack));
@@ -677,7 +681,7 @@ void mob_hit(CHAR_DATA *ch, CHAR_DATA *victim, int dt)
 	{
 		one_hit(ch, victim, dt);
 
-		if (ch->fighting != victim)
+		if (Deref(ch->fighting) != victim)
 			return;
 	}
 
@@ -688,7 +692,7 @@ void mob_hit(CHAR_DATA *ch, CHAR_DATA *victim, int dt)
 	{
 		one_hit(ch, victim, gsn_dual_wield);
 
-		if (ch->fighting != victim)
+		if (Deref(ch->fighting) != victim)
 			return;
 	}
 
@@ -708,7 +712,7 @@ void mob_hit(CHAR_DATA *ch, CHAR_DATA *victim, int dt)
 	{
 		one_hit(ch, victim, dt);
 
-		if (ch->fighting != victim)
+		if (Deref(ch->fighting) != victim)
 			return;
 	}
 
@@ -716,7 +720,7 @@ void mob_hit(CHAR_DATA *ch, CHAR_DATA *victim, int dt)
 	{
 		one_hit(ch, victim, gsn_dual_wield);
 
-		if (ch->fighting != victim)
+		if (Deref(ch->fighting) != victim)
 			return;
 	}
 
@@ -732,10 +736,10 @@ void mob_hit(CHAR_DATA *ch, CHAR_DATA *victim, int dt)
 			case CLASS_NONE:
 				break;
 			case CLASS_WARRIOR:
-				warrior_ai(ch, ch->fighting);
+				warrior_ai(ch, Deref(ch->fighting));
 				return;
 			case CLASS_THIEF:
-				thief_ai(ch, ch->fighting);
+				thief_ai(ch, Deref(ch->fighting));
 				return;
 			default:
 				break;
@@ -940,7 +944,7 @@ int one_hit_new(CHAR_DATA *ch, CHAR_DATA *victim, int dt, bool specials, bool bl
 
 	if (wield
 		&& ch->Class()->GetIndex() == CLASS_PALADIN
-		&& ch->fighting
+		&& Deref(ch->fighting)
 		&& dt >= TYPE_HIT
 		&& (rdt = check_arms(ch, wield, false)) > 0) // check_arms returns 0 if normal
 	{
@@ -971,7 +975,7 @@ int one_hit_new(CHAR_DATA *ch, CHAR_DATA *victim, int dt, bool specials, bool bl
 
 	if (result && wield != nullptr)
 	{
-		if (ch->fighting == victim && is_weapon_stat(wield, WEAPON_POISON))
+		if (Deref(ch->fighting) == victim && is_weapon_stat(wield, WEAPON_POISON))
 		{
 			int level = 10;
 			OBJ_AFFECT_DATA *poison;
@@ -1090,7 +1094,7 @@ int damage_new(CHAR_DATA *ch, CHAR_DATA *victim, int idam, int dt, int dam_type,
 				&& dnoun
 				&& dnoun[strlen(dnoun) - 1] == '*'))
 		{
-			if (victim->fighting == nullptr)
+			if (Deref(victim->fighting) == nullptr)
 				set_fighting(victim, ch);
 
 			if (victim->timer <= 4)
@@ -1099,7 +1103,7 @@ int damage_new(CHAR_DATA *ch, CHAR_DATA *victim, int idam, int dt, int dam_type,
 
 		if (victim->position > POS_STUNNED && victim != ch)
 		{
-			if (ch->fighting == nullptr
+			if (Deref(ch->fighting) == nullptr
 				&& !((is_same_group(ch, victim) || is_safe_new(ch, victim, false))
 					&& dnoun
 					&& dnoun[strlen(dnoun) - 1] == '*'))
@@ -1613,7 +1617,7 @@ bool is_safe_new(CHAR_DATA *ch, CHAR_DATA *victim, bool show)
 	if (victim->in_room == nullptr)
 		return true;
 
-	if (is_affected(ch, gsn_shroud_of_light) && !ch->fighting)
+	if (is_affected(ch, gsn_shroud_of_light) && !Deref(ch->fighting))
 	{
 		affect_strip(ch, gsn_shroud_of_light);
 		send_to_char("As you act aggressively your shroud of the light vanishes!\n\r", ch);
@@ -1640,8 +1644,8 @@ bool is_safe_new(CHAR_DATA *ch, CHAR_DATA *victim, bool show)
 		&& !is_affected_by(ch,AFF_CHARM)
 		&& !is_affected_by(victim,AFF_CHARM) && !ch->desc
 		&& !ch->hunting && !victim->hunting && victim!=ch
-		&& ch->fighting != victim
-		&& victim->fighting != ch
+		&& Deref(ch->fighting) != victim
+		&& Deref(victim->fighting) != ch
 		&& !ch->desc && !victim->desc)
 	{
 		return true;
@@ -1655,8 +1659,8 @@ bool is_safe_new(CHAR_DATA *ch, CHAR_DATA *victim, bool show)
 		&& victim->desc == nullptr
 		&& !is_npc(ch)
 		&& get_trust(ch) < 58
-		&& victim->fighting != ch
-		&& ch->fighting != victim)
+		&& Deref(victim->fighting) != ch
+		&& Deref(ch->fighting) != victim)
 	{
 		if (show)
 		{
@@ -1678,7 +1682,7 @@ bool is_safe_new(CHAR_DATA *ch, CHAR_DATA *victim, bool show)
 		return true;
 	}
 
-	if (victim->fighting == ch || victim == ch)
+	if (Deref(victim->fighting) == ch || victim == ch)
 		return false;
 
 	if (is_npc(ch) && ch->last_fought == victim)
@@ -1752,7 +1756,7 @@ bool is_safe_new(CHAR_DATA *ch, CHAR_DATA *victim, bool show)
 		if (is_npc(ch))
 		{ /* NPC doing the killing */
 			/* charmed mobs and pets cannot attack players while owned */
-			if (is_affected_by(ch, AFF_CHARM) && ch->master != nullptr && ch->master->fighting != victim)
+			if (is_affected_by(ch, AFF_CHARM) && ch->master != nullptr && Deref(ch->master->fighting) != victim)
 			{
 				send_to_char("Players are your friends!\n\r", ch);
 				return true;
@@ -1797,7 +1801,7 @@ bool is_safe_spell(CHAR_DATA *ch, CHAR_DATA *victim, bool area)
 	if (is_affected_by(victim, AFF_NOSHOW))
 		return true;
 
-	if (victim->fighting == ch || victim == ch)
+	if (Deref(victim->fighting) == ch || victim == ch)
 		return false;
 
 	if (is_immortal(ch) && ch->level > LEVEL_IMMORTAL && !area)
@@ -1834,13 +1838,13 @@ bool is_safe_spell(CHAR_DATA *ch, CHAR_DATA *victim, bool area)
 				return true;
 
 			/* legal kill? -- cannot hit mob fighting non-group member */
-			if (victim->fighting != nullptr && !is_same_group(ch, victim->fighting))
+			if (Deref(victim->fighting) != nullptr && !is_same_group(ch, Deref(victim->fighting)))
 				return true;
 		}
 		else
 		{
 			/* area effect spells do not hit other mobs */
-			if (area && !is_same_group(victim, ch->fighting))
+			if (area && !is_same_group(victim, Deref(ch->fighting)))
 				return true;
 		}
 	}
@@ -1854,7 +1858,7 @@ bool is_safe_spell(CHAR_DATA *ch, CHAR_DATA *victim, bool area)
 		if (is_npc(ch))
 		{
 			/* charmed mobs and pets cannot attack players while owned */
-			if (is_affected_by(ch, AFF_CHARM) && ch->master != nullptr && ch->master->fighting != victim)
+			if (is_affected_by(ch, AFF_CHARM) && ch->master != nullptr && Deref(ch->master->fighting) != victim)
 				return true;
 
 			/* safe room? */
@@ -1862,7 +1866,7 @@ bool is_safe_spell(CHAR_DATA *ch, CHAR_DATA *victim, bool area)
 				return true;
 
 			/* legal kill? -- mobs only hit players grouped with opponent*/
-			if (ch->fighting != nullptr && !is_same_group(ch->fighting, victim))
+			if (Deref(ch->fighting) != nullptr && !is_same_group(Deref(ch->fighting), victim))
 				return true;
 		}
 
@@ -2815,7 +2819,7 @@ void check_analyze(CHAR_DATA *ch, CHAR_DATA *victim)
 		if (victim != ch->analyzePC)
 			ch->analyze = 0;
 
-		ch->analyzePC = ch->fighting;
+		ch->analyzePC = Deref(ch->fighting);
 		if (ch->analyze < 50)
 			ch->analyze++;
 	*/
@@ -2838,7 +2842,7 @@ void check_analyze(CHAR_DATA *ch, CHAR_DATA *victim)
 	if (victim != ch->analyzePC)
 		ch->analyze = 0;
 
-	ch->analyzePC = ch->fighting;
+	ch->analyzePC = Deref(ch->fighting);
 
 	if (is_npc(victim))
 	{
@@ -2892,7 +2896,7 @@ void set_fighting(CHAR_DATA *ch, CHAR_DATA *victim)
 {
 	char buf[MSL];
 
-	if (ch->fighting != nullptr)
+	if (Deref(ch->fighting) != nullptr)
 		return;
 
 	if (ch == victim)
@@ -2919,7 +2923,7 @@ void set_fighting(CHAR_DATA *ch, CHAR_DATA *victim)
 	un_shroud(ch, nullptr);
 	un_shroud(victim, nullptr);
 
-	ch->fighting = victim;
+	ch->fighting = victim->self;
 	ch->position = POS_FIGHTING;
 
 	if (is_npc(victim))
@@ -2943,6 +2947,14 @@ void combat_alert(CHAR_DATA *victim, int type, CHAR_DATA *ch)
 
 /*
  * Stop fights.
+ *
+ * The sweep below clears everyone attacking ch, and it stays even though
+ * fighting is a handle now. It is not lifetime bookkeeping: of this
+ * function's callers only extract_char is about death, and the rest --
+ * fleeing, disengaging, a wiznet freeze, a mob leaving the room, a spell
+ * breaking combat -- leave both characters alive. Handles expire on free and
+ * know nothing about a fight ending, so dropping the sweep would leave
+ * characters swinging at an opponent who had walked away.
  */
 void stop_fighting(CHAR_DATA *ch, bool fBoth)
 {
@@ -2950,7 +2962,7 @@ void stop_fighting(CHAR_DATA *ch, bool fBoth)
 
 	for (fch = char_list; fch != nullptr; fch = fch->next)
 	{
-		if (fch == ch || (fBoth && fch->fighting == ch))
+		if (fch == ch || (fBoth && Deref(fch->fighting) == ch))
 		{
 			fch->fighting = nullptr;
 			fch->position = POS_STANDING;
@@ -4870,7 +4882,7 @@ void thief_ai(CHAR_DATA *mob, CHAR_DATA *victim)
 				&& mobweap->value[0] == WEAPON_DAGGER)
 			|| ((mobweap = get_eq_char(mob, WEAR_DUAL_WIELD)) != nullptr
 				&& mobweap->value[0] == WEAPON_DAGGER))
-		&& victim->fighting != mob)
+		&& Deref(victim->fighting) != mob)
 	{
 		do_circle_stab(mob, "");
 	}
@@ -5086,7 +5098,7 @@ void do_bash(CHAR_DATA *ch, char *argument)
 
 	if (arg[0] == '\0')
 	{
-		victim = ch->fighting;
+		victim = Deref(ch->fighting);
 
 		if (victim == nullptr)
 		{
@@ -5304,7 +5316,7 @@ void do_bash(CHAR_DATA *ch, char *argument)
 	/* level */
 	chance += (ch->level - victim->level);
 
-	if (!is_npc(ch) && !is_npc(victim) && (victim->fighting == nullptr || ch->fighting == nullptr))
+	if (!is_npc(ch) && !is_npc(victim) && (Deref(victim->fighting) == nullptr || Deref(ch->fighting) == nullptr))
 	{
 		sprintf(buf, "Help! %s is bashing me!", pers(ch, victim));
 		do_myell(victim, buf, ch);
@@ -5373,7 +5385,7 @@ void do_dirt(CHAR_DATA *ch, char *argument)
 
 	if (arg[0] == '\0')
 	{
-		victim = ch->fighting;
+		victim = Deref(ch->fighting);
 		if (victim == nullptr)
 		{
 			send_to_char("But you aren't in combat!\n\r", ch);
@@ -5494,7 +5506,7 @@ void do_dirt(CHAR_DATA *ch, char *argument)
 		act("$n is blinded by the dirt in $s eyes!", victim, nullptr, nullptr, TO_ROOM);
 		act("$n kicks dirt in your eyes!", ch, nullptr, victim, TO_VICT);
 
-		if (!is_npc(ch) && !is_npc(victim) && (victim->fighting == nullptr || ch->fighting == nullptr))
+		if (!is_npc(ch) && !is_npc(victim) && (Deref(victim->fighting) == nullptr || Deref(ch->fighting) == nullptr))
 			do_myell(victim, "Help! Someone just kicked dirt in my eyes!", ch);
 
 		damage(ch, victim, number_range(2, 5), gsn_dirt, DAM_NONE, true);
@@ -5522,7 +5534,7 @@ void do_dirt(CHAR_DATA *ch, char *argument)
 		/* PK yells....add these to most attacks that can initiate PKs.
 		-Ceran
 		*/
-		if (!is_npc(ch) && !is_npc(victim) && (victim->fighting == nullptr || ch->fighting == nullptr))
+		if (!is_npc(ch) && !is_npc(victim) && (Deref(victim->fighting) == nullptr || Deref(ch->fighting) == nullptr))
 		{
 			switch (number_range(0, 1))
 			{
@@ -5564,7 +5576,7 @@ void do_trip(CHAR_DATA *ch, char *argument)
 
 	if (arg[0] == '\0')
 	{
-		victim = ch->fighting;
+		victim = Deref(ch->fighting);
 
 		if (victim == nullptr)
 		{
@@ -5641,7 +5653,7 @@ void do_trip(CHAR_DATA *ch, char *argument)
 	/* now the attack */
 	if (number_percent() < chance)
 	{
-		if (!is_npc(ch) && !is_npc(victim) && (ch->fighting == nullptr || victim->fighting == nullptr))
+		if (!is_npc(ch) && !is_npc(victim) && (Deref(ch->fighting) == nullptr || Deref(victim->fighting) == nullptr))
 		{
 			sprintf(buf, "Help! %s just tripped me!", pers(ch, victim));
 			do_myell(victim, buf, ch);
@@ -5669,7 +5681,7 @@ void do_trip(CHAR_DATA *ch, char *argument)
 	}
 	else
 	{
-		if (!is_npc(ch) && !is_npc(victim) && (ch->fighting == nullptr || victim->fighting == nullptr))
+		if (!is_npc(ch) && !is_npc(victim) && (Deref(ch->fighting) == nullptr || Deref(victim->fighting) == nullptr))
 		{
 			sprintf(buf, "Help! %s just tried to trip me!", pers(ch, victim));
 			do_myell(victim, buf, ch);
@@ -5719,19 +5731,19 @@ void do_hit(CHAR_DATA *ch, char *argument)
 		return;
 	}
 
-	if (victim->fighting != ch)
+	if (Deref(victim->fighting) != ch)
 	{
 		send_to_char("That person isn't fighting you.\n\r", ch);
 		return;
 	}
 
-	if (victim == ch->fighting)
+	if (victim == Deref(ch->fighting))
 	{
 		send_to_char("You're trying as hard as you can!\n\r", ch);
 		return;
 	}
 
-	ch->fighting = victim;
+	ch->fighting = victim->self;
 	ch->batter = 0;
 }
 
@@ -5942,7 +5954,7 @@ void do_ambush(CHAR_DATA *ch, char *argument)
 		return;
 	}
 
-	if (ch->fighting != nullptr)
+	if (Deref(ch->fighting) != nullptr)
 	{
 		send_to_char("But you're still fighting!\n\r", ch);
 		return;
@@ -5975,20 +5987,20 @@ void do_ambush(CHAR_DATA *ch, char *argument)
 
 	chance = get_skill(ch, gsn_moving_ambush);
 
-	if (victim->fighting != nullptr &&
+	if (Deref(victim->fighting) != nullptr &&
 		(chance < 3 || ch->level < skill_table[gsn_moving_ambush].skill_level[ch->Class()->GetIndex()]))
 	{
 		send_to_char("They are moving around too much to ambush.\n\r", ch);
 		return;
 	}
 
-	if (victim->fighting != nullptr && number_percent() >= chance)
+	if (Deref(victim->fighting) != nullptr && number_percent() >= chance)
 	{
 		send_to_char("You can't quite pin them down for your ambush.\n\r", ch);
 		return;
 	}
 
-	if (!is_npc(ch) && !is_npc(victim) && victim->fighting == nullptr)
+	if (!is_npc(ch) && !is_npc(victim) && Deref(victim->fighting) == nullptr)
 	{
 		sprintf(buf, "Help! I've been ambushed by %s!", pers(ch, victim));
 		do_myell(victim, buf, ch);
@@ -6042,7 +6054,7 @@ void do_rescue(CHAR_DATA *ch, char *argument)
 		return;
 	}
 
-	fch = victim->fighting;
+	fch = Deref(victim->fighting);
 
 	if (fch == nullptr)
 	{
@@ -6050,7 +6062,7 @@ void do_rescue(CHAR_DATA *ch, char *argument)
 		return;
 	}
 
-	if (is_safe(ch, victim->fighting))
+	if (is_safe(ch, Deref(victim->fighting)))
 		return;
 
 	WAIT_STATE(ch, skill_table[gsn_rescue].beats);
@@ -6088,7 +6100,7 @@ void do_kick(CHAR_DATA *ch, char *argument)
 		return;
 	}
 
-	victim = ch->fighting;
+	victim = Deref(ch->fighting);
 
 	if (victim == nullptr)
 	{
@@ -6161,7 +6173,7 @@ void do_disarm(CHAR_DATA *ch, char *argument)
 		return;
 	}
 
-	victim = ch->fighting;
+	victim = Deref(ch->fighting);
 
 	if (victim == nullptr)
 	{
@@ -6235,7 +6247,7 @@ void do_disarm(CHAR_DATA *ch, char *argument)
 
 void do_surrender(CHAR_DATA *ch, char *argument)
 {
-	CHAR_DATA *mob = ch->fighting;
+	CHAR_DATA *mob = Deref(ch->fighting);
 
 	if (mob == nullptr)
 	{
@@ -6466,7 +6478,7 @@ void do_cleave(CHAR_DATA *ch, char *argument)
 		return;
 	}
 
-	if (victim->fighting != nullptr)
+	if (Deref(victim->fighting) != nullptr)
 	{
 		send_to_char("They are moving too much to cleave.\n\r", ch);
 		return;
@@ -6609,7 +6621,7 @@ void do_tail(CHAR_DATA *ch, char *argument)
 
 	if (arg[0] == '\0')
 	{
-		victim = ch->fighting;
+		victim = Deref(ch->fighting);
 
 		if (victim == nullptr)
 		{
@@ -6679,7 +6691,7 @@ void do_throw(CHAR_DATA *ch, char *argument)
 	one_argument(argument, arg);
 
 	if (arg[0] == '\0')
-		victim = ch->fighting;
+		victim = Deref(ch->fighting);
 	else
 		victim = get_char_room(ch, arg);
 
@@ -6695,7 +6707,7 @@ void do_throw(CHAR_DATA *ch, char *argument)
 		return;
 	}
 
-	if ((victim->fighting != ch) && (ch->fighting != victim))
+	if ((Deref(victim->fighting) != ch) && (Deref(ch->fighting) != victim))
 	{
 		send_to_char("But you aren't engaged in combat with them.\n\r", ch);
 		return;
@@ -6868,7 +6880,7 @@ void do_throw(CHAR_DATA *ch, char *argument)
 	damage_old(ch, victim, dam, gsn_throw, DAM_BASH, true);
 	WAIT_STATE(ch, 2 * PULSE_VIOLENCE);
 
-	if (ch->fighting == victim)
+	if (Deref(ch->fighting) == victim)
 		check_ground_control(ch, victim, chance, dam);
 }
 
@@ -6892,7 +6904,7 @@ void do_nerve(CHAR_DATA *ch, char *argument)
 	one_argument(argument, arg);
 
 	if (arg[0] == '\0')
-		victim = ch->fighting;
+		victim = Deref(ch->fighting);
 	else
 		victim = get_char_room(ch, arg);
 
@@ -6952,13 +6964,13 @@ void do_nerve(CHAR_DATA *ch, char *argument)
 		WAIT_STATE(ch, PULSE_VIOLENCE);
 	}
 
-	if (!is_npc(ch) && !is_npc(victim) && (ch->fighting == nullptr || victim->fighting == nullptr))
+	if (!is_npc(ch) && !is_npc(victim) && (Deref(ch->fighting) == nullptr || Deref(victim->fighting) == nullptr))
 	{
 		sprintf(buf, "Help, %s is attacking me!", pers(ch, victim));
 		do_myell(victim, buf, ch);
 	}
 
-	if (victim->fighting == nullptr)
+	if (Deref(victim->fighting) == nullptr)
 	{
 		multi_hit(victim, ch, TYPE_UNDEFINED);
 	}
@@ -7049,7 +7061,7 @@ void do_blindness_dust(CHAR_DATA *ch, char *argument)
 	send_to_char("You throw a handful of blindness dust into the room!\n\r", ch);
 	check_improve(ch, gsn_blindness_dust, true, 2);
 
-	if (ch->fighting != nullptr)
+	if (Deref(ch->fighting) != nullptr)
 		fighting = true;
 
 	init_affect(&af);
@@ -7085,13 +7097,13 @@ void do_blindness_dust(CHAR_DATA *ch, char *argument)
 			affect_to_char(vch, &af);
 		}
 
-		if (!is_npc(vch) && !is_npc(ch) && (vch->fighting == nullptr || (!fighting)))
+		if (!is_npc(vch) && !is_npc(ch) && (Deref(vch->fighting) == nullptr || (!fighting)))
 		{
 			sprintf(buf, "Help! %s just threw dust in my eyes!", pers(ch, vch));
 			do_myell(vch, buf, ch);
 		}
 
-		if (vch->fighting == nullptr)
+		if (Deref(vch->fighting) == nullptr)
 			multi_hit(vch, ch, TYPE_UNDEFINED);
 	}
 }
@@ -7135,7 +7147,7 @@ void do_poison_dust(CHAR_DATA *ch, char *argument)
 	send_to_char("You throw a handful of poison dust into the room!\n\r", ch);
 	check_improve(ch, gsn_poison_dust, true, 2);
 
-	if (ch->fighting != nullptr)
+	if (Deref(ch->fighting) != nullptr)
 		fighting = true;
 
 	af.aftype = AFT_SKILL;
@@ -7173,14 +7185,14 @@ void do_poison_dust(CHAR_DATA *ch, char *argument)
 			affect_to_char(vch, &af);
 		}
 
-		if (!is_npc(vch) && !is_npc(ch) && (vch->fighting == nullptr || (!fighting)))
+		if (!is_npc(vch) && !is_npc(ch) && (Deref(vch->fighting) == nullptr || (!fighting)))
 		{
 			sprintf(buf, "Help! %s just threw dust in my eyes!", pers(ch, vch));
 			do_myell(vch, buf, ch);
 		}
 	return;
 
-		if (vch->fighting == nullptr)
+		if (Deref(vch->fighting) == nullptr)
 			multi_hit(vch, ch, TYPE_UNDEFINED);
 	}
 }
@@ -7484,7 +7496,7 @@ void do_tame(CHAR_DATA *ch, char *argument)
 	one_argument(argument, arg);
 
 	if (arg[0] == '\0')
-		victim = ch->fighting;
+		victim = Deref(ch->fighting);
 	else
 		victim = get_char_room(ch, arg);
 
@@ -7601,7 +7613,7 @@ void do_shield_cleave(CHAR_DATA *ch, char *argument)
 	one_argument(argument, arg);
 
 	if (arg[0] == '\0')
-		victim = ch->fighting;
+		victim = Deref(ch->fighting);
 	else
 		victim = get_char_room(ch, arg);
 
@@ -7655,7 +7667,7 @@ void do_shield_cleave(CHAR_DATA *ch, char *argument)
 	if (!using_primary)
 		chance -= 15;
 
-	if (!is_npc(victim) && ch->fighting != victim)
+	if (!is_npc(victim) && Deref(ch->fighting) != victim)
 	{
 		sprintf(buf, "Help! %s just shield cleaved me!", pers(ch, victim));
 		do_myell(victim, buf, ch);
@@ -7900,7 +7912,7 @@ void do_intimidate(CHAR_DATA *ch, char *argument)
 	one_argument(argument, arg);
 
 	if (arg[0] == '\0')
-		victim = ch->fighting;
+		victim = Deref(ch->fighting);
 	else
 		victim = get_char_room(ch, arg);
 
@@ -7964,7 +7976,7 @@ void do_flee(CHAR_DATA *ch, char *argument)
 	int attempt, chance, dir;
 	bool pounced = false;
 
-	victim = ch->fighting;
+	victim = Deref(ch->fighting);
 
 	if (victim == nullptr)
 	{
@@ -8035,7 +8047,7 @@ void do_flee(CHAR_DATA *ch, char *argument)
 		if (!is_npc(panther)
 			&& is_affected(panther, gsn_rage)
 			&& panther->pcdata->tribe == TRIBE_PANTHER
-			&& panther->fighting == ch)
+			&& Deref(panther->fighting) == ch)
 		{
 			break;
 		}
@@ -8186,7 +8198,7 @@ void do_assassinate(CHAR_DATA *ch, char *argument)
 		return;
 	}
 
-	if (victim->fighting != nullptr || victim->position == POS_FIGHTING)
+	if (Deref(victim->fighting) != nullptr || victim->position == POS_FIGHTING)
 	{
 		send_to_char("They are moving around too much to get in close for the kill.\n\r", ch);
 		return;
@@ -8322,7 +8334,7 @@ void do_lash(CHAR_DATA *ch, char *argument)
 
 	if (arg[0] == '\0')
 	{
-		victim = ch->fighting;
+		victim = Deref(ch->fighting);
 
 		if (victim == nullptr)
 		{
@@ -8376,7 +8388,7 @@ void do_lash(CHAR_DATA *ch, char *argument)
 	if (is_npc(victim))
 		chance += (ch->level - victim->level) * 3;
 
-	if (!is_npc(ch) && !is_npc(victim) && (victim->fighting == nullptr || ch->fighting == nullptr))
+	if (!is_npc(ch) && !is_npc(victim) && (Deref(victim->fighting) == nullptr || Deref(ch->fighting) == nullptr))
 	{
 		sprintf(buf, "Help! %s is lashing me!", pers(ch, victim));
 		do_myell(victim, buf, ch);
@@ -8389,7 +8401,7 @@ void do_lash(CHAR_DATA *ch, char *argument)
 		act("You lash at $N's legs but miss.", ch, 0, victim, TO_CHAR);
 		check_improve(ch, gsn_lash, false, 1);
 
-		if (ch->fighting == nullptr)
+		if (Deref(ch->fighting) == nullptr)
 			set_fighting(ch, victim);
 
 		WAIT_STATE(ch, PULSE_VIOLENCE * 2);
@@ -8406,7 +8418,7 @@ void do_lash(CHAR_DATA *ch, char *argument)
 
 	damage_old(ch, victim, dice(2, 7), gsn_lash, DAM_BASH, true);
 
-	if (ch->fighting == nullptr)
+	if (Deref(ch->fighting) == nullptr)
 		multi_hit(victim, ch, TYPE_UNDEFINED);
 
 	victim->position = POS_RESTING;
@@ -8434,7 +8446,7 @@ void do_pugil(CHAR_DATA *ch, char *argument)
 
 	if (arg[0] == '\0')
 	{
-		victim = ch->fighting;
+		victim = Deref(ch->fighting);
 
 		if (victim == nullptr)
 		{
@@ -8453,7 +8465,7 @@ void do_pugil(CHAR_DATA *ch, char *argument)
 		}
 	}
 
-	if (ch->fighting == nullptr)
+	if (Deref(ch->fighting) == nullptr)
 	{
 		send_to_char("You can't pugil someone like that.\n\r", ch);
 		return;
@@ -8553,7 +8565,7 @@ void do_call_to_arms(CHAR_DATA *ch, char *arguement)
 		return;
 	}
 
-	if (ch->fighting == nullptr)
+	if (Deref(ch->fighting) == nullptr)
 	{
 		send_to_char("You give a stirring call to arms, but alas there is nobody to fight.\n\r", ch);
 		act("$n cries out to nobody in particular to fight nobody in particular.", ch, nullptr, nullptr, TO_ROOM);
@@ -8600,7 +8612,7 @@ void do_call_to_arms(CHAR_DATA *ch, char *arguement)
 		if (ch->mana < 15)
 			continue;
 
-		if (ch->fighting == nullptr)
+		if (Deref(ch->fighting) == nullptr)
 			continue;
 
 		if (target->level > (ch->level + 12))
@@ -8619,9 +8631,9 @@ void do_call_to_arms(CHAR_DATA *ch, char *arguement)
 		ch->mana -= 15;
 
 		act("$N rallies to your call!", ch, nullptr, target, TO_CHAR);
-		act("$n screams and rushes to attack $N!", target, nullptr, ch->fighting, TO_NOTVICT);
-		act("$n screams and rushes forwards to attack you!", target, nullptr, ch->fighting, TO_VICT);
-		multi_hit(target, ch->fighting, TYPE_UNDEFINED);
+		act("$n screams and rushes to attack $N!", target, nullptr, Deref(ch->fighting), TO_NOTVICT);
+		act("$n screams and rushes forwards to attack you!", target, nullptr, Deref(ch->fighting), TO_VICT);
+		multi_hit(target, Deref(ch->fighting), TYPE_UNDEFINED);
 		continue;
 	}
 
@@ -8785,6 +8797,7 @@ bool check_maneuvering(CHAR_DATA *ch, CHAR_DATA *victim, int dt)
 	int chance, count = 0;
 	bool ableth = false;
 	CHAR_DATA *vch, *vch_next;
+	CHAR_DATA *tank;
 	char buf1[MAX_STRING_LENGTH], buf2[MAX_STRING_LENGTH];
 
 	if (!is_npc(victim))
@@ -8814,7 +8827,7 @@ bool check_maneuvering(CHAR_DATA *ch, CHAR_DATA *victim, int dt)
 		person he is tanking..get to be maneuvered around */
 		if (vch != victim)
 		{
-			if (vch->fighting == victim && victim->fighting != vch)
+			if (Deref(vch->fighting) == victim && Deref(victim->fighting) != vch)
 				count++;
 
 			if (vch == ch && count < 3)
@@ -8825,8 +8838,10 @@ bool check_maneuvering(CHAR_DATA *ch, CHAR_DATA *victim, int dt)
 	/* Mob level difference */
 	chance -= ch->level - victim->level;
 
+	tank = Deref(victim->fighting);
+
 	/* Can't be fighting directly */
-	if (ch == victim->fighting || !ableth)
+	if (ch == tank || !ableth)
 		return false;
 
 	/* Skill % * 65% chance of it happening */
@@ -8838,7 +8853,7 @@ bool check_maneuvering(CHAR_DATA *ch, CHAR_DATA *victim, int dt)
 
 	/* Echo the messages to the relative people */
 	sprintf(buf1, "You position yourself on the far side of %s, keeping %s at bay.\n\r",
-			is_npc(victim->fighting) ? victim->fighting->short_descr : victim->fighting->name,
+			is_npc(tank) ? tank->short_descr : tank->name,
 			is_npc(ch) ? ch->short_descr : ch->name);
 	send_to_char(buf1, victim);
 
@@ -9083,7 +9098,7 @@ bool check_sidestep(CHAR_DATA *ch, CHAR_DATA *victim, int skill, int mod)
 		chance = (int)(chance * ((float)mod / 100));
 	}
 
-	if (victim->fighting)
+	if (Deref(victim->fighting))
 		return false;
 
 	if (!can_see(victim, ch))
@@ -9192,7 +9207,7 @@ void do_gore(CHAR_DATA *ch, char *argument)
 		return;
 	}
 
-	if (ch->fighting)
+	if (Deref(ch->fighting))
 	{
 		send_to_char("You can't gore in combat!\n\r", ch);
 		return;
@@ -9292,7 +9307,7 @@ void do_headbutt(CHAR_DATA *ch, char *argument)
 		return;
 	}
 
-	victim = ch->fighting;
+	victim = Deref(ch->fighting);
 
 	if (victim == nullptr)
 	{
@@ -9383,21 +9398,25 @@ void do_headbutt(CHAR_DATA *ch, char *argument)
 
 void do_disengage(CHAR_DATA *ch, char *argument)
 {
-	if (!ch->fighting)
+	CHAR_DATA *opponent;
+
+	opponent = Deref(ch->fighting);
+
+	if (opponent == nullptr)
 	{
 		send_to_char("You aren't fighting anyone!\n\r", ch);
 		return;
 	}
 
-	if (ch->fighting->fighting == ch)
+	if (Deref(opponent->fighting) == ch)
 	{
 		send_to_char("It's called fleeing.  Look into it.\n\r", ch);
 		return;
 	}
 
-	act("You cease attacking $N.", ch, 0, ch->fighting, TO_CHAR);
-	act("$n ceases attacking you.", ch, 0, ch->fighting, TO_VICT);
-	act("$n ceases attacking $N.", ch, 0, ch->fighting, TO_NOTVICT);
+	act("You cease attacking $N.", ch, 0, opponent, TO_CHAR);
+	act("$n ceases attacking you.", ch, 0, opponent, TO_VICT);
+	act("$n ceases attacking $N.", ch, 0, opponent, TO_NOTVICT);
 
 	stop_fighting(ch, false);
 

--- a/code/fight.c
+++ b/code/fight.c
@@ -1664,7 +1664,7 @@ bool is_safe_new(CHAR_DATA *ch, CHAR_DATA *victim, bool show)
 		&& is_npc(victim)
 		&& !is_affected_by(ch,AFF_CHARM)
 		&& !is_affected_by(victim,AFF_CHARM) && !ch->desc
-		&& !ch->hunting && !victim->hunting && victim!=ch
+		&& !Deref(ch->hunting) && !Deref(victim->hunting) && victim!=ch
 		&& Deref(ch->fighting) != victim
 		&& Deref(victim->fighting) != ch
 		&& !ch->desc && !victim->desc)

--- a/code/fight.c
+++ b/code/fight.c
@@ -341,6 +341,16 @@ void check_assist(CHAR_DATA *ch, CHAR_DATA *victim)
 
 /*
  * Do one group of attacks.
+ *
+ * The `Deref(ch->fighting) != victim` test repeated after each attack below is
+ * the guard that stops the rest of the round when the fight is already over --
+ * the victim died and stop_fighting cleared the field, or the attacker was
+ * switched onto someone else. It has to re-read the handle every time, because
+ * the thing it is checking for is caused by the one_hit immediately above it.
+ *
+ * Do NOT hoist these into a local. A cached opponent from before the first
+ * swing compares equal forever, the guard never fires, and every remaining
+ * attack in the round lands on a character that may already be freed.
  */
 void multi_hit(CHAR_DATA *ch, CHAR_DATA *victim, int dt)
 {
@@ -639,6 +649,11 @@ void multi_hit(CHAR_DATA *ch, CHAR_DATA *victim, int dt)
 
 /* procedure for all mobile attacks */
 
+/*
+ * Same rule as multi_hit above: the repeated `Deref(ch->fighting) != victim`
+ * checks are the round's abort condition and must re-read the handle after
+ * every swing. Caching the opponent defeats them.
+ */
 void mob_hit(CHAR_DATA *ch, CHAR_DATA *victim, int dt)
 {
 	int chance, number;
@@ -975,6 +990,10 @@ int one_hit_new(CHAR_DATA *ch, CHAR_DATA *victim, int dt, bool specials, bool bl
 
 	if (result && wield != nullptr)
 	{
+		// Re-read rather than reusing anything from before the damage_new
+		// above: this test is asking whether the victim survived the hit and
+		// is still the one being fought, so it only means something if it goes
+		// back through the handle.
 		if (Deref(ch->fighting) == victim && is_weapon_stat(wield, WEAPON_POISON))
 		{
 			int level = 10;

--- a/code/fight.c
+++ b/code/fight.c
@@ -3451,6 +3451,27 @@ void raw_kill(CHAR_DATA *ch, CHAR_DATA *victim)
 
 	extract_char(victim, false);
 
+	// Death clears every other player's record of having fought the victim, and
+	// cancels their trust in them. Both used to be done inside extract_char and
+	// that was the wrong home: a slain player is not removed from the world,
+	// they are moved to the altar and stay in char_list, so these are game
+	// rules rather than lifetime cleanup, and a handle will not expire them.
+	// Placed immediately after the call so the ordering is exactly what it was.
+	//
+	// No test covers this loop -- raw_kill needs far more world than the test
+	// suite stands up. The suite pins the half that led here (extract_char
+	// leaves a slain player alive, so the references stay live and something
+	// else has to drop them); this is the half that answers it. Deleting it
+	// will not fail a build or a test, it will quietly restore a bug.
+	for (CHAR_DATA *wch = char_list; wch != nullptr; wch = wch->next)
+	{
+		if (Deref(wch->last_fight_opponent) == victim)
+			wch->last_fight_opponent = nullptr;
+
+		if (!is_npc(wch) && Deref(wch->pcdata->trusting) == victim)
+			wch->pcdata->trusting = nullptr;
+	}
+
 	for (auto it = victim->affected.begin(); it != victim->affected.end(); )
 	{
 		auto next = std::next(it);
@@ -3513,6 +3534,8 @@ void raw_kill(CHAR_DATA *ch, CHAR_DATA *victim)
 	af.level = victim->level;
 	affect_to_char(victim, &af);
 
+	// The victim's own half of the fight record; the other players' half is
+	// cleared up by extract_char, above.
 	victim->last_fight_opponent = nullptr;
 	victim->last_fight_time = 0;
 

--- a/code/fight.c
+++ b/code/fight.c
@@ -224,14 +224,16 @@ void check_assist(CHAR_DATA *ch, CHAR_DATA *victim)
 			if (!is_npc(ch) || is_affected_by(ch, AFF_CHARM))
 			{
 				/* First check defending */
-				if (rch->defending != nullptr)
+				CHAR_DATA *guarded = Deref(rch->defending);
+
+				if (guarded != nullptr)
 				{
 					CHAR_DATA *fch;
 
 					fch = Deref(ch->fighting);
 
-					if (rch->defending != nullptr
-						&& rch->defending == ch
+					if (guarded != nullptr
+						&& guarded == ch
 						&& fch != nullptr
 						&& Deref(fch->fighting) == ch
 						&& number_percent() < get_skill(rch, gsn_defend)
@@ -2135,7 +2137,7 @@ bool check_parry(CHAR_DATA *ch, CHAR_DATA *victim, int dt)
 	chance -= ch->batter;
 	chance -= ch->analyze;
 
-	if (victim->analyzePC == ch)
+	if (Deref(victim->analyzePC) == ch)
 		chance += victim->analyze;
 
 	if (!is_npc(victim) && IS_SET(victim->act, PLR_MORON))
@@ -2257,7 +2259,7 @@ bool check_shield_block(CHAR_DATA *ch, CHAR_DATA *victim, int dt)
 	chance -= ch->batter;
 	chance -= ch->analyze;
 
-	if (victim->analyzePC == ch)
+	if (Deref(victim->analyzePC) == ch)
 		chance += victim->analyze;
 
 	if (check_entwine(victim, 1))
@@ -2420,7 +2422,7 @@ bool check_dodge(CHAR_DATA *ch, CHAR_DATA *victim, int dt)
 	chance += ch->balance;
 	chance -= ch->analyze;
 
-	if (victim->analyzePC == ch)
+	if (Deref(victim->analyzePC) == ch)
 		chance += victim->analyze;
 
 	if (!is_npc(victim) && style_check(gsn_evasion, victim->pcdata->style))
@@ -2546,7 +2548,7 @@ bool check_avoid(CHAR_DATA *ch, CHAR_DATA *victim, int dt)
 
 	chance -= ch->analyze;
 
-	if (victim->analyzePC == ch)
+	if (Deref(victim->analyzePC) == ch)
 		chance += victim->analyze;
 
 	if (!is_npc(victim))
@@ -2707,7 +2709,7 @@ bool check_fend(CHAR_DATA *ch, CHAR_DATA *victim, int dt)
 	if (ch->size > victim->size + 1)
 		skill /= pow(2, (ch->size - (victim->size - 1)));
 
-	if (victim->analyzePC == ch)
+	if (Deref(victim->analyzePC) == ch)
 		skill += victim->analyze;
 
 	skill = URANGE(5, skill, 85);
@@ -2780,7 +2782,7 @@ bool check_deflect(CHAR_DATA *ch, CHAR_DATA *victim, int dt)
 	chance -= victim->balance;
 	chance += ch->balance;
 
-	if (victim->analyzePC == ch)
+	if (Deref(victim->analyzePC) == ch)
 		chance += victim->analyze;
 
 	if (chance > 95)
@@ -2839,10 +2841,10 @@ void check_analyze(CHAR_DATA *ch, CHAR_DATA *victim)
 		if (number_percent () > (skill - 125 + (5 * get_curr_stat(ch,STAT_INT))))
 			return;
 
-		if (victim != ch->analyzePC)
+		if (victim != Deref(ch->analyzePC))
 			ch->analyze = 0;
 
-		ch->analyzePC = Deref(ch->fighting);
+		ch->analyzePC = ch->fighting;		// handle to handle; no lookup needed
 		if (ch->analyze < 50)
 			ch->analyze++;
 	*/
@@ -2862,10 +2864,10 @@ void check_analyze(CHAR_DATA *ch, CHAR_DATA *victim)
 	if (number_percent() > (skill - 125 + (5 * intel)))
 		return;
 
-	if (victim != ch->analyzePC)
+	if (victim != Deref(ch->analyzePC))
 		ch->analyze = 0;
 
-	ch->analyzePC = Deref(ch->fighting);
+	ch->analyzePC = ch->fighting;		// handle to handle; no lookup needed
 
 	if (is_npc(victim))
 	{
@@ -7871,6 +7873,7 @@ void do_defend(CHAR_DATA *ch, char *argument)
 	CHAR_DATA *victim;
 	char arg[MAX_STRING_LENGTH];
 	char buf[MAX_STRING_LENGTH];
+	CHAR_DATA *ward;
 
 	one_argument(argument, arg);
 	if (get_skill(ch, gsn_defend) == 0 || ch->level < skill_table[gsn_defend].skill_level[ch->Class()->GetIndex()])
@@ -7879,12 +7882,14 @@ void do_defend(CHAR_DATA *ch, char *argument)
 		return;
 	}
 
+	ward = Deref(ch->defending);
+
 	if (arg[0] == '\0')
 	{
-		if (ch->defending == nullptr)
+		if (ward == nullptr)
 			sprintf(buf, "You aren't defending anyone right now.\n\r");
 		else
-			sprintf(buf, "You are defending %s.\n\r", ch->defending->name);
+			sprintf(buf, "You are defending %s.\n\r", ward->name);
 
 		send_to_char(buf, ch);
 		return;
@@ -7911,14 +7916,14 @@ void do_defend(CHAR_DATA *ch, char *argument)
 		return;
 	}
 
-	if (ch->defending != nullptr)
+	if (ward != nullptr)
 	{
-		act("You stop defending $N.", ch, 0, ch->defending, TO_CHAR);
-		act("$n stops defending you.", ch, 0, ch->defending, TO_VICT);
+		act("You stop defending $N.", ch, 0, ward, TO_CHAR);
+		act("$n stops defending you.", ch, 0, ward, TO_VICT);
 	}
 
 	act("You start defending $N.\n\r", ch, 0, victim, TO_CHAR);
-	ch->defending = victim;
+	ch->defending = victim->self;
 	act("$n is now defending you.", ch, 0, victim, TO_VICT);
 }
 

--- a/code/fight.c
+++ b/code/fight.c
@@ -1219,7 +1219,7 @@ int damage_new(CHAR_DATA *ch, CHAR_DATA *victim, int idam, int dt, int dam_type,
 		}
 
 		if (ch != victim)
-			damage_new(ch, laf->owner, (int)(dam * 0.25f), gsn_empathy, DAM_INTERNAL, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "spiritual link");
+			damage_new(ch, Deref(laf->owner), (int)(dam * 0.25f), gsn_empathy, DAM_INTERNAL, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "spiritual link");
 
 		dam *= .75;
 	}
@@ -1293,16 +1293,16 @@ int damage_new(CHAR_DATA *ch, CHAR_DATA *victim, int idam, int dt, int dam_type,
 	{
 		af = affect_find(victim->affected, gsn_holy_shroud);
 
-		if (af->owner == victim && is_evil(ch))
+		if (Deref(af->owner) == victim && is_evil(ch))
 			dam *= .5;
 
-		if (af->owner == victim && !is_evil(ch))
+		if (Deref(af->owner) == victim && !is_evil(ch))
 			dam *= .8;
 
-		if (af->owner != victim && is_evil(ch))
+		if (Deref(af->owner) != victim && is_evil(ch))
 			dam *= .75;
 
-		if (af->owner != victim && !is_evil(ch))
+		if (Deref(af->owner) != victim && !is_evil(ch))
 			dam *= .9;
 	}
 
@@ -1319,7 +1319,7 @@ int damage_new(CHAR_DATA *ch, CHAR_DATA *victim, int idam, int dt, int dam_type,
 
 	if (ch != nullptr
 		&& (af = affect_find(ch->affected, gsn_divine_ward)) != nullptr
-		&& af->owner == victim
+		&& Deref(af->owner) == victim
 		&& dam_type != DAM_TRUESTRIKE)
 	{
 		if (af->modifier == 1)
@@ -1438,8 +1438,8 @@ int damage_new(CHAR_DATA *ch, CHAR_DATA *victim, int idam, int dt, int dam_type,
 
 	/* retribution */
 	AFFECT_DATA *paf = affect_find(ch->affected, gsn_retribution);
-	if (paf && paf->owner == victim)
-		paf->modifier = std::min((int)dam + paf->modifier, paf->owner->level * 8);
+	if (paf && Deref(paf->owner) == victim)
+		paf->modifier = std::min((int)dam + paf->modifier, Deref(paf->owner)->level * 8);
 
 	/*
 	 * Hurt the victim.
@@ -9228,10 +9228,10 @@ void bleeding_tick(CHAR_DATA *ch, AFFECT_DATA *af)
 
 	send_to_char("You continue bleeding from your wounds.\n\r", ch);
 
-	if (!af->owner)
-		af->owner = ch;
+	if (!Deref(af->owner))
+		af->owner = ch->self;
 
-	damage_new(af->owner, ch, af->level, gsn_bleeding, DAM_OTHER, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, nullptr);
+	damage_new(Deref(af->owner), ch, af->level, gsn_bleeding, DAM_OTHER, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, nullptr);
 }
 
 void do_gore(CHAR_DATA *ch, char *argument)
@@ -9317,7 +9317,7 @@ void do_gore(CHAR_DATA *ch, char *argument)
 			af.type = gsn_bleeding;
 			af.aftype = AFT_MALADY;
 			af.level = ch->level;
-			af.owner = ch;
+			af.owner = ch->self;
 			af.duration = 4;
 			af.location = APPLY_STR;
 			af.modifier = -ch->level / 10;
@@ -9397,7 +9397,7 @@ void do_headbutt(CHAR_DATA *ch, char *argument)
 			af.where = TO_AFFECTS;
 			af.type = gsn_headbutt;
 			af.aftype = AFT_SKILL;
-			af.owner = ch;
+			af.owner = ch->self;
 			af.level = ch->level;
 			af.duration = 2;
 
@@ -9420,7 +9420,7 @@ void do_headbutt(CHAR_DATA *ch, char *argument)
 			af.where = TO_AFFECTS;
 			af.type = gsn_headbutt;
 			af.aftype = AFT_SKILL;
-			af.owner = ch;
+			af.owner = ch->self;
 			af.level = ch->level;
 			af.duration = 2;
 

--- a/code/fight.c
+++ b/code/fight.c
@@ -1134,7 +1134,7 @@ int damage_new(CHAR_DATA *ch, CHAR_DATA *victim, int idam, int dt, int dam_type,
 		/*
 		 * More charm stuff.
 		 */
-		if (victim->master == ch && !(dnoun && dnoun[strlen(dnoun) - 1] == '*'))
+		if (Deref(victim->master) == ch && !(dnoun && dnoun[strlen(dnoun) - 1] == '*'))
 			stop_follower(victim);
 	}
 
@@ -1568,8 +1568,8 @@ int damage_new(CHAR_DATA *ch, CHAR_DATA *victim, int idam, int dt, int dam_type,
 				&& number_bits(2) == 0
 				&& victim->hit < victim->max_hit / 5))
 			|| ((is_affected_by(victim, AFF_CHARM)
-					&& victim->master != nullptr
-					&& victim->master->in_room != victim->in_room)
+					&& Deref(victim->master) != nullptr
+					&& Deref(victim->master)->in_room != victim->in_room)
 				&& dt != gsn_parting_blow))
 		{
 			do_flee(victim, "");
@@ -1733,7 +1733,7 @@ bool is_safe_new(CHAR_DATA *ch, CHAR_DATA *victim, bool show)
 			return true;
 		}
 
-		if (is_affected_by(victim, AFF_CHARM) && victim->master != nullptr && !is_npc(victim->master))
+		if (is_affected_by(victim, AFF_CHARM) && Deref(victim->master) != nullptr && !is_npc(Deref(victim->master)))
 		{
 			if (show)
 			{
@@ -1752,7 +1752,7 @@ bool is_safe_new(CHAR_DATA *ch, CHAR_DATA *victim, bool show)
 		if (!is_npc(ch))
 		{
 			/* no charmed creatures unless in pk of master */
-			if (is_affected_by(victim, AFF_CHARM) && victim->master && !can_pk(ch, victim->master))
+			if (is_affected_by(victim, AFF_CHARM) && Deref(victim->master) && !can_pk(ch, Deref(victim->master)))
 			{
 				if (show)
 				{
@@ -1766,7 +1766,7 @@ bool is_safe_new(CHAR_DATA *ch, CHAR_DATA *victim, bool show)
 		}
 		else
 		{
-			if (is_affected_by(ch, AFF_CHARM) && is_affected_by(victim, AFF_CHARM) && !can_pk(ch->master, victim->master))
+			if (is_affected_by(ch, AFF_CHARM) && is_affected_by(victim, AFF_CHARM) && !can_pk(Deref(ch->master), Deref(victim->master)))
 				return true;
 		}
 	}
@@ -1775,7 +1775,9 @@ bool is_safe_new(CHAR_DATA *ch, CHAR_DATA *victim, bool show)
 		if (is_npc(ch))
 		{ /* NPC doing the killing */
 			/* charmed mobs and pets cannot attack players while owned */
-			if (is_affected_by(ch, AFF_CHARM) && ch->master != nullptr && Deref(ch->master->fighting) != victim)
+			CHAR_DATA *owner = Deref(ch->master);
+
+			if (is_affected_by(ch, AFF_CHARM) && owner != nullptr && Deref(owner->fighting) != victim)
 			{
 				send_to_char("Players are your friends!\n\r", ch);
 				return true;
@@ -1853,7 +1855,7 @@ bool is_safe_spell(CHAR_DATA *ch, CHAR_DATA *victim, bool area)
 				return true;
 
 			/* no charmed creatures unless owner */
-			if (is_affected_by(victim, AFF_CHARM) && (area || ch != victim->master))
+			if (is_affected_by(victim, AFF_CHARM) && (area || ch != Deref(victim->master)))
 				return true;
 
 			/* legal kill? -- cannot hit mob fighting non-group member */
@@ -1877,7 +1879,9 @@ bool is_safe_spell(CHAR_DATA *ch, CHAR_DATA *victim, bool area)
 		if (is_npc(ch))
 		{
 			/* charmed mobs and pets cannot attack players while owned */
-			if (is_affected_by(ch, AFF_CHARM) && ch->master != nullptr && Deref(ch->master->fighting) != victim)
+			CHAR_DATA *owner = Deref(ch->master);
+
+			if (is_affected_by(ch, AFF_CHARM) && owner != nullptr && Deref(owner->fighting) != victim)
 				return true;
 
 			/* safe room? */
@@ -3356,11 +3360,11 @@ void raw_kill(CHAR_DATA *ch, CHAR_DATA *victim)
 
 	if (is_npc(ch)
 		&& is_affected_by(ch, AFF_CHARM)
-		&& ch->master
-		&& ch->master->in_room
-		&& ch->master->in_room == ch->in_room)
+		&& Deref(ch->master)
+		&& Deref(ch->master)->in_room
+		&& Deref(ch->master)->in_room == ch->in_room)
 	{
-		ch = ch->master;
+		ch = Deref(ch->master);
 	}
 
 	if (IS_SET(victim->progtypes, MPROG_DEATH))
@@ -3413,7 +3417,7 @@ void raw_kill(CHAR_DATA *ch, CHAR_DATA *victim)
 	{
 		gch_next = gch->next;
 
-		if (is_npc(gch) && gch->master == victim && gch->pIndexData->vnum != ACADEMY_PET && !is_npc(victim))
+		if (is_npc(gch) && Deref(gch->master) == victim && gch->pIndexData->vnum != ACADEMY_PET && !is_npc(victim))
 			extract_char(gch, true);
 	}
 
@@ -3547,8 +3551,8 @@ void raw_kill(CHAR_DATA *ch, CHAR_DATA *victim)
 			send_to_char("The banshee wails as you feel closer to a permanent death.\n\r", victim);
 	}
 
-	if (is_npc(ch) && is_affected_by(ch, AFF_CHARM) && ch->master)
-		ch = ch->master;
+	if (is_npc(ch) && is_affected_by(ch, AFF_CHARM) && Deref(ch->master))
+		ch = Deref(ch->master);
 
 	if (infidels == true)
 	{
@@ -3728,7 +3732,7 @@ void group_gain(CHAR_DATA *ch, CHAR_DATA *victim)
 		{
 			// if(!is_npc(gch))
 			members++;
-			group_levels += (is_npc(gch) && gch->master) ? gch->master->level : gch->level;
+			group_levels += (is_npc(gch) && Deref(gch->master)) ? Deref(gch->master)->level : gch->level;
 			// note: the preceding code skews the group average a bit in favor of the group leader if there's npcs in
 			// the group but i don't really care
 		}
@@ -3737,7 +3741,7 @@ void group_gain(CHAR_DATA *ch, CHAR_DATA *victim)
 	if (members == 0)
 		members = 1;
 
-	lch = (ch->leader != nullptr) ? ch->leader : ch;
+	lch = (Deref(ch->leader) != nullptr) ? Deref(ch->leader) : ch;
 
 	if (ch->in_room == nullptr)
 		return;
@@ -5154,7 +5158,7 @@ void do_bash(CHAR_DATA *ch, char *argument)
 	if (is_safe(ch, victim))
 		return;
 
-	if (is_affected_by(ch, AFF_CHARM) && ch->master == victim)
+	if (is_affected_by(ch, AFF_CHARM) && Deref(ch->master) == victim)
 	{
 		act("But $N is your friend!", ch, nullptr, victim, TO_CHAR);
 		return;
@@ -5446,7 +5450,7 @@ void do_dirt(CHAR_DATA *ch, char *argument)
 	if (check_sidestep(ch, victim, gsn_dirt, 95))
 		return;
 
-	if (is_affected_by(ch, AFF_CHARM) && ch->master == victim)
+	if (is_affected_by(ch, AFF_CHARM) && Deref(ch->master) == victim)
 	{
 		act("But $N is such a good friend!", ch, nullptr, victim, TO_CHAR);
 		return;
@@ -5640,7 +5644,7 @@ void do_trip(CHAR_DATA *ch, char *argument)
 		return;
 	}
 
-	if (is_affected_by(ch, AFF_CHARM) && ch->master == victim)
+	if (is_affected_by(ch, AFF_CHARM) && Deref(ch->master) == victim)
 	{
 		act("$N is your beloved master.", ch, nullptr, victim, TO_CHAR);
 		return;
@@ -5804,7 +5808,7 @@ void do_kill(CHAR_DATA *ch, char *argument)
 	if (is_safe(ch, victim))
 		return;
 
-	if (is_affected_by(ch, AFF_CHARM) && ch->master == victim)
+	if (is_affected_by(ch, AFF_CHARM) && Deref(ch->master) == victim)
 	{
 		act("$N is your beloved master.", ch, nullptr, victim, TO_CHAR);
 		return;
@@ -5873,7 +5877,7 @@ void do_murder(CHAR_DATA *ch, char *argument)
 	if (check_sidestep(ch, victim, 0, 50))
 		return;
 
-	if (is_affected_by(ch, AFF_CHARM) && ch->master == victim)
+	if (is_affected_by(ch, AFF_CHARM) && Deref(ch->master) == victim)
 	{
 		act("$N is your beloved master.", ch, nullptr, victim, TO_CHAR);
 		return;
@@ -7448,7 +7452,7 @@ void do_enlist(CHAR_DATA *ch, char *argument)
 
 	for (check = char_list; check != nullptr; check = check->next)
 	{
-		if (is_affected(check, gsn_enlist) && check->master == ch)
+		if (is_affected(check, gsn_enlist) && Deref(check->master) == ch)
 		{
 			send_to_char("You already have a devoted recruit following you.\n\r", ch);
 			return;
@@ -7482,8 +7486,8 @@ void do_enlist(CHAR_DATA *ch, char *argument)
 		return;
 	}
 
-	victim->leader = ch;
-	victim->master = ch;
+	victim->leader = ch->self;
+	victim->master = ch->self;
 
 	init_affect(&af);
 	af.where = TO_AFFECTS;
@@ -8381,7 +8385,7 @@ void do_lash(CHAR_DATA *ch, char *argument)
 	if (is_safe(ch, victim))
 		return;
 
-	if (is_affected_by(ch, AFF_CHARM) && ch->master == victim)
+	if (is_affected_by(ch, AFF_CHARM) && Deref(ch->master) == victim)
 	{
 		act("But $N is your friend!", ch, nullptr, victim, TO_CHAR);
 		return;

--- a/code/handler.c
+++ b/code/handler.c
@@ -495,12 +495,13 @@ int get_skill(CHAR_DATA *ch, int sn)
 	bool using_switched= false;
 	CHAR_DATA *original = ch;
 	CHAR_DATA *opponent;
+	DESCRIPTOR_DATA *connection = Deref(ch->desc);
 
-	if (is_npc(ch) && ch->desc && Deref(ch->desc->original) && IS_SET(ch->comm, COMM_SWITCHSKILLS))
+	if (is_npc(ch) && connection && Deref(connection->original) && IS_SET(ch->comm, COMM_SWITCHSKILLS))
 		using_switched = true;
 
 	if (using_switched)
-		ch = Deref(ch->desc->original);
+		ch = Deref(connection->original);
 
 	if (sn == -1) /* shorthand for level based skills */
 	{
@@ -849,8 +850,10 @@ void reset_char(CHAR_DATA *ch)
  */
 int get_trust(CHAR_DATA *ch)
 {
-	if (ch->desc != nullptr && Deref(ch->desc->original) != nullptr)
-		ch = Deref(ch->desc->original);
+	DESCRIPTOR_DATA *connection = Deref(ch->desc);
+
+	if (connection != nullptr && Deref(connection->original) != nullptr)
+		ch = Deref(connection->original);
 
 	if (ch->trust)
 		return ch->trust;
@@ -2306,7 +2309,9 @@ void extract_char(CHAR_DATA *ch, bool fPull)
 		total_wealth -= ch->pIndexData->wealth;
 	}
 
-	if (ch->desc != nullptr && Deref(ch->desc->original) != nullptr)
+	DESCRIPTOR_DATA *connection = Deref(ch->desc);
+
+	if (connection != nullptr && Deref(connection->original) != nullptr)
 	{
 		do_return(ch, "");
 		ch->desc = nullptr;
@@ -2804,7 +2809,7 @@ bool can_see(CHAR_DATA *ch, CHAR_DATA *victim)
 	if (!is_immortal(ch) && is_affected_by(victim, AFF_NOSHOW))
 		return false;
 
-	if (is_cabal_guard(ch) && !ch->desc)
+	if (is_cabal_guard(ch) && !Deref(ch->desc))
 		return true;
 
 	if (get_trust(ch) < victim->invis_level)

--- a/code/handler.c
+++ b/code/handler.c
@@ -1715,7 +1715,7 @@ void char_to_room(CHAR_DATA *ch, ROOM_INDEX_DATA *pRoomIndex)
 		}
 	}
 
-	if ((!IS_ZERO_VECTOR(ch->in_room->affected_by) || ch->in_room->has_rune) && is_immortal(ch))
+	if ((!IS_ZERO_VECTOR(ch->in_room->affected_by) || ch->in_room->rune != nullptr) && is_immortal(ch))
 		do_raffects(ch, "");
 }
 

--- a/code/handler.c
+++ b/code/handler.c
@@ -39,6 +39,7 @@
 #include <algorithm>
 #include "merc.h"
 #include "handler.h"
+#include "entity/handles.h"
 #include "magic.h"
 #include "recycle.h"
 #include "tables.h"
@@ -2096,14 +2097,14 @@ void obj_to_obj(OBJ_DATA *obj, OBJ_DATA *obj_to)
 
 	obj->next_content = obj_to->contains;
 	obj_to->contains = obj;
-	obj->in_obj = obj_to;
+	obj->in_obj = obj_to->self;
 	obj->in_room = nullptr;
 	obj->carried_by = nullptr;
 
 	if (obj_to->pIndexData->vnum == OBJ_VNUM_PIT)
 		obj->cost = 0;
 
-	for (; obj_to != nullptr; obj_to = obj_to->in_obj)
+	for (; obj_to != nullptr; obj_to = Deref(obj_to->in_obj))
 	{
 		if (obj_to->carried_by != nullptr)
 		{
@@ -2119,7 +2120,7 @@ void obj_from_obj(OBJ_DATA *obj)
 {
 	OBJ_DATA *obj_from;
 
-	if ((obj_from = obj->in_obj) == nullptr)
+	if ((obj_from = Deref(obj->in_obj)) == nullptr)
 	{
 		RS.Logger.Debug("Obj_from_obj: null obj_from.");
 		return;
@@ -2152,7 +2153,7 @@ void obj_from_obj(OBJ_DATA *obj)
 	obj->next_content = nullptr;
 	obj->in_obj = nullptr;
 
-	for (; obj_from != nullptr; obj_from = obj_from->in_obj)
+	for (; obj_from != nullptr; obj_from = Deref(obj_from->in_obj))
 	{
 		if (obj_from->carried_by != nullptr)
 		{

--- a/code/handler.c
+++ b/code/handler.c
@@ -2178,11 +2178,14 @@ void extract_obj(OBJ_DATA *obj)
 	OBJ_DATA *obj_content;
 	OBJ_DATA *obj_next;
 
+	// Asks whether there is a live container to detach from, not merely whether
+	// the field was ever set: a carrier that has already been freed has no
+	// carrying list left to unlink from.
 	if (obj->in_room != nullptr)
 		obj_from_room(obj);
-	else if (obj->carried_by != nullptr)
+	else if (Deref(obj->carried_by) != nullptr)
 		obj_from_char(obj);
-	else if (obj->in_obj != nullptr)
+	else if (Deref(obj->in_obj) != nullptr)
 		obj_from_obj(obj);
 
 	obj->pIndexData->limcount -= 1;

--- a/code/handler.c
+++ b/code/handler.c
@@ -2257,9 +2257,6 @@ void extract_char(CHAR_DATA *ch, bool fPull)
 	// pass here: they stop resolving when free_char retires its slot.
 	for (tch = char_list; tch != nullptr; tch = tch->next)
 	{
-		if (!is_npc(ch) && !is_npc(tch) && tch->last_fight_name == ch->true_name)
-			tch->last_fight_name = nullptr;
-
 		if (!is_npc(tch) && !is_npc(ch) && tch->pcdata->trusting == ch)
 			tch->pcdata->trusting = nullptr;
 

--- a/code/handler.c
+++ b/code/handler.c
@@ -1720,7 +1720,7 @@ void obj_to_char(OBJ_DATA *obj, CHAR_DATA *ch)
 {
 	obj->next_content = ch->carrying;
 	ch->carrying = obj;
-	obj->carried_by = ch;
+	obj->carried_by = ch->self;
 	obj->in_room = nullptr;
 	obj->in_obj = nullptr;
 	ch->carry_number += get_obj_number(obj);
@@ -1734,7 +1734,7 @@ void obj_from_char(OBJ_DATA *obj)
 {
 	CHAR_DATA *ch;
 
-	if ((ch = obj->carried_by) == nullptr)
+	if ((ch = Deref(obj->carried_by)) == nullptr)
 	{
 		RS.Logger.Debug("Obj_from_char: null ch.");
 		return;
@@ -1950,9 +1950,11 @@ void unequip_char(CHAR_DATA *ch, OBJ_DATA *obj, bool show)
 		return;
 	}
 
-	if (obj->wear_loc == WEAR_WIELD && check_entwine(obj->carried_by, 0))
+	CHAR_DATA *carrier = Deref(obj->carried_by);
+
+	if (obj->wear_loc == WEAR_WIELD && check_entwine(carrier, 0))
 	{
-		do_uncoil(obj->carried_by, "automagic");
+		do_uncoil(carrier, "automagic");
 	}
 
 	obj->wear_loc = -1;
@@ -2106,9 +2108,9 @@ void obj_to_obj(OBJ_DATA *obj, OBJ_DATA *obj_to)
 
 	for (; obj_to != nullptr; obj_to = Deref(obj_to->in_obj))
 	{
-		if (obj_to->carried_by != nullptr)
+		if (CHAR_DATA *carrier = Deref(obj_to->carried_by))
 		{
-			obj_to->carried_by->carry_weight += get_obj_weight(obj);
+			carrier->carry_weight += get_obj_weight(obj);
 		}
 	}
 }
@@ -2155,9 +2157,9 @@ void obj_from_obj(OBJ_DATA *obj)
 
 	for (; obj_from != nullptr; obj_from = Deref(obj_from->in_obj))
 	{
-		if (obj_from->carried_by != nullptr)
+		if (CHAR_DATA *carrier = Deref(obj_from->carried_by))
 		{
-			obj_from->carried_by->carry_weight -= get_obj_weight(obj);
+			carrier->carry_weight -= get_obj_weight(obj);
 		}
 	}
 }
@@ -4256,7 +4258,7 @@ void affect_modify_obj(OBJ_DATA *obj, OBJ_AFFECT_DATA *paf, bool fAdd)
 				BITWISE_OR(obj->affected_by, paf->bitvector);
 				break;
 			case TO_OBJ_APPLY:
-				ch = obj->carried_by;
+				ch = Deref(obj->carried_by);
 				wear = obj->wear_loc;
 
 				if (ch && (wear != WEAR_NONE))
@@ -4282,7 +4284,7 @@ void affect_modify_obj(OBJ_DATA *obj, OBJ_AFFECT_DATA *paf, bool fAdd)
 			BITWISE_XAND(obj->affected_by, paf->bitvector);
 			break;
 		case TO_OBJ_APPLY:
-			ch = obj->carried_by;
+			ch = Deref(obj->carried_by);
 			wear = obj->wear_loc;
 
 			if (ch && (wear != WEAR_NONE))

--- a/code/handler.c
+++ b/code/handler.c
@@ -118,7 +118,7 @@ int count_users(OBJ_DATA *obj)
 
 	for (fch = obj->in_room->people; fch != nullptr; fch = fch->next_in_room)
 	{
-		if (fch->on == obj)
+		if (fch->on == obj->self)
 			count++;
 	}
 
@@ -2030,9 +2030,13 @@ void obj_from_room(OBJ_DATA *obj)
 	if (obj->item_type == ITEM_CAMPFIRE)
 		in_room->light = std::max(in_room->light - obj->value[0], 0);
 
+	// This is not a liveness check, and it cannot be replaced by one. Most
+	// callers leave the object entirely alive -- it is being picked up, blown
+	// into the next room, or relocated. What ends is the character's use of it,
+	// because it is no longer here to sit on.
 	for (ch = in_room->people; ch != nullptr; ch = ch->next_in_room)
 	{
-		if (ch->on == obj)
+		if (ch->on == obj->self)
 			ch->on = nullptr;
 	}
 

--- a/code/handler.c
+++ b/code/handler.c
@@ -638,7 +638,7 @@ int get_skill(CHAR_DATA *ch, int sn)
 	{
 		af = affect_find(opponent->affected, gsn_traitors_luck);
 
-		if (ch == af->owner)
+		if (ch == Deref(af->owner))
 			skill += 20;
 	}
 
@@ -930,7 +930,7 @@ int get_curr_stat(CHAR_DATA *ch, int stat)
 	{
 		af = affect_find(opponent->affected, gsn_traitors_luck);
 
-		if (ch == af->owner)
+		if (ch == Deref(af->owner))
 			mod = 2;
 	}
 
@@ -1623,7 +1623,7 @@ void char_from_room(CHAR_DATA *ch)
 	{
 		af = affect_find_room(prev_room->affected, gsn_gravity_well);
 
-		if (ch == af->owner)
+		if (ch == Deref(af->owner))
 			gravity_well_explode(prev_room, af);
 	}
 	if (!is_affected(ch, gsn_pull) && (check_entwine(ch, 1) || check_entwine(ch, 2)))
@@ -1638,7 +1638,7 @@ void char_from_room(CHAR_DATA *ch)
 			}
 		}
 
-		do_uncoil(aaf->owner, "automagic");
+		do_uncoil(Deref(aaf->owner), "automagic");
 	}
 	else if (!is_affected(ch, gsn_pull) && check_entwine(ch, 0))
 	{
@@ -2238,7 +2238,6 @@ void extract_char(CHAR_DATA *ch, bool fPull)
 {
 	OBJ_DATA *obj;
 	OBJ_DATA *obj_next;
-	CHAR_DATA *tch;
 	ROOM_INDEX_DATA *room;
 
 	if (ch->in_room == nullptr)
@@ -2251,17 +2250,6 @@ void extract_char(CHAR_DATA *ch, bool fPull)
 		RS.Logger.Warn("Extract_char: in_room is nullptr.  {}{}.",
 			is_npc(ch) ? "Vnum is " : "Name is ",
 			is_npc(ch) ? vn : ch->name);
-	}
-	// Clears the inbound references that are still raw pointers and so cannot
-	// expire on their own. Handle-typed references to this character need no
-	// pass here: they stop resolving when free_char retires its slot.
-	for (tch = char_list; tch != nullptr; tch = tch->next)
-	{
-		for (auto &af : tch->affected)
-		{
-			if (af.owner == ch)
-				af.owner = nullptr;
-		}
 	}
 
 	nuke_pets(ch);
@@ -2311,13 +2299,21 @@ void extract_char(CHAR_DATA *ch, bool fPull)
 		ch->desc = nullptr;
 	}
 
+	// A character's room affects end with them. This is not the reference
+	// expiring -- that happens on its own now -- it is the effect itself being
+	// destroyed, which a handle cannot do: a disowned wall of fire goes on
+	// burning everyone who walks in, and every consumer of raf->owner in
+	// act_move.c and update.c hands it straight to damage_new and is_safe.
+	//
+	// It sits below the altar return deliberately, so it fires only when the
+	// character is really being freed. A slain player keeps what they placed.
 	for (room = top_affected_room; room; room = room->aff_next)
 	{
 		for (auto it = room->affected.begin(); it != room->affected.end(); )
 		{
 			auto next = std::next(it);
 
-			if (it->owner == ch)
+			if (Deref(it->owner) == ch)
 				affect_remove_room(room, &*it);
 
 			it = next;
@@ -2838,7 +2834,7 @@ bool can_see(CHAR_DATA *ch, CHAR_DATA *victim)
 	{
 		paf = affect_find_area(ch->in_room->area->affected, gsn_whiteout);
 
-		if (paf && paf->owner != ch)
+		if (paf && Deref(paf->owner) != ch)
 			return false;
 	}
 
@@ -2923,7 +2919,7 @@ bool can_see_obj(CHAR_DATA *ch, OBJ_DATA *obj)
 	{
 		oaf = affect_find_obj(obj->affected, gsn_stash);
 
-		if (oaf->owner != ch && !is_immortal(ch))
+		if (Deref(oaf->owner) != ch && !is_immortal(ch))
 			return false;
 	}
 
@@ -2943,7 +2939,7 @@ bool can_see_obj(CHAR_DATA *ch, OBJ_DATA *obj)
 	{
 		paf = affect_find_area(ch->in_room->area->affected, gsn_whiteout);
 
-		if (paf && paf->owner != ch)
+		if (paf && Deref(paf->owner) != ch)
 			return false;
 	}
 

--- a/code/handler.c
+++ b/code/handler.c
@@ -494,6 +494,7 @@ int get_skill(CHAR_DATA *ch, int sn)
 	AFFECT_DATA *af;
 	bool using_switched= false;
 	CHAR_DATA *original = ch;
+	CHAR_DATA *opponent;
 
 	if (is_npc(ch) && ch->desc && ch->desc->original && IS_SET(ch->comm, COMM_SWITCHSKILLS))
 		using_switched = true;
@@ -630,17 +631,19 @@ int get_skill(CHAR_DATA *ch, int sn)
 	if (is_affected_room(ch->in_room, gsn_infidels_fate) && is_good(ch))
 		skill += (int)(skill * .1);
 
-	if (ch->fighting && is_affected(ch->fighting, gsn_traitors_luck))
+	opponent = Deref(ch->fighting);
+
+	if (opponent && is_affected(opponent, gsn_traitors_luck))
 	{
-		af = affect_find(ch->fighting->affected, gsn_traitors_luck);
+		af = affect_find(opponent->affected, gsn_traitors_luck);
 
 		if (ch == af->owner)
 			skill += 20;
 	}
 
-	if (ch->fighting
-		&& (is_evil(ch) && is_affected(ch->fighting, gsn_awe))
-		&& ch->level > ch->fighting->level
+	if (opponent
+		&& (is_evil(ch) && is_affected(opponent, gsn_awe))
+		&& ch->level > opponent->level
 		&& number_percent() > 96)
 	{
 		skill = 0;
@@ -865,6 +868,7 @@ int get_trust(CHAR_DATA *ch)
 int get_curr_stat(CHAR_DATA *ch, int stat)
 {
 	AFFECT_DATA *af;
+	CHAR_DATA *opponent;
 	int max;
 	int mod = 0;
 
@@ -917,9 +921,11 @@ int get_curr_stat(CHAR_DATA *ch, int stat)
 		max = std::min(max, 25);
 	}
 
-	if (ch->fighting && is_affected(ch->fighting, gsn_traitors_luck))
+	opponent = Deref(ch->fighting);
+
+	if (opponent && is_affected(opponent, gsn_traitors_luck))
 	{
-		af = affect_find(ch->fighting->affected, gsn_traitors_luck);
+		af = affect_find(opponent->affected, gsn_traitors_luck);
 
 		if (ch == af->owner)
 			mod = 2;
@@ -2874,7 +2880,7 @@ bool can_see(CHAR_DATA *ch, CHAR_DATA *victim)
 
 	if (is_affected_by(victim, AFF_HIDE)
 		&& !is_affected_by(ch, AFF_DETECT_HIDDEN)
-		&& victim->fighting == nullptr
+		&& Deref(victim->fighting) == nullptr
 		&& !(is_affected(ch, gsn_darksight)
 			&& (af = affect_find(ch->affected, gsn_darksight))
 			&& af->aftype == AFT_SKILL

--- a/code/handler.c
+++ b/code/handler.c
@@ -2257,9 +2257,6 @@ void extract_char(CHAR_DATA *ch, bool fPull)
 	// pass here: they stop resolving when free_char retires its slot.
 	for (tch = char_list; tch != nullptr; tch = tch->next)
 	{
-		if (!is_npc(tch) && !is_npc(ch) && tch->pcdata->trusting == ch)
-			tch->pcdata->trusting = nullptr;
-
 		for (auto &af : tch->affected)
 		{
 			if (af.owner == ch)

--- a/code/handler.c
+++ b/code/handler.c
@@ -2233,7 +2233,6 @@ void delay_extract(CHAR_DATA *ch)
  */
 void extract_char(CHAR_DATA *ch, bool fPull)
 {
-	CHAR_DATA *wch;
 	OBJ_DATA *obj;
 	OBJ_DATA *obj_next;
 	CHAR_DATA *tch;
@@ -2311,12 +2310,6 @@ void extract_char(CHAR_DATA *ch, bool fPull)
 	{
 		do_return(ch, "");
 		ch->desc = nullptr;
-	}
-
-	for (wch = char_list; wch != nullptr; wch = wch->next)
-	{
-		if (wch->reply == ch)
-			wch->reply = nullptr;
 	}
 
 	for (room = top_affected_room; room; room = room->aff_next)

--- a/code/handler.c
+++ b/code/handler.c
@@ -2247,12 +2247,11 @@ void extract_char(CHAR_DATA *ch, bool fPull)
 			is_npc(ch) ? "Vnum is " : "Name is ",
 			is_npc(ch) ? vn : ch->name);
 	}
-	/* remove all tracking */
+	// Clears the inbound references that are still raw pointers and so cannot
+	// expire on their own. Handle-typed references to this character need no
+	// pass here: they stop resolving when free_char retires its slot.
 	for (tch = char_list; tch != nullptr; tch = tch->next)
 	{
-		if (tch->last_fought == ch)
-			tch->last_fought = nullptr;
-
 		if (!is_npc(ch) && !is_npc(tch) && tch->last_fight_name == ch->true_name)
 			tch->last_fight_name = nullptr;
 

--- a/code/handler.c
+++ b/code/handler.c
@@ -496,11 +496,11 @@ int get_skill(CHAR_DATA *ch, int sn)
 	CHAR_DATA *original = ch;
 	CHAR_DATA *opponent;
 
-	if (is_npc(ch) && ch->desc && ch->desc->original && IS_SET(ch->comm, COMM_SWITCHSKILLS))
+	if (is_npc(ch) && ch->desc && Deref(ch->desc->original) && IS_SET(ch->comm, COMM_SWITCHSKILLS))
 		using_switched = true;
 
 	if (using_switched)
-		ch = ch->desc->original;
+		ch = Deref(ch->desc->original);
 
 	if (sn == -1) /* shorthand for level based skills */
 	{
@@ -849,8 +849,8 @@ void reset_char(CHAR_DATA *ch)
  */
 int get_trust(CHAR_DATA *ch)
 {
-	if (ch->desc != nullptr && ch->desc->original != nullptr)
-		ch = ch->desc->original;
+	if (ch->desc != nullptr && Deref(ch->desc->original) != nullptr)
+		ch = Deref(ch->desc->original);
 
 	if (ch->trust)
 		return ch->trust;
@@ -2306,7 +2306,7 @@ void extract_char(CHAR_DATA *ch, bool fPull)
 		total_wealth -= ch->pIndexData->wealth;
 	}
 
-	if (ch->desc != nullptr && ch->desc->original != nullptr)
+	if (ch->desc != nullptr && Deref(ch->desc->original) != nullptr)
 	{
 		do_return(ch, "");
 		ch->desc = nullptr;
@@ -2347,9 +2347,6 @@ void extract_char(CHAR_DATA *ch, bool fPull)
 			return;
 		}
 	}
-
-	if (ch->desc != nullptr)
-		ch->desc->character = nullptr;
 
 	free_char(ch);
 }

--- a/code/interp.c
+++ b/code/interp.c
@@ -750,7 +750,7 @@ void interpret(CHAR_DATA *ch, char *argument)
 
 	if ((!is_npc(ch) && IS_SET(ch->act, PLR_LOG)) || fLogAll || cmd_table[cmd].log == LOG_ALWAYS)
 	{
-		auto buffer = fmt::format("Log {}: {}", ch->desc->original ? ch->desc->original->true_name : ch->true_name, logline);
+		auto buffer = fmt::format("Log {}: {}", Deref(ch->desc->original) ? Deref(ch->desc->original)->true_name : ch->true_name, logline);
 		wiznet(buffer.data(), ch, nullptr, WIZ_SECURE, 0, get_trust(ch));
 		RS.Logger.Info(buffer);
 	}

--- a/code/interp.c
+++ b/code/interp.c
@@ -750,20 +750,32 @@ void interpret(CHAR_DATA *ch, char *argument)
 
 	if ((!is_npc(ch) && IS_SET(ch->act, PLR_LOG)) || fLogAll || cmd_table[cmd].log == LOG_ALWAYS)
 	{
+		// A mob has no connection, and neither does a link-dead player. Both
+		// reach this: the condition above fires for any command flagged
+		// LOG_ALWAYS, and for every command at all while fLogAll is on.
 		DESCRIPTOR_DATA *connection = Deref(ch->desc);
-		CHAR_DATA *switchedFrom = Deref(connection->original);
-		auto buffer = fmt::format("Log {}: {}", switchedFrom ? switchedFrom->true_name : ch->true_name, logline);
+		CHAR_DATA *switchedFrom = connection != nullptr ? Deref(connection->original) : nullptr;
+		const char *actor = switchedFrom != nullptr ? switchedFrom->true_name : ch->true_name;
+
+		// And a mob has no true_name either -- create_mobile sets `name` and
+		// leaves this one null -- so the fallback is the second half of the
+		// same problem rather than defensiveness.
+		if (actor == nullptr)
+			actor = ch->name;
+
+		auto buffer = fmt::format("Log {}: {}", actor, logline);
 		wiznet(buffer.data(), ch, nullptr, WIZ_SECURE, 0, get_trust(ch));
 		RS.Logger.Info(buffer);
 	}
 
 	DESCRIPTOR_DATA *snooped = Deref(ch->desc);
+	DESCRIPTOR_DATA *snooper = snooped != nullptr ? Deref(snooped->snoop_by) : nullptr;
 
-	if (snooped != nullptr && snooped->snoop_by != nullptr)
+	if (snooper != nullptr)
 	{
-		write_to_buffer(snooped->snoop_by, "% ", 2);
-		write_to_buffer(snooped->snoop_by, logline, 0);
-		write_to_buffer(snooped->snoop_by, "\n\r", 2);
+		write_to_buffer(snooper, "% ", 2);
+		write_to_buffer(snooper, logline, 0);
+		write_to_buffer(snooper, "\n\r", 2);
 	}
 
 	/* Hold person */

--- a/code/interp.c
+++ b/code/interp.c
@@ -38,6 +38,7 @@
 #include <string.h>
 #include <time.h>
 #include "merc.h"
+#include "entity/handles.h"
 #include "interp.h"
 #include "ban.h"
 #include "handler.h"
@@ -1003,7 +1004,7 @@ void interpret(CHAR_DATA *ch, char *argument)
 			case TAR_CHAR_OFFENSIVE:
 				if (argument[0] == '\0')
 				{
-					if ((victim = ch->fighting) == nullptr)
+					if ((victim = Deref(ch->fighting)) == nullptr)
 					{
 						send_to_char("Do that to who?\n\r", ch);
 						return;
@@ -1112,7 +1113,7 @@ void interpret(CHAR_DATA *ch, char *argument)
 		if (skill_table[sn].target == TAR_CHAR_OFFENSIVE
 			&& victim
 			&& victim != ch
-			&& !victim->fighting
+			&& !Deref(victim->fighting)
 			&& victim->master != ch)
 		{
 			multi_hit(victim, ch, TYPE_UNDEFINED);

--- a/code/interp.c
+++ b/code/interp.c
@@ -1114,7 +1114,7 @@ void interpret(CHAR_DATA *ch, char *argument)
 			&& victim
 			&& victim != ch
 			&& !Deref(victim->fighting)
-			&& victim->master != ch)
+			&& Deref(victim->master) != ch)
 		{
 			multi_hit(victim, ch, TYPE_UNDEFINED);
 		}

--- a/code/interp.c
+++ b/code/interp.c
@@ -750,16 +750,20 @@ void interpret(CHAR_DATA *ch, char *argument)
 
 	if ((!is_npc(ch) && IS_SET(ch->act, PLR_LOG)) || fLogAll || cmd_table[cmd].log == LOG_ALWAYS)
 	{
-		auto buffer = fmt::format("Log {}: {}", Deref(ch->desc->original) ? Deref(ch->desc->original)->true_name : ch->true_name, logline);
+		DESCRIPTOR_DATA *connection = Deref(ch->desc);
+		CHAR_DATA *switchedFrom = Deref(connection->original);
+		auto buffer = fmt::format("Log {}: {}", switchedFrom ? switchedFrom->true_name : ch->true_name, logline);
 		wiznet(buffer.data(), ch, nullptr, WIZ_SECURE, 0, get_trust(ch));
 		RS.Logger.Info(buffer);
 	}
 
-	if (ch->desc != nullptr && ch->desc->snoop_by != nullptr)
+	DESCRIPTOR_DATA *snooped = Deref(ch->desc);
+
+	if (snooped != nullptr && snooped->snoop_by != nullptr)
 	{
-		write_to_buffer(ch->desc->snoop_by, "% ", 2);
-		write_to_buffer(ch->desc->snoop_by, logline, 0);
-		write_to_buffer(ch->desc->snoop_by, "\n\r", 2);
+		write_to_buffer(snooped->snoop_by, "% ", 2);
+		write_to_buffer(snooped->snoop_by, logline, 0);
+		write_to_buffer(snooped->snoop_by, "\n\r", 2);
 	}
 
 	/* Hold person */

--- a/code/iprog.c
+++ b/code/iprog.c
@@ -584,15 +584,15 @@ bool iprog_unset(OBJ_INDEX_DATA *obj, const char *progtype, const char *name)
 /* ITEM FUNCTIONS */
 void fight_prog_drow_talisman(OBJ_DATA *obj, CHAR_DATA *ch)
 {
-	if (!is_worn(obj) || number_percent() > 7 || !ch->fighting)
+	if (!is_worn(obj) || number_percent() > 7 || !Deref(ch->fighting))
 		return;
 
 	act("$p pulses and glows a sickly shade of green!", ch, obj, 0, TO_ALL);
 
 	if (number_percent() > 50)
-		obj_cast_spell(skill_lookup("frost breath"), ch->level, ch, ch->fighting, obj);
+		obj_cast_spell(skill_lookup("frost breath"), ch->level, ch, Deref(ch->fighting), obj);
 	else
-		obj_cast_spell(skill_lookup("acid blast"), 60, ch, ch->fighting, obj);
+		obj_cast_spell(skill_lookup("acid blast"), 60, ch, Deref(ch->fighting), obj);
 }
 
 void fight_prog_devils_eye(OBJ_DATA *obj, CHAR_DATA *ch)
@@ -602,9 +602,9 @@ void fight_prog_devils_eye(OBJ_DATA *obj, CHAR_DATA *ch)
 
 	if (number_percent() < 5)
 	{
-		act("The Devil's Eye suddenly pivots and stares directly into $n's face!", ch, 0, ch->fighting, TO_NOTVICT);
-		act("The Devil's Eye suddenly pivots and stares directly into your face!", ch, 0, ch->fighting, TO_VICT);
-		damage_new(ch, ch->fighting, dice(12, 12), TYPE_UNDEFINED, DAM_SLASH, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "heartquake");
+		act("The Devil's Eye suddenly pivots and stares directly into $n's face!", ch, 0, Deref(ch->fighting), TO_NOTVICT);
+		act("The Devil's Eye suddenly pivots and stares directly into your face!", ch, 0, Deref(ch->fighting), TO_VICT);
+		damage_new(ch, Deref(ch->fighting), dice(12, 12), TYPE_UNDEFINED, DAM_SLASH, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "heartquake");
 	}
 }
 
@@ -619,10 +619,10 @@ void fight_prog_skean(OBJ_DATA *obj, CHAR_DATA *ch)
 	if (number_percent() < 6)
 	{
 		percent = number_percent();
-		if (ch->fighting->Class()->ctype == CLASS_COMMUNER && !is_affected(ch->fighting, gsn_severed))
+		if (Deref(ch->fighting)->Class()->ctype == CLASS_COMMUNER && !is_affected(Deref(ch->fighting), gsn_severed))
 		{
-			act("An enchanted obsidian skean blazes through the air, leaving a trail of fire!", ch, 0, ch->fighting, TO_ROOM);
-			act("Your vital ties to the gods' empowerment have been severed!", ch, 0, ch->fighting, TO_VICT);
+			act("An enchanted obsidian skean blazes through the air, leaving a trail of fire!", ch, 0, Deref(ch->fighting), TO_ROOM);
+			act("Your vital ties to the gods' empowerment have been severed!", ch, 0, Deref(ch->fighting), TO_VICT);
 
 			init_affect(&af);
 			af.where = TO_AFFECTS;
@@ -631,15 +631,15 @@ void fight_prog_skean(OBJ_DATA *obj, CHAR_DATA *ch)
 			af.level = ch->level;
 			af.modifier = 10 + dice(1, 8);
 			af.duration = dice(1, 2);
-			new_affect_to_char(ch->fighting, &af);
+			new_affect_to_char(Deref(ch->fighting), &af);
 
 			return;
 		}
 
 		if (!IS_SET(ch->affected_by, AFF_BLIND))
 		{
-			act("An enchanted obsidian skean darts toward your eyes, gouging you painfully!", ch, 0, ch->fighting, TO_VICT);
-			act("An enchanted obsidian skean darts toward $N's eyes, gouging $M painfully!", ch, 0, ch->fighting, TO_NOTVICT);
+			act("An enchanted obsidian skean darts toward your eyes, gouging you painfully!", ch, 0, Deref(ch->fighting), TO_VICT);
+			act("An enchanted obsidian skean darts toward $N's eyes, gouging $M painfully!", ch, 0, Deref(ch->fighting), TO_NOTVICT);
 
 			init_affect(&af);
 			af.where = TO_AFFECTS;
@@ -649,15 +649,15 @@ void fight_prog_skean(OBJ_DATA *obj, CHAR_DATA *ch)
 
 			SET_BIT(af.bitvector, AFF_BLIND);
 			af.duration = dice(1, 4);
-			new_affect_to_char(ch->fighting, &af);
+			new_affect_to_char(Deref(ch->fighting), &af);
 
 			return;
 		}
 
-		if (is_good(ch->fighting))
+		if (is_good(Deref(ch->fighting)))
 		{
-			act("You swoon for a moment, and the world goes slightly hazy...", ch->fighting, 0, 0, TO_CHAR);
-			WAIT_STATE(ch->fighting, PULSE_VIOLENCE * 2);
+			act("You swoon for a moment, and the world goes slightly hazy...", Deref(ch->fighting), 0, 0, TO_CHAR);
+			WAIT_STATE(Deref(ch->fighting), PULSE_VIOLENCE * 2);
 			return;
 		}
 	}
@@ -675,7 +675,7 @@ void fight_prog_cankerworm(OBJ_DATA *obj, CHAR_DATA *ch)
 		dam = dice((ch->level), 3);
 		act("The Cankerworm leaps from your hands momentarily!", ch, 0, 0, TO_CHAR);
 		act("The Cankerworm seems to leap from $n's hands momentarily!", ch, 0, 0, TO_ROOM);
-		damage_new(ch, ch->fighting, dam, TYPE_UNDEFINED, DAM_SLASH, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "burrowing axe");
+		damage_new(ch, Deref(ch->fighting), dam, TYPE_UNDEFINED, DAM_SLASH, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "burrowing axe");
 	}
 }
 
@@ -700,7 +700,7 @@ void fight_prog_axe_trelaran(OBJ_DATA *obj, CHAR_DATA *ch)
 		if (number_percent() < 6 && (crown->pIndexData->vnum == 21825))
 		{
 			act("$p suddenly shifts to the likeness of a gaping dragon head, as it spits out a blast of acid!", ch, obj, 0, TO_ALL);
-			obj_cast_spell(skill_lookup("acid blast"), ch->level, ch, ch->fighting, obj);
+			obj_cast_spell(skill_lookup("acid blast"), ch->level, ch, Deref(ch->fighting), obj);
 		}
 	}
 }
@@ -947,12 +947,12 @@ void invoke_prog_tattoo_zethus(OBJ_DATA *obj, CHAR_DATA *ch, char *argument)
 	act("$n concentrates intently for a moment.", ch, 0, 0, TO_ROOM);
 	obj->value[0] -= 1;
 
-	if (!saves_spell(ch->level + dice(1, 5), ch->fighting, DAM_NEGATIVE))
+	if (!saves_spell(ch->level + dice(1, 5), Deref(ch->fighting), DAM_NEGATIVE))
 	{
-		act("A flash of darkness arcs between $n and $N, leaving $N looking hopeless!", ch, 0, ch->fighting, TO_NOTVICT);
-		act("A flash of darkness arcs between you and $N as you sever $N's link with $S god.", ch, 0, ch->fighting, TO_CHAR);
-		act("Negative energy crackles in the air around you, temporarily severing your link with your god!", ch, 0, ch->fighting, TO_VICT);
-		damage_new(ch, ch->fighting, ch->level + 15, TYPE_UNDEFINED, DAM_NEGATIVE, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "energy wave");
+		act("A flash of darkness arcs between $n and $N, leaving $N looking hopeless!", ch, 0, Deref(ch->fighting), TO_NOTVICT);
+		act("A flash of darkness arcs between you and $N as you sever $N's link with $S god.", ch, 0, Deref(ch->fighting), TO_CHAR);
+		act("Negative energy crackles in the air around you, temporarily severing your link with your god!", ch, 0, Deref(ch->fighting), TO_VICT);
+		damage_new(ch, Deref(ch->fighting), ch->level + 15, TYPE_UNDEFINED, DAM_NEGATIVE, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "energy wave");
 		damage_new(ch, ch, ch->level - 15, TYPE_UNDEFINED, DAM_INTERNAL, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "exertion");
 
 		init_affect(&af);
@@ -962,7 +962,7 @@ void invoke_prog_tattoo_zethus(OBJ_DATA *obj, CHAR_DATA *ch, char *argument)
 		af.aftype = AFT_POWER;
 		af.location = APPLY_WIS;
 		af.modifier = -(ch->level / 5);
-		new_affect_to_char(ch->fighting, &af);
+		new_affect_to_char(Deref(ch->fighting), &af);
 	}
 
 	ch->mana = ch->mana - 50;
@@ -1075,7 +1075,7 @@ void speech_prog_ice_dragon_statue(OBJ_DATA *obj, CHAR_DATA *ch, char *speech)
 
 void fight_prog_scales(OBJ_DATA *obj, CHAR_DATA *ch)
 {
-	CHAR_DATA *victim = ch->fighting;
+	CHAR_DATA *victim = Deref(ch->fighting);
 
 	switch (obj->value[2])
 	{
@@ -1245,7 +1245,7 @@ void greet_prog_corpse_explode(OBJ_DATA *obj, CHAR_DATA *ch)
 
 void fight_prog_horde_bull(OBJ_DATA *obj, CHAR_DATA *ch)
 {
-	if (!is_affected(ch, gsn_rage) || !ch->fighting || number_percent() > (.1 * get_skill(ch, gsn_rage)))
+	if (!is_affected(ch, gsn_rage) || !Deref(ch->fighting) || number_percent() > (.1 * get_skill(ch, gsn_rage)))
 		return;
 
 	if (ch->hit >= ch->max_hit)
@@ -1259,32 +1259,32 @@ void fight_prog_horde_bull(OBJ_DATA *obj, CHAR_DATA *ch)
 
 void fight_prog_horde_bear(OBJ_DATA *obj, CHAR_DATA *ch)
 {
-	if (!is_affected(ch, gsn_rage) || !ch->fighting || number_percent() > (.15 * get_skill(ch, gsn_rage)))
+	if (!is_affected(ch, gsn_rage) || !Deref(ch->fighting) || number_percent() > (.15 * get_skill(ch, gsn_rage)))
 		return;
 
-	act("The rage of the Bear roars through you as you charge into $N, sending $m sprawling!", ch, 0, ch->fighting, TO_CHAR);
-	act("$n gets a wild look in $s eyes, charging into you and sending you sprawling!", ch, 0, ch->fighting, TO_VICT);
-	act("$n gets a wild look in $s eyes, charging into $N and sending $m sprawling!", ch, 0, ch->fighting, TO_NOTVICT);
+	act("The rage of the Bear roars through you as you charge into $N, sending $m sprawling!", ch, 0, Deref(ch->fighting), TO_CHAR);
+	act("$n gets a wild look in $s eyes, charging into you and sending you sprawling!", ch, 0, Deref(ch->fighting), TO_VICT);
+	act("$n gets a wild look in $s eyes, charging into $N and sending $m sprawling!", ch, 0, Deref(ch->fighting), TO_NOTVICT);
 
-	WAIT_STATE(ch->fighting, (int)(PULSE_VIOLENCE * 1.9));
+	WAIT_STATE(Deref(ch->fighting), (int)(PULSE_VIOLENCE * 1.9));
 
-	damage_new(ch, ch->fighting, dice(8, 8), TYPE_UNDEFINED, DAM_BASH, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "charge");
+	damage_new(ch, Deref(ch->fighting), dice(8, 8), TYPE_UNDEFINED, DAM_BASH, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "charge");
 }
 
 void fight_prog_horde_lion(OBJ_DATA *obj, CHAR_DATA *ch)
 {
 	AFFECT_DATA af;
 
-	if (!is_affected(ch, gsn_rage) || !ch->fighting || number_percent() > (.18 * get_skill(ch, gsn_rage)))
+	if (!is_affected(ch, gsn_rage) || !Deref(ch->fighting) || number_percent() > (.18 * get_skill(ch, gsn_rage)))
 		return;
 
-	act("The spirit of the Lion surges through you as you claw at $N's flesh!", ch, 0, ch->fighting, TO_CHAR);
-	act("$n gets a wild look in $s eyes, clawing viciously at $N!", ch, 0, ch->fighting, TO_NOTVICT);
-	act("$n gets a wild look in $s eyes, clawing viciously at you!", ch, 0, ch->fighting, TO_VICT);
+	act("The spirit of the Lion surges through you as you claw at $N's flesh!", ch, 0, Deref(ch->fighting), TO_CHAR);
+	act("$n gets a wild look in $s eyes, clawing viciously at $N!", ch, 0, Deref(ch->fighting), TO_NOTVICT);
+	act("$n gets a wild look in $s eyes, clawing viciously at you!", ch, 0, Deref(ch->fighting), TO_VICT);
 
-	damage_new(ch, ch->fighting, dice(ch->level - 2, 4), TYPE_UNDEFINED, DAM_BASH, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "raking claws$");
+	damage_new(ch, Deref(ch->fighting), dice(ch->level - 2, 4), TYPE_UNDEFINED, DAM_BASH, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "raking claws$");
 
-	if (!ch->fighting || is_affected(ch->fighting, gsn_bleeding))
+	if (!Deref(ch->fighting) || is_affected(Deref(ch->fighting), gsn_bleeding))
 		return;
 
 	init_affect(&af);
@@ -1298,28 +1298,28 @@ void fight_prog_horde_lion(OBJ_DATA *obj, CHAR_DATA *ch)
 	af.owner = ch;
 	af.tick_fun = bleeding_tick;
 	af.end_fun = nullptr;
-	new_affect_to_char(ch->fighting, &af);
+	new_affect_to_char(Deref(ch->fighting), &af);
 
-	send_to_char("Blood begins to gush from your vicious wounds.\n\r", ch->fighting);
-	act("Bright red blood begins to gush from $n's wounds.", ch->fighting, 0, 0, TO_ROOM);
+	send_to_char("Blood begins to gush from your vicious wounds.\n\r", Deref(ch->fighting));
+	act("Bright red blood begins to gush from $n's wounds.", Deref(ch->fighting), 0, 0, TO_ROOM);
 }
 
 void fight_prog_horde_wolf(OBJ_DATA *obj, CHAR_DATA *ch)
 {
 	AFFECT_DATA af;
 
-	if (!is_affected(ch, gsn_rage) || !ch->fighting || number_percent() > (.18 * get_skill(ch, gsn_rage)))
+	if (!is_affected(ch, gsn_rage) || !Deref(ch->fighting) || number_percent() > (.18 * get_skill(ch, gsn_rage)))
 		return;
 
-	act("The spirit of the Wolf enrages you as you leap at $N and sink your fangs into $S throat!", ch, 0, ch->fighting, TO_CHAR);
-	act("$n gets a wild look in $s eyes and leaps at $N, sinking $s teeth into $S throat!", ch, 0, ch->fighting, TO_NOTVICT);
-	act("$n gets a wild look in $s eyes and leaps at you, sinking $s teeth into your throat!", ch, 0, ch->fighting, TO_VICT);
-	damage_new(ch, ch->fighting, dice(ch->level, 2), TYPE_UNDEFINED, DAM_BASH, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "bite");
+	act("The spirit of the Wolf enrages you as you leap at $N and sink your fangs into $S throat!", ch, 0, Deref(ch->fighting), TO_CHAR);
+	act("$n gets a wild look in $s eyes and leaps at $N, sinking $s teeth into $S throat!", ch, 0, Deref(ch->fighting), TO_NOTVICT);
+	act("$n gets a wild look in $s eyes and leaps at you, sinking $s teeth into your throat!", ch, 0, Deref(ch->fighting), TO_VICT);
+	damage_new(ch, Deref(ch->fighting), dice(ch->level, 2), TYPE_UNDEFINED, DAM_BASH, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "bite");
 
-	if (!ch->fighting)
+	if (!Deref(ch->fighting))
 		return;
 
-	if (!is_affected(ch->fighting, gsn_bleeding))
+	if (!is_affected(Deref(ch->fighting), gsn_bleeding))
 	{
 		init_affect(&af);
 		af.where = TO_AFFECTS;
@@ -1331,10 +1331,10 @@ void fight_prog_horde_wolf(OBJ_DATA *obj, CHAR_DATA *ch)
 		af.duration = ch->level / 10;
 		af.owner = ch;
 		af.end_fun = nullptr;
-		new_affect_to_char(ch->fighting, &af);
+		new_affect_to_char(Deref(ch->fighting), &af);
 	}
 
-	if (!is_affected(ch->fighting, gsn_mangled) && number_percent() < (get_skill(ch, gsn_rage) * .28))
+	if (!is_affected(Deref(ch->fighting), gsn_mangled) && number_percent() < (get_skill(ch, gsn_rage) * .28))
 	{
 		init_affect(&af);
 		af.where = TO_AFFECTS;
@@ -1346,24 +1346,24 @@ void fight_prog_horde_wolf(OBJ_DATA *obj, CHAR_DATA *ch)
 		af.duration = ch->level / 18;
 		af.owner = ch;
 		af.end_fun = nullptr;
-		new_affect_to_char(ch->fighting, &af);
+		new_affect_to_char(Deref(ch->fighting), &af);
 
-		act("You hear the satisfying crunch of bone as you tear deeply into $N's throat.", ch, 0, ch->fighting, TO_CHAR);
-		act("You hear the crunch of bone as $n tears deeply into your throat.", ch, 0, ch->fighting, TO_VICT);
-		act("You hear the crunch of bone as $n tears deeply into $N's throat.", ch, 0, ch->fighting, TO_NOTVICT);
+		act("You hear the satisfying crunch of bone as you tear deeply into $N's throat.", ch, 0, Deref(ch->fighting), TO_CHAR);
+		act("You hear the crunch of bone as $n tears deeply into your throat.", ch, 0, Deref(ch->fighting), TO_VICT);
+		act("You hear the crunch of bone as $n tears deeply into $N's throat.", ch, 0, Deref(ch->fighting), TO_NOTVICT);
 	}
 }
 
 void fight_prog_horde_hawk(OBJ_DATA *obj, CHAR_DATA *ch)
 {
-	if (!is_affected(ch, gsn_rage) || !ch->fighting || number_percent() > (.2 * get_skill(ch, gsn_rage)))
+	if (!is_affected(ch, gsn_rage) || !Deref(ch->fighting) || number_percent() > (.2 * get_skill(ch, gsn_rage)))
 		return;
 
-	act("The spirit of the Hawk flows through you as you sense a weakness in $N's defenses and strike!", ch, 0, ch->fighting, TO_CHAR);
-	act("$n pauses for a moment before unleashing a well aimed blow at you.", ch, 0, ch->fighting, TO_VICT);
-	act("$n pauses for a moment before unleashing a well aimed blow at $N.", ch, 0, ch->fighting, TO_NOTVICT);
+	act("The spirit of the Hawk flows through you as you sense a weakness in $N's defenses and strike!", ch, 0, Deref(ch->fighting), TO_CHAR);
+	act("$n pauses for a moment before unleashing a well aimed blow at you.", ch, 0, Deref(ch->fighting), TO_VICT);
+	act("$n pauses for a moment before unleashing a well aimed blow at $N.", ch, 0, Deref(ch->fighting), TO_NOTVICT);
 
-	one_hit_new(ch, ch->fighting, TYPE_TRUESTRIKE, HIT_NOSPECIALS, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, nullptr);
+	one_hit_new(ch, Deref(ch->fighting), TYPE_TRUESTRIKE, HIT_NOSPECIALS, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, nullptr);
 }
 
 void pulse_prog_horde_jackal(OBJ_DATA *obj, bool isTick)
@@ -1374,12 +1374,12 @@ void pulse_prog_horde_jackal(OBJ_DATA *obj, bool isTick)
 	if (!ch)
 		return;
 
-	victim = ch->fighting;
+	victim = Deref(ch->fighting);
 
 	if (is_affected(ch, gsn_jackal))
 		affect_strip(ch, gsn_jackal);
 
-	if (!ch->fighting || !is_affected(ch, gsn_rage))
+	if (!Deref(ch->fighting) || !is_affected(ch, gsn_rage))
 		return;
 
 	init_affect(&af);
@@ -1417,17 +1417,17 @@ bool death_prog_trophy_belt(OBJ_DATA *belt, CHAR_DATA *ch)
 
 void fight_prog_ruins_sword(OBJ_DATA *obj, CHAR_DATA *ch)
 {
-	if (!ch->fighting || number_percent() > 12)
+	if (!Deref(ch->fighting) || number_percent() > 12)
 		return;
 
 	if (!is_worn(obj))
 		return;
 
-	act("Rivulets of water suddenly flow over $p as the blade lashes out at $N!", ch, obj, ch->fighting, TO_CHAR);
-	act("Rivulets of water suddenly flow over $p as the blade lashes out at you!", ch, obj, ch->fighting, TO_VICT);
-	act("Rivulets of water suddenly flow over $p as the blade lashes out at $N!", ch, obj, ch->fighting, TO_NOTVICT);
+	act("Rivulets of water suddenly flow over $p as the blade lashes out at $N!", ch, obj, Deref(ch->fighting), TO_CHAR);
+	act("Rivulets of water suddenly flow over $p as the blade lashes out at you!", ch, obj, Deref(ch->fighting), TO_VICT);
+	act("Rivulets of water suddenly flow over $p as the blade lashes out at $N!", ch, obj, Deref(ch->fighting), TO_NOTVICT);
 
-	obj_cast_spell(skill_lookup("drown"), ch->level / 2, ch, ch->fighting, obj);
+	obj_cast_spell(skill_lookup("drown"), ch->level / 2, ch, Deref(ch->fighting), obj);
 }
 
 void verb_prog_check_bounties(OBJ_DATA *obj, CHAR_DATA *ch, char *argument)
@@ -1566,7 +1566,7 @@ void verb_prog_ilopheth_bush(OBJ_DATA *obj, CHAR_DATA *ch, char *argument)
 {
 	ROOM_INDEX_DATA *room;
 
-	if (ch->fighting)
+	if (Deref(ch->fighting))
 	{
 		send_to_char("You're otherwise occupied right now.\n\r", ch);
 		return;
@@ -1588,7 +1588,7 @@ void verb_prog_ilopheth_climb_tree(OBJ_DATA *obj, CHAR_DATA *ch, char *argument)
 {
 	ROOM_INDEX_DATA *to_room = get_room_index(4100);
 
-	if (ch->fighting)
+	if (Deref(ch->fighting))
 	{
 		send_to_char("You're somewhat distracted right now.\n\r", ch);
 		return;
@@ -1615,7 +1615,7 @@ void verb_prog_antava_touch_hand(OBJ_DATA *obj, CHAR_DATA *ch, char *argument)
 	if (ch->in_room->vnum != 462)
 		return;
 
-	if (ch->fighting)
+	if (Deref(ch->fighting))
 	{
 		send_to_char("You're too busy fighting to do that!\n\r", ch);
 		return;
@@ -1662,7 +1662,7 @@ void verb_prog_sidhe_climb_vine(OBJ_DATA *obj, CHAR_DATA *ch, char *argument)
 		return;
 	}
 
-	if (ch->fighting)
+	if (Deref(ch->fighting))
 	{
 		send_to_char("You're somewhat distracted right now.\n\r", ch);
 		return;
@@ -1928,7 +1928,7 @@ void verb_prog_energize_tattoo(OBJ_DATA *obj, CHAR_DATA *ch, char *argument)
 		return;
 	}
 
-	if (is_npc(ch->fighting))
+	if (is_npc(Deref(ch->fighting)))
 	{
 		send_to_char("You must find a purer source of power.\n\r", ch);
 		return;
@@ -1940,13 +1940,13 @@ void verb_prog_energize_tattoo(OBJ_DATA *obj, CHAR_DATA *ch, char *argument)
 		return;
 	}
 
-	act("You attempt to siphon some energy from $N to power your tattoo.", ch, 0, ch->fighting, TO_CHAR);
-	act("You feel a cold sensation run through your body.", ch, 0, ch->fighting, TO_VICT);
+	act("You attempt to siphon some energy from $N to power your tattoo.", ch, 0, Deref(ch->fighting), TO_CHAR);
+	act("You feel a cold sensation run through your body.", ch, 0, Deref(ch->fighting), TO_VICT);
 
-	if (!saves_spell(ch->level, ch->fighting, DAM_NEGATIVE))
+	if (!saves_spell(ch->level, Deref(ch->fighting), DAM_NEGATIVE))
 	{
-		damage_new(ch, ch->fighting, dice(1, 10), TYPE_UNDEFINED, DAM_NEGATIVE, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "energy sapping");
-		ch->fighting->mana -= (int)(2.8 * ch->level);
+		damage_new(ch, Deref(ch->fighting), dice(1, 10), TYPE_UNDEFINED, DAM_NEGATIVE, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "energy sapping");
+		Deref(ch->fighting)->mana -= (int)(2.8 * ch->level);
 		obj->value[0]++;
 
 		init_affect_obj(&oaf);
@@ -2065,14 +2065,14 @@ void verb_prog_throw_net(OBJ_DATA *obj, CHAR_DATA *ch, char *argument)
 
 	if (argument[0] == '\0')
 	{
-		if (!ch->fighting)
+		if (!Deref(ch->fighting))
 		{
 			send_to_char("Throw the net at who?\n\r", ch);
 			return;
 		}
 		else
 		{
-			victim = ch->fighting;
+			victim = Deref(ch->fighting);
 		}
 	}
 	else
@@ -2116,7 +2116,7 @@ void verb_prog_throw_net(OBJ_DATA *obj, CHAR_DATA *ch, char *argument)
 	obj_from_char(obj);
 	extract_obj(obj);
 
-	if (!ch->fighting)
+	if (!Deref(ch->fighting))
 	{
 		sprintf(buf, "Help!  %s just threw a net on me!", ch->name);
 		do_yell(victim, buf);
@@ -2132,14 +2132,14 @@ void verb_prog_fire_pistol(OBJ_DATA *obj, CHAR_DATA *ch, char *argument)
 
 	if (argument[0] == '\0')
 	{
-		if (!ch->fighting)
+		if (!Deref(ch->fighting))
 		{
 			send_to_char("Bust a cap in whose ass?\n\r", ch);
 			return;
 		}
 		else
 		{
-			victim = ch->fighting;
+			victim = Deref(ch->fighting);
 		}
 	}
 	else
@@ -2335,7 +2335,7 @@ void fight_prog_essence_darkness(OBJ_DATA *obj, CHAR_DATA *ch)
 	if (number_percent() > 35)
 		return;
 
-	if ((victim = ch->fighting) == nullptr)
+	if ((victim = Deref(ch->fighting)) == nullptr)
 		return;
 
 	ch->alignment = std::max(-1000, ch->alignment - 10);
@@ -2375,7 +2375,7 @@ void verb_prog_rub_talisman(OBJ_DATA *obj, CHAR_DATA *ch, char *argument)
 	if (check_deny_magic(ch))
 		return;
 
-	if (ch->fighting)
+	if (Deref(ch->fighting))
 	{
 		send_to_char("Nothing seems to happen.\n\r", ch);
 		return;
@@ -3596,7 +3596,7 @@ void verb_prog_roll_tablet(OBJ_DATA *obj, CHAR_DATA *ch, char *argument)
 {
 	EXIT_DATA *exit = ch->in_room->exit[Directions::East];
 
-	if (ch->fighting != nullptr)
+	if (Deref(ch->fighting) != nullptr)
 	{
 		send_to_char("You're too busy fighting to roll the tablet!\n\r", ch);
 		return;
@@ -3750,7 +3750,7 @@ void verb_prog_iseldheim_lever_pull(OBJ_DATA *obj, CHAR_DATA *ch, char *argument
 
 void fight_prog_bugzapper(OBJ_DATA *obj, CHAR_DATA *ch)
 {
-	CHAR_DATA *victim = ch->fighting;
+	CHAR_DATA *victim = Deref(ch->fighting);
 
 	if (!victim || !is_npc(victim) || victim->pIndexData->vnum < 3000 || victim->pIndexData->vnum > 3010 || !is_worn(obj))
 		return;
@@ -3764,7 +3764,7 @@ void fight_prog_bugzapper(OBJ_DATA *obj, CHAR_DATA *ch)
 void fight_prog_arms_light(OBJ_DATA *obj, CHAR_DATA *ch)
 {
 	AFFECT_DATA af;
-	CHAR_DATA *victim = ch->fighting;
+	CHAR_DATA *victim = Deref(ch->fighting);
 
 	if (!victim)
 		return;
@@ -4064,7 +4064,7 @@ void verb_prog_fallendesert_climb_ladder(OBJ_DATA *obj, CHAR_DATA *ch, char *arg
 
 	to_room = get_room_index(vnum);
 
-	if (ch->fighting)
+	if (Deref(ch->fighting))
 	{
 		send_to_char("You're somewhat distracted right now.\n\r", ch);
 		return;
@@ -4109,7 +4109,7 @@ void verb_prog_fallendesert_(OBJ_DATA *obj, CHAR_DATA *ch, char *argument)
 
 	to_room = get_room_index(vnum);
 
-	if (ch->fighting)
+	if (Deref(ch->fighting))
 	{
 		send_to_char("You're somewhat distracted right now.\n\r", ch);
 		return;

--- a/code/iprog.c
+++ b/code/iprog.c
@@ -39,6 +39,7 @@
 #include <algorithm>
 #include <time.h>
 #include "merc.h"
+#include "entity/handles.h"
 #include "iprog.h"
 #include "magic.h"
 #include "interp.h"
@@ -716,7 +717,7 @@ void fight_prog_cure_critical(OBJ_DATA *obj, CHAR_DATA *ch)
 
 void pulse_prog_steal(OBJ_DATA *obj, bool isTick)
 {
-	CHAR_DATA *vch, *ch = obj->carried_by;
+	CHAR_DATA *vch, *ch = Deref(obj->carried_by);
 	OBJ_DATA *stolen = nullptr;
 	bool dbreak= false;
 	int invnum = number_range(0, 5), i = 0;
@@ -977,8 +978,8 @@ void entry_prog_explosives(OBJ_DATA *obj)
 	if (obj->timer == 0)
 		return;
 
-	if (obj->carried_by != nullptr)
-		act("You hear soft ticking from somewhere.", obj->carried_by, nullptr, nullptr, TO_ROOM);
+	if (CHAR_DATA *carrier = Deref(obj->carried_by))
+		act("You hear soft ticking from somewhere.", carrier, nullptr, nullptr, TO_ROOM);
 }
 
 bool death_prog_explosives(OBJ_DATA *obj, CHAR_DATA *ch)
@@ -1367,7 +1368,7 @@ void fight_prog_horde_hawk(OBJ_DATA *obj, CHAR_DATA *ch)
 
 void pulse_prog_horde_jackal(OBJ_DATA *obj, bool isTick)
 {
-	CHAR_DATA *victim, *ch = obj->carried_by;
+	CHAR_DATA *victim, *ch = Deref(obj->carried_by);
 	AFFECT_DATA af;
 
 	if (!ch)
@@ -3128,7 +3129,7 @@ void communion_handler(CHAR_DATA *ch)
 
 void pulse_prog_cimar_babies(OBJ_DATA *obj, bool isTick)
 {
-	CHAR_DATA *ch = obj->carried_by;
+	CHAR_DATA *ch = Deref(obj->carried_by);
 
 	if (ch == nullptr || is_npc(ch))
 		return;
@@ -3194,7 +3195,7 @@ void verb_prog_feed_baby(OBJ_DATA *obj, CHAR_DATA *ch, char *argument)
 
 void baby_end(OBJ_DATA *obj, OBJ_AFFECT_DATA *af)
 {
-	CHAR_DATA *ch = obj->carried_by;
+	CHAR_DATA *ch = Deref(obj->carried_by);
 
 	if (ch == nullptr)
 		return;
@@ -3205,7 +3206,7 @@ void baby_end(OBJ_DATA *obj, OBJ_AFFECT_DATA *af)
 
 void baby_burp(OBJ_DATA *obj, OBJ_AFFECT_DATA *af)
 {
-	CHAR_DATA *ch = obj->carried_by;
+	CHAR_DATA *ch = Deref(obj->carried_by);
 
 	if (ch == nullptr)
 		return;
@@ -3351,7 +3352,7 @@ void verb_prog_pour_wine(OBJ_DATA *obj, CHAR_DATA *ch, char *argument)
 
 void wine_pulse(OBJ_DATA *obj, OBJ_AFFECT_DATA *af)
 {
-	CHAR_DATA *ch = obj->carried_by;
+	CHAR_DATA *ch = Deref(obj->carried_by);
 
 	if (obj->value[1] == 0)
 	{

--- a/code/iprog.c
+++ b/code/iprog.c
@@ -1083,7 +1083,7 @@ void speech_prog_ice_dragon_statue(OBJ_DATA *obj, CHAR_DATA *ch, char *speech)
 	act("$p shatters violently in a cloud of ice. As it clears, a dragon of pure ice hovers over you.", dragon, obj, 0, TO_ROOM);
 	add_follower(dragon, ch);
 
-	dragon->leader = ch;
+	dragon->leader = ch->self;
 
 	SET_BIT(dragon->affected_by, AFF_CHARM);
 

--- a/code/iprog.c
+++ b/code/iprog.c
@@ -582,6 +582,23 @@ bool iprog_unset(OBJ_INDEX_DATA *obj, const char *progtype, const char *name)
 }
 
 /* ITEM FUNCTIONS */
+
+//
+// The progs below read `Deref(ch->fighting)` several times each rather than
+// once into a local. That is deliberate throughout this file -- do NOT
+// collapse it.
+//
+// These run in the middle of a fight, and most of them deal damage. Once
+// damage_new or obj_cast_spell has run, the opponent may be dead and freed:
+// extract_char clears the field, free_char retires the slot, and the next
+// new_char can hand the same address straight back out. Re-reading the handle
+// yields null at that point, which every site here already handles. A hoisted
+// CHAR_DATA * would instead keep pointing at a recycled character struct.
+//
+// Read once into a local only where nothing in between can end the fight; see
+// entity/handles.h for the rule in full.
+//
+
 void fight_prog_drow_talisman(OBJ_DATA *obj, CHAR_DATA *ch)
 {
 	if (!is_worn(obj) || number_percent() > 7 || !Deref(ch->fighting))

--- a/code/iprog.c
+++ b/code/iprog.c
@@ -1194,7 +1194,7 @@ void get_prog_bad_idea(OBJ_DATA *obj, CHAR_DATA *ch)
 		af.where = TO_AFFECTS;
 		af.aftype = AFT_MALADY;
 		af.type = gsn_plague;
-		af.owner = ch;
+		af.owner = ch->self;
 		af.level = 50;
 		af.duration = 30;
 		af.location = APPLY_STR;
@@ -1218,7 +1218,7 @@ void get_prog_bad_idea(OBJ_DATA *obj, CHAR_DATA *ch)
 		af.where = TO_AFFECTS;
 		af.aftype = AFT_MALADY;
 		af.type = gsn_imprisonvoice;
-		af.owner = ch;
+		af.owner = ch->self;
 		af.level = 99;
 		af.duration = -1;
 		af.location = APPLY_NONE;
@@ -1312,7 +1312,7 @@ void fight_prog_horde_lion(OBJ_DATA *obj, CHAR_DATA *ch)
 	af.modifier = 0;
 	af.level = ch->level - 5;
 	af.duration = ch->level / 7;
-	af.owner = ch;
+	af.owner = ch->self;
 	af.tick_fun = bleeding_tick;
 	af.end_fun = nullptr;
 	new_affect_to_char(Deref(ch->fighting), &af);
@@ -1346,7 +1346,7 @@ void fight_prog_horde_wolf(OBJ_DATA *obj, CHAR_DATA *ch)
 		af.modifier = 0;
 		af.level = ch->level - 5;
 		af.duration = ch->level / 10;
-		af.owner = ch;
+		af.owner = ch->self;
 		af.end_fun = nullptr;
 		new_affect_to_char(Deref(ch->fighting), &af);
 	}
@@ -1361,7 +1361,7 @@ void fight_prog_horde_wolf(OBJ_DATA *obj, CHAR_DATA *ch)
 		af.modifier = 0;
 		af.level = ch->level - 5;
 		af.duration = ch->level / 18;
-		af.owner = ch;
+		af.owner = ch->self;
 		af.end_fun = nullptr;
 		new_affect_to_char(Deref(ch->fighting), &af);
 
@@ -1577,7 +1577,7 @@ void verb_prog_tilt_scales(OBJ_DATA *obj, CHAR_DATA *ch, char *argument)
 		oaf.location = APPLY_OBJ_V1;
 		oaf.type = gsn_bash;
 		oaf.aftype = AFT_SKILL;
-		oaf.owner = ch;
+		oaf.owner = ch->self;
 		affect_to_obj(obj, &oaf);
 	}
 }
@@ -2038,7 +2038,7 @@ void verb_prog_harness_crystal(OBJ_DATA *obj, CHAR_DATA *ch, char *argument)
 		return;
 	}
 
-	if (oaf->owner == ch)
+	if (Deref(oaf->owner) == ch)
 	{
 		efficiency = 50;
 	}
@@ -2319,7 +2319,7 @@ void hit_prog_essence_darkness(OBJ_DATA *obj, CHAR_DATA *ch, CHAR_DATA *victim, 
 
 		SET_BIT(af.bitvector, AFF_CURSE);
 
-		af.owner = ch;
+		af.owner = ch->self;
 		affect_to_char(victim, &af);
 
 		af.location = APPLY_SAVES;
@@ -3047,14 +3047,14 @@ void communion_handler(CHAR_DATA *ch)
 
 			cabal_members[CABAL_HORDE]++;
 
-			if (is_immortal(af->owner) && is_immortal(ch))
+			if (is_immortal(Deref(af->owner)) && is_immortal(ch))
 			{
 				Induction record;
-				record.ch = af->owner->true_name;
+				record.ch = Deref(af->owner)->true_name;
 				record.victim = ch->true_name;
 				record.cabal = CABAL_HORDE;
 				record.ctime = current_time;
-				record.chsite = af->owner->pcdata->host;
+				record.chsite = Deref(af->owner)->pcdata->host;
 				record.victimsite = ch->pcdata->host;
 
 				auto inductions = InductionRepository(RS.DbRift);

--- a/code/iprog.c
+++ b/code/iprog.c
@@ -1491,16 +1491,19 @@ void verb_prog_check_bounties(OBJ_DATA *obj, CHAR_DATA *ch, char *argument)
 
 	for (d = descriptor_list; d != nullptr; d = d->next)
 	{
-		if (d->connected == CON_PLAYING && d->character && d->character->in_room != nullptr)
+		if (d->connected == CON_PLAYING && Deref(d->character) && Deref(d->character)->in_room != nullptr)
 		{
-			if (d->character->pcdata && d->character->pcdata->bounty)
+			if (Deref(d->character)->pcdata && Deref(d->character)->pcdata->bounty)
 			{
 				found = true;
 
-				if (d->character == ch)
+				if (Deref(d->character) == ch)
 					sprintf(buf, "Hm, I see your name on this list, do you think it's wise for you to be here?");
 				else
-					sprintf(buf, "%s has %ld gold on %s head.", d->character->name, d->character->pcdata->bounty, his_her[URANGE(0, d->character->sex, 2)]);
+				{
+					CHAR_DATA *marked = Deref(d->character);
+					sprintf(buf, "%s has %ld gold on %s head.", marked->name, marked->pcdata->bounty, his_her[URANGE(0, marked->sex, 2)]);
+				}
 
 				do_say(mob, buf);
 			}

--- a/code/ispec.c
+++ b/code/ispec.c
@@ -6,6 +6,7 @@
 #include <string.h>
 #include <time.h>
 #include "merc.h"
+#include "entity/handles.h"
 #include "spec.h"
 #include "tables.h"
 #include "interp.h"
@@ -38,20 +39,20 @@ END_SPEC
 	
 BEGIN_SPEC(ispec_torture_flail)
 	EVENT_IFIGHT
-		if(number_percent()>91 && ch->fighting)
+		if(number_percent()>91 && Deref(ch->fighting))
 		{
 			AFFECT_DATA af;
 			init_affect(&af);
-			act("A scream escapes your flail as a shadow tears at $N's eyes!",ch,0,ch->fighting,TO_CHAR);
-			act("A scream escapes $n's flail as a shadow tears at $N's eyes!",ch,0,ch->fighting,TO_NOTVICT);
-			act("A scream escapes $n's flail as a shadow tears at your eyes!",ch,0,ch->fighting,TO_VICT);
-			act("$n appears to be blinded.",ch->fighting,0,0,TO_ROOM);
+			act("A scream escapes your flail as a shadow tears at $N's eyes!",ch,0,Deref(ch->fighting),TO_CHAR);
+			act("A scream escapes $n's flail as a shadow tears at $N's eyes!",ch,0,Deref(ch->fighting),TO_NOTVICT);
+			act("A scream escapes $n's flail as a shadow tears at your eyes!",ch,0,Deref(ch->fighting),TO_VICT);
+			act("$n appears to be blinded.",Deref(ch->fighting),0,0,TO_ROOM);
 			af.type = gsn_blindness;
 			af.aftype = AFT_MALADY;
 			af.level = ch->level;
 			af.duration = 2;
 			SET_BIT(af.bitvector, AFF_BLIND);
-			affect_to_char(ch->fighting, &af);
+			affect_to_char(Deref(ch->fighting), &af);
 		}
 	END_EVENT
 END_SPEC
@@ -69,18 +70,18 @@ END_SPEC
 
 BEGIN_SPEC(ispec_qwhip)
 	EVENT_IONEHIT
-		if(number_percent()>96 && ch->fighting)
+		if(number_percent()>96 && Deref(ch->fighting))
 		{
-			act("Sadistic urges compel you to lash out viciously at $N!",ch,0,ch->fighting,TO_CHAR);
+			act("Sadistic urges compel you to lash out viciously at $N!",ch,0,Deref(ch->fighting),TO_CHAR);
 			//(*dam) = (int)((float)*dam * 1.3);
 			//(*dt)   = 42;
 			//ch->hit = std::min(ch->max_hit, ch->hit + ((*dam) / 4));
 		}
 	END_EVENT
 	EVENT_IFIGHT
-		if(number_percent()>97 && IS_SET(ch->fighting->parts,PART_LEGS))
+		if(number_percent()>97 && IS_SET(Deref(ch->fighting)->parts,PART_LEGS))
 		{
-			CHAR_DATA *victim = ch->fighting;
+			CHAR_DATA *victim = Deref(ch->fighting);
 			act("$n wraps $s whip around $N's legs, sending $M staggering!",ch,0,victim,TO_NOTVICT);
 			act("You wrap your whip around $N's legs, sending $M staggering.",ch,0,victim,TO_CHAR);
 			act("$n wraps $s whip around your legs, sending you staggering!",ch,0,victim,TO_VICT);

--- a/code/magic.c
+++ b/code/magic.c
@@ -3522,7 +3522,7 @@ void spell_locate_object(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 			|| is_obj_stat(obj, ITEM_NOLOCATE)
 			|| number_percent() > level
 			|| ch->level < obj->level
-			|| (obj->carried_by && is_immortal(obj->carried_by)))
+			|| (Deref(obj->carried_by) && is_immortal(Deref(obj->carried_by))))
 		{
 			continue;
 		}
@@ -3534,11 +3534,13 @@ void spell_locate_object(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 		while (OBJ_DATA *outer = Deref(in_obj->in_obj))
 			in_obj = outer;
 
-		if (in_obj->carried_by != nullptr)
+		CHAR_DATA *carrier = Deref(in_obj->carried_by);
+
+		if (carrier != nullptr)
 		{
-			if (!is_affected(in_obj->carried_by, gsn_shadow_cloak))
+			if (!is_affected(carrier, gsn_shadow_cloak))
 			{
-				sprintf(buf, "%s is carried by %s.\n\r", obj->short_descr, pers(in_obj->carried_by, ch));
+				sprintf(buf, "%s is carried by %s.\n\r", obj->short_descr, pers(carrier, ch));
 			}
 			else
 			{
@@ -3549,7 +3551,9 @@ void spell_locate_object(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 		}
 		else if (in_obj->in_room != nullptr)
 		{
-			if (is_affected(in_obj->carried_by, gsn_stash))
+			// carrier is null on this branch -- the object is in a room, not held.
+			// Preserved as found; is_affected tolerates null and returns false.
+			if (is_affected(carrier, gsn_stash))
 				sprintf(buf, "%s's location is blurry, you have a hard time trying to locate it.\n\r", obj->short_descr);
 			else
 				sprintf(buf, "%s is in %s.\n\r", obj->short_descr, get_room_name(in_obj->in_room));

--- a/code/magic.c
+++ b/code/magic.c
@@ -218,8 +218,9 @@ bool saves_spell(int level, CHAR_DATA *victim, int dam_type)
 	int roll;
 	float save;
 	AFFECT_DATA *af;
+	CHAR_DATA *opponent = Deref(victim->fighting);
 	//    char buf[MSL];
-	if (victim->fighting && get_trust(victim->fighting) == MAX_LEVEL)
+	if (opponent && get_trust(opponent) == MAX_LEVEL)
 		return false;
 
 	if (victim->saving_throw < 0)
@@ -257,7 +258,7 @@ bool saves_spell(int level, CHAR_DATA *victim, int dam_type)
 	if (is_affected(victim, gsn_traitors_luck))
 	{
 		af = affect_find(victim->affected, gsn_traitors_luck);
-		if (victim->fighting && (victim->fighting == af->owner))
+		if (opponent && (opponent == af->owner))
 			save -= 50;
 	}
 
@@ -268,11 +269,11 @@ bool saves_spell(int level, CHAR_DATA *victim, int dam_type)
 	roll = number_percent();
 
 	/*
-	if(victim->fighting && !is_npc(victim->fighting) && !is_npc(victim))
+	if(Deref(victim->fighting) && !is_npc(Deref(victim->fighting)) && !is_npc(victim))
 	{
 		sprintf(buf,"Saves_spell: Caster is probably %s, victim is %s, dt is %d.  Victim level %d, spell level %d (%d - %.2f%%mod)."\
 			" Victim has %dsvs (%.2f%%mod).  Chance of saving is %d, roll is %d: %s",
-			victim->fighting->name,
+			Deref(victim->fighting)->name,
 			victim->true_name,
 			dam_type,
 			victim->level,
@@ -598,7 +599,7 @@ void cast_myell(CHAR_DATA *ch, CHAR_DATA *victim)
 	if (victim == ch)
 		return;
 
-	if (!is_npc(ch) && !is_npc(victim) && (ch->fighting == nullptr || victim->fighting == nullptr))
+	if (!is_npc(ch) && !is_npc(victim) && (Deref(ch->fighting) == nullptr || Deref(victim->fighting) == nullptr))
 	{
 		if (can_see(ch, victim) && victim->position > POS_SLEEPING)
 		{
@@ -834,7 +835,7 @@ void do_cast(CHAR_DATA *ch, char *argument)
 		case TAR_CHAR_OFFENSIVE:
 			if (arg2[0] == '\0')
 			{
-				if ((victim = ch->fighting) == nullptr)
+				if ((victim = Deref(ch->fighting)) == nullptr)
 				{
 					send_to_char("Cast the spell on whom?\n\r", ch);
 					return;
@@ -910,7 +911,7 @@ void do_cast(CHAR_DATA *ch, char *argument)
 		case TAR_OBJ_CHAR_OFF:
 			if (arg2[0] == '\0')
 			{
-				if ((victim = ch->fighting) == nullptr)
+				if ((victim = Deref(ch->fighting)) == nullptr)
 				{
 					send_to_char("Cast the spell on whom or what?\n\r", ch);
 					return;
@@ -1074,7 +1075,7 @@ void do_cast(CHAR_DATA *ch, char *argument)
 			&& get_skill(victim, gsn_nullify) > 1
 			&& !(is_npc(victim) && victim->cabal != CABAL_SCION)
 			&& (!is_immortal(ch) || !is_immortal(victim))
-			&& (!victim->fighting || (saves_spell(ch->level, victim, DAM_OTHER) && number_percent() < 50)))
+			&& (!Deref(victim->fighting) || (saves_spell(ch->level, victim, DAM_OTHER) && number_percent() < 50)))
 		{
 			if (!cabal_down(victim, CABAL_SCION))
 			{
@@ -1111,7 +1112,7 @@ void do_cast(CHAR_DATA *ch, char *argument)
 		for (vch = ch->in_room->people; vch; vch = vch_next)
 		{
 			vch_next = vch->next_in_room;
-			if (victim == vch && victim->fighting == nullptr)
+			if (victim == vch && Deref(victim->fighting) == nullptr)
 			{
 				multi_hit(victim, ch, TYPE_UNDEFINED);
 				break;
@@ -1151,7 +1152,7 @@ void obj_cast_spell(int sn, int level, CHAR_DATA *ch, CHAR_DATA *victim, OBJ_DAT
 			break;
 		case TAR_CHAR_OFFENSIVE:
 			if (victim == nullptr)
-				victim = ch->fighting;
+				victim = Deref(ch->fighting);
 
 			if (victim == nullptr)
 			{
@@ -1189,9 +1190,9 @@ void obj_cast_spell(int sn, int level, CHAR_DATA *ch, CHAR_DATA *victim, OBJ_DAT
 		case TAR_OBJ_CHAR_OFF:
 			if (victim == nullptr && obj == nullptr)
 			{
-				if (ch->fighting != nullptr)
+				if (Deref(ch->fighting) != nullptr)
 				{
-					victim = ch->fighting;
+					victim = Deref(ch->fighting);
 				}
 				else
 				{
@@ -1237,20 +1238,20 @@ void obj_cast_spell(int sn, int level, CHAR_DATA *ch, CHAR_DATA *victim, OBJ_DAT
 
 			break;
 		case TAR_CHAR_AMBIGUOUS:
-			if (victim == ch && !ch->fighting)
+			if (victim == ch && !Deref(ch->fighting))
 			{
 				vo = (void *)victim;
 				target = TARGET_CHAR;
 			}
-			else if (victim == nullptr && !ch->fighting)
+			else if (victim == nullptr && !Deref(ch->fighting))
 			{
 				victim = ch;
 				vo = (void *)victim;
 				target = TARGET_CHAR;
 			}
-			else if (victim == nullptr && ch->fighting)
+			else if (victim == nullptr && Deref(ch->fighting))
 			{
-				victim = ch->fighting;
+				victim = Deref(ch->fighting);
 				vo = (void *)victim;
 				target = TARGET_CHAR;
 			}
@@ -1281,7 +1282,7 @@ void obj_cast_spell(int sn, int level, CHAR_DATA *ch, CHAR_DATA *victim, OBJ_DAT
 		for (vch = ch->in_room->people; vch; vch = vch_next)
 		{
 			vch_next = vch->next_in_room;
-			if (victim == vch && victim->fighting == nullptr)
+			if (victim == vch && Deref(victim->fighting) == nullptr)
 			{
 				multi_hit(victim, ch, TYPE_UNDEFINED);
 				break;
@@ -2638,7 +2639,7 @@ void spell_dispel_magic(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 	bool commune = false;
 	int spell;
 
-	if (!ch->fighting && !str_cmp(target_name, ""))
+	if (!Deref(ch->fighting) && !str_cmp(target_name, ""))
 	{
 		ch->wait = 0;
 
@@ -2646,8 +2647,8 @@ void spell_dispel_magic(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 		return;
 	}
 
-	if (ch->fighting && !str_cmp(target_name, ""))
-		victim = ch->fighting;
+	if (Deref(ch->fighting) && !str_cmp(target_name, ""))
+		victim = Deref(ch->fighting);
 
 	target_name = one_argument(target_name, arg1);
 	one_argument(target_name, arg2);
@@ -2666,13 +2667,13 @@ void spell_dispel_magic(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 	if (ch->Class()->ctype == CLASS_COMMUNER)
 		commune = true;
 
-	if (!is_npc(victim) && (ch != victim) && (!ch->fighting || !victim->fighting))
+	if (!is_npc(victim) && (ch != victim) && (!Deref(ch->fighting) || !Deref(victim->fighting)))
 	{
 		sprintf(buf, "Die, %s, you sorcerous dog!", pers(ch, victim));
 		do_myell(victim, buf, ch);
 	}
 
-	if (!victim->fighting && (ch != victim))
+	if (!Deref(victim->fighting) && (ch != victim))
 		multi_hit(victim, ch, TYPE_UNDEFINED);
 
 	if (arg2[0] == '\0')
@@ -2744,7 +2745,7 @@ void spell_fireball(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 		if (is_same_group(vch, ch) || is_safe(ch, vch) || is_same_cabal(ch, vch))
 			continue;
 
-		if (!is_npc(ch) && !is_npc(vch) && (ch->fighting == nullptr || vch->fighting == nullptr))
+		if (!is_npc(ch) && !is_npc(vch) && (Deref(ch->fighting) == nullptr || Deref(vch->fighting) == nullptr))
 		{
 			switch (number_range(0, 2))
 			{
@@ -2986,7 +2987,7 @@ void spell_gate(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 	CHAR_DATA *victim;
 	bool gate_pet;
 
-	if (ch->fighting != nullptr)
+	if (Deref(ch->fighting) != nullptr)
 	{
 		send_to_char("You can't concentrate enough.\n\r", ch);
 		return;
@@ -4334,7 +4335,7 @@ void spell_summon(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 		|| (is_npc(victim) && IS_SET(victim->act, ACT_AGGRESSIVE))
 		|| (is_npc(victim) && victim->level >= (level + 10))
 		|| (!is_npc(victim) && victim->level >= LEVEL_IMMORTAL && !is_immortal(ch))
-		|| victim->fighting != nullptr
+		|| Deref(victim->fighting) != nullptr
 		|| (is_npc(victim) && IS_SET(victim->imm_flags, IMM_SUMMON))
 		|| (is_npc(victim) && victim->pIndexData->pShop != nullptr)
 		|| (is_npc(victim) && IS_SET(victim->act, ACT_AGGRESSIVE))
@@ -4694,7 +4695,7 @@ void spell_word_of_recall(int sn, int level, CHAR_DATA *ch, void *vo, int target
 
 void recall_execute(CHAR_DATA *ch, ROOM_INDEX_DATA *location)
 {
-	if (ch->fighting || ch->disrupted)
+	if (Deref(ch->fighting) || ch->disrupted)
 	{
 		send_to_char("The magic of the recall spell dissipates as your focus is disrupted.\n\r", ch);
 		return;
@@ -4803,13 +4804,13 @@ void spell_fire_breath(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 		vch_next = vch->next_in_room;
 		/*
 		if (is_safe_spell(ch,vch,true)
-			|| (is_npc(vch) && is_npc(ch) && (ch->fighting != vch || vch->fighting != ch)))
+			|| (is_npc(vch) && is_npc(ch) && (Deref(ch->fighting) != vch || Deref(vch->fighting) != ch)))
 		{
 			continue;
 		}
 		*/
 
-		if (is_safe(ch, vch) && vch->fighting != nullptr && vch->fighting != ch)
+		if (is_safe(ch, vch) && Deref(vch->fighting) != nullptr && Deref(vch->fighting) != ch)
 			continue;
 
 		if (is_same_group(vch, ch))
@@ -4881,13 +4882,13 @@ void spell_frost_breath(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 		vch_next = vch->next_in_room;
 		/*
 		if (is_safe_spell(ch,vch,true)
-			||  (is_npc(vch) && is_npc(ch) && (ch->fighting != vch || vch->fighting != ch)))
+			||  (is_npc(vch) && is_npc(ch) && (Deref(ch->fighting) != vch || Deref(vch->fighting) != ch)))
 		{
 			continue;
 		}
 		*/
 
-		if ((is_safe(ch, vch) && vch->fighting != nullptr && vch->fighting != ch) || vch == ch)
+		if ((is_safe(ch, vch) && Deref(vch->fighting) != nullptr && Deref(vch->fighting) != ch) || vch == ch)
 			continue;
 
 		if (vch == victim) /* full damage */
@@ -4936,7 +4937,7 @@ void spell_gas_breath(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 	{
 		vch_next = vch->next_in_room;
 
-		if (is_safe(ch, vch) && vch->fighting != nullptr && vch->fighting != ch)
+		if (is_safe(ch, vch) && Deref(vch->fighting) != nullptr && Deref(vch->fighting) != ch)
 			continue;
 
 		if (is_same_group(ch, vch))
@@ -5054,7 +5055,7 @@ void spell_iceball(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 		if (is_safe(ch, vch))
 			continue;
 
-		if (!is_npc(ch) && !is_npc(vch) && (ch->fighting == nullptr || vch->fighting == nullptr))
+		if (!is_npc(ch) && !is_npc(vch) && (Deref(ch->fighting) == nullptr || Deref(vch->fighting) == nullptr))
 		{
 			switch (number_range(0, 2))
 			{
@@ -5331,7 +5332,7 @@ void spell_safety(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 		if (IS_SET(gch->in_room->room_flags, ROOM_NO_RECALL) || is_affected_by(gch, AFF_CURSE))
 			continue;
 
-		if (gch->fighting != nullptr)
+		if (Deref(gch->fighting) != nullptr)
 			stop_fighting(gch, true);
 
 		char_from_room(gch);
@@ -5652,7 +5653,7 @@ void spell_deathspell(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 		if (is_safe(ch, vch))
 			continue;
 
-		if (!is_npc(ch) && !is_npc(vch) && (ch->fighting == nullptr || vch->fighting == nullptr))
+		if (!is_npc(ch) && !is_npc(vch) && (Deref(ch->fighting) == nullptr || Deref(vch->fighting) == nullptr))
 		{
 			switch (number_range(0, 2))
 			{
@@ -5732,7 +5733,7 @@ void spell_lifebane(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 		if (vch == ch)
 			tmp_dam /= 2;
 
-		if (!is_npc(ch) && !is_npc(vch) && (ch->fighting == nullptr || vch->fighting == nullptr))
+		if (!is_npc(ch) && !is_npc(vch) && (Deref(ch->fighting) == nullptr || Deref(vch->fighting) == nullptr))
 		{
 			switch (number_range(0, 2))
 			{
@@ -5811,7 +5812,7 @@ void spell_heavenly_sceptre_fire(int sn, int level, CHAR_DATA *ch, void *vo, int
 	int dam;
 	CHAR_DATA *victim;
 
-	victim = ch->fighting;
+	victim = Deref(ch->fighting);
 
 	if (is_affected(ch, sn) || victim == nullptr || ch->level < 30)
 	{

--- a/code/magic.c
+++ b/code/magic.c
@@ -258,7 +258,7 @@ bool saves_spell(int level, CHAR_DATA *victim, int dam_type)
 	if (is_affected(victim, gsn_traitors_luck))
 	{
 		af = affect_find(victim->affected, gsn_traitors_luck);
-		if (opponent && (opponent == af->owner))
+		if (opponent && (opponent == Deref(af->owner)))
 			save -= 50;
 	}
 
@@ -1420,7 +1420,7 @@ void spell_blindness(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 	af.level = level;
 	af.location = APPLY_HITROLL;
 	af.modifier = -4;
-	af.owner = ch;
+	af.owner = ch->self;
 
 	dur = level / 4;
 
@@ -3736,7 +3736,7 @@ void spell_plague(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 
 	SET_BIT(af.bitvector, AFF_PLAGUE);
 
-	af.owner = ch;
+	af.owner = ch->self;
 	af.tick_fun = plague_tick;
 	af.end_fun = nullptr;
 	new_affect_join(victim, &af);
@@ -3791,7 +3791,7 @@ void plague_tick(CHAR_DATA *ch, AFFECT_DATA *af)
 	dam = std::min(ch->level, af->level);
 	dam = std::max((int)(dam * .7), 10);
 
-	damage_new(af->owner, ch, dam, gsn_plague, DAM_DISEASE, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "sickness");
+	damage_new(Deref(af->owner), ch, dam, gsn_plague, DAM_DISEASE, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "sickness");
 
 	ch->mana -= number_range(af->level / 2, (int)(af->level * 1.5));
 	ch->move -= number_range(af->level / 2, (int)(af->level * 1.5));
@@ -3851,7 +3851,7 @@ void spell_poison(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 
 	SET_BIT(af.bitvector, AFF_POISON);
 
-	af.owner = ch;
+	af.owner = ch->self;
 	af.end_fun = nullptr;
 	af.tick_fun = poison_tick;
 	new_affect_to_char(victim, &af);
@@ -3868,10 +3868,10 @@ void poison_tick(CHAR_DATA *ch, AFFECT_DATA *af)
 	act("$n shivers and suffers.", ch, nullptr, nullptr, TO_ROOM);
 	send_to_char("You shiver and suffer.\n\r", ch);
 
-	if (!af->owner)
-		af->owner = ch;
+	if (!Deref(af->owner))
+		af->owner = ch->self;
 
-	damage_new(af->owner, ch, af->level, gsn_poison, DAM_POISON, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "poison");
+	damage_new(Deref(af->owner), ch, af->level, gsn_poison, DAM_POISON, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "poison");
 }
 
 void spell_protection(int sn, int level, CHAR_DATA *ch, void *vo, int target)
@@ -4985,7 +4985,7 @@ void spell_nether_breath(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 		af.modifier = level / 3;
 		af.duration = 12;
 		af.level = level;
-		af.owner = ch;
+		af.owner = ch->self;
 
 		SET_BIT(af.bitvector, AFF_CURSE);
 
@@ -5134,7 +5134,7 @@ void sanguine_blind(CHAR_DATA *ch, CHAR_DATA *victim)
 	af.type = gsn_blindness;
 	af.name = palloc_string("infected eyes");
 	af.level = ch->level;
-	af.owner = ch;
+	af.owner = ch->self;
 	af.duration = number_percent() > 50 ? 1 : 0;
 	af.location = 0;
 	af.modifier = 0;
@@ -5273,7 +5273,7 @@ void spell_consecrate(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 	raf.duration = number_range(4, 6);
 	raf.location = APPLY_NONE;
 	raf.modifier = 0;
-	raf.owner = ch;
+	raf.owner = ch->self;
 	raf.end_fun = nullptr;
 	raf.tick_fun = nullptr;
 	new_affect_to_room(ch->in_room, &raf);
@@ -5928,7 +5928,7 @@ void spell_forget(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 	af.aftype = AFT_SPELL;
 	af.type = sn;
 	af.modifier = 0;
-	af.owner = ch;
+	af.owner = ch->self;
 	af.duration = level / 10;
 	af.location = 0;
 	af.level = level;
@@ -6635,7 +6635,7 @@ void spell_talismanic_aura(int sn, int level, CHAR_DATA *ch, void *vo, int targe
 	af.duration = 8;
 	af.location = APPLY_DAM_MOD;
 	af.modifier = -(short)(ch->level * reduction);
-	af.owner = ch;
+	af.owner = ch->self;
 	af.end_fun = talismanic_end;
 	af.mod_name = MOD_PROTECTION;
 

--- a/code/magic.c
+++ b/code/magic.c
@@ -7,6 +7,7 @@
 #include <algorithm>
 #include "merc.h"
 #include "magic.h"
+#include "entity/handles.h"
 #include "characterClasses/necro.h"
 #include "recycle.h"
 #include "tables.h"
@@ -3529,8 +3530,9 @@ void spell_locate_object(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 		found = true;
 		number++;
 
-		for (in_obj = obj; in_obj->in_obj != nullptr; in_obj = in_obj->in_obj)
-			;
+		in_obj = obj;
+		while (OBJ_DATA *outer = Deref(in_obj->in_obj))
+			in_obj = outer;
 
 		if (in_obj->carried_by != nullptr)
 		{

--- a/code/magic.c
+++ b/code/magic.c
@@ -850,7 +850,7 @@ void do_cast(CHAR_DATA *ch, char *argument)
 				}
 			}
 
-			if (is_affected_by(ch, AFF_CHARM) && ch->master == victim)
+			if (is_affected_by(ch, AFF_CHARM) && Deref(ch->master) == victim)
 			{
 				send_to_char("You can't do that on your own master.\n\r", ch);
 				return;
@@ -926,7 +926,7 @@ void do_cast(CHAR_DATA *ch, char *argument)
 
 			if (target == TARGET_CHAR) /* check the sanity of the attack */
 			{
-				if (is_affected_by(ch, AFF_CHARM) && ch->master == victim)
+				if (is_affected_by(ch, AFF_CHARM) && Deref(ch->master) == victim)
 				{
 					send_to_char("You can't do that on your own follower.\n\r", ch);
 					return;
@@ -1104,7 +1104,7 @@ void do_cast(CHAR_DATA *ch, char *argument)
 
 	if ((targtype == TAR_CHAR_OFFENSIVE || (targtype == TAR_OBJ_CHAR_OFF && target == TARGET_CHAR))
 		&& victim != ch
-		&& victim->master != ch
+		&& Deref(victim->master) != ch
 		&& !(is_affected(victim, gsn_bind_feet) && sn == gsn_bind_feet))
 	{
 		CHAR_DATA *vch, *vch_next;
@@ -1274,7 +1274,7 @@ void obj_cast_spell(int sn, int level, CHAR_DATA *ch, CHAR_DATA *victim, OBJ_DAT
 			|| (skill_table[sn].target == TAR_OBJ_CHAR_OFF && target == TARGET_CHAR)
 			|| (skill_table[sn].target == TAR_CHAR_AMBIGUOUS && (!trusts(ch, victim) && !is_safe(ch, victim))))
 		&& victim != ch
-		&& victim->master != ch)
+		&& Deref(victim->master) != ch)
 	{
 		CHAR_DATA *vch;
 		CHAR_DATA *vch_next;
@@ -1505,7 +1505,7 @@ void spell_cancellation(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 
 	if (arg2[0] == '\0')
 	{
-		if ((!is_npc(ch) && is_npc(victim) && !(is_affected_by(ch, AFF_CHARM) && ch->master == victim))
+		if ((!is_npc(ch) && is_npc(victim) && !(is_affected_by(ch, AFF_CHARM) && Deref(ch->master) == victim))
 			|| (is_npc(ch) && !is_npc(victim)))
 		{
 			send_to_char("You failed.\n\r", ch);
@@ -1727,7 +1727,7 @@ void spell_charm_person(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 
 	for (check = char_list; check != nullptr; check = check->next)
 	{
-		if (check->leader == ch && is_affected_by(check, AFF_CHARM))
+		if (Deref(check->leader) == ch && is_affected_by(check, AFF_CHARM))
 			count++;
 	}
 
@@ -1737,12 +1737,12 @@ void spell_charm_person(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 		return;
 	}
 
-	if (victim->master)
+	if (Deref(victim->master))
 		stop_follower(victim);
 
 	add_follower(victim, ch);
 
-	victim->leader = ch;
+	victim->leader = ch->self;
 
 	init_affect(&af);
 	af.where = TO_AFFECTS;
@@ -3043,7 +3043,7 @@ void spell_gate(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 		return;
 	}
 
-	if (ch->pet != nullptr && ch->in_room == ch->pet->in_room)
+	if (Deref(ch->pet) != nullptr && ch->in_room == Deref(ch->pet)->in_room)
 		gate_pet = true;
 	else
 		gate_pet = false;
@@ -3062,14 +3062,14 @@ void spell_gate(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 
 	if (gate_pet)
 	{
-		act("$n steps through a gate and vanishes.", ch->pet, nullptr, nullptr, TO_ROOM);
-		send_to_char("You step through a gate and vanish.\n\r", ch->pet);
+		act("$n steps through a gate and vanishes.", Deref(ch->pet), nullptr, nullptr, TO_ROOM);
+		send_to_char("You step through a gate and vanish.\n\r", Deref(ch->pet));
 
-		char_from_room(ch->pet);
-		char_to_room(ch->pet, victim->in_room);
+		char_from_room(Deref(ch->pet));
+		char_to_room(Deref(ch->pet), victim->in_room);
 
-		act("$n has arrived through a gate.", ch->pet, nullptr, nullptr, TO_ROOM);
-		do_look(ch->pet, "auto");
+		act("$n has arrived through a gate.", Deref(ch->pet), nullptr, nullptr, TO_ROOM);
+		do_look(Deref(ch->pet), "auto");
 	}
 }
 
@@ -4546,7 +4546,7 @@ void spell_turn_undead(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 	{
 		for (follower = char_list; follower != nullptr; follower = follower->next)
 		{
-			if (follower->master == ch && IS_SET(follower->act, ACT_UNDEAD) && follower != ch)
+			if (Deref(follower->master) == ch && IS_SET(follower->act, ACT_UNDEAD) && follower != ch)
 			{
 				num++;
 				count += follower->level;
@@ -4579,8 +4579,8 @@ void spell_turn_undead(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 				act("$n stares in hatred for a moment then suddenly becomes very subdued.", victim, 0, 0, TO_NOTVICT);
 				stop_fighting(victim, true);
 
-				victim->master = ch;
-				victim->leader = ch;
+				victim->master = ch->self;
+				victim->leader = ch->self;
 
 				SET_BIT(victim->affected_by, AFF_CHARM);
 				REMOVE_BIT(victim->act, ACT_AGGRESSIVE);

--- a/code/mem.c
+++ b/code/mem.c
@@ -156,6 +156,7 @@ EXIT_DATA *new_exit(void)
 	pExit->key = 0;
 	pExit->keyword = nullptr;
 	pExit->description = nullptr;
+	pExit->rune = nullptr;
 
 	return pExit;
 }
@@ -255,7 +256,6 @@ ROOM_INDEX_DATA *new_room_index(void)
 
 	pRoom->move_progs= false;
 	pRoom->rune = nullptr;
-	pRoom->has_rune= false;
 	pRoom->light = 0;
 	pRoom->reset_first = nullptr;
 	pRoom->reset_last = nullptr;

--- a/code/merc.h
+++ b/code/merc.h
@@ -296,7 +296,10 @@ struct rune_data
 {
 	RUNE_FUN *function;
 	void *placed_on;
-	CHAR_DATA *owner;
+	// The caster. Non-owning: a rune is placed on a door or a room precisely so
+	// it can outlive the moment it was cast in, and nothing has ever cleared
+	// this, so every reader has to cope with the caster being gone.
+	Handle<CHAR_DATA> owner;
 	int target_type;
 	int trigger_type;
 	int level;

--- a/code/merc.h
+++ b/code/merc.h
@@ -109,8 +109,8 @@ int remove();
 
 #include "entity/fwd.h"
 #include "entity/limits.h"
-// descriptor_data below carries Handle<CHAR_DATA> members, so the template has
-// to be visible here and not just to whoever includes this header.
+// descriptor_data below carries Handle members, so the template has to be
+// visible here and not just to whoever includes this header.
 #include "entity/handles.h"
 
 //
@@ -312,6 +312,10 @@ struct rune_data
 struct descriptor_data
 {
 	DESCRIPTOR_DATA *next;
+	// This connection's own handle, handed out so a character can name it
+	// without holding a pointer into a recycled struct. Registered by
+	// new_descriptor and retired by free_descriptor.
+	Handle<DESCRIPTOR_DATA> self;
 	DESCRIPTOR_DATA *snoop_by;
 	// The body this connection drives, and -- while an immortal is switched
 	// into a mob -- the immortal's own body parked behind it. Non-owning both

--- a/code/merc.h
+++ b/code/merc.h
@@ -1303,6 +1303,9 @@ struct trap_data
 // Solution to Horde trophy ugliness
 //
 
+// One node of a mob tracking search. The search owns every node it makes and
+// outlives none of them (see PathSearch in act_move.c); `prev`, `dir_to` and
+// room->path are all non-owning pointers between nodes of the same search.
 struct pathfind_data
 {
 	ROOM_INDEX_DATA *room;				// What room is this?

--- a/code/merc.h
+++ b/code/merc.h
@@ -109,6 +109,9 @@ int remove();
 
 #include "entity/fwd.h"
 #include "entity/limits.h"
+// descriptor_data below carries Handle<CHAR_DATA> members, so the template has
+// to be visible here and not just to whoever includes this header.
+#include "entity/handles.h"
 
 //
 // String and memory management parameters.
@@ -310,8 +313,15 @@ struct descriptor_data
 {
 	DESCRIPTOR_DATA *next;
 	DESCRIPTOR_DATA *snoop_by;
-	CHAR_DATA *character;
-	CHAR_DATA *original;
+	// The body this connection drives, and -- while an immortal is switched
+	// into a mob -- the immortal's own body parked behind it. Non-owning both
+	// ways: a character can be extracted while the connection lives on, so
+	// these are handles rather than pointers. `character` used to be nulled by
+	// hand on each of the five paths that free it; `original` was nulled on
+	// none of them, and check_playing reads its `true_name` for every open
+	// connection on every login attempt.
+	Handle<CHAR_DATA> character;
+	Handle<CHAR_DATA> original;
 	bool valid;
 	char *host;
 	short descriptor;

--- a/code/merc.h
+++ b/code/merc.h
@@ -319,7 +319,10 @@ struct descriptor_data
 	// without holding a pointer into a recycled struct. Registered by
 	// new_descriptor and retired by free_descriptor.
 	Handle<DESCRIPTOR_DATA> self;
-	DESCRIPTOR_DATA *snoop_by;
+	// The connection watching this one, if any. Non-owning; it expires by
+	// itself when that connection closes, which is what close_socket's
+	// hand-written sweep over descriptor_list used to do.
+	Handle<DESCRIPTOR_DATA> snoop_by;
 	// The body this connection drives, and -- while an immortal is switched
 	// into a mob -- the immortal's own body parked behind it. Non-owning both
 	// ways: a character can be extracted while the connection lives on, so

--- a/code/merc.h
+++ b/code/merc.h
@@ -326,7 +326,6 @@ struct descriptor_data
 	// connection on every login attempt.
 	Handle<CHAR_DATA> character;
 	Handle<CHAR_DATA> original;
-	bool valid;
 	char *host;
 	short descriptor;
 	short connected;

--- a/code/misc.c
+++ b/code/misc.c
@@ -7,6 +7,7 @@
 #include <time.h>
 #include <ctype.h>
 #include "merc.h"
+#include "entity/handles.h"
 #include "misc.h"
 #include "magic.h"
 #include "comm.h"
@@ -613,7 +614,7 @@ void do_chess(CHAR_DATA *ch, char *argument)
 	argument = one_argument(argument, arg4);
 	arg4[2] = '\0';
 
-	if (ch->fighting)
+	if (Deref(ch->fighting))
 	{
 		send_to_char("You really have more important things to worry about right now.\n\r", ch);
 		return;

--- a/code/misc.c
+++ b/code/misc.c
@@ -498,7 +498,7 @@ void spell_summon_nephilim(int sn, int level, CHAR_DATA *ch, void *vo, int targe
 
 	add_follower(nephilim, ch);
 
-	nephilim->leader = ch;
+	nephilim->leader = ch->self;
 
 	SET_BIT(nephilim->affected_by, AFF_CHARM);
 }

--- a/code/moremagic.c
+++ b/code/moremagic.c
@@ -38,6 +38,7 @@
 #include <string.h>
 #include <algorithm>
 #include "merc.h"
+#include "entity/handles.h"
 #include "moremagic.h"
 #include "weather_enums.h"
 #include "recycle.h"
@@ -102,7 +103,7 @@ void spell_enlarge(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 	send_to_char("Your entire body and gear rapidly grow in size, but you feel somewhat more frail afterward.\n\r", victim);
 	act("$n suddenly swells in all directions, expanding to half again $s normal size!", victim, 0, 0, TO_ROOM);
 
-	if (!is_npc(victim) && !trusts(ch, victim) && (!ch->fighting || !victim->fighting))
+	if (!is_npc(victim) && !trusts(ch, victim) && (!Deref(ch->fighting) || !Deref(victim->fighting)))
 	{
 		sprintf(buf, "Die, %s, you sorcerous dog!", pers(ch, victim));
 		do_myell(victim, buf, ch);
@@ -621,7 +622,7 @@ void spell_group_teleport(int sn, int level, CHAR_DATA *ch, void *vo, int target
 		{
 			g_next = group->next_in_room;
 
-			if (!is_same_group(group, ch) || (group->fighting != nullptr) || group == ch)
+			if (!is_same_group(group, ch) || (Deref(group->fighting) != nullptr) || group == ch)
 				continue;
 
 			if (group == ch)

--- a/code/mprog.c
+++ b/code/mprog.c
@@ -907,9 +907,9 @@ void pulse_prog_demon(CHAR_DATA *mob)
 
 	if (!victim || !elemental->in_room || !victim->in_room || victim->ghost > 0)
 	{
-		if (mob->master && victim->ghost > 0)
+		if (Deref(mob->master) && victim->ghost > 0)
 		{
-			sprintf(buf, "%s I have taken the soul of %s. Your debt will one day be collected.", mob->master->name, victim->name);
+			sprintf(buf, "%s I have taken the soul of %s. Your debt will one day be collected.", Deref(mob->master)->name, victim->name);
 			do_tell(mob, buf);
 		}
 
@@ -1357,7 +1357,7 @@ bool death_prog_glass(CHAR_DATA *mob, CHAR_DATA *killer)
 {
 
 	CHAR_DATA *ch, *vch, *vch_next;
-	ch = mob->leader;
+	ch = Deref(mob->leader);
 
 	if (ch == nullptr)
 		return false;
@@ -1509,7 +1509,7 @@ bool move_prog_theatre_guard(CHAR_DATA *ch, CHAR_DATA *mob, ROOM_INDEX_DATA *fro
 void greet_prog_necro_skull(CHAR_DATA *mob, CHAR_DATA *ch)
 {
 	char buf[MSL];
-	CHAR_DATA *master = mob->leader;
+	CHAR_DATA *master = Deref(mob->leader);
 
 	if (ch == master)
 		return;
@@ -1537,7 +1537,7 @@ bool death_prog_necro_skull(CHAR_DATA *mob, CHAR_DATA *killer)
 
 void pulse_prog_necro_skull(CHAR_DATA *mob)
 {
-	if (mob->leader == nullptr)
+	if (Deref(mob->leader) == nullptr)
 	{
 		act("$n crumbles into a pile of dust.", mob, 0, 0, TO_ROOM);
 		extract_char(mob, true);
@@ -2239,7 +2239,7 @@ void pulse_prog_imp(CHAR_DATA *mob)
 	for (victim = mob->in_room->people; victim; victim = victim->next_in_room)
 	{
 		if (number_percent() < 98
-			|| (mob->master && (victim == mob->master || is_safe_new(mob->master, victim, false)))
+			|| (Deref(mob->master) && (victim == Deref(mob->master) || is_safe_new(Deref(mob->master), victim, false)))
 			|| mob == victim)
 		{
 			continue;
@@ -2270,7 +2270,7 @@ void fight_prog_geulgon(CHAR_DATA *mob, CHAR_DATA *victim)
 {
 	CHAR_DATA *vch;
 	CHAR_DATA *vch_next;
-	CHAR_DATA *ch = mob->master;
+	CHAR_DATA *ch = Deref(mob->master);
 	if (Deref(mob->fighting) == nullptr)
 		return;
 
@@ -2314,7 +2314,7 @@ void fight_prog_geulgon(CHAR_DATA *mob, CHAR_DATA *victim)
 void give_prog_minotaur(CHAR_DATA *mob, CHAR_DATA *ch, OBJ_DATA *obj)
 {
 
-	if (ch != mob->master)
+	if (ch != Deref(mob->master))
 	{
 		act("$N snarls angrily at $n's offering, taking $p and breaking it over his knee!", ch, obj, mob, TO_ROOM);
 		act("$n snarls angrily at your offering, taking $p and breaking it over his knee!", mob, obj, ch, TO_VICT);
@@ -3463,7 +3463,7 @@ void pulse_prog_glass(CHAR_DATA *mob)
 		af.type = gsn_bleeding;
 		af.aftype = AFT_MALADY;
 		af.level = mob->level;
-		af.owner = mob->leader;
+		af.owner = Deref(mob->leader);
 		af.end_fun = nullptr;
 		new_affect_to_char(victim, &af);
 
@@ -3478,7 +3478,7 @@ void pulse_prog_glass(CHAR_DATA *mob)
 		caf.type = gsn_trophy;
 		caf.level = mob->level;
 		caf.aftype = AFT_SKILL;
-		caf.owner = mob->leader;
+		caf.owner = Deref(mob->leader);
 		caf.end_fun = nullptr;
 		new_affect_to_char(mob, &caf);
 	}

--- a/code/mprog.c
+++ b/code/mprog.c
@@ -1306,11 +1306,11 @@ void pulse_prog_tahlu_mist_ward(CHAR_DATA *mob)
 	for (d = descriptor_list; d != nullptr; d = d->next)
 	{
 		if (d->connected == CON_PLAYING
-			&& d->character->in_room != nullptr
-			&& d->character->in_room->area == mob->in_room->area
-			&& is_evil(d->character))
+			&& Deref(d->character)->in_room != nullptr
+			&& Deref(d->character)->in_room->area == mob->in_room->area
+			&& is_evil(Deref(d->character)))
 		{
-			ch = d->character;
+			ch = Deref(d->character);
 			mist = create_mobile(get_mob_index(1616));
 
 			char_to_room(mist, ch->in_room);
@@ -3229,10 +3229,10 @@ void pulse_prog_area_echo_ward(CHAR_DATA *mob)
 	for (d = descriptor_list; d; d = d->next)
 	{
 		if (d->connected != CON_PLAYING
-			|| !d->character->in_room
-			|| d->character->in_room->area != mob->in_room->area
-			|| d->character->in_room->vnum < mob->armor[0]
-			|| d->character->in_room->vnum > mob->armor[1])
+			|| !Deref(d->character)->in_room
+			|| Deref(d->character)->in_room->area != mob->in_room->area
+			|| Deref(d->character)->in_room->vnum < mob->armor[0]
+			|| Deref(d->character)->in_room->vnum > mob->armor[1])
 		{
 			continue;
 		}

--- a/code/mprog.c
+++ b/code/mprog.c
@@ -907,7 +907,10 @@ void pulse_prog_demon(CHAR_DATA *mob)
 
 	if (!victim || !elemental->in_room || !victim->in_room || victim->ghost > 0)
 	{
-		if (Deref(mob->master) && victim->ghost > 0)
+		// `victim` is one of the things that can be null here -- it is the
+		// first clause of the condition above -- so the message about having
+		// taken its soul has to check for it before reading one.
+		if (victim && Deref(mob->master) && victim->ghost > 0)
 		{
 			sprintf(buf, "%s I have taken the soul of %s. Your debt will one day be collected.", Deref(mob->master)->name, victim->name);
 			do_tell(mob, buf);

--- a/code/mprog.c
+++ b/code/mprog.c
@@ -1552,11 +1552,11 @@ void attack_prog_lesser_demon(CHAR_DATA *mob, CHAR_DATA *attacker)
 	if (!af)
 		return;
 
-	if (mob->pIndexData->vnum == MOB_VNUM_BARBAS && attacker != af->owner && af->owner)
+	if (mob->pIndexData->vnum == MOB_VNUM_BARBAS && attacker != Deref(af->owner) && Deref(af->owner))
 	{
 		do_say(mob, "Bah, ya bloody fool, you'll pay for this!");
 
-		sprintf(buf, "%s I'll be back for ye another time, weakling.", af->owner->name);
+		sprintf(buf, "%s I'll be back for ye another time, weakling.", Deref(af->owner)->name);
 		do_tell(mob, buf);
 
 		act("$n vanishes in a crimson flash!", mob, 0, 0, TO_ROOM);
@@ -1567,31 +1567,31 @@ void attack_prog_lesser_demon(CHAR_DATA *mob, CHAR_DATA *attacker)
 		char_to_room(mob, get_room_index(3));
 
 		RS.Queue.AddToQueue(1, "attack_prog_lesser_demon", "delay_extract", delay_extract, mob);
-		af->owner->pcdata->lesserdata[LESSER_BARBAS] = FAVOR_NONE;
+		Deref(af->owner)->pcdata->lesserdata[LESSER_BARBAS] = FAVOR_NONE;
 		return;
 	}
 
 	if (mob->pIndexData->vnum == MOB_VNUM_BARBAS)
 		return;
 
-	if (attacker == af->owner)
+	if (attacker == Deref(af->owner))
 	{
 		switch (mob->pIndexData->vnum)
 		{
 			case MOB_VNUM_BARBAS:
-				af->owner->pcdata->lesserdata[LESSER_BARBAS] = FAVOR_FAILED;
+				Deref(af->owner)->pcdata->lesserdata[LESSER_BARBAS] = FAVOR_FAILED;
 				break;
 			case MOB_VNUM_FURCAS:
-				af->owner->pcdata->lesserdata[LESSER_FURCAS] = FAVOR_FAILED;
+				Deref(af->owner)->pcdata->lesserdata[LESSER_FURCAS] = FAVOR_FAILED;
 				break;
 			case MOB_VNUM_MALAPHAR:
-				af->owner->pcdata->lesserdata[LESSER_MALAPHAR] = FAVOR_FAILED;
+				Deref(af->owner)->pcdata->lesserdata[LESSER_MALAPHAR] = FAVOR_FAILED;
 				break;
 			case MOB_VNUM_AAMON:
-				af->owner->pcdata->lesserdata[LESSER_AAMON] = FAVOR_FAILED;
+				Deref(af->owner)->pcdata->lesserdata[LESSER_AAMON] = FAVOR_FAILED;
 				break;
 			case MOB_VNUM_IPOS:
-				af->owner->pcdata->lesserdata[LESSER_IPOS] = FAVOR_FAILED;
+				Deref(af->owner)->pcdata->lesserdata[LESSER_IPOS] = FAVOR_FAILED;
 				break;
 			default:
 				return;
@@ -1610,24 +1610,24 @@ void attack_prog_lesser_demon(CHAR_DATA *mob, CHAR_DATA *attacker)
 		return;
 	}
 
-	if (attacker != af->owner)
+	if (attacker != Deref(af->owner))
 	{
 		switch (mob->pIndexData->vnum)
 		{
 			case MOB_VNUM_BARBAS:
-				af->owner->pcdata->lesserdata[LESSER_BARBAS] = FAVOR_NONE;
+				Deref(af->owner)->pcdata->lesserdata[LESSER_BARBAS] = FAVOR_NONE;
 				break;
 			case MOB_VNUM_FURCAS:
-				af->owner->pcdata->lesserdata[LESSER_FURCAS] = FAVOR_NONE;
+				Deref(af->owner)->pcdata->lesserdata[LESSER_FURCAS] = FAVOR_NONE;
 				break;
 			case MOB_VNUM_MALAPHAR:
-				af->owner->pcdata->lesserdata[LESSER_MALAPHAR] = FAVOR_NONE;
+				Deref(af->owner)->pcdata->lesserdata[LESSER_MALAPHAR] = FAVOR_NONE;
 				break;
 			case MOB_VNUM_AAMON:
-				af->owner->pcdata->lesserdata[LESSER_AAMON] = FAVOR_NONE;
+				Deref(af->owner)->pcdata->lesserdata[LESSER_AAMON] = FAVOR_NONE;
 				break;
 			case MOB_VNUM_IPOS:
-				af->owner->pcdata->lesserdata[LESSER_IPOS] = FAVOR_NONE;
+				Deref(af->owner)->pcdata->lesserdata[LESSER_IPOS] = FAVOR_NONE;
 				break;
 			default:
 				return;
@@ -1636,7 +1636,7 @@ void attack_prog_lesser_demon(CHAR_DATA *mob, CHAR_DATA *attacker)
 		sprintf(buf, "%s, you fool, you'll pay for this!", attacker->name);
 		do_say(mob, buf);
 
-		sprintf(buf, "%s I'll be back for ye another time, weakling.", af->owner->name);
+		sprintf(buf, "%s I'll be back for ye another time, weakling.", Deref(af->owner)->name);
 		do_tell(mob, buf);
 
 		act("$n vanishes in a crimson flash!", mob, 0, 0, TO_ROOM);
@@ -1712,7 +1712,7 @@ bool death_prog_barbas(CHAR_DATA *mob, CHAR_DATA *killer)
 
 	act("Emitting a ghastly grunt, Barbas falls to the ground in a heap and disappears.", mob, 0, 0, TO_ROOM);
 
-	if (killer != af->owner)
+	if (killer != Deref(af->owner))
 		return false;
 
 	send_to_char("You feel a gluttonous lust enter your body as you stand victorious!\n\r", killer);
@@ -1733,7 +1733,7 @@ void speech_prog_aamon(CHAR_DATA *mob, CHAR_DATA *ch, char *speech)
 	if (!af)
 		return;
 
-	if (ch != af->owner)
+	if (ch != Deref(af->owner))
 		return;
 
 	lowspeech = talloc_string(lowstring(speech));
@@ -1845,7 +1845,7 @@ void greet_prog_furcas(CHAR_DATA *mob, CHAR_DATA *ch)
 	if (!af)
 		return;
 
-	if (ch != af->owner)
+	if (ch != Deref(af->owner))
 		return;
 
 	act("Eyes wide with amazement and fear, $n leaps backward away from you!", mob, 0, ch, TO_VICT);
@@ -1870,10 +1870,10 @@ void speech_prog_ipos(CHAR_DATA *mob, CHAR_DATA *ch, char *speech)
 	if (!af)
 		return;
 
-	if (!af->owner)
+	if (!Deref(af->owner))
 		return;
 
-	if (ch != af->owner)
+	if (ch != Deref(af->owner))
 		return;
 
 	if (af->modifier > 4)
@@ -1938,10 +1938,10 @@ void speech_prog_oze(CHAR_DATA *mob, CHAR_DATA *ch, char *speech)
 	AFFECT_DATA *af = affect_find(mob->affected, gsn_greater_demon);
 	char buf[MSL];
 
-	if (!af || !af->owner)
+	if (!af || !Deref(af->owner))
 		return;
 
-	if (ch != af->owner)
+	if (ch != Deref(af->owner))
 		return;
 
 	if (!str_prefix("yes", speech))
@@ -1988,10 +1988,10 @@ void speech_prog_gamygyn(CHAR_DATA *mob, CHAR_DATA *ch, char *speech)
 	char buf[MSL];
 	std::string buffer;
 
-	if (!paf || !paf->owner)
+	if (!paf || !Deref(paf->owner))
 		return;
 
-	if (ch != paf->owner)
+	if (ch != Deref(paf->owner))
 		return;
 
 	if (!str_prefix("yes", speech))
@@ -2011,7 +2011,7 @@ void speech_prog_gamygyn(CHAR_DATA *mob, CHAR_DATA *ch, char *speech)
 		af.where = TO_AFFECTS;
 		af.aftype = AFT_INVIS;
 		af.type = gsn_gamygyn_soul;
-		af.owner = ch;
+		af.owner = ch->self;
 		af.level = 60;
 		af.duration = 1000;
 		af.modifier = 0;
@@ -2042,10 +2042,10 @@ void speech_prog_orobas(CHAR_DATA *mob, CHAR_DATA *ch, char *speech)
 	char buf[MSL];
 	std::string buffer;
 
-	if (!paf || !paf->owner)
+	if (!paf || !Deref(paf->owner))
 		return;
 
-	if (ch != paf->owner)
+	if (ch != Deref(paf->owner))
 		return;
 
 	if (!str_prefix("yes", speech))
@@ -2071,7 +2071,7 @@ void speech_prog_orobas(CHAR_DATA *mob, CHAR_DATA *ch, char *speech)
 		af.where = TO_AFFECTS;
 		af.aftype = AFT_INVIS;
 		af.type = gsn_orobas_soul;
-		af.owner = ch;
+		af.owner = ch->self;
 		af.level = 60;
 		af.duration = 1000;
 		af.modifier = 0;
@@ -2101,10 +2101,10 @@ void speech_prog_geryon(CHAR_DATA *mob, CHAR_DATA *ch, char *speech)
 	AFFECT_DATA *paf = affect_find(mob->affected, gsn_greater_demon);
 	char buf[MSL];
 
-	if (!paf || !paf->owner)
+	if (!paf || !Deref(paf->owner))
 		return;
 
-	if (ch != paf->owner)
+	if (ch != Deref(paf->owner))
 		return;
 
 	if (!str_prefix("eye", speech))
@@ -2157,10 +2157,10 @@ void speech_prog_cimeries(CHAR_DATA *mob, CHAR_DATA *ch, char *speech)
 {
 	AFFECT_DATA *paf = affect_find(mob->affected, gsn_greater_demon);
 
-	if (!paf || !paf->owner)
+	if (!paf || !Deref(paf->owner))
 		return;
 
-	if (ch != paf->owner)
+	if (ch != Deref(paf->owner))
 		return;
 
 	if (!str_prefix("ear", speech))
@@ -2501,7 +2501,7 @@ void pulse_prog_wizard_summon(CHAR_DATA *mob)
 			paf = nullptr;
 			for (auto &paf_elem : mob->affected)
 			{
-				if (paf_elem.type == gsn_bash && paf_elem.owner == vch)
+				if (paf_elem.type == gsn_bash && Deref(paf_elem.owner) == vch)
 				{
 					found = true;
 					paf = &paf_elem;
@@ -2536,7 +2536,7 @@ void pulse_prog_wizard_summon(CHAR_DATA *mob)
 			af.where = TO_AFFECTS;
 			af.modifier = 10;
 			af.duration = -1;
-			af.owner = vch;
+			af.owner = vch->self;
 			af.type = gsn_bash;
 			affect_to_char(mob, &af);
 		}
@@ -3463,7 +3463,7 @@ void pulse_prog_glass(CHAR_DATA *mob)
 		af.type = gsn_bleeding;
 		af.aftype = AFT_MALADY;
 		af.level = mob->level;
-		af.owner = Deref(mob->leader);
+		af.owner = mob->leader;
 		af.end_fun = nullptr;
 		new_affect_to_char(victim, &af);
 
@@ -3478,7 +3478,7 @@ void pulse_prog_glass(CHAR_DATA *mob)
 		caf.type = gsn_trophy;
 		caf.level = mob->level;
 		caf.aftype = AFT_SKILL;
-		caf.owner = Deref(mob->leader);
+		caf.owner = mob->leader;
 		caf.end_fun = nullptr;
 		new_affect_to_char(mob, &caf);
 	}
@@ -3618,7 +3618,7 @@ void greet_prog_face_sucker(CHAR_DATA *mob, CHAR_DATA *ch)
 	af.type = gsn_blindness;
 	af.location = APPLY_HITROLL;
 	af.modifier = -10;
-	af.owner = mob;
+	af.owner = mob->self;
 	af.duration = 6;
 	af.pulse_fun = sucker_pulse;
 

--- a/code/mprog.c
+++ b/code/mprog.c
@@ -31,6 +31,7 @@
 #include <string.h>
 #include <time.h>
 #include "merc.h"
+#include "entity/handles.h"
 #include "mprog.h"
 #include "characterClasses/ap.h"
 #include "note.h"
@@ -524,7 +525,7 @@ void pulse_prog_arangird_patrol(CHAR_DATA *mob)
 	OBJ_DATA *robes;
 	int dir_next = -1;
 
-	if (mob->fighting)
+	if (Deref(mob->fighting))
 		return;
 
 	if (!mob->in_room)
@@ -630,7 +631,7 @@ void greet_prog_ruins_spirit(CHAR_DATA *mob, CHAR_DATA *ch)
 {
 	char buf[MSL];
 
-	if (mob->fighting || is_immortal(ch))
+	if (Deref(mob->fighting) || is_immortal(ch))
 		return;
 
 	if (check_stealth(ch, mob))
@@ -823,7 +824,7 @@ void pulse_prog_formian_queen(CHAR_DATA *mob)
 	if (!mob->in_room)
 		return;
 
-	if (mob->fighting)
+	if (Deref(mob->fighting))
 		return;
 
 	if (is_affected(mob, gsn_timer))
@@ -920,7 +921,7 @@ void pulse_prog_demon(CHAR_DATA *mob)
 	if (number_percent() > 50)
 		return;
 
-	if (elemental->fighting)
+	if (Deref(elemental->fighting))
 		return;
 
 	if (mob->position != POS_STANDING)
@@ -952,7 +953,7 @@ bool aggress_prog_arangird_demon(CHAR_DATA *mob, CHAR_DATA *attacker)
 		act("An invisible barrier flares around $n, protecting $m from harm.", mob, 0, attacker, TO_VICT);
 		act("An invisible barrier flares around $n as $N approaches.", mob, 0, attacker, TO_NOTVICT);
 
-		if (attacker->fighting == mob)
+		if (Deref(attacker->fighting) == mob)
 			stop_fighting(attacker, mob);
 
 		return true;
@@ -1026,7 +1027,7 @@ void pulse_prog_ilopheth_piranha(CHAR_DATA *mob)
 	if ((room = mob->in_room) == nullptr)
 		return;
 
-	if (mob->fighting)
+	if (Deref(mob->fighting))
 		return;
 
 	if (mob->position <= POS_RESTING)
@@ -1081,7 +1082,7 @@ void pulse_prog_ilopheth_piranha(CHAR_DATA *mob)
 			if (adjmob->pIndexData->vnum != 9011)
 				continue;
 
-			if (adjmob->fighting)
+			if (Deref(adjmob->fighting))
 				continue;
 
 			if (number_percent() > 50)
@@ -1103,7 +1104,7 @@ void pulse_prog_ilopheth_weatherbeaten(CHAR_DATA *mob)
 	if (!mob->in_room || mob->pIndexData->vnum != 9010)
 		return;
 
-	if (mob->fighting || mob->position < POS_RESTING)
+	if (Deref(mob->fighting) || mob->position < POS_RESTING)
 		return;
 
 	if (sun == SolarPosition::Sunset && mob->in_room->vnum == 9121)
@@ -1124,7 +1125,7 @@ void pulse_prog_alstea_ehrlouge(CHAR_DATA *mob)
 {
 	ROOM_INDEX_DATA *study = get_room_index(105);
 
-	if (mob->fighting || mob->position > POS_RESTING)
+	if (Deref(mob->fighting) || mob->position > POS_RESTING)
 		return;
 
 	if (mob->in_room->vnum != 105)
@@ -1480,8 +1481,8 @@ void pulse_prog_shopkeeper(CHAR_DATA *mob)
 
 		act("$t tosses $n out of $s shop.", vch, mob->short_descr, 0, TO_ROOM);
 
-		if (mob->fighting)
-			stop_fighting(mob, mob->fighting);
+		if (Deref(mob->fighting))
+			stop_fighting(mob, Deref(mob->fighting));
 
 		do_look(vch, "auto");
 	}
@@ -1661,7 +1662,7 @@ void beat_prog_barbas(CHAR_DATA *mob)
 	if (!ch)
 		return;
 
-	if (mob->fighting)
+	if (Deref(mob->fighting))
 		return;
 
 	if (ch->ghost > 0)
@@ -2270,7 +2271,7 @@ void fight_prog_geulgon(CHAR_DATA *mob, CHAR_DATA *victim)
 	CHAR_DATA *vch;
 	CHAR_DATA *vch_next;
 	CHAR_DATA *ch = mob->master;
-	if (mob->fighting == nullptr)
+	if (Deref(mob->fighting) == nullptr)
 		return;
 
 	if (!victim)
@@ -2300,7 +2301,7 @@ void fight_prog_geulgon(CHAR_DATA *mob, CHAR_DATA *victim)
 				if (ch->cabal > 0 && ch->cabal == vch->cabal)
 					continue;
 
-				if (is_safe(ch, vch) && vch->fighting != nullptr && vch->fighting != ch)
+				if (is_safe(ch, vch) && Deref(vch->fighting) != nullptr && Deref(vch->fighting) != ch)
 					continue;
 
 				spell_iceball(skill_lookup("iceball"), mob->level, mob, vch, TAR_IGNORE);
@@ -2419,7 +2420,7 @@ void fight_prog_gking(CHAR_DATA *mob, CHAR_DATA *victim)
 
 void pulse_prog_nocturnal_mob(CHAR_DATA *mob)
 {
-	if ((sun == SolarPosition::Sunrise || sun == SolarPosition::Daylight) && number_percent() < 30 && mob->fighting == nullptr)
+	if ((sun == SolarPosition::Sunrise || sun == SolarPosition::Daylight) && number_percent() < 30 && Deref(mob->fighting) == nullptr)
 	{
 		extract_char(mob, true);
 	}
@@ -2427,7 +2428,7 @@ void pulse_prog_nocturnal_mob(CHAR_DATA *mob)
 
 void pulse_prog_diurnal_mob(CHAR_DATA *mob)
 {
-	if (sun == SolarPosition::Dark && number_percent() < 30 && mob->fighting == nullptr)
+	if (sun == SolarPosition::Dark && number_percent() < 30 && Deref(mob->fighting) == nullptr)
 	{
 		extract_char(mob, true);
 	}
@@ -2677,7 +2678,7 @@ void beat_prog_law_track(CHAR_DATA *mob)
 		return;
 	}
 
-	if (mob->fighting)
+	if (Deref(mob->fighting))
 		return;
 
 	if (ch->ghost > 0)
@@ -3247,7 +3248,7 @@ void pulse_prog_area_echo_ward(CHAR_DATA *mob)
 
 void pulse_prog_shade(CHAR_DATA *mob)
 {
-	CHAR_DATA *victim = mob->fighting;
+	CHAR_DATA *victim = Deref(mob->fighting);
 	int sn;
 	char *spell = nullptr;
 	if (!victim || number_percent() > 13)
@@ -3274,7 +3275,7 @@ void pulse_prog_shade(CHAR_DATA *mob)
 
 void pulse_prog_banshee(CHAR_DATA *mob)
 {
-	CHAR_DATA *victim = mob->fighting;
+	CHAR_DATA *victim = Deref(mob->fighting);
 	int sn, dam;
 	char *spell = nullptr;
 
@@ -3312,7 +3313,7 @@ void pulse_prog_banshee(CHAR_DATA *mob)
 
 void pulse_prog_phantasm(CHAR_DATA *mob)
 {
-	CHAR_DATA *victim = mob->fighting;
+	CHAR_DATA *victim = Deref(mob->fighting);
 	int sn = 0;
 	char *spell = nullptr;
 
@@ -3355,7 +3356,7 @@ void pulse_prog_phantasm(CHAR_DATA *mob)
 
 void pulse_prog_ravghoul(CHAR_DATA *mob)
 {
-	CHAR_DATA *victim = mob->fighting;
+	CHAR_DATA *victim = Deref(mob->fighting);
 	AFFECT_DATA af;
 
 	if (victim == nullptr || victim->in_room != mob->in_room || number_percent() > 10)
@@ -3416,7 +3417,7 @@ void pulse_prog_ravghoul(CHAR_DATA *mob)
 
 void pulse_prog_behemoth(CHAR_DATA *mob)
 {
-	CHAR_DATA *victim = mob->fighting;
+	CHAR_DATA *victim = Deref(mob->fighting);
 
 	if (victim == nullptr || victim->in_room != mob->in_room || number_percent() > 15)
 		return;
@@ -3438,7 +3439,7 @@ void pulse_prog_behemoth(CHAR_DATA *mob)
 
 void pulse_prog_glass(CHAR_DATA *mob)
 {
-	CHAR_DATA *victim = mob->fighting;
+	CHAR_DATA *victim = Deref(mob->fighting);
 	AFFECT_DATA af, caf;
 
 	if (victim
@@ -3493,7 +3494,7 @@ void pulse_prog_night_creeps(CHAR_DATA *mob)
 
 	if ((sun == SolarPosition::Sunrise || sun == SolarPosition::Daylight) && !is_affected_by(mob, AFF_NOSHOW))
 	{
-		if (mob->fighting)
+		if (Deref(mob->fighting))
 			stop_fighting(mob, true);
 
 		act("As the first rays of the sun emerge, $n scuttles away with sickening speed.", mob, 0, 0, TO_ROOM);
@@ -3518,35 +3519,43 @@ void pulse_prog_night_creeps(CHAR_DATA *mob)
 
 		return;
 	}
-	else if (mob->fighting && mob->pIndexData->vnum == 3001)
+	else if (Deref(mob->fighting) && mob->pIndexData->vnum == 3001)
 	{
 		AFFECT_DATA af;
+		CHAR_DATA *target;
 
 		if (number_percent() < 91)
 			return;
 
-		act("With a vicious clacking noise, $n sinks its razor-sharp pincers into $N!", mob, 0, mob->fighting, TO_NOTVICT);
-		act("With a vicious clacking noise, $n sinks its razor-sharp pincers into you!", mob, 0, mob->fighting, TO_VICT);
-		damage_new(mob, mob->fighting, dice(mob->fighting->level / 3, 3), TYPE_UNDEFINED, DAM_PIERCE, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "pincering claws$");
+		target = Deref(mob->fighting);
+
+		act("With a vicious clacking noise, $n sinks its razor-sharp pincers into $N!", mob, 0, target, TO_NOTVICT);
+		act("With a vicious clacking noise, $n sinks its razor-sharp pincers into you!", mob, 0, target, TO_VICT);
+		damage_new(mob, target, dice(target->level / 3, 3), TYPE_UNDEFINED, DAM_PIERCE, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "pincering claws$");
+
+		// Re-read rather than reusing the local above: a lethal damage_new
+		// ends the fight, so the target from before the hit may no longer be
+		// the one this mob is fighting -- or there may be none at all.
+		target = Deref(mob->fighting);
 
 		init_affect(&af);
 		af.where = TO_AFFECTS;
 		af.aftype = AFT_MALADY;
-		af.level = (short)(mob->fighting->level / 2.5);
-		af.duration = mob->fighting->level / 10;
+		af.level = (short)(target->level / 2.5);
+		af.duration = target->level / 10;
 
 		if (number_range(1, 2) == 1)
 			af.location = APPLY_STR;
 		else
 			af.location = APPLY_DEX;
 
-		af.modifier = 0 - mob->fighting->level / 11;
+		af.modifier = 0 - target->level / 11;
 		af.type = af.location == APPLY_STR ? gsn_abite : gsn_lbite;
 
-		if (!is_affected(mob->fighting, gsn_lbite) && !is_affected(mob->fighting, gsn_abite))
+		if (!is_affected(target, gsn_lbite) && !is_affected(target, gsn_abite))
 			af.tick_fun = bleeding_tick;
 
-		affect_to_char(mob->fighting, &af);
+		affect_to_char(target, &af);
 	}
 }
 
@@ -3583,7 +3592,7 @@ void greet_prog_face_sucker(CHAR_DATA *mob, CHAR_DATA *ch)
 	char buf[MSL];
 	AFFECT_DATA af;
 
-	if (mob->fighting
+	if (Deref(mob->fighting)
 		|| is_npc(ch)
 		|| mob == ch
 		|| mob->hunting == ch

--- a/code/mprog.c
+++ b/code/mprog.c
@@ -1655,7 +1655,7 @@ void attack_prog_lesser_demon(CHAR_DATA *mob, CHAR_DATA *attacker)
 
 void beat_prog_barbas(CHAR_DATA *mob)
 {
-	CHAR_DATA *ch = mob->last_fought;
+	CHAR_DATA *ch = Deref(mob->last_fought);
 	ROOM_INDEX_DATA *old_room = mob->in_room;
 	char buf[MSL];
 
@@ -2601,7 +2601,7 @@ void speech_prog_notescribe(CHAR_DATA *mob, CHAR_DATA *ch, char *speech)
 
 void beat_prog_law_track(CHAR_DATA *mob)
 {
-	CHAR_DATA *ch = mob->last_fought;
+	CHAR_DATA *ch = Deref(mob->last_fought);
 	char buf[MSL];
 	int min = 0, max = 0;
 
@@ -2653,12 +2653,13 @@ void beat_prog_law_track(CHAR_DATA *mob)
 
 	if (ch == nullptr)
 	{
-		mob->last_fought = check_sector(min, max);
+		CHAR_DATA *found = check_sector(min, max);
 
-		if (mob->last_fought != nullptr)
+		if (found != nullptr)
 		{
+			mob->last_fought = found->self;
 			set_aggressor_hunt(mob);
-			ch = mob->last_fought;
+			ch = found;
 		}
 		else
 		{
@@ -2706,7 +2707,7 @@ void beat_prog_law_track(CHAR_DATA *mob)
 			sprintf(buf, "%s, now you die!", ch->name);
 
 		do_yell(mob, buf);
-		multi_hit(mob, mob->last_fought, TYPE_UNDEFINED);
+		multi_hit(mob, Deref(mob->last_fought), TYPE_UNDEFINED);
 		return;
 	}
 
@@ -2763,13 +2764,14 @@ CHAR_DATA *check_sector(int min, int max)
 void set_aggressor_hunt(CHAR_DATA *mob)
 {
 	char store[MSL];
+	CHAR_DATA *quarry = Deref(mob->last_fought);
 
-	if (!can_see(mob, mob->last_fought) || mob->last_fought->ghost > 0 || is_affected(mob, gsn_gag))
+	if (!can_see(mob, quarry) || quarry->ghost > 0 || is_affected(mob, gsn_gag))
 		return;
 
-	if (mob->in_room != mob->last_fought->in_room)
+	if (mob->in_room != quarry->in_room)
 	{
-		sprintf(store, "Halt, %s, you murderous scum!  You will bleed from there to the gates!", mob->last_fought->name);
+		sprintf(store, "Halt, %s, you murderous scum!  You will bleed from there to the gates!", quarry->name);
 		do_yell(mob, store);
 	}
 

--- a/code/mprog.c
+++ b/code/mprog.c
@@ -902,7 +902,7 @@ void greet_prog_outer_guardian(CHAR_DATA *mob, CHAR_DATA *ch)
 void pulse_prog_demon(CHAR_DATA *mob)
 {
 	CHAR_DATA *elemental = mob;
-	CHAR_DATA *victim = elemental->hunting;
+	CHAR_DATA *victim = Deref(elemental->hunting);
 	char buf[250];
 
 	if (!victim || !elemental->in_room || !victim->in_room || victim->ghost > 0)
@@ -3567,7 +3567,7 @@ void sucker_pulse(CHAR_DATA *ch, AFFECT_DATA *af)
 
 	for (owner = char_list; owner; owner = owner->next)
 	{
-		if (is_npc(owner) && owner->pIndexData->vnum == 3002 && owner->hunting == ch)
+		if (is_npc(owner) && owner->pIndexData->vnum == 3002 && Deref(owner->hunting) == ch)
 			break;
 	}
 
@@ -3597,14 +3597,14 @@ void greet_prog_face_sucker(CHAR_DATA *mob, CHAR_DATA *ch)
 	if (Deref(mob->fighting)
 		|| is_npc(ch)
 		|| mob == ch
-		|| mob->hunting == ch
+		|| Deref(mob->hunting) == ch
 		|| !can_see(mob, ch)
 		|| is_safe_new(mob, ch, false))
 	{
 		return;
 	}
 
-	mob->hunting = ch;
+	mob->hunting = ch->self;
 
 	sprintf(buf, "%sSuddenly, something pale and slimy falls from the ceiling, landing on your face!%s", get_char_color(ch, "red"), END_COLOR(ch));
 	act(buf, mob, 0, ch, TO_VICT);

--- a/code/mspec.c
+++ b/code/mspec.c
@@ -5,6 +5,7 @@
 #include <time.h>
 #include <algorithm>
 #include "merc.h"
+#include "entity/handles.h"
 #include "mspec.h"
 #include "handler.h"
 #include "spec.h"
@@ -386,7 +387,7 @@ BEGIN_SPEC(mspec_academy_pet)
 
 		if (ch->in_room != ch->leader->in_room)
 		{
-			if (ch->fighting)
+			if (Deref(ch->fighting))
 			{
 				act("$n seems to fade into the shadows.", ch, 0, 0, TO_ROOM);
 				stop_fighting(ch, true);
@@ -408,7 +409,7 @@ BEGIN_SPEC(mspec_academy_pet)
 			return 0;
 		}
 
-		if (number_percent() > 96 && !ch->fighting && !IS_SET(ch->comm, COMM_NOGOSSIP))
+		if (number_percent() > 96 && !Deref(ch->fighting) && !IS_SET(ch->comm, COMM_NOGOSSIP))
 		{
 			char *msg;
 

--- a/code/mspec.c
+++ b/code/mspec.c
@@ -264,8 +264,8 @@ void create_academy_pet(CHAR_DATA *ch)
 
 	add_follower(mob, ch);
 
-	mob->leader = ch;
-	ch->pet = mob;
+	mob->leader = ch->self;
+	ch->pet = mob->self;
 
 	RS.Logger.Info("entered create_academy_pet queue");
 	RS.Queue.AddToQueue(3, "create_academy_pet", "do_say_queue", do_say_queue, mob,
@@ -292,10 +292,10 @@ void apet_force(CHAR_DATA *ch, const char *cmd, int delay)
 
 void apet_at_room(CHAR_DATA *ch, int vnum)
 {
-	ch->leader->master = nullptr;
-	ch->master = ch->leader;
+	CHAR_DATA *player = Deref(ch->leader);
 
-	CHAR_DATA *player = ch->leader;
+	player->master = nullptr;
+	ch->master = ch->leader;
 
 	char buf[MSL], cname[50];
 
@@ -344,40 +344,46 @@ void apet_walk_to_room(CHAR_DATA *ch, int vnum)
 
 	walk_to_room(ch, room);
 
-	if (ch->in_room == oldroom || ch->in_room != ch->leader->in_room)
+	// Read after the move rather than before it: walk_to_room relocates this
+	// mob and can fire progs on the way.
+	CHAR_DATA *player = Deref(ch->leader);
+
+	if (ch->in_room == oldroom || ch->in_room != player->in_room)
 	{
-		if (ch->in_room != ch->leader->in_room)
+		if (ch->in_room != player->in_room)
 		{
 			char_from_room(ch);
-			char_to_room(ch, ch->leader->in_room);
+			char_to_room(ch, player->in_room);
 		}
 
 		do_say(ch, "I can't seem to lead us over there from here.  Try heading back to another part of town?");
 
-		ch->leader->master = ch;
-		ch->master = ch->leader;
+		player->master = ch->self;
+		ch->master = ch->leader;		// handle to handle; no lookup needed
 		return;
 	}
 
-	WAIT_STATE(ch->leader, PULSE_VIOLENCE);
+	WAIT_STATE(player, PULSE_VIOLENCE);
 
 	RS.Queue.AddToQueue(2, "apet_walk_to_room", "apet_walk_to_room", apet_walk_to_room, ch, vnum);
 }
 
 BEGIN_SPEC(mspec_academy_pet)
 	EVENT_MPULSE
-		if (!ch->leader)
+		CHAR_DATA *player = Deref(ch->leader);
+
+		if (player == nullptr)
 		{
 			extract_char(ch, true);
 			return 0;
 		}
 
-		if (ch->leader->level > 22 && !is_immortal(ch->leader))
+		if (player->level > 22 && !is_immortal(player))
 		{
 			do_say(ch, "You are strong enough to stand on your own now.  Perhaps we shall meet again.");
 			act("$n fades into the shadows.", ch, 0, 0, TO_ROOM);
 
-			ch->leader->pet = nullptr;
+			player->pet = nullptr;
 			ch->leader = nullptr;
 			ch->master = nullptr;
 
@@ -385,7 +391,7 @@ BEGIN_SPEC(mspec_academy_pet)
 			return 0;
 		}
 
-		if (ch->in_room != ch->leader->in_room)
+		if (ch->in_room != player->in_room)
 		{
 			if (Deref(ch->fighting))
 			{
@@ -394,9 +400,9 @@ BEGIN_SPEC(mspec_academy_pet)
 			}
 
 			char_from_room(ch);
-			char_to_room(ch, ch->leader->in_room);
+			char_to_room(ch, player->in_room);
 
-			act("$n emerges from the shadows behind you.", ch, 0, ch->leader, TO_VICT);
+			act("$n emerges from the shadows behind you.", ch, 0, player, TO_VICT);
 			return 0;
 		}
 
@@ -419,7 +425,7 @@ BEGIN_SPEC(mspec_academy_pet)
 					msg = "I know an inexpensive place to buy food, if you need some.";
 					break;
 				case 1:
-					if (get_skill(ch->leader, gsn_enhanced_damage) < 1)
+					if (get_skill(player, gsn_enhanced_damage) < 1)
 						msg = "Looking for adventure? I know just the place!";
 					else
 						msg = "I've heard of a new place for you to learn that might be ideal for you.";
@@ -434,7 +440,7 @@ BEGIN_SPEC(mspec_academy_pet)
 					break;
 			}
 
-			if (ch->leader->level < 15 && number_percent() > 50)
+			if (player->level < 15 && number_percent() > 50)
 				msg = "When you are ready to leave the Academy, walk out or recall and you will be trained to the twentieth level of your guild.";
 
 			do_say(ch, msg);
@@ -443,7 +449,7 @@ BEGIN_SPEC(mspec_academy_pet)
 	END_EVENT
 
 	EVENT_MSPEECH
-		if (ch != mob->leader)
+		if (ch != Deref(mob->leader))
 			return 0;
 
 		char arg1[MSL];
@@ -463,7 +469,7 @@ BEGIN_SPEC(mspec_academy_pet)
 				return 0;
 			}
 
-			ch->master = mob;
+			ch->master = mob->self;
 			mob->master = nullptr;
 
 			apet_walk_to_room(mob, CIM_FOOD);
@@ -480,7 +486,7 @@ BEGIN_SPEC(mspec_academy_pet)
 				return 0;
 			}
 
-			ch->master = mob;
+			ch->master = mob->self;
 			mob->master = nullptr;
 
 			apet_walk_to_room(mob, CIM_WATER);
@@ -500,7 +506,7 @@ BEGIN_SPEC(mspec_academy_pet)
 				return 0;
 			}
 
-			ch->master = mob;
+			ch->master = mob->self;
 			mob->master = nullptr;
 
 			int vnum = 0, cclass = ch->Class()->GetIndex();
@@ -588,7 +594,7 @@ BEGIN_SPEC(mspec_academy_pet)
 				return 0;
 			}
 
-			ch->master = mob;
+			ch->master = mob->self;
 			mob->master = nullptr;
 
 			apet_walk_to_room(mob, CIM_BOAT);
@@ -618,7 +624,7 @@ BEGIN_SPEC(mspec_academy_pet)
 
 		stop_fighting(mob, true);
 
-		if (!mob->leader)
+		if (!Deref(mob->leader))
 			extract_char(mob, true);
 
 		return 1;

--- a/code/olc.c
+++ b/code/olc.c
@@ -237,7 +237,7 @@ bool run_olc_editor(DESCRIPTOR_DATA *d)
 
 bool is_editing(CHAR_DATA *ch)
 {
-	switch (ch->desc->editor)
+	switch (Deref(ch->desc)->editor)
 	{
 		case ED_AREA:
 		case ED_ROOM:
@@ -257,7 +257,7 @@ char *olc_ed_name(CHAR_DATA *ch)
 
 	buf[0] = '\0';
 
-	switch (ch->desc->editor)
+	switch (Deref(ch->desc)->editor)
 	{
 		case ED_AREA:
 			sprintf(buf, "AEdit");
@@ -289,10 +289,10 @@ char *olc_ed_vnum(CHAR_DATA *ch)
 
 	buf[0] = '\0';
 
-	switch (ch->desc->editor)
+	switch (Deref(ch->desc)->editor)
 	{
 		case ED_AREA:
-			pArea = (AREA_DATA *)ch->desc->pEdit;
+			pArea = (AREA_DATA *)Deref(ch->desc)->pEdit;
 			sprintf(buf, "%d", pArea ? pArea->vnum : 0);
 			break;
 		case ED_ROOM:
@@ -300,11 +300,11 @@ char *olc_ed_vnum(CHAR_DATA *ch)
 			sprintf(buf, "%d", pRoom ? pRoom->vnum : 0);
 			break;
 		case ED_OBJECT:
-			pObj = (OBJ_INDEX_DATA *)ch->desc->pEdit;
+			pObj = (OBJ_INDEX_DATA *)Deref(ch->desc)->pEdit;
 			sprintf(buf, "%d", pObj ? pObj->vnum : 0);
 			break;
 		case ED_MOBILE:
-			pMob = (MOB_INDEX_DATA *)ch->desc->pEdit;
+			pMob = (MOB_INDEX_DATA *)Deref(ch->desc)->pEdit;
 			sprintf(buf, "%d", pMob ? pMob->vnum : 0);
 			break;
 		default:
@@ -350,7 +350,7 @@ void show_olc_cmds(CHAR_DATA *ch, const struct olc_cmd_type *olc_table)
  ****************************************************************************/
 bool show_commands(CHAR_DATA *ch, char *argument)
 {
-	switch (ch->desc->editor)
+	switch (Deref(ch->desc)->editor)
 	{
 		case ED_AREA:
 			show_olc_cmds(ch, aedit_table);
@@ -394,8 +394,8 @@ AREA_DATA *get_area_data(int vnum)
  ****************************************************************************/
 bool edit_done(CHAR_DATA *ch)
 {
-	ch->desc->pEdit = nullptr;
-	ch->desc->editor = 0;
+	Deref(ch->desc)->pEdit = nullptr;
+	Deref(ch->desc)->editor = 0;
 
 	send_to_char("Exiting Riftshadow OLC...\n\r", ch);
 	return false;
@@ -813,8 +813,8 @@ void do_aedit(CHAR_DATA *ch, char *argument)
 		return;
 	}
 
-	ch->desc->pEdit = (void *)pArea;
-	ch->desc->editor = ED_AREA;
+	Deref(ch->desc)->pEdit = (void *)pArea;
+	Deref(ch->desc)->editor = ED_AREA;
 
 	aedit_show(ch, "");
 }
@@ -858,7 +858,7 @@ void do_redit(CHAR_DATA *ch, char *argument)
 		if (redit_create(ch, argument))
 		{
 			char_from_room(ch);
-			char_to_room(ch, (ROOM_INDEX_DATA *)ch->desc->pEdit);
+			char_to_room(ch, (ROOM_INDEX_DATA *)Deref(ch->desc)->pEdit);
 			SET_BIT(pRoom->area->area_flags, AREA_CHANGED);
 			pRoom = ch->in_room;
 		}
@@ -886,7 +886,7 @@ void do_redit(CHAR_DATA *ch, char *argument)
 		return;
 	}
 
-	ch->desc->editor = ED_ROOM;
+	Deref(ch->desc)->editor = ED_ROOM;
 	redit_show(ch, "");
 }
 
@@ -926,9 +926,9 @@ void do_oedit(CHAR_DATA *ch, char *argument)
 			return;
 		}
 
-		ch->desc->pEdit = (void *)pObj;
+		Deref(ch->desc)->pEdit = (void *)pObj;
 		ch->pcdata->editing_item = value;
-		ch->desc->editor = ED_OBJECT;
+		Deref(ch->desc)->editor = ED_OBJECT;
 
 		oedit_show(ch, "");
 		return;
@@ -962,7 +962,7 @@ void do_oedit(CHAR_DATA *ch, char *argument)
 			if (oedit_create(ch, argument))
 			{
 				SET_BIT(pArea->area_flags, AREA_CHANGED);
-				ch->desc->editor = ED_OBJECT;
+				Deref(ch->desc)->editor = ED_OBJECT;
 				oedit_show(ch, "");
 			}
 
@@ -1001,8 +1001,8 @@ void do_medit(CHAR_DATA *ch, char *argument)
 			return;
 		}
 
-		ch->desc->pEdit = (void *)pMob;
-		ch->desc->editor = ED_MOBILE;
+		Deref(ch->desc)->pEdit = (void *)pMob;
+		Deref(ch->desc)->editor = ED_MOBILE;
 
 		medit_show(ch, "");
 		return;
@@ -1036,7 +1036,7 @@ void do_medit(CHAR_DATA *ch, char *argument)
 			if (medit_create(ch, argument))
 			{
 				SET_BIT(pArea->area_flags, AREA_CHANGED);
-				ch->desc->editor = ED_MOBILE;
+				Deref(ch->desc)->editor = ED_MOBILE;
 			}
 
 			return;

--- a/code/olc.c
+++ b/code/olc.c
@@ -289,10 +289,12 @@ char *olc_ed_vnum(CHAR_DATA *ch)
 
 	buf[0] = '\0';
 
-	switch (Deref(ch->desc)->editor)
+	DESCRIPTOR_DATA *d = Deref(ch->desc);
+
+	switch (d->editor)
 	{
 		case ED_AREA:
-			pArea = (AREA_DATA *)Deref(ch->desc)->pEdit;
+			pArea = (AREA_DATA *)d->pEdit;
 			sprintf(buf, "%d", pArea ? pArea->vnum : 0);
 			break;
 		case ED_ROOM:
@@ -300,11 +302,11 @@ char *olc_ed_vnum(CHAR_DATA *ch)
 			sprintf(buf, "%d", pRoom ? pRoom->vnum : 0);
 			break;
 		case ED_OBJECT:
-			pObj = (OBJ_INDEX_DATA *)Deref(ch->desc)->pEdit;
+			pObj = (OBJ_INDEX_DATA *)d->pEdit;
 			sprintf(buf, "%d", pObj ? pObj->vnum : 0);
 			break;
 		case ED_MOBILE:
-			pMob = (MOB_INDEX_DATA *)Deref(ch->desc)->pEdit;
+			pMob = (MOB_INDEX_DATA *)d->pEdit;
 			sprintf(buf, "%d", pMob ? pMob->vnum : 0);
 			break;
 		default:
@@ -394,8 +396,10 @@ AREA_DATA *get_area_data(int vnum)
  ****************************************************************************/
 bool edit_done(CHAR_DATA *ch)
 {
-	Deref(ch->desc)->pEdit = nullptr;
-	Deref(ch->desc)->editor = 0;
+	DESCRIPTOR_DATA *d = Deref(ch->desc);
+
+	d->pEdit = nullptr;
+	d->editor = 0;
 
 	send_to_char("Exiting Riftshadow OLC...\n\r", ch);
 	return false;
@@ -813,8 +817,10 @@ void do_aedit(CHAR_DATA *ch, char *argument)
 		return;
 	}
 
-	Deref(ch->desc)->pEdit = (void *)pArea;
-	Deref(ch->desc)->editor = ED_AREA;
+	DESCRIPTOR_DATA *d = Deref(ch->desc);
+
+	d->pEdit = (void *)pArea;
+	d->editor = ED_AREA;
 
 	aedit_show(ch, "");
 }
@@ -926,9 +932,11 @@ void do_oedit(CHAR_DATA *ch, char *argument)
 			return;
 		}
 
-		Deref(ch->desc)->pEdit = (void *)pObj;
+		DESCRIPTOR_DATA *d = Deref(ch->desc);
+
+		d->pEdit = (void *)pObj;
 		ch->pcdata->editing_item = value;
-		Deref(ch->desc)->editor = ED_OBJECT;
+		d->editor = ED_OBJECT;
 
 		oedit_show(ch, "");
 		return;
@@ -1001,8 +1009,10 @@ void do_medit(CHAR_DATA *ch, char *argument)
 			return;
 		}
 
-		Deref(ch->desc)->pEdit = (void *)pMob;
-		Deref(ch->desc)->editor = ED_MOBILE;
+		DESCRIPTOR_DATA *d = Deref(ch->desc);
+
+		d->pEdit = (void *)pMob;
+		d->editor = ED_MOBILE;
 
 		medit_show(ch, "");
 		return;

--- a/code/olc.c
+++ b/code/olc.c
@@ -217,16 +217,16 @@ bool run_olc_editor(DESCRIPTOR_DATA *d)
 	switch (d->editor)
 	{
 		case ED_AREA:
-			aedit(d->character, d->incomm);
+			aedit(Deref(d->character), d->incomm);
 			break;
 		case ED_ROOM:
-			redit(d->character, d->incomm);
+			redit(Deref(d->character), d->incomm);
 			break;
 		case ED_OBJECT:
-			oedit(d->character, d->incomm);
+			oedit(Deref(d->character), d->incomm);
 			break;
 		case ED_MOBILE:
-			medit(d->character, d->incomm);
+			medit(Deref(d->character), d->incomm);
 			break;
 		default:
 			return false;

--- a/code/olc.h
+++ b/code/olc.h
@@ -65,10 +65,10 @@ typedef	bool OLC_FUN (CHAR_DATA *ch, char *argument);
 
 
 /* Return pointers to what is being edited. */
-#define EDIT_MOB(ch, mob)		(mob = (MOB_INDEX_DATA *)ch->desc->pEdit)
-#define EDIT_OBJ(ch, obj)		(obj = (OBJ_INDEX_DATA *)ch->desc->pEdit)
+#define EDIT_MOB(ch, mob)		(mob = (MOB_INDEX_DATA *)Deref(ch->desc)->pEdit)
+#define EDIT_OBJ(ch, obj)		(obj = (OBJ_INDEX_DATA *)Deref(ch->desc)->pEdit)
 #define EDIT_ROOM(ch, room)		(room = ch->in_room)
-#define EDIT_AREA(ch, area)		(area = (AREA_DATA *)ch->desc->pEdit)
+#define EDIT_AREA(ch, area)		(area = (AREA_DATA *)Deref(ch->desc)->pEdit)
 
 
 /*

--- a/code/olc_act.c
+++ b/code/olc_act.c
@@ -532,11 +532,11 @@ bool redit_mshow(CHAR_DATA *ch, char *argument)
 			return false;
 		}
 
-		ch->desc->pEdit = (void *)pMob;
+		Deref(ch->desc)->pEdit = (void *)pMob;
 	}
 
 	medit_show(ch, argument);
-	ch->desc->pEdit = (void *)ch->in_room;
+	Deref(ch->desc)->pEdit = (void *)ch->in_room;
 	return false;
 }
 
@@ -567,11 +567,11 @@ bool redit_oshow(CHAR_DATA *ch, char *argument)
 			return false;
 		}
 
-		ch->desc->pEdit = (void *)pObj;
+		Deref(ch->desc)->pEdit = (void *)pObj;
 	}
 
 	oedit_show(ch, argument);
-	ch->desc->pEdit = (void *)ch->in_room;
+	Deref(ch->desc)->pEdit = (void *)ch->in_room;
 	return false;
 }
 
@@ -1762,7 +1762,7 @@ bool aedit_create(CHAR_DATA *ch, char *argument)
 	pArea = new_area();
 	area_last->next = pArea;
 	area_last = pArea; /* Thanks, Walker. */
-	ch->desc->pEdit = (void *)pArea;
+	Deref(ch->desc)->pEdit = (void *)pArea;
 
 	SET_BIT(pArea->area_flags, AREA_ADDED);
 	send_to_char("Area Created.\n\r", ch);
@@ -2982,7 +2982,7 @@ bool redit_create(CHAR_DATA *ch, char *argument)
 	iHash = value % MAX_KEY_HASH;
 	pRoom->next = room_index_hash[iHash];
 	room_index_hash[iHash] = pRoom;
-	ch->desc->pEdit = (void *)pRoom;
+	Deref(ch->desc)->pEdit = (void *)pRoom;
 
 	sprintf(buf, "Room #%d created.\n\r", value);
 	send_to_char(buf, ch);
@@ -4908,7 +4908,7 @@ bool oedit_create(CHAR_DATA *ch, char *argument)
 	iHash = value % MAX_KEY_HASH;
 	pObj->next = obj_index_hash[iHash];
 	obj_index_hash[iHash] = pObj;
-	ch->desc->pEdit = (void *)pObj;
+	Deref(ch->desc)->pEdit = (void *)pObj;
 
 	send_to_char("Object Created.\n\r", ch);
 	return true;
@@ -5968,7 +5968,7 @@ bool medit_create(CHAR_DATA *ch, char *argument)
 
 	pMob->next = mob_index_hash[iHash];
 	mob_index_hash[iHash] = pMob;
-	ch->desc->pEdit = (void *)pMob;
+	Deref(ch->desc)->pEdit = (void *)pMob;
 
 	send_to_char("Mobile Created.\n\r", ch);
 	return true;

--- a/code/olc_save.c
+++ b/code/olc_save.c
@@ -1145,26 +1145,26 @@ void do_asave(CHAR_DATA *ch, char *argument)
 		if (!str_cmp(arg1, "area"))
 		{
 			/* Is character currently editing. */
-			if (ch->desc->editor == 0)
+			if (Deref(ch->desc)->editor == 0)
 			{
 				send_to_char("You are not editing an area therefore an area vnum is required.\n\r", ch);
 				return;
 			}
 
 			/* Find the area to save. */
-			switch (ch->desc->editor)
+			switch (Deref(ch->desc)->editor)
 			{
 				case ED_AREA:
-					pArea = (AREA_DATA *)ch->desc->pEdit;
+					pArea = (AREA_DATA *)Deref(ch->desc)->pEdit;
 					break;
 				case ED_ROOM:
 					pArea = ch->in_room->area;
 					break;
 				case ED_OBJECT:
-					pArea = ((OBJ_INDEX_DATA *)ch->desc->pEdit)->area;
+					pArea = ((OBJ_INDEX_DATA *)Deref(ch->desc)->pEdit)->area;
 					break;
 				case ED_MOBILE:
-					pArea = ((MOB_INDEX_DATA *)ch->desc->pEdit)->area;
+					pArea = ((MOB_INDEX_DATA *)Deref(ch->desc)->pEdit)->area;
 					break;
 				default:
 					pArea = ch->in_room->area;

--- a/code/olc_save.c
+++ b/code/olc_save.c
@@ -1144,27 +1144,29 @@ void do_asave(CHAR_DATA *ch, char *argument)
 		/* -------------------------------------- */
 		if (!str_cmp(arg1, "area"))
 		{
+			DESCRIPTOR_DATA *d = Deref(ch->desc);
+
 			/* Is character currently editing. */
-			if (Deref(ch->desc)->editor == 0)
+			if (d->editor == 0)
 			{
 				send_to_char("You are not editing an area therefore an area vnum is required.\n\r", ch);
 				return;
 			}
 
 			/* Find the area to save. */
-			switch (Deref(ch->desc)->editor)
+			switch (d->editor)
 			{
 				case ED_AREA:
-					pArea = (AREA_DATA *)Deref(ch->desc)->pEdit;
+					pArea = (AREA_DATA *)d->pEdit;
 					break;
 				case ED_ROOM:
 					pArea = ch->in_room->area;
 					break;
 				case ED_OBJECT:
-					pArea = ((OBJ_INDEX_DATA *)Deref(ch->desc)->pEdit)->area;
+					pArea = ((OBJ_INDEX_DATA *)d->pEdit)->area;
 					break;
 				case ED_MOBILE:
-					pArea = ((MOB_INDEX_DATA *)Deref(ch->desc)->pEdit)->area;
+					pArea = ((MOB_INDEX_DATA *)d->pEdit)->area;
 					break;
 				default:
 					pArea = ch->in_room->area;

--- a/code/quest.c
+++ b/code/quest.c
@@ -815,17 +815,17 @@ void pulse_prog_ilopheth_hermit(CHAR_DATA *mob)
 
 	for (d = descriptor_list; d; d = d->next)
 	{
-		if (d->connected == CON_PLAYING && !is_npc(d->character) && d->character->in_room != nullptr &&
-			d->character->in_room->area != nullptr && d->character->in_room->area == mob->in_room->area &&
-			d->character->pcdata->quests[TALISMANIC_QUEST] == 5 && number_percent() < 5)
+		if (d->connected == CON_PLAYING && !is_npc(Deref(d->character)) && Deref(d->character)->in_room != nullptr &&
+			Deref(d->character)->in_room->area != nullptr && Deref(d->character)->in_room->area == mob->in_room->area &&
+			Deref(d->character)->pcdata->quests[TALISMANIC_QUEST] == 5 && number_percent() < 5)
 		{
-			sprintf(buf, "%s You!  Coming again to grub, eh?  You'll pay, oh yes yes, you will!", d->character->name);
+			sprintf(buf, "%s You!  Coming again to grub, eh?  You'll pay, oh yes yes, you will!", Deref(d->character)->name);
 			do_tell(mob, buf);
 
-			act("A bolt of lightning streaks down from the clouds above!", d->character, 0, 0, TO_ALL);
-			do_myell(d->character, "Argh!  I've been struck by lightning!", nullptr);
+			act("A bolt of lightning streaks down from the clouds above!", Deref(d->character), 0, 0, TO_ALL);
+			do_myell(Deref(d->character), "Argh!  I've been struck by lightning!", nullptr);
 
-			damage_new(mob, d->character, dice(d->character->level, 8), gsn_call_lightning, DAM_LIGHTNING, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "The lightning strike*");
+			damage_new(mob, Deref(d->character), dice(Deref(d->character)->level, 8), gsn_call_lightning, DAM_LIGHTNING, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "The lightning strike*");
 		}
 	}
 

--- a/code/quest.c
+++ b/code/quest.c
@@ -6,6 +6,7 @@
 #include <string.h>
 #include <time.h>
 #include "merc.h"
+#include "entity/handles.h"
 #include "quest.h"
 #include "comm.h"
 #include "update.h"
@@ -736,10 +737,10 @@ void pulse_prog_talismanic_page(OBJ_DATA *obj, bool isTick)
 	OBJ_DATA *scrap;
 	CHAR_DATA *ch;
 
-	if (!obj->carried_by)
-		return;
+	ch = Deref(obj->carried_by);
 
-	ch = obj->carried_by;
+	if (ch == nullptr)
+		return;
 
 	if (is_npc(ch))
 		return;
@@ -760,10 +761,10 @@ void pulse_prog_talismanic_scrap(OBJ_DATA *obj, bool isTick)
 	OBJ_DATA *page;
 	CHAR_DATA *ch;
 
-	if (!obj->carried_by)
-		return;
+	ch = Deref(obj->carried_by);
 
-	ch = obj->carried_by;
+	if (ch == nullptr)
+		return;
 
 	if (is_npc(ch))
 		return;

--- a/code/quest.c
+++ b/code/quest.c
@@ -1021,7 +1021,7 @@ void give_prog_starvin_pete(CHAR_DATA *mob, CHAR_DATA *ch, OBJ_DATA *obj)
 			if (!str_cmp(material_table[obj->pIndexData->material_index].mat_name, "meat"))
 			{
 				if (is_affected(mob, gsn_bash)
-					&& ((paf = affect_find(mob->affected, gsn_bash)) != nullptr && (ch == paf->owner)))
+					&& ((paf = affect_find(mob->affected, gsn_bash)) != nullptr && (ch == Deref(paf->owner))))
 				{
 					act("$n gobbles down $p noisily.", mob, obj, ch, TO_ALL);
 					do_say(mob, "Pete got no more money for you.");
@@ -1046,7 +1046,7 @@ void give_prog_starvin_pete(CHAR_DATA *mob, CHAR_DATA *ch, OBJ_DATA *obj)
 				af.aftype = AFT_INVIS;
 				af.type = gsn_bash;
 				af.duration = 2;
-				af.owner = ch;
+				af.owner = ch->self;
 			}
 			else
 			{

--- a/code/recycle.c
+++ b/code/recycle.c
@@ -236,47 +236,6 @@ void free_race_data(RACE_DATA *race_specs)
 	}
 }
 
-PATHFIND_DATA *new_path_data(void)
-{
-	PATHFIND_DATA *path = new PATHFIND_DATA;
-
-	path->room = nullptr;
-	path->evaluated= false;
-	path->dir_from = -1;
-	path->steps = -1;
-	path->prev = nullptr;
-
-	for (int i = 0; i < 6; i++)
-	{
-		path->dir_to[i] = nullptr;
-	}
-
-	return path;
-}
-
-void free_path(PATHFIND_DATA *path)
-{
-	if (!path->dir_to[Directions::North]
-		&& !path->dir_to[Directions::East]
-		&& !path->dir_to[Directions::South]
-		&& !path->dir_to[Directions::West]
-		&& !path->dir_to[Directions::Up]
-		&& !path->dir_to[Directions::Down])
-	{
-		delete path;
-	}
-	else
-	{
-		for (int i = 0; i < 6; i++)
-		{
-			if (path->dir_to[i])
-				free_path(path->dir_to[i]);
-		}
-
-		delete path;
-	}
-}
-
 /* stuff for recycling extended descs -- UGLY */
 
 extra_descr_data::~extra_descr_data()

--- a/code/recycle.c
+++ b/code/recycle.c
@@ -83,6 +83,10 @@ DESCRIPTOR_DATA *new_descriptor(void)
 	*d = d_zero;
 
 	d->valid = true;
+
+	// After the reset, which zeroes the old handle along with everything else.
+	d->self = descriptorHandles.Add(d);
+
 	return d;
 }
 
@@ -97,6 +101,13 @@ void free_descriptor(DESCRIPTOR_DATA *d)
 		delete[] d->outbuf;
 
 	d->valid = false;
+
+	// Expires every handle to this connection. Must happen before it goes on
+	// the free list, since new_descriptor can hand the same address straight
+	// back out.
+	descriptorHandles.Remove(d->self);
+	d->self = nullptr;
+
 	d->next = descriptor_free;
 	descriptor_free = d;
 }

--- a/code/recycle.c
+++ b/code/recycle.c
@@ -82,8 +82,6 @@ DESCRIPTOR_DATA *new_descriptor(void)
 
 	*d = d_zero;
 
-	d->valid = true;
-
 	// After the reset, which zeroes the old handle along with everything else.
 	d->self = descriptorHandles.Add(d);
 
@@ -92,15 +90,17 @@ DESCRIPTOR_DATA *new_descriptor(void)
 
 void free_descriptor(DESCRIPTOR_DATA *d)
 {
-	if (!(d != nullptr && d->valid))
+	// The slot map answers "is this a live connection this module handed out",
+	// which is what the old `valid` bool was for and one thing more: a
+	// descriptor that was never registered has a null handle, so a stack-built
+	// one cannot be pushed onto the free list by mistake.
+	if (d == nullptr || Deref(d->self) != d)
 		return;
 
 	free_pstring(d->host);
 
 	if (d->outbuf)
 		delete[] d->outbuf;
-
-	d->valid = false;
 
 	// Expires every handle to this connection. Must happen before it goes on
 	// the free list, since new_descriptor can hand the same address straight
@@ -459,8 +459,6 @@ OBJ_DATA *new_obj(void)
 
 	*obj = obj_zero;
 
-	obj->valid = true;
-
 	// After the reset, which zeroes the old handle along with everything else.
 	obj->self = objectHandles.Add(obj);
 
@@ -469,7 +467,7 @@ OBJ_DATA *new_obj(void)
 
 void free_obj(OBJ_DATA *obj)
 {
-	if (!(obj != nullptr && obj->valid))
+	if (obj == nullptr || Deref(obj->self) != obj)
 		return;
 
 	obj->affected.clear();
@@ -482,7 +480,6 @@ void free_obj(OBJ_DATA *obj)
 	free_pstring(obj->short_descr);
 
 	// free_pstring( obj->owner     );
-	obj->valid = false;
 
 	// Expires every handle to this object. Must happen before it goes on the
 	// free list, since new_obj can hand the same address straight back out.
@@ -517,8 +514,6 @@ CHAR_DATA *new_char(void)
 	// `*ch = ch_zero` copy-assign; move-assigning a value-initialized
 	// temporary zeroes the PODs and frees/clears the owned members.
 	*ch = CHAR_DATA();
-
-	ch->valid = true;
 
 	// After the reset, which zeroes the old handle along with everything else.
 	ch->self = charHandles.Add(ch);
@@ -570,7 +565,7 @@ void free_char(CHAR_DATA *ch)
 	OBJ_DATA *obj;
 	OBJ_DATA *obj_next;
 
-	if (!(ch != nullptr && ch->valid) || !ch)
+	if (ch == nullptr || Deref(ch->self) != ch)
 		return;
 
 	if (is_npc(ch))
@@ -612,8 +607,6 @@ void free_char(CHAR_DATA *ch)
 
 	ch->next = char_free;
 	char_free = ch;
-
-	ch->valid = false;
 }
 
 std::unique_ptr<PC_DATA> new_pcdata(void)
@@ -621,7 +614,6 @@ std::unique_ptr<PC_DATA> new_pcdata(void)
 	auto pcdata = std::make_unique<PC_DATA>();	// value-init zeroes every POD field
 
 	pcdata->buffer = new BUFFER;
-	pcdata->valid = true;
 
 	return pcdata;
 }

--- a/code/recycle.c
+++ b/code/recycle.c
@@ -46,6 +46,7 @@
 #include "recycle.h"
 #include "comm.h"
 #include "db.h"
+#include "entity/handles.h"
 #include "handler.h"
 #include "newmem.h"
 #include "misc.h"
@@ -448,6 +449,10 @@ OBJ_DATA *new_obj(void)
 	*obj = obj_zero;
 
 	obj->valid = true;
+
+	// After the reset, which zeroes the old handle along with everything else.
+	obj->self = objectHandles.Add(obj);
+
 	return obj;
 }
 
@@ -467,6 +472,12 @@ void free_obj(OBJ_DATA *obj)
 
 	// free_pstring( obj->owner     );
 	obj->valid = false;
+
+	// Expires every handle to this object. Must happen before it goes on the
+	// free list, since new_obj can hand the same address straight back out.
+	objectHandles.Remove(obj->self);
+	obj->self = nullptr;
+
 	obj->next = obj_free;
 	obj_free = obj;
 }
@@ -497,6 +508,9 @@ CHAR_DATA *new_char(void)
 	*ch = CHAR_DATA();
 
 	ch->valid = true;
+
+	// After the reset, which zeroes the old handle along with everything else.
+	ch->self = charHandles.Add(ch);
 
 	ch->name = &str_empty[0];
 	ch->short_descr = &str_empty[0];
@@ -579,6 +593,11 @@ void free_char(CHAR_DATA *ch)
 
 	ch->pcdata.reset();
 	ch->gen_data.reset();
+
+	// Expires every handle to this character. Must happen before it goes on the
+	// free list, since new_char can hand the same address straight back out.
+	charHandles.Remove(ch->self);
+	ch->self = nullptr;
 
 	ch->next = char_free;
 	char_free = ch;

--- a/code/recycle.h
+++ b/code/recycle.h
@@ -67,8 +67,6 @@ IPROG_DATA *new_iprog(void);
 RACE_DATA *new_race_data(void);
 void free_race_data(RACE_DATA *race_specs);
 /* pathfind recycling */
-PATHFIND_DATA *new_path_data(void);
-void free_path(PATHFIND_DATA *path);
 /* extra descr — value type owned by parents in std::list; see entity/extra_descr.h */
 /* affect — value type owned by parents in std::list; see entity/affect_data.h */
 /* apply — value type owned by parents in std::list; see entity/affect_data.h */

--- a/code/save.c
+++ b/code/save.c
@@ -99,8 +99,8 @@ void save_char_obj(CHAR_DATA *ch)
 	if (is_npc(ch) || mPort == 4000) // do not save, sir!!!
 		return;
 
-	if (ch->desc != nullptr && ch->desc->original != nullptr)
-		ch = ch->desc->original;
+	if (ch->desc != nullptr && Deref(ch->desc->original) != nullptr)
+		ch = Deref(ch->desc->original);
 
 	if (!check_parse_name(ch->true_name))
 		wiznet("ALERT!! $N/$F name corrupt!!", ch, nullptr, 0, 0, 0);
@@ -925,7 +925,7 @@ bool load_char_obj(DESCRIPTOR_DATA *d, char *name)
 	ch = new_char();
 	ch->pcdata = new_pcdata();
 
-	d->character = ch;
+	d->character = ch->self;
 	ch->desc = d;
 	ch->pcdata->entering_text = false;
 	ch->name = palloc_string(name);

--- a/code/save.c
+++ b/code/save.c
@@ -586,6 +586,8 @@ void fwrite_char(CHAR_DATA *ch, FILE *fp)
 
 		paf.aftype = isAftSpell(paf.aftype);
 
+		CHAR_DATA *owner = Deref(paf.owner);
+
 		fprintf(fp, "Affc '%s' %3d %3d %3d %3d %3d %s %3d %s '%s'\n",
 			skill_table[paf.type].name,
 			paf.where,
@@ -595,7 +597,7 @@ void fwrite_char(CHAR_DATA *ch, FILE *fp)
 			paf.location,
 			print_flags(paf.bitvector),
 			paf.aftype,
-			paf.owner ? paf.owner->name : "none", paf.name ? paf.name : "none");
+			owner ? owner->name : "none", paf.name ? paf.name : "none");
 	}
 
 	if (!ch->pcdata->trophy.empty()
@@ -864,6 +866,8 @@ void fwrite_obj(CHAR_DATA *ch, OBJ_DATA *obj, FILE *fp, int iNest)
 
 		paf.aftype = isAftSpell(paf.aftype);
 
+		CHAR_DATA *owner = Deref(paf.owner);
+
 		fprintf(fp, "Affc '%s' %3d %3d %3d %3d %3d %s %d %s\n",
 			skill_table[paf.type].name,
 			paf.where,
@@ -873,7 +877,7 @@ void fwrite_obj(CHAR_DATA *ch, OBJ_DATA *obj, FILE *fp, int iNest)
 			paf.location,
 			print_flags(paf.bitvector),
 			paf.aftype,
-			paf.owner ? paf.owner->name : "none");
+			owner ? owner->name : "none");
 	}
 
 	// Save only applies the object has beyond its prototype. The list was a
@@ -1263,13 +1267,13 @@ void fread_char(CHAR_DATA *ch, FILE *fp)
 					{
 						if (!str_cmp(wch->name, owner))
 						{
-							paf.owner = wch;
+							paf.owner = wch->self;
 							break;
 						}
 					}
 
 					if (!str_cmp(ch->name, owner))
-						paf.owner = ch;
+						paf.owner = ch->self;
 
 					afname = fread_word(fp);
 
@@ -1913,13 +1917,13 @@ void fread_pet(CHAR_DATA *ch, FILE *fp)
 					owner = fread_word(fp);
 
 					if (strcmp(owner, "none")) // safe default
-						paf.owner = ch;
+						paf.owner = ch->self;
 
 					for (wch = char_list; wch; wch = wch->next)
 					{
 						if (!str_cmp(wch->name, owner))
 						{
-							paf.owner = wch;
+							paf.owner = wch->self;
 							break;
 						}
 					}
@@ -2134,13 +2138,13 @@ void fread_obj(CHAR_DATA *ch, FILE *fp)
 					{
 						if (!str_cmp(wch->name, owner))
 						{
-							paf.owner = wch;
+							paf.owner = wch->self;
 							break;
 						}
 					}
 
 					if (!str_cmp(ch->name, owner))
-						paf.owner = ch;
+						paf.owner = ch->self;
 
 					obj->affected.push_front(paf);
 					fMatch = true;

--- a/code/save.c
+++ b/code/save.c
@@ -99,8 +99,10 @@ void save_char_obj(CHAR_DATA *ch)
 	if (is_npc(ch) || mPort == 4000) // do not save, sir!!!
 		return;
 
-	if (ch->desc != nullptr && Deref(ch->desc->original) != nullptr)
-		ch = Deref(ch->desc->original);
+	DESCRIPTOR_DATA *connection = Deref(ch->desc);
+
+	if (connection != nullptr && Deref(connection->original) != nullptr)
+		ch = Deref(connection->original);
 
 	if (!check_parse_name(ch->true_name))
 		wiznet("ALERT!! $N/$F name corrupt!!", ch, nullptr, 0, 0, 0);
@@ -926,7 +928,7 @@ bool load_char_obj(DESCRIPTOR_DATA *d, char *name)
 	ch->pcdata = new_pcdata();
 
 	d->character = ch->self;
-	ch->desc = d;
+	ch->desc = d->self;
 	ch->pcdata->entering_text = false;
 	ch->name = palloc_string(name);
 	ch->id = get_pc_id();

--- a/code/save.c
+++ b/code/save.c
@@ -6,6 +6,7 @@
 #include <time.h>
 #include <algorithm>
 #include "merc.h"
+#include "entity/handles.h"
 #include "save.h"
 #include "newmem.h"
 #include "recycle.h"
@@ -144,13 +145,13 @@ void save_char_obj(CHAR_DATA *ch)
 			fwrite_obj(ch, ch->pcdata->old->carrying, fp, 0);
 
 		/* save the pets */
-		if (ch->pet != nullptr && ch->pet->in_room == ch->in_room)
-			fwrite_pet(ch->pet, fp);
+		if (Deref(ch->pet) != nullptr && Deref(ch->pet)->in_room == ch->in_room)
+			fwrite_pet(Deref(ch->pet), fp);
 
 		for (search = char_list; search != nullptr; search = search->next)
 		{
 			if (is_npc(search)
-				&& search->master == ch
+				&& Deref(search->master) == ch
 				&& (IS_SET(search->act, ACT_UNDEAD)
 					|| (!strcmp(ch->Class()->name, "necromancer") && !IS_SET(search->act, ACT_PET)))
 				/*  && search->in_room->vnum==ch->in_room->vnum */
@@ -216,7 +217,7 @@ void fread_charmie(CHAR_DATA *ch, FILE *fp)
 	char_to_room(charmed, get_room_index(roomvnum));
 	add_follower(charmed, ch);
 
-	charmed->leader = ch;
+	charmed->leader = ch->self;
 
 	init_affect(&af);
 	af.where = TO_AFFECTS;
@@ -1969,9 +1970,9 @@ void fread_pet(CHAR_DATA *ch, FILE *fp)
 			case 'E':
 				if (!str_cmp(word, "End"))
 				{
-					pet->leader = ch;
-					pet->master = ch;
-					ch->pet = pet;
+					pet->leader = ch->self;
+					pet->master = ch->self;
+					ch->pet = pet->self;
 					/* adjust hp mana move up  -- here for speed's sake */
 					percent = (current_time - lastlogoff) * 25 / (2 * 60 * 60);
 

--- a/code/save.c
+++ b/code/save.c
@@ -147,8 +147,10 @@ void save_char_obj(CHAR_DATA *ch)
 			fwrite_obj(ch, ch->pcdata->old->carrying, fp, 0);
 
 		/* save the pets */
-		if (Deref(ch->pet) != nullptr && Deref(ch->pet)->in_room == ch->in_room)
-			fwrite_pet(Deref(ch->pet), fp);
+		CHAR_DATA *pet = Deref(ch->pet);
+
+		if (pet != nullptr && pet->in_room == ch->in_room)
+			fwrite_pet(pet, fp);
 
 		for (search = char_list; search != nullptr; search = search->next)
 		{

--- a/code/save.c
+++ b/code/save.c
@@ -921,8 +921,6 @@ bool load_char_obj(DESCRIPTOR_DATA *d, char *name)
 	int pos;
 	int i;
 
-	CHAR_DATA *charg = new CHAR_DATA;
-
 	ch = new_char();
 	ch->pcdata = new_pcdata();
 

--- a/code/stdlibs/handle.h
+++ b/code/stdlibs/handle.h
@@ -1,0 +1,196 @@
+#ifndef STDLIBS_HANDLE_H
+#define STDLIBS_HANDLE_H
+
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <vector>
+
+//
+// A generational handle and the slot map that issues it.
+//
+// The problem this solves: the recycled entity types hand out reused
+// addresses. When one is freed it goes onto a free list and the very next
+// allocation can return the same address, so a raw back-reference to a dead
+// entity does not merely dangle -- it can silently start pointing at whatever
+// took its place. Today that is policed by a `valid` bool plus hand-written
+// scrub loops that walk every entity nulling inbound references to the one
+// being freed.
+//
+// A handle is that `valid` check folded into the reference itself. It names a
+// slot and the generation of that slot at the moment the handle was made.
+// Deref compares generations, so a handle to a freed entity resolves to null
+// forever -- no scrub loop required, and no chance of resolving to the
+// entity's replacement.
+//
+// Two invariants carry most of the weight:
+//
+//   * Generation 0 is reserved and never issued, so an all-zero handle is a
+//     null handle. Entities are reset by value-initializing over them and a
+//     few places still clear memory wholesale; both must produce a null
+//     reference rather than one pointing at slot 0.
+//
+//   * A slot whose generation counter is spent is retired permanently rather
+//     than wrapped. Wrapping is the one way a generational handle can still
+//     resolve to the wrong object, and it is silent -- no sanitizer sees it.
+//     Burning a slot is far cheaper than that.
+//
+// Note there is deliberately no `operator bool` and no `operator->`. A handle
+// being non-null does not mean it is live, so a truthiness test would read
+// like the raw-pointer check it replaces while answering a different question.
+// Every read goes through Deref, which forces the liveness check to be
+// visible at the point of use.
+//
+
+template <typename T, typename GenT>
+class SlotMap;
+
+/// A non-owning, generation-checked reference to an entity held in a SlotMap.
+/// Trivially copyable and 64 bits wide, so it can be stored in the entity
+/// structs anywhere a raw pointer is stored today.
+template <typename T, typename GenT = std::uint32_t>
+class Handle
+{
+public:
+	Handle() = default;
+
+	/// Lets an existing `x = nullptr` clear a field that used to be a pointer.
+	Handle(std::nullptr_t) {}
+
+	/// True when this handle names nothing at all. Says nothing about whether
+	/// the entity it names is still alive -- only Deref answers that.
+	bool IsNull() const { return generation == 0; }
+
+	bool operator==(const Handle &other) const
+	{
+		return index == other.index && generation == other.generation;
+	}
+
+	bool operator!=(const Handle &other) const { return !(*this == other); }
+
+private:
+	friend class SlotMap<T, GenT>;
+
+	std::uint32_t	index = 0;
+	GenT			generation = 0;		// 0 is reserved: an all-zero handle is null.
+};
+
+/// Issues handles for entities and answers whether a handle is still good.
+///
+/// The map does not own the entities and never moves them -- it stores plain
+/// pointers to objects allocated elsewhere. That is not an oversight: the
+/// codebase caches raw entity pointers across list mutations all over the
+/// place, so storage that relocates its elements would break those callers.
+/// Registering a pointer here changes nothing about who allocates or frees it.
+///
+/// GenT is the width of the generation counter. It exists so tests can
+/// exhaust a counter in reasonable time; production callers want the default.
+template <typename T, typename GenT = std::uint32_t>
+class SlotMap
+{
+public:
+	using HandleType = Handle<T, GenT>;
+
+	/// Registers an entity and returns a handle to it. A null entity gets a
+	/// null handle and consumes no slot.
+	HandleType Add(T *entity)
+	{
+		HandleType handle;
+
+		if (entity == nullptr)
+			return handle;
+
+		std::uint32_t slotIndex;
+
+		if (freeHead == NO_SLOT)
+		{
+			slotIndex = static_cast<std::uint32_t>(slots.size());
+			slots.push_back(Slot());
+		}
+		else
+		{
+			slotIndex = freeHead;
+			freeHead = slots[slotIndex].nextFree;
+		}
+
+		Slot &slot = slots[slotIndex];
+		slot.entity = entity;
+		slot.nextFree = NO_SLOT;
+		liveCount++;
+
+		handle.index = slotIndex;
+		handle.generation = slot.generation;
+
+		return handle;
+	}
+
+	/// Expires every handle to this entity. Removing something already removed
+	/// is a silent no-op, matching how the free_X functions behave today --
+	/// and it matters, because bumping the generation on a stray call would
+	/// spend the slot's counter for nothing.
+	void Remove(HandleType handle)
+	{
+		if (Find(handle) == nullptr)
+			return;
+
+		Slot &slot = slots[handle.index];
+		slot.entity = nullptr;
+		liveCount--;
+
+		// A spent counter retires the slot. It is never reused, so the handles
+		// already issued against it stay expired for good.
+		if (slot.generation == std::numeric_limits<GenT>::max())
+			return;
+
+		slot.generation++;
+		slot.nextFree = freeHead;
+		freeHead = handle.index;
+	}
+
+	/// The entity this handle names, or null if the handle is null, expired,
+	/// or malformed. This is the only way to read through a handle.
+	T *Deref(HandleType handle) const
+	{
+		const Slot *slot = Find(handle);
+
+		return slot != nullptr ? slot->entity : nullptr;
+	}
+
+	bool IsLive(HandleType handle) const { return Deref(handle) != nullptr; }
+
+	/// Entities currently registered.
+	std::size_t LiveCount() const { return liveCount; }
+
+	/// Slots ever allocated, live plus free plus retired. Only interesting for
+	/// tests and for watching slot churn over a long run.
+	std::size_t SlotCount() const { return slots.size(); }
+
+private:
+	static constexpr std::uint32_t NO_SLOT = ~static_cast<std::uint32_t>(0);
+
+	struct Slot
+	{
+		T *				entity = nullptr;	// null while the slot is free or retired
+		GenT			generation = 1;		// starts at 1; 0 is the reserved null generation
+		std::uint32_t	nextFree = NO_SLOT;
+	};
+
+	const Slot *Find(HandleType handle) const
+	{
+		if (handle.IsNull() || handle.index >= slots.size())
+			return nullptr;
+
+		const Slot &slot = slots[handle.index];
+
+		if (slot.generation != handle.generation || slot.entity == nullptr)
+			return nullptr;
+
+		return &slot;
+	}
+
+	std::vector<Slot>	slots;
+	std::uint32_t		freeHead = NO_SLOT;
+	std::size_t			liveCount = 0;
+};
+
+#endif /* STDLIBS_HANDLE_H */

--- a/code/stdlibs/handle.h
+++ b/code/stdlibs/handle.h
@@ -68,6 +68,19 @@ public:
 
 	bool operator!=(const Handle &other) const { return !(*this == other); }
 
+	// Comparing against nullptr is deliberately a compile error, even though
+	// assigning nullptr is not. Without these the converting constructor above
+	// makes `h == nullptr` compile and quietly mean "was never assigned",
+	// which is not the question a raw-pointer null check used to ask -- that
+	// one meant "is there something there", and the handle's answer to it is
+	// Deref(h) == nullptr. The two differ for exactly the case handles exist
+	// to catch: a reference to an entity that has since been freed.
+	//
+	// Deleting them puts those sites back in front of a human, which is the
+	// same reason there is no operator bool and no operator->.
+	bool operator==(std::nullptr_t) const = delete;
+	bool operator!=(std::nullptr_t) const = delete;
+
 private:
 	friend class SlotMap<T, GenT>;
 

--- a/code/string.c
+++ b/code/string.c
@@ -47,7 +47,7 @@ void string_edit(CHAR_DATA *ch, char **pString)
 	else
 		**pString = '\0';
 
-	ch->desc->pString = pString;
+	Deref(ch->desc)->pString = pString;
 }
 
 /*****************************************************************************
@@ -70,7 +70,7 @@ void string_append(CHAR_DATA *ch, char **pString)
 	if (*(*pString + strlen(*pString) - 1) != '\r')
 		send_to_char("\n\r", ch);
 
-	ch->desc->pString = pString;
+	Deref(ch->desc)->pString = pString;
 }
 
 /*****************************************************************************
@@ -108,6 +108,9 @@ char *string_replace(char *orig, char *old, char *newstr)
  ****************************************************************************/
 void string_add(CHAR_DATA *ch, char *argument)
 {
+	// This whole function edits one connection's OLC string buffer; nothing in
+	// it can close the socket, so the connection is read once.
+	DESCRIPTOR_DATA *connection = Deref(ch->desc);
 	char buf[MAX_STRING_LENGTH];
 	char obuf[MSL * 2];
 	int len = 0;
@@ -130,14 +133,14 @@ void string_add(CHAR_DATA *ch, char *argument)
 		if (!str_cmp(arg1, ".c"))
 		{
 			send_to_char("String cleared.\n\r", ch);
-			**ch->desc->pString = '\0';
+			**connection->pString = '\0';
 			return;
 		}
 
 		if (!str_cmp(arg1, ".s"))
 		{
 			send_to_char("String so far:\n\r", ch);
-			send_to_char(*ch->desc->pString, ch);
+			send_to_char(*connection->pString, ch);
 			return;
 		}
 
@@ -150,7 +153,7 @@ void string_add(CHAR_DATA *ch, char *argument)
 			}
 
 			smash_tilde(arg3); /* Just to be sure -- Hugin */
-			*ch->desc->pString = string_replace(*ch->desc->pString, arg2, arg3);
+			*connection->pString = string_replace(*connection->pString, arg2, arg3);
 
 			auto buffer = fmt::format("'{}' replaced with '{}'.\n\r", arg2, arg3);
 			send_to_char(buffer.c_str(), ch);
@@ -159,20 +162,20 @@ void string_add(CHAR_DATA *ch, char *argument)
 
 		if (!str_cmp(arg1, ".f"))
 		{
-			*ch->desc->pString = format_string(*ch->desc->pString);
+			*connection->pString = format_string(*connection->pString);
 			send_to_char("String formatted.\n\r", ch);
 			return;
 		}
 
 		if (!str_cmp(arg1, ".d"))
 		{
-			if (**ch->desc->pString == '\0')
+			if (**connection->pString == '\0')
 			{
 				send_to_char("No lines left to delete.\n\r", ch);
 				return;
 			}
 
-			strcpy(obuf, *ch->desc->pString);
+			strcpy(obuf, *connection->pString);
 
 			for (len = strlen(obuf); len > 0; len--)
 			{
@@ -188,16 +191,16 @@ void string_add(CHAR_DATA *ch, char *argument)
 					else
 					{
 						obuf[len + 1] = '\0';
-						free_pstring(*ch->desc->pString);
-						*ch->desc->pString = palloc_string(obuf);
+						free_pstring(*connection->pString);
+						*connection->pString = palloc_string(obuf);
 						return send_to_char("Line deleted.\n\r", ch);
 					}
 				}
 			}
 
 			obuf[0] = '\0';
-			free_pstring(*ch->desc->pString);
-			*ch->desc->pString = palloc_string(obuf);
+			free_pstring(*connection->pString);
+			*connection->pString = palloc_string(obuf);
 
 			send_to_char("Line Deleted.\n\r", ch);
 			return;
@@ -223,11 +226,11 @@ void string_add(CHAR_DATA *ch, char *argument)
 
 	if (*argument == '~' || *argument == '@')
 	{
-		ch->desc->pString = nullptr;
+		connection->pString = nullptr;
 		return;
 	}
 
-	strcpy(buf, *ch->desc->pString);
+	strcpy(buf, *connection->pString);
 
 	/*
 	 * Truncate strings to MAX_STRING_LENGTH.
@@ -238,7 +241,7 @@ void string_add(CHAR_DATA *ch, char *argument)
 		send_to_char("String too long, last line skipped.\n\r", ch);
 
 		/* Force character out of editing mode. */
-		ch->desc->pString = nullptr;
+		connection->pString = nullptr;
 		return;
 	}
 
@@ -250,8 +253,8 @@ void string_add(CHAR_DATA *ch, char *argument)
 
 	strcat(buf, argument);
 	strcat(buf, "\n\r");
-	free_pstring(*ch->desc->pString);
-	*ch->desc->pString = palloc_string(buf);
+	free_pstring(*connection->pString);
+	*connection->pString = palloc_string(buf);
 }
 
 /*

--- a/code/update.c
+++ b/code/update.c
@@ -1634,7 +1634,8 @@ void obj_update(void)
 		}
 		else if (obj->in_room != nullptr && (rch = obj->in_room->people) != nullptr)
 		{
-			if (!(obj->in_obj && obj->in_obj->pIndexData->vnum == OBJ_VNUM_PIT && !can_wear(obj->in_obj, ITEM_TAKE)))
+			OBJ_DATA *container = Deref(obj->in_obj);
+			if (!(container && container->pIndexData->vnum == OBJ_VNUM_PIT && !can_wear(container, ITEM_TAKE)))
 			{
 				act(message, rch, obj, nullptr, TO_ROOM);
 				act(message, rch, obj, nullptr, TO_CHAR);

--- a/code/update.c
+++ b/code/update.c
@@ -1185,14 +1185,14 @@ void char_update(void)
 			&& ch->in_room
 			&& number_percent() < 90
 			&& !is_affected_by(ch, AFF_SLEEP)
-			&& ch->fighting == nullptr)
+			&& Deref(ch->fighting) == nullptr)
 		{
 			if (IS_SET(ch->act, ACT_DIURNAL) && is_affected_by(ch, AFF_NOSHOW))
 				REMOVE_BIT(ch->affected_by, AFF_NOSHOW);
 			else if (IS_SET(ch->act, ACT_NOCTURNAL) && !is_affected_by(ch, AFF_NOSHOW))
 				SET_BIT(ch->affected_by, AFF_NOSHOW);
 		}
-		else if (is_npc(ch) && sun >= SolarPosition::Sunset && ch->in_room && number_percent() < 90 && ch->fighting == nullptr)
+		else if (is_npc(ch) && sun >= SolarPosition::Sunset && ch->in_room && number_percent() < 90 && Deref(ch->fighting) == nullptr)
 		{
 			if (IS_SET(ch->act, ACT_NOCTURNAL) && is_affected_by(ch, AFF_NOSHOW))
 				REMOVE_BIT(ch->affected_by, AFF_NOSHOW);
@@ -1330,7 +1330,7 @@ void char_update(void)
 				{
 					ch->was_in_room = ch->in_room;
 
-					if (ch->fighting != nullptr)
+					if (Deref(ch->fighting) != nullptr)
 						stop_fighting(ch, true);
 
 					act("$n disappears into the void.", ch, nullptr, nullptr, TO_ROOM);
@@ -1732,7 +1732,7 @@ instead...(Ceran)
 void track_attack(CHAR_DATA *mob, CHAR_DATA *victim)
 {
 	char buf[MSL];
-	if (mob->in_room != victim->in_room || !can_see(mob, victim) || mob->fighting || is_affected_by(mob, AFF_NOSHOW))
+	if (mob->in_room != victim->in_room || !can_see(mob, victim) || Deref(mob->fighting) || is_affected_by(mob, AFF_NOSHOW))
 		return;
 
 	if (mob->pIndexData->attack_yell)
@@ -1761,7 +1761,7 @@ void track_update(void)
 		{
 			if (tch->position > POS_RESTING
 				&& number_range(1, 10) == 1
-				&& !tch->fighting
+				&& !Deref(tch->fighting)
 				&& tch->home_room
 				&& tch->in_room != tch->home_room
 				&& (tch->in_room->vnum < tch->pIndexData->restrict_low
@@ -1773,7 +1773,7 @@ void track_update(void)
 			continue;
 		}
 
-		if (tch->fighting || is_affected_by(tch, AFF_NOSHOW))
+		if (Deref(tch->fighting) || is_affected_by(tch, AFF_NOSHOW))
 			continue;
 
 		if (tch->in_room == tch->last_fought->in_room)
@@ -1792,7 +1792,7 @@ void track_update(void)
 
 		track_attack(tch, tch->last_fought);
 
-		if (!tch->fighting)
+		if (!Deref(tch->fighting))
 			tch->tracktimer--;
 
 		if (tch->tracktimer == 0)
@@ -1823,6 +1823,7 @@ void aggr_update(void)
 	CHAR_DATA *vch;
 	CHAR_DATA *vch_next;
 	CHAR_DATA *victim;
+	CHAR_DATA *opponent;
 	int timer;
 	char buf[MAX_STRING_LENGTH];
 
@@ -1859,13 +1860,15 @@ void aggr_update(void)
 		if (is_affected_by(wch, AFF_SLOW))
 			timer--;
 
-		if (wch->fighting &&
+		opponent = Deref(wch->fighting);
+
+		if (opponent &&
 			((!is_npc(wch) && timer >= pc_race_table[wch->race].racePulse) || (is_npc(wch) && timer >= 12)))
 		{
-			update_pc_last_fight(wch, wch->fighting);
+			update_pc_last_fight(wch, opponent);
 
-			if (is_awake(wch) && wch->in_room == wch->fighting->in_room)
-				multi_hit(wch, wch->fighting, TYPE_UNDEFINED);
+			if (is_awake(wch) && wch->in_room == opponent->in_room)
+				multi_hit(wch, opponent, TYPE_UNDEFINED);
 			else
 				stop_fighting(wch, false);
 
@@ -1875,7 +1878,7 @@ void aggr_update(void)
 		if (wch->position == POS_SLEEPING && IS_SET(wch->imm_flags, IMM_SLEEP))
 			wch->position = POS_STANDING;
 
-		if (is_affected_by(wch, AFF_RAGE) && is_awake(wch) && !wch->fighting && !(wch->desc == nullptr && !is_npc(wch)))
+		if (is_affected_by(wch, AFF_RAGE) && is_awake(wch) && !Deref(wch->fighting) && !(wch->desc == nullptr && !is_npc(wch)))
 		{
 			for (vch = wch->in_room->people; vch != nullptr; vch = vch_next)
 			{
@@ -1921,7 +1924,7 @@ void aggr_update(void)
 			}
 		}
 
-		if (!is_npc(wch) && is_affected(wch, gsn_divine_frenzy) && is_awake(wch) && !wch->fighting)
+		if (!is_npc(wch) && is_affected(wch, gsn_divine_frenzy) && is_awake(wch) && !Deref(wch->fighting))
 		{
 			for (vch = wch->in_room->people; vch != nullptr; vch = vch_next)
 			{
@@ -1950,7 +1953,7 @@ void aggr_update(void)
 
 		if (is_affected(wch, gsn_mark_of_wrath)
 			&& is_awake(wch)
-			&& !wch->fighting
+			&& !Deref(wch->fighting)
 			&& !(wch->desc == nullptr && !is_npc(wch)))
 		{
 			AFFECT_DATA *paf = affect_find(wch->affected, gsn_mark_of_wrath);
@@ -2001,7 +2004,7 @@ void aggr_update(void)
 				|| IS_SET(ch->in_room->room_flags, ROOM_SAFE)
 				|| (is_npc(ch) && is_affected_by(ch, AFF_NOSHOW))
 				|| is_affected_by(ch, AFF_CALM)
-				|| ch->fighting != nullptr
+				|| Deref(ch->fighting) != nullptr
 				|| is_affected_by(ch, AFF_CHARM)
 				|| !is_awake(ch)
 				|| (IS_SET(ch->act, ACT_WIMPY) && is_awake(wch))
@@ -2834,7 +2837,7 @@ void room_affect_update(void)
 				if (is_affected(victim, gsn_airshield))
 					chance = 0;
 				if (number_percent() >= chance || (is_npc(victim) && IS_SET(victim->act, ACT_SENTINEL)) ||
-					victim->fighting || victim->invis_level > LEVEL_HERO)
+					Deref(victim->fighting) || victim->invis_level > LEVEL_HERO)
 					continue;
 				to_room = get_random_exit(room);
 
@@ -3000,7 +3003,7 @@ bool do_mob_cast(CHAR_DATA *ch)
 	short i, sn, rnd, in_room = 0, room_occupant = 0;
 	CHAR_DATA *vch, *victim;
 
-	if (!is_npc(ch) || !ch->fighting || ch->pIndexData->cast_spell[0] == nullptr)
+	if (!is_npc(ch) || !Deref(ch->fighting) || ch->pIndexData->cast_spell[0] == nullptr)
 		return false;
 
 	for (;;)
@@ -3015,14 +3018,14 @@ bool do_mob_cast(CHAR_DATA *ch)
 	if (sn < 1)
 		return false;
 
-	victim = ch->fighting;
+	victim = Deref(ch->fighting);
 	// Share the wealth.
 	//
 	if (skill_table[sn].target == TAR_CHAR_OFFENSIVE)
 	{
 		for (victim = ch->in_room->people; victim != nullptr; victim = victim->next_in_room)
 		{
-			if (victim && !is_npc(victim) && victim->fighting && victim->fighting == ch)
+			if (victim && !is_npc(victim) && Deref(victim->fighting) && Deref(victim->fighting) == ch)
 				in_room++;
 		}
 
@@ -3030,14 +3033,14 @@ bool do_mob_cast(CHAR_DATA *ch)
 
 		for (vch = ch->in_room->people; vch != nullptr; vch = vch->next_in_room)
 		{
-			if (!is_npc(vch) && vch->fighting == ch)
+			if (!is_npc(vch) && Deref(vch->fighting) == ch)
 				room_occupant++;
 
 			if (rnd == room_occupant)
 				break;
 		}
 
-		victim = vch != nullptr ? vch : ch->fighting;
+		victim = vch != nullptr ? vch : Deref(ch->fighting);
 	}
 
 	if (skill_table[sn].target == TAR_CHAR_DEFENSIVE)

--- a/code/update.c
+++ b/code/update.c
@@ -1396,29 +1396,35 @@ void char_update(void)
 						break;
 				}
 				else if (paf->type == gsn_entwine
-					&& (paf->owner == nullptr || (paf->owner && ch->in_room != paf->owner->in_room)))
+					&& (Deref(paf->owner) == nullptr || (Deref(paf->owner) && ch->in_room != Deref(paf->owner)->in_room)))
 				{
 					affect_remove(ch, paf);
 				}
 				else
 				{
-					if (((paf->owner && paf->owner->Class()->GetIndex() == CLASS_PALADIN)
-							|| (!paf->owner && ch->Class()->GetIndex() == CLASS_PALADIN)
-							&& trusts(ch, paf->owner ? paf->owner : ch))
+					// Read once: this branch only rolls, messages and adjusts
+					// durations, so nothing in it can free the owner. The
+					// branches above that call tick_fun can, which is why this
+					// is not hoisted out of the chain.
+					CHAR_DATA *owner = Deref(paf->owner);
+
+					if (((owner && owner->Class()->GetIndex() == CLASS_PALADIN)
+							|| (!owner && ch->Class()->GetIndex() == CLASS_PALADIN)
+							&& trusts(ch, owner ? owner : ch))
 						&& paf->aftype == AFT_COMMUNE)
 					{
-						if (number_percent() < (get_skill(paf->owner ? paf->owner : ch, gsn_channeling) * .85)
+						if (number_percent() < (get_skill(owner ? owner : ch, gsn_channeling) * .85)
 							&& !(skill_table[paf->type].dispel & CAN_CLEANSE))
 						{
-							check_improve(paf->owner ? paf->owner : ch, gsn_channeling, true, 1);
+							check_improve(owner ? owner : ch, gsn_channeling, true, 1);
 
-							if (!paf->owner || ch == paf->owner)
+							if (!owner || ch == owner)
 							{
 								act("You feel invigorated as your $t supplication is renewed by your deity.", ch, skill_table[paf->type].name, 0, TO_CHAR);
 							}
 							else
 							{
-								act("You feel invigorated as $N renews your $t supplication.", ch, skill_table[paf->type].name, paf->owner, TO_CHAR);
+								act("You feel invigorated as $N renews your $t supplication.", ch, skill_table[paf->type].name, owner, TO_CHAR);
 							}
 
 							paf->duration = paf->init_duration;
@@ -1979,7 +1985,7 @@ void aggr_update(void)
 			{
 				vch_next = vch->next_in_room;
 
-				if (paf->owner->ghost > 0)
+				if (Deref(paf->owner)->ghost > 0)
 				{
 					affect_remove(wch, paf);
 					break;		// paf is gone; nothing further reads the mark
@@ -1994,7 +2000,7 @@ void aggr_update(void)
 				if (is_safe_new(wch, vch, false))
 					continue;
 
-				if (vch == paf->owner)
+				if (vch == Deref(paf->owner))
 				{
 					sprintf(buf, "%sCatching sight of the mark upon %s's brow, you are consumed with wrath!%s\n\r",
 						get_char_color(wch, "lightred"),
@@ -2507,7 +2513,7 @@ void room_affect_update(void)
 							if (is_npc(victim) && IS_SET(victim->act, ACT_SENTINEL))
 								continue;
 
-							if (!is_npc(victim) && is_safe_new(af->owner, victim, false))
+							if (!is_npc(victim) && is_safe_new(Deref(af->owner), victim, false))
 								continue;
 
 							if (victim->invis_level > LEVEL_HERO)
@@ -2564,7 +2570,7 @@ void room_affect_update(void)
 					{
 						v_next = vch->next_in_room;
 
-						if (!is_npc(vch) && is_safe_new(af->owner, vch, false))
+						if (!is_npc(vch) && is_safe_new(Deref(af->owner), vch, false))
 							continue;
 
 						send_to_char("Your lungs burn furiously, desperate for air!\n\r", vch);
@@ -2588,7 +2594,7 @@ void room_affect_update(void)
 				{
 					v_next = vch->next_in_room;
 
-					if (is_safe_new(af->owner, vch, false))
+					if (is_safe_new(Deref(af->owner), vch, false))
 						continue;
 
 					dam = dice(10, 15);
@@ -2599,7 +2605,7 @@ void room_affect_update(void)
 					}
 
 					send_to_char("Large chunks of rubble tumble down from the ceiling, crushing you!\n\r", vch);
-					damage_new(af->owner, vch, dam, TYPE_UNDEFINED, DAM_BASH, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "the falling debris*");
+					damage_new(Deref(af->owner), vch, dam, TYPE_UNDEFINED, DAM_BASH, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "the falling debris*");
 				}
 			}
 		}
@@ -2652,17 +2658,17 @@ void room_affect_update(void)
 				{
 					v_next = vch->next_in_room;
 
-					if (vch == af->owner)
+					if (vch == Deref(af->owner))
 						continue;
 
-					if (!is_npc(vch) && is_safe_new(af->owner, vch, false))
+					if (!is_npc(vch) && is_safe_new(Deref(af->owner), vch, false))
 						continue;
 
 					if (!is_npc(vch))
 					{
-						if (vch->in_room == af->owner->in_room)
+						if (vch->in_room == Deref(af->owner)->in_room)
 						{
-							sprintf(buf, "Help! I'm being drowned by %s's tidal wave!", pers(af->owner, vch));
+							sprintf(buf, "Help! I'm being drowned by %s's tidal wave!", pers(Deref(af->owner), vch));
 							do_myell(vch, buf, nullptr);
 						}
 						else
@@ -2672,7 +2678,7 @@ void room_affect_update(void)
 						}
 					}
 
-					damage_new(af->owner, vch, dice(af2->modifier, 10), gsn_tidalwave, DAM_DROWNING, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "the tidal wave*");
+					damage_new(Deref(af->owner), vch, dice(af2->modifier, 10), gsn_tidalwave, DAM_DROWNING, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "the tidal wave*");
 				}
 
 				if (room->sector_type != SECT_WATER)
@@ -2688,13 +2694,13 @@ void room_affect_update(void)
 					{
 						v_next = vch->next_in_room;
 
-						if (vch == af->owner)
+						if (vch == Deref(af->owner))
 							continue;
 
-						if (!is_npc(vch) && is_safe_new(af->owner, vch, false))
+						if (!is_npc(vch) && is_safe_new(Deref(af->owner), vch, false))
 							continue;
 
-						damage_new(af->owner, vch, dice(af2->modifier, 10), gsn_tidalwave, DAM_BASH, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "the crashing wave*");
+						damage_new(Deref(af->owner), vch, dice(af2->modifier, 10), gsn_tidalwave, DAM_BASH, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "the crashing wave*");
 						WAIT_STATE(vch, PULSE_VIOLENCE * 2);
 					}
 				}
@@ -2721,7 +2727,7 @@ void room_affect_update(void)
 					if (is_immortal(vch))
 						continue;
 
-					if (!is_safe(vch, af->owner) && !is_affected(vch, gsn_neutralize))
+					if (!is_safe(vch, Deref(af->owner)) && !is_affected(vch, gsn_neutralize))
 					{
 						if (!is_affected(vch, gsn_noxious_fumes))
 						{
@@ -2795,7 +2801,7 @@ void room_affect_update(void)
 
 						new_affect_join(vch, &cvaf2);
 
-						damage_new(af->owner, vch, dam, af->type, DAM_POISON, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "the noxious fumes*$");
+						damage_new(Deref(af->owner), vch, dam, af->type, DAM_POISON, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "the noxious fumes*$");
 					}
 				}
 			}
@@ -2809,6 +2815,11 @@ void room_affect_update(void)
 		if (is_affected_area(room->area, gsn_cyclone))
 		{
 			aaf = affect_find_area(room->area->affected, gsn_cyclone);
+
+			// An area affect outlives its caster -- nothing removes it when
+			// they go -- and the winds still move objects without one. Only the
+			// damage needs somebody to attribute it to.
+			CHAR_DATA *caster = Deref(aaf->owner);
 
 			for (obj = room->contents; obj != nullptr; obj = obj->next_content)
 			{
@@ -2834,16 +2845,20 @@ void room_affect_update(void)
 					continue;
 
 				act("The violent winds blow $p in!", to_room->people, obj, 0, TO_ALL);
-				victim = get_random_ch(aaf->owner, to_room);
+
+				if (caster == nullptr)
+					continue;
+
+				victim = get_random_ch(caster, to_room);
 
 				if (!victim)
 					continue;
 
-				if (victim == aaf->owner)
+				if (victim == caster)
 					continue;
 
 				dam = dice(obj->weight + 1, 8);
-				damage_new(aaf->owner, victim, dam, skill_lookup("cyclone"), DAM_BASH, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "the flying debris*");
+				damage_new(caster, victim, dam, skill_lookup("cyclone"), DAM_BASH, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "the flying debris*");
 			}
 			for (victim = room->people; victim != nullptr; victim = v_next)
 			{

--- a/code/update.c
+++ b/code/update.c
@@ -1356,6 +1356,14 @@ void char_update(void)
 		}
 		else
 		{
+			// Held across the loop because a tick can free the character, and
+			// free_char clears ch->self on the way out -- so reading the handle
+			// back off `ch` afterwards would be reading the freed struct, and
+			// would read the *replacement's* handle if the address had already
+			// been reissued. This copy keeps the generation the loop started
+			// with, which is exactly the case a handle exists to catch.
+			Handle<CHAR_DATA> ticking = ch->self;
+
 			for (auto it = ch->affected.begin(); it != ch->affected.end(); )
 			{
 				auto next = std::next(it);
@@ -1373,7 +1381,7 @@ void char_update(void)
 
 					/* A tick can extract (free) the character, clearing its
 					 * affect list; stop before touching the stale iterator. */
-					if (!ch->valid || (!ghost && ch->ghost > 0))
+					if (Deref(ticking) != ch || (!ghost && ch->ghost > 0))
 						break;
 
 					if (!paf)
@@ -1392,7 +1400,7 @@ void char_update(void)
 					if (paf->tick_fun)
 						(*paf->tick_fun)(ch, paf);
 
-					if (!ch->valid || (!ghost && ch->ghost > 0))
+					if (Deref(ticking) != ch || (!ghost && ch->ghost > 0))
 						break;
 				}
 				else if (paf->type == gsn_entwine
@@ -1524,6 +1532,11 @@ void obj_update(void)
 				affect_strip_obj(obj, gsn_immolate);
 		}
 
+		// Held across the loop for the same reason as char_update's: free_obj
+		// clears obj->self, so the handle has to be copied before the tick that
+		// might run it.
+		Handle<OBJ_DATA> ticking = obj->self;
+
 		/* go through affects and decrement */
 		for (auto it = obj->affected.begin(); it != obj->affected.end(); )
 		{
@@ -1537,7 +1550,7 @@ void obj_update(void)
 			/* A tick can extract (free) the object — e.g. a spent crystal
 			 * crumbling to dust — which clears its affect list. Stop before
 			 * touching the now-invalidated iterator. */
-			if (!obj->valid)
+			if (Deref(ticking) != obj)
 				break;
 
 			if (paf->duration > 0)

--- a/code/update.c
+++ b/code/update.c
@@ -1757,7 +1757,7 @@ void track_update(void)
 		if (!is_npc(tch))
 			continue;
 
-		if (!tch->last_fought)
+		if (!Deref(tch->last_fought))
 		{
 			if (tch->position > POS_RESTING
 				&& number_range(1, 10) == 1
@@ -1776,9 +1776,19 @@ void track_update(void)
 		if (Deref(tch->fighting) || is_affected_by(tch, AFF_NOSHOW))
 			continue;
 
-		if (tch->in_room == tch->last_fought->in_room)
+		// Every Deref below re-reads the handle on purpose. Do NOT collapse
+		// them into one local: track_attack calls multi_hit and can kill the
+		// quarry outright, and smart_track/track_char move this mob into
+		// another room, which can trigger progs that do the same. Any of those
+		// can end the hunt partway through this block.
+		//
+		// A hoisted CHAR_DATA * would keep pointing at a character struct that
+		// has already gone back on the free list -- the exact failure this
+		// field stopped being a raw pointer to avoid. Re-reading costs an
+		// array index and an integer compare, and yields null instead.
+		if (tch->in_room == Deref(tch->last_fought)->in_room)
 		{
-			track_attack(tch, tch->last_fought);
+			track_attack(tch, Deref(tch->last_fought));
 			continue;
 		}
 
@@ -1786,11 +1796,11 @@ void track_update(void)
 			continue;
 
 		if (IS_SET(tch->act, ACT_SMARTTRACK))
-			smart_track(tch->last_fought, tch);
+			smart_track(Deref(tch->last_fought), tch);
 		else
-			track_char(tch->last_fought, tch);
+			track_char(Deref(tch->last_fought), tch);
 
-		track_attack(tch, tch->last_fought);
+		track_attack(tch, Deref(tch->last_fought));
 
 		if (!Deref(tch->fighting))
 			tch->tracktimer--;
@@ -1860,6 +1870,11 @@ void aggr_update(void)
 		if (is_affected_by(wch, AFF_SLOW))
 			timer--;
 
+		// Safe to read once and reuse, unlike the tracking loop above: nothing
+		// between this read and its last use can end the fight.
+		// update_pc_last_fight only assigns fields, and multi_hit is the final
+		// use rather than an intermediate one. The reads further down are
+		// after multi_hit, so those go back through the handle.
 		opponent = Deref(wch->fighting);
 
 		if (opponent &&

--- a/code/update.c
+++ b/code/update.c
@@ -539,7 +539,7 @@ void gain_condition(CHAR_DATA *ch, int iCond, int value)
 	if (value == 0 || is_npc(ch) || is_immortal(ch) || is_heroimm(ch) || IS_SET(ch->act, PLR_NOVOID))
 		return;
 
-	if (!ch->desc)
+	if (!Deref(ch->desc))
 		return;
 
 	condition = ch->pcdata->condition[iCond];
@@ -1350,7 +1350,7 @@ void char_update(void)
 			gain_condition(ch, COND_HUNGER, 1);
 		}
 
-		if (!is_npc(ch) && ch->desc == nullptr)
+		if (!is_npc(ch) && Deref(ch->desc) == nullptr)
 		{
 			/* nothing */
 		}
@@ -1471,7 +1471,9 @@ void char_update(void)
 	{
 		ch_next = ch->next;
 
-		if (ch->desc != nullptr && ch->desc->descriptor % 3 == save_number)
+		DESCRIPTOR_DATA *connection = Deref(ch->desc);
+
+		if (connection != nullptr && connection->descriptor % 3 == save_number)
 			save_char_obj(ch);
 	}
 }
@@ -1893,7 +1895,7 @@ void aggr_update(void)
 		if (wch->position == POS_SLEEPING && IS_SET(wch->imm_flags, IMM_SLEEP))
 			wch->position = POS_STANDING;
 
-		if (is_affected_by(wch, AFF_RAGE) && is_awake(wch) && !Deref(wch->fighting) && !(wch->desc == nullptr && !is_npc(wch)))
+		if (is_affected_by(wch, AFF_RAGE) && is_awake(wch) && !Deref(wch->fighting) && !(Deref(wch->desc) == nullptr && !is_npc(wch)))
 		{
 			for (vch = wch->in_room->people; vch != nullptr; vch = vch_next)
 			{
@@ -1969,7 +1971,7 @@ void aggr_update(void)
 		if (is_affected(wch, gsn_mark_of_wrath)
 			&& is_awake(wch)
 			&& !Deref(wch->fighting)
-			&& !(wch->desc == nullptr && !is_npc(wch)))
+			&& !(Deref(wch->desc) == nullptr && !is_npc(wch)))
 		{
 			AFFECT_DATA *paf = affect_find(wch->affected, gsn_mark_of_wrath);
 

--- a/code/update.c
+++ b/code/update.c
@@ -40,6 +40,7 @@
 #include <algorithm>
 #include "merc.h"
 #include "update.h"
+#include "entity/handles.h"
 #include "weather_enums.h"
 #include "direction.h"
 #include "newmem.h"
@@ -291,7 +292,7 @@ int hit_gain(CHAR_DATA *ch)
 			gain /= 2;
 	}
 
-	if (ch->on != nullptr && ch->on->item_type == ITEM_FURNITURE)
+	if (OBJ_DATA *seatedOn = Deref(ch->on); seatedOn != nullptr && seatedOn->item_type == ITEM_FURNITURE)
 		gain = (gain * 7 / 5);
 
 	if (is_affected(ch, gsn_bleeding))
@@ -424,7 +425,7 @@ int mana_gain(CHAR_DATA *ch)
 			gain /= 2;
 	}
 
-	if (ch->on != nullptr && ch->on->item_type == ITEM_FURNITURE)
+	if (OBJ_DATA *seatedOn = Deref(ch->on); seatedOn != nullptr && seatedOn->item_type == ITEM_FURNITURE)
 		gain = gain * 7 / 5;
 
 	if (is_affected_by(ch, AFF_POISON))
@@ -500,7 +501,7 @@ int move_gain(CHAR_DATA *ch)
 
 	gain *= ch->in_room->heal_rate / 100;
 
-	if (ch->on != nullptr && ch->on->item_type == ITEM_FURNITURE)
+	if (OBJ_DATA *seatedOn = Deref(ch->on); seatedOn != nullptr && seatedOn->item_type == ITEM_FURNITURE)
 		gain = gain * 6 / 5;
 
 	if (is_affected_by(ch, AFF_POISON))

--- a/code/update.c
+++ b/code/update.c
@@ -292,7 +292,9 @@ int hit_gain(CHAR_DATA *ch)
 			gain /= 2;
 	}
 
-	if (OBJ_DATA *seatedOn = Deref(ch->on); seatedOn != nullptr && seatedOn->item_type == ITEM_FURNITURE)
+	OBJ_DATA *seatedOn = Deref(ch->on);
+
+	if (seatedOn != nullptr && seatedOn->item_type == ITEM_FURNITURE)
 		gain = (gain * 7 / 5);
 
 	if (is_affected(ch, gsn_bleeding))
@@ -425,7 +427,9 @@ int mana_gain(CHAR_DATA *ch)
 			gain /= 2;
 	}
 
-	if (OBJ_DATA *seatedOn = Deref(ch->on); seatedOn != nullptr && seatedOn->item_type == ITEM_FURNITURE)
+	OBJ_DATA *seatedOn = Deref(ch->on);
+
+	if (seatedOn != nullptr && seatedOn->item_type == ITEM_FURNITURE)
 		gain = gain * 7 / 5;
 
 	if (is_affected_by(ch, AFF_POISON))
@@ -501,7 +505,9 @@ int move_gain(CHAR_DATA *ch)
 
 	gain *= ch->in_room->heal_rate / 100;
 
-	if (OBJ_DATA *seatedOn = Deref(ch->on); seatedOn != nullptr && seatedOn->item_type == ITEM_FURNITURE)
+	OBJ_DATA *seatedOn = Deref(ch->on);
+
+	if (seatedOn != nullptr && seatedOn->item_type == ITEM_FURNITURE)
 		gain = gain * 6 / 5;
 
 	if (is_affected_by(ch, AFF_POISON))
@@ -1483,6 +1489,11 @@ void obj_update(void)
 	for (obj = object_list; obj != nullptr; obj = obj_next)
 	{
 		CHAR_DATA *rch;
+		// Re-read from obj->carried_by before each use below, never cached across
+		// them: the cabal-item branch calls obj_from_char/obj_to_char, which move
+		// the object to a different carrier. A value read earlier in the iteration
+		// is stale from that point on.
+		CHAR_DATA *carrier;
 		char *message;
 
 		obj_next = obj->next;
@@ -1490,14 +1501,16 @@ void obj_update(void)
 		if (obj->moved)
 			obj->moved= false;
 
+		carrier = Deref(obj->carried_by);
+
 		if ((is_affected_by(obj, AFF_OBJ_BURNING)
-				&& (obj->carried_by
-					&& (obj->carried_by->in_room->sector_type == SECT_WATER
-						||  obj->carried_by->in_room->sector_type == SECT_UNDERWATER)))
+				&& (carrier
+					&& (carrier->in_room->sector_type == SECT_WATER
+						||  carrier->in_room->sector_type == SECT_UNDERWATER)))
 			|| (obj->in_room
 				&& (obj->in_room->sector_type == SECT_WATER || obj->in_room->sector_type == SECT_UNDERWATER)))
 		{
-			act("The water extinguishes $p.", obj->carried_by, obj, 0, TO_CHAR);
+			act("The water extinguishes $p.", carrier, obj, 0, TO_CHAR);
 
 			if (is_affected_obj(obj, gsn_immolate))
 				affect_strip_obj(obj, gsn_immolate);
@@ -1586,14 +1599,16 @@ void obj_update(void)
 		}
 
 		/* Check explosives */
-		if (obj && obj->pIndexData->vnum == OBJ_EXPLOSIVES && obj->carried_by)
+		carrier = Deref(obj->carried_by);
+
+		if (obj && obj->pIndexData->vnum == OBJ_EXPLOSIVES && carrier)
 		{
-			bag_explode(obj->carried_by, obj, 1);
+			bag_explode(carrier, obj, 1);
 			continue;
 		}
 
 		/* Alright. Is this a cabal item? */
-		if (isCabalItem(obj) && is_npc(obj->carried_by))
+		if (isCabalItem(obj) && is_npc(Deref(obj->carried_by)))
 		{
 			obj->timer = 0;
 			continue;
@@ -1611,25 +1626,30 @@ void obj_update(void)
 				continue;
 			}
 
-			act(message, obj->carried_by, obj, nullptr, TO_CHAR);
+			// Told to whoever is holding it now, before the handover below --
+			// these two calls are what makes `carrier` unsafe to cache across
+			// the iteration.
+			act(message, Deref(obj->carried_by), obj, nullptr, TO_CHAR);
 			obj_from_char(obj);
 			obj_to_char(obj, cguard);
 			obj->timer = 0;
 			continue;
 		}
 
-		if (obj->carried_by != nullptr)
+		carrier = Deref(obj->carried_by);
+
+		if (carrier != nullptr)
 		{
-			if (is_npc(obj->carried_by) && obj->carried_by->pIndexData->pShop != nullptr)
+			if (is_npc(carrier) && carrier->pIndexData->pShop != nullptr)
 			{
-				obj->carried_by->gold++;
+				carrier->gold++;
 			}
 			else
 			{
-				act(message, obj->carried_by, obj, nullptr, TO_CHAR);
+				act(message, carrier, obj, nullptr, TO_CHAR);
 
 				if (obj->wear_loc == WEAR_FLOAT)
-					act(message, obj->carried_by, obj, nullptr, TO_ROOM);
+					act(message, carrier, obj, nullptr, TO_ROOM);
 			}
 		}
 		else if (obj->in_room != nullptr && (rch = obj->in_room->people) != nullptr)
@@ -2961,8 +2981,10 @@ void iprog_pulse_update(bool isTick)
 			}
 		}
 
+		CHAR_DATA *carrier = Deref(obj->carried_by);
+
 		if ((obj->in_room != nullptr && obj->in_room->area->nplayer > 0)
-		|| (obj->carried_by && obj->carried_by->in_room && obj->carried_by->in_room->area->nplayer > 0))
+		|| (carrier && carrier->in_room && carrier->in_room->area->nplayer > 0))
 		{
 			if (IS_SET(obj->progtypes, IPROG_PULSE))
 				(obj->pIndexData->iprogs->pulse_prog)(obj, isTick);

--- a/code/update.c
+++ b/code/update.c
@@ -902,19 +902,21 @@ void time_update(void)
 	{
 		for (d = descriptor_list; d != nullptr; d = d->next)
 		{
+			CHAR_DATA *wch = Deref(d->character);
+
 			if (d->connected == CON_PLAYING
-				&& Deref(d->character)->in_room
-				&& Deref(d->character)->in_room->sector_type != SECT_UNDERWATER
-				&& is_outside(Deref(d->character))
-				&& is_awake(Deref(d->character))
-				&& !is_editing(Deref(d->character))
-				&& !(is_affected_area(Deref(d->character)->in_room->area, gsn_whiteout))
-				&& !(is_affected_area(Deref(d->character)->in_room->area, gsn_cyclone))
-				&& !(is_affected_by(Deref(d->character), AFF_BLIND)))
+				&& wch->in_room
+				&& wch->in_room->sector_type != SECT_UNDERWATER
+				&& is_outside(wch)
+				&& is_awake(wch)
+				&& !is_editing(wch)
+				&& !(is_affected_area(wch->in_room->area, gsn_whiteout))
+				&& !(is_affected_area(wch->in_room->area, gsn_cyclone))
+				&& !(is_affected_by(wch, AFF_BLIND)))
 			{
-				colorconv(colbuf, buf, Deref(d->character));
-				send_to_char(colbuf, Deref(d->character));
-				send_to_char("\n\r", Deref(d->character));
+				colorconv(colbuf, buf, wch);
+				send_to_char(colbuf, wch);
+				send_to_char("\n\r", wch);
 			}
 		}
 	}
@@ -1250,9 +1252,11 @@ void char_update(void)
 			colorconv(buf1, "{GYou are now level 20.{x\n\r", ch);
 			send_to_char(buf1, ch);
 
-			if (Deref(ch->pet))
+			CHAR_DATA *pet = Deref(ch->pet);
+
+			if (pet)
 			{
-				sprintf(buf1, "Remember, you can ask your familiar questions.  For example, 'say %s, how do I get to my guild?'.\n\r", Deref(ch->pet)->short_descr);
+				sprintf(buf1, "Remember, you can ask your familiar questions.  For example, 'say %s, how do I get to my guild?'.\n\r", pet->short_descr);
 				send_to_char(buf1, ch);
 			}
 		}
@@ -3070,7 +3074,7 @@ bool do_mob_cast(CHAR_DATA *ch)
 	{
 		for (victim = ch->in_room->people; victim != nullptr; victim = victim->next_in_room)
 		{
-			if (victim && !is_npc(victim) && Deref(victim->fighting) && Deref(victim->fighting) == ch)
+			if (victim && !is_npc(victim) && Deref(victim->fighting) == ch)
 				in_room++;
 		}
 

--- a/code/update.c
+++ b/code/update.c
@@ -1250,9 +1250,9 @@ void char_update(void)
 			colorconv(buf1, "{GYou are now level 20.{x\n\r", ch);
 			send_to_char(buf1, ch);
 
-			if (ch->pet)
+			if (Deref(ch->pet))
 			{
-				sprintf(buf1, "Remember, you can ask your familiar questions.  For example, 'say %s, how do I get to my guild?'.\n\r", ch->pet->short_descr);
+				sprintf(buf1, "Remember, you can ask your familiar questions.  For example, 'say %s, how do I get to my guild?'.\n\r", Deref(ch->pet)->short_descr);
 				send_to_char(buf1, ch);
 			}
 		}

--- a/code/update.c
+++ b/code/update.c
@@ -903,18 +903,18 @@ void time_update(void)
 		for (d = descriptor_list; d != nullptr; d = d->next)
 		{
 			if (d->connected == CON_PLAYING
-				&& d->character->in_room
-				&& d->character->in_room->sector_type != SECT_UNDERWATER
-				&& is_outside(d->character)
-				&& is_awake(d->character)
-				&& !is_editing(d->character)
-				&& !(is_affected_area(d->character->in_room->area, gsn_whiteout))
-				&& !(is_affected_area(d->character->in_room->area, gsn_cyclone))
-				&& !(is_affected_by(d->character, AFF_BLIND)))
+				&& Deref(d->character)->in_room
+				&& Deref(d->character)->in_room->sector_type != SECT_UNDERWATER
+				&& is_outside(Deref(d->character))
+				&& is_awake(Deref(d->character))
+				&& !is_editing(Deref(d->character))
+				&& !(is_affected_area(Deref(d->character)->in_room->area, gsn_whiteout))
+				&& !(is_affected_area(Deref(d->character)->in_room->area, gsn_cyclone))
+				&& !(is_affected_by(Deref(d->character), AFF_BLIND)))
 			{
-				colorconv(colbuf, buf, d->character);
-				send_to_char(colbuf, d->character);
-				send_to_char("\n\r", d->character);
+				colorconv(colbuf, buf, Deref(d->character));
+				send_to_char(colbuf, Deref(d->character));
+				send_to_char("\n\r", Deref(d->character));
 			}
 		}
 	}

--- a/code/utility.c
+++ b/code/utility.c
@@ -513,7 +513,9 @@ char* pers (CHAR_DATA *ch, CHAR_DATA *looker)
 	if (can_see(looker, ch) && !is_affected(looker, gsn_plasma_arc))
 		return is_npc(ch) ? ch->short_descr : ch->name;
 
-	if (is_immortal(ch) && !is_npc(ch) && ch->invis_level > 50 && (!ch->desc || !Deref(ch->desc->original)))
+	DESCRIPTOR_DATA *connection = Deref(ch->desc);
+
+	if (is_immortal(ch) && !is_npc(ch) && ch->invis_level > 50 && (!connection || !Deref(connection->original)))
 		return "An Immortal";
 
 	return "someone";
@@ -525,5 +527,7 @@ bool is_switched (CHAR_DATA *ch)
 	if (ch == nullptr)
 		return false;
 
-	return ch->desc && Deref(ch->desc->original);	// ROM OLC
+	DESCRIPTOR_DATA *connection = Deref(ch->desc);
+
+	return connection && Deref(connection->original);	// ROM OLC
 }

--- a/code/utility.c
+++ b/code/utility.c
@@ -513,7 +513,7 @@ char* pers (CHAR_DATA *ch, CHAR_DATA *looker)
 	if (can_see(looker, ch) && !is_affected(looker, gsn_plasma_arc))
 		return is_npc(ch) ? ch->short_descr : ch->name;
 
-	if (is_immortal(ch) && !is_npc(ch) && ch->invis_level > 50 && (!ch->desc || !ch->desc->original))
+	if (is_immortal(ch) && !is_npc(ch) && ch->invis_level > 50 && (!ch->desc || !Deref(ch->desc->original)))
 		return "An Immortal";
 
 	return "someone";
@@ -525,5 +525,5 @@ bool is_switched (CHAR_DATA *ch)
 	if (ch == nullptr)
 		return false;
 
-	return ch->desc && ch->desc->original;	// ROM OLC
+	return ch->desc && Deref(ch->desc->original);	// ROM OLC
 }

--- a/code/vote.c
+++ b/code/vote.c
@@ -260,7 +260,7 @@ void do_vote(CHAR_DATA *ch, char *argument)
 		vote.vote_for = arg1;
 		vote.cabal = ch->cabal;
 		vote.time = current_time;
-		vote.host = ch->pcdata->host ? ch->pcdata->host : ch->desc->host;
+		vote.host = ch->pcdata->host ? ch->pcdata->host : Deref(ch->desc)->host;
 
 		votes.Add(vote);
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -33,6 +33,7 @@ set(TEST_SRC_FILES act_obj_tests.c
 	player_tests.c
 	prof_tests.c
 	queue_tests.c
+	rune_tests.c
 	theft_tests.c
 	vote_tests.c
 	utility_tests.c

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -29,6 +29,7 @@ set(TEST_SRC_FILES act_obj_tests.c
 	sitecomment_tests.c
 	sitetracker_tests.c
 	graveyard_tests.c
+	handle_tests.c
 	player_tests.c
 	prof_tests.c
 	queue_tests.c

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -24,6 +24,7 @@ set(TEST_SRC_FILES act_obj_tests.c
 	magic_tests.c
 	mprog_tests.c
 	note_tests.c
+	pathfind_tests.c
 	offering_tests.c
 	pklog_tests.c
 	sitecomment_tests.c

--- a/tests/act_obj_tests.c
+++ b/tests/act_obj_tests.c
@@ -1,4 +1,5 @@
 #include "catch.hpp"
+#include "../code/entity/handles.h"
 #include "../code/act_obj.h"
 #include "../code/merc.h"
 #include "../code/handler.h"
@@ -44,6 +45,7 @@ void TestHelperSetPlayerStats(char_data *player, short value)
 char_data* TestHelperCreateNPC()
 {
 	auto npc = new char_data();
+	npc->self = charHandles.Add(npc);	// as new_char would
 	SET_BIT(npc->act, ACT_IS_NPC);
 	npc->pIndexData = new mob_index_data();
 	return npc;
@@ -69,6 +71,7 @@ void TestHelperLoadCClass()
 char_data* TestHelperCreatePlayer(char *name, obj_data *item = nullptr)
 {
 	auto player = new char_data();
+	player->self = charHandles.Add(player);	// as new_char would
 	player->name = name;
 	auto dnew = new descriptor_data();
 	player->pcdata = std::make_unique<pc_data>();
@@ -112,6 +115,7 @@ room_index_data* TestHelperCreateRoom()
 obj_data* TestHelperCreateItem(char *itemName = "broken_lamp", int cost = 0)
 {
 	auto item = new obj_data();
+	item->self = objectHandles.Add(item);	// as new_obj would
 	item->name = itemName;
 	item->cost = cost;
 	item->wear_loc = -1;

--- a/tests/act_obj_tests.c
+++ b/tests/act_obj_tests.c
@@ -74,6 +74,7 @@ char_data* TestHelperCreatePlayer(char *name, obj_data *item = nullptr)
 	player->self = charHandles.Add(player);	// as new_char would
 	player->name = name;
 	auto dnew = new descriptor_data();
+	dnew->self = descriptorHandles.Add(dnew);	// as new_descriptor would
 	player->pcdata = std::make_unique<pc_data>();
 	TestHelperLoadCClass();
 	player->SetClass(5);
@@ -86,7 +87,7 @@ char_data* TestHelperCreatePlayer(char *name, obj_data *item = nullptr)
 	dnew->editor = 0;	  /* OLC */
 	dnew->outbuf = new char[dnew->outsize];
 	dnew->outtop = 0;	
-	player->desc = dnew;
+	player->desc = dnew->self;
 
 	if(item != nullptr)
 		obj_to_char(item, player);
@@ -222,7 +223,7 @@ SCENARIO("testing selling to merchants", "[do_sell]")
 
 			do_sell(player1, arg);
 			auto expected = "Sell what?";
-			auto actual = player1->desc->outbuf;
+			auto actual = Deref(player1->desc)->outbuf;
 			THEN("do_sell should return after notifying the player and rejecting the command.")
 			{
 				REQUIRE(strstr(actual,expected) != nullptr);
@@ -237,7 +238,7 @@ SCENARIO("testing selling to merchants", "[do_sell]")
 			TestHelperAddPlayerToRoom(player, room);
 			do_sell(player, arg);
 			auto expected = "Sell to whom? Yourself?";
-			auto actual = player->desc->outbuf;
+			auto actual = Deref(player->desc)->outbuf;
 
 			THEN("do_sell should return after notifying the player and rejecting the command.")
 			{
@@ -256,7 +257,7 @@ SCENARIO("testing selling to merchants", "[do_sell]")
 			
 			do_sell(player, arg);
 			auto expected = "You cannot sell what you do not have.";
-			auto actual = player->desc->outbuf;
+			auto actual = Deref(player->desc)->outbuf;
 
 			THEN("do_sell should return after notifying the player and rejecting the command.")
 			{
@@ -294,7 +295,7 @@ SCENARIO("testing selling to merchants", "[do_sell]")
 			TestHelperAddPlayerToRoom(keeper, room);
 			
 			do_sell(player, item->name);
-			auto actual = player->desc->outbuf;
+			auto actual = Deref(player->desc)->outbuf;
 			auto expected = "You would never trade for coin when coin can be taken!";
 			THEN("it should not be sold to the shopkeeper")
 			{
@@ -316,7 +317,7 @@ SCENARIO("testing selling to merchants", "[do_sell]")
 			
 			do_sell(player, item->name);
 			auto expected = "The shopkeeper haggles with you about the price - you seem poorly equipped for this.";
-			auto actual = player->desc->outbuf;
+			auto actual = Deref(player->desc)->outbuf;
 
 			THEN("it should be sold to the shopkeeper at an unskilled multiplier")
 			{
@@ -340,7 +341,7 @@ SCENARIO("testing selling to merchants", "[do_sell]")
 			
 			do_sell(player, item->name);
 			auto expected = "The shopkeeper reluctantly concedes to your final price.";
-			auto actual = player->desc->outbuf;
+			auto actual = Deref(player->desc)->outbuf;
 
 			THEN("it should be sold to the shopkeeper at a skilled multiplier")
 			{

--- a/tests/cabal_tests.c
+++ b/tests/cabal_tests.c
@@ -12,6 +12,7 @@ char_data* TestHelperCreatePlayer(char *name = "player 1")
 	player->pcdata = std::make_unique<pc_data>();
 	player->name = name;
 	auto dnew = new descriptor_data();
+	dnew->self = descriptorHandles.Add(dnew);	// as new_descriptor would
 	dnew->showstr_head = nullptr;
 	dnew->showstr_point = nullptr;
 	dnew->outsize = 2000;
@@ -20,7 +21,7 @@ char_data* TestHelperCreatePlayer(char *name = "player 1")
 	dnew->editor = 0;	  /* OLC */
 	dnew->outbuf = new char[dnew->outsize];
 	dnew->outtop = 0;	
-	player->desc = dnew;
+	player->desc = dnew->self;
 
 	return player;
 }

--- a/tests/fight_tests.c
+++ b/tests/fight_tests.c
@@ -1,7 +1,11 @@
 #include "catch.hpp"
 #include "../code/fight.h"
 #include "../code/entity/char_data.h"
+#include "../code/entity/handles.h"
 #include "../code/enums.h"
+#include "../code/handler.h"
+#include "../code/db.h"
+#include "../code/recycle.h"
 
 SCENARIO("testing updating victim position", "[update_pos]")
 {
@@ -21,5 +25,274 @@ SCENARIO("testing updating victim position", "[update_pos]")
 				delete victim;
 			}
 		}
+	}
+}
+
+//
+// ch->fighting -- what it means for the reference to go away.
+//
+// stop_fighting is the only thing that clears the field, and it is easy to
+// read it as lifetime bookkeeping because extract_char calls it. It is not.
+// Of its ~70 callers exactly one -- extract_char -- is about death. The rest
+// leave both characters completely alive: fleeing, `stop`, a wiznet freeze, a
+// mob submerging, a spell breaking combat. So the rule it encodes is "the
+// fight ended", which is a question about combat state, not about whether the
+// other character still exists.
+//
+// These pin that behavior, because it is the specification against which any
+// change to the field's type is judged.
+//
+// Fighting() is the single point that has to change if the field's type
+// changes; every assertion below is written through it and stays as-is.
+//
+
+namespace
+{
+	CHAR_DATA *Fighting(CHAR_DATA *ch)
+	{
+		return Deref(ch->fighting);
+	}
+
+	/// stop_fighting walks char_list, so a character has to be on it to be
+	/// reached at all. Characters come from new_char so that they are
+	/// registered in the slot map and their liveness is a thing a test can
+	/// assert on.
+	CHAR_DATA *MakeCombatant()
+	{
+		CHAR_DATA *ch = new_char();
+		ch->hit = 100;
+		ch->position = POS_FIGHTING;
+
+		ch->next = char_list;
+		char_list = ch;
+
+		return ch;
+	}
+
+	void ClearCombatants()
+	{
+		CHAR_DATA *next;
+
+		for (CHAR_DATA *ch = char_list; ch != nullptr; ch = next)
+		{
+			next = ch->next;
+			free_char(ch);
+		}
+
+		char_list = nullptr;
+	}
+}
+
+SCENARIO("stop_fighting with fBoth ends the fight on both sides", "[stop_fighting]")
+{
+	GIVEN("two characters fighting each other")
+	{
+		CHAR_DATA *ch = MakeCombatant();
+		CHAR_DATA *victim = MakeCombatant();
+
+		ch->fighting = victim->self;
+		victim->fighting = ch->self;
+
+		WHEN("one of them stops fighting with fBoth set")
+		{
+			stop_fighting(ch, true);
+
+			THEN("neither is fighting any more")
+			{
+				REQUIRE(Fighting(ch) == nullptr);
+				REQUIRE(Fighting(victim) == nullptr);
+			}
+
+			THEN("both are still perfectly live characters")
+			{
+				// This is the whole reason the clear cannot be replaced by a
+				// liveness check: nobody died, the fight just ended.
+				REQUIRE(ch->valid);
+				REQUIRE(victim->valid);
+				REQUIRE(Deref(ch->self) == ch);
+				REQUIRE(Deref(victim->self) == victim);
+			}
+		}
+
+		ClearCombatants();
+	}
+}
+
+SCENARIO("stop_fighting without fBoth clears only the character named", "[stop_fighting]")
+{
+	GIVEN("two characters fighting each other")
+	{
+		CHAR_DATA *ch = MakeCombatant();
+		CHAR_DATA *victim = MakeCombatant();
+
+		ch->fighting = victim->self;
+		victim->fighting = ch->self;
+
+		WHEN("one of them stops fighting with fBoth clear")
+		{
+			stop_fighting(ch, false);
+
+			THEN("the other keeps swinging at it")
+			{
+				// The asymmetry is load-bearing: this is how a character
+				// disengages while remaining a target.
+				REQUIRE(Fighting(ch) == nullptr);
+				REQUIRE(Fighting(victim) == ch);
+			}
+		}
+
+		ClearCombatants();
+	}
+}
+
+SCENARIO("stop_fighting leaves a fight it is not part of alone", "[stop_fighting]")
+{
+	GIVEN("two separate fights in progress")
+	{
+		CHAR_DATA *ch = MakeCombatant();
+		CHAR_DATA *victim = MakeCombatant();
+		CHAR_DATA *bystander = MakeCombatant();
+		CHAR_DATA *itsTarget = MakeCombatant();
+
+		ch->fighting = victim->self;
+		victim->fighting = ch->self;
+		bystander->fighting = itsTarget->self;
+		itsTarget->fighting = bystander->self;
+
+		WHEN("the first fight is stopped")
+		{
+			stop_fighting(ch, true);
+
+			THEN("the unrelated fight is untouched")
+			{
+				REQUIRE(Fighting(bystander) == itsTarget);
+				REQUIRE(Fighting(itsTarget) == bystander);
+			}
+		}
+
+		ClearCombatants();
+	}
+}
+
+SCENARIO("stop_fighting puts everyone it clears back on their feet", "[stop_fighting]")
+{
+	GIVEN("two characters fighting each other")
+	{
+		CHAR_DATA *ch = MakeCombatant();
+		CHAR_DATA *victim = MakeCombatant();
+
+		ch->fighting = victim->self;
+		victim->fighting = ch->self;
+
+		WHEN("the fight is stopped on both sides")
+		{
+			stop_fighting(ch, true);
+
+			THEN("both are standing rather than still in a fighting stance")
+			{
+				REQUIRE(ch->position == POS_STANDING);
+				REQUIRE(victim->position == POS_STANDING);
+			}
+		}
+
+		ClearCombatants();
+	}
+}
+
+SCENARIO("stop_fighting strips entwine from everyone it clears", "[stop_fighting]")
+{
+	GIVEN("two characters fighting each other, both entwined")
+	{
+		CHAR_DATA *ch = MakeCombatant();
+		CHAR_DATA *victim = MakeCombatant();
+
+		ch->fighting = victim->self;
+		victim->fighting = ch->self;
+
+		for (CHAR_DATA *each : {ch, victim})
+		{
+			AFFECT_DATA af;
+			init_affect(&af);
+			af.type = gsn_entwine;
+			af.where = TO_AFFECTS;
+			af.duration = 5;
+			affect_to_char(each, &af);
+		}
+
+		REQUIRE(is_affected(ch, gsn_entwine) == true);
+		REQUIRE(is_affected(victim, gsn_entwine) == true);
+
+		WHEN("the fight is stopped on both sides")
+		{
+			stop_fighting(ch, true);
+
+			THEN("neither is entwined any more")
+			{
+				// Being held in place is a property of the fight, so it goes
+				// when the fight does -- for the attacker as well as the
+				// character stop_fighting was called on.
+				REQUIRE(is_affected(ch, gsn_entwine) == false);
+				REQUIRE(is_affected(victim, gsn_entwine) == false);
+			}
+		}
+
+		ClearCombatants();
+	}
+}
+
+SCENARIO("stop_fighting reaches only characters on char_list", "[stop_fighting]")
+{
+	GIVEN("an attacker that is not on the global character list")
+	{
+		CHAR_DATA *ch = MakeCombatant();
+		CHAR_DATA *offList = new_char();
+		offList->hit = 100;
+		offList->fighting = ch->self;
+
+		WHEN("the character it is attacking stops fighting with fBoth set")
+		{
+			stop_fighting(ch, true);
+
+			THEN("the off-list attacker still refers to it")
+			{
+				// Documents the mechanism's reach rather than a reachable game
+				// state: the sweep is over char_list, so anything not on that
+				// list keeps its reference. That is exactly the gap a handle
+				// closes, and it is why the field's type matters.
+				REQUIRE(Fighting(offList) == ch);
+			}
+		}
+
+		free_char(offList);
+		ClearCombatants();
+	}
+}
+
+SCENARIO("a reference to a freed opponent reads as nothing", "[stop_fighting]")
+{
+	GIVEN("an attacker whose target the sweep cannot reach")
+	{
+		CHAR_DATA *attacker = MakeCombatant();
+		CHAR_DATA *target = new_char();
+
+		attacker->fighting = target->self;
+
+		REQUIRE(Fighting(attacker) == target);
+
+		WHEN("the target is freed without any scrub running")
+		{
+			// The counterpart to the test above: that one shows the sweep's
+			// reach ends at char_list, this one shows what now covers the gap.
+			// A raw pointer here was a reference into a character struct that
+			// the free list can hand straight back out to the next new_char.
+			free_char(target);
+
+			THEN("the reference reads as nothing rather than as recycled memory")
+			{
+				REQUIRE(Fighting(attacker) == nullptr);
+			}
+		}
+
+		ClearCombatants();
 	}
 }

--- a/tests/fight_tests.c
+++ b/tests/fight_tests.c
@@ -107,8 +107,6 @@ SCENARIO("stop_fighting with fBoth ends the fight on both sides", "[stop_fightin
 			{
 				// This is the whole reason the clear cannot be replaced by a
 				// liveness check: nobody died, the fight just ended.
-				REQUIRE(ch->valid);
-				REQUIRE(victim->valid);
 				REQUIRE(Deref(ch->self) == ch);
 				REQUIRE(Deref(victim->self) == victim);
 			}

--- a/tests/handle_tests.c
+++ b/tests/handle_tests.c
@@ -157,6 +157,30 @@ TEST_CASE("assigning nullptr clears a handle", "[handle]")
 }
 
 //
+// The distinction the deleted `operator==(nullptr_t)` protects. Assigning
+// nullptr has to keep working, which means the converting constructor has to
+// exist, which would otherwise make `handle == nullptr` compile and answer a
+// different question than the raw-pointer null check it replaced.
+//
+TEST_CASE("a handle to a freed entity is not null, but derefs to null", "[handle]")
+{
+	SlotMap<Widget> map;
+	Widget widget;
+
+	auto handle = map.Add(&widget);
+	map.Remove(handle);
+
+	// "Was never assigned" and "no longer resolves" are different states, and
+	// only the second one is what a null check on the old raw pointer meant.
+	REQUIRE(!handle.IsNull());
+	REQUIRE(map.Deref(handle) == nullptr);
+
+	// So these two disagree, which is why asking the wrong one is a compile
+	// error rather than a silent wrong answer.
+	REQUIRE(handle.IsNull() != (map.Deref(handle) == nullptr));
+}
+
+//
 // Removing something twice is a silent no-op today (`if (!(p && p->valid))
 // return;` in the free_X functions). Preserve that: the second Remove must not
 // bump the generation again, or it would burn a generation per stray call.

--- a/tests/handle_tests.c
+++ b/tests/handle_tests.c
@@ -181,9 +181,10 @@ TEST_CASE("a handle to a freed entity is not null, but derefs to null", "[handle
 }
 
 //
-// Removing something twice is a silent no-op today (`if (!(p && p->valid))
-// return;` in the free_X functions). Preserve that: the second Remove must not
-// bump the generation again, or it would burn a generation per stray call.
+// Removing something twice is a silent no-op, which the free_X functions now
+// depend on directly: their double-free guard *is* `Deref(p->self) != p`, so
+// the second Remove must not bump the generation again or it would burn a
+// generation per stray call.
 //
 TEST_CASE("removing an already-expired handle is a no-op", "[handle]")
 {

--- a/tests/handle_tests.c
+++ b/tests/handle_tests.c
@@ -1,0 +1,339 @@
+#include <cstring>
+#include <limits>
+#include <type_traits>
+#include <vector>
+
+#include "catch.hpp"
+#include "../code/stdlibs/handle.h"
+
+//
+// These tests are deliberately standalone: nothing here touches CHAR_DATA,
+// OBJ_DATA or the game at all. The point is to pin down the handle semantics
+// on their own terms before any entity depends on them.
+//
+// The entity type below stands in for a recycled game struct. The only thing
+// that matters is that it is an ordinary struct the slot map does not own.
+//
+
+namespace
+{
+	struct Widget
+	{
+		int id = 0;
+	};
+
+	// A slot map with an 8-bit generation counter. Identical behavior to the
+	// production uint32_t width, but a generation counter that can actually be
+	// exhausted inside a test.
+	using NarrowMap = SlotMap<Widget, unsigned char>;
+	using NarrowHandle = Handle<Widget, unsigned char>;
+}
+
+TEST_CASE("a default-constructed handle is null and derefs to nothing", "[handle]")
+{
+	SlotMap<Widget> map;
+	Handle<Widget> handle;
+
+	REQUIRE(handle.IsNull());
+	REQUIRE(map.Deref(handle) == nullptr);
+	REQUIRE(!map.IsLive(handle));
+}
+
+//
+// This is the property that makes handles safe to embed in the recycled entity
+// structs. Those structs are routinely reset by value-initializing a fresh
+// temporary over them, and a few places still clear memory wholesale. Both
+// produce all-zero bytes, so all-zero MUST mean "null", never "slot 0,
+// generation 0". Generation 0 is reserved for exactly this reason.
+//
+TEST_CASE("an all-zero handle is null, so zeroing a struct clears it", "[handle]")
+{
+	SlotMap<Widget> map;
+	Widget widget;
+
+	auto handle = map.Add(&widget);
+	REQUIRE(!handle.IsNull());
+
+	std::memset(&handle, 0, sizeof(handle));
+
+	REQUIRE(handle.IsNull());
+	REQUIRE(map.Deref(handle) == nullptr);
+}
+
+TEST_CASE("a handle derefs to the entity it was made from", "[handle]")
+{
+	SlotMap<Widget> map;
+	Widget first{11};
+	Widget second{22};
+
+	auto firstHandle = map.Add(&first);
+	auto secondHandle = map.Add(&second);
+
+	REQUIRE(map.Deref(firstHandle) == &first);
+	REQUIRE(map.Deref(secondHandle) == &second);
+	REQUIRE(map.Deref(firstHandle)->id == 11);
+	REQUIRE(map.Deref(secondHandle)->id == 22);
+	REQUIRE(firstHandle != secondHandle);
+}
+
+TEST_CASE("removing an entity expires its handle", "[handle]")
+{
+	SlotMap<Widget> map;
+	Widget widget{7};
+
+	auto handle = map.Add(&widget);
+	REQUIRE(map.IsLive(handle));
+
+	map.Remove(handle);
+
+	REQUIRE(!map.IsLive(handle));
+	REQUIRE(map.Deref(handle) == nullptr);
+
+	// The entity itself is untouched -- the slot map never owned it.
+	REQUIRE(widget.id == 7);
+}
+
+//
+// The reason this whole mechanism exists. new_char() hands back recycled
+// addresses, so a raw back-reference to a dead character can silently start
+// pointing at whichever character next lands on that address. A stale handle
+// must expire instead -- it must never resolve to the slot's new occupant.
+//
+TEST_CASE("a stale handle does not resolve to the entity that reuses its slot", "[handle]")
+{
+	SlotMap<Widget> map;
+	Widget original{1};
+	Widget replacement{2};
+
+	auto staleHandle = map.Add(&original);
+	map.Remove(staleHandle);
+
+	auto freshHandle = map.Add(&replacement);
+
+	// The slot was genuinely recycled -- this is not passing by accident.
+	REQUIRE(map.SlotCount() == 1);
+	REQUIRE(staleHandle != freshHandle);
+
+	REQUIRE(map.Deref(staleHandle) == nullptr);
+	REQUIRE(map.Deref(freshHandle) == &replacement);
+}
+
+TEST_CASE("handles compare by identity, including a handle to itself", "[handle]")
+{
+	SlotMap<Widget> map;
+	Widget first;
+	Widget second;
+
+	auto firstHandle = map.Add(&first);
+	auto copyOfFirst = firstHandle;
+	auto secondHandle = map.Add(&second);
+
+	REQUIRE(firstHandle == copyOfFirst);
+	REQUIRE(firstHandle != secondHandle);
+
+	// A follower whose leader is itself is load-bearing game logic, not a
+	// dangling reference: self-comparison must hold and must stay live.
+	REQUIRE(map.Deref(firstHandle) == map.Deref(copyOfFirst));
+	REQUIRE(map.IsLive(copyOfFirst));
+
+	Handle<Widget> nullHandle;
+	Handle<Widget> anotherNullHandle;
+	REQUIRE(nullHandle == anotherNullHandle);
+	REQUIRE(nullHandle != firstHandle);
+}
+
+TEST_CASE("assigning nullptr clears a handle", "[handle]")
+{
+	SlotMap<Widget> map;
+	Widget widget;
+
+	auto handle = map.Add(&widget);
+	REQUIRE(!handle.IsNull());
+
+	handle = nullptr;
+
+	REQUIRE(handle.IsNull());
+	REQUIRE(map.Deref(handle) == nullptr);
+}
+
+//
+// Removing something twice is a silent no-op today (`if (!(p && p->valid))
+// return;` in the free_X functions). Preserve that: the second Remove must not
+// bump the generation again, or it would burn a generation per stray call.
+//
+TEST_CASE("removing an already-expired handle is a no-op", "[handle]")
+{
+	SlotMap<Widget> map;
+	Widget widget;
+	Widget replacement;
+
+	auto handle = map.Add(&widget);
+	map.Remove(handle);
+	map.Remove(handle);
+	map.Remove(handle);
+
+	REQUIRE(map.LiveCount() == 0);
+	REQUIRE(map.SlotCount() == 1);
+
+	auto freshHandle = map.Add(&replacement);
+	REQUIRE(map.Deref(freshHandle) == &replacement);
+	REQUIRE(map.Deref(handle) == nullptr);
+}
+
+TEST_CASE("a handle with an out-of-range slot derefs to nothing", "[handle]")
+{
+	SlotMap<Widget> map;
+	Widget widget;
+
+	auto handle = map.Add(&widget);
+	auto garbage = handle;
+
+	std::memset(&garbage, 0xFF, sizeof(garbage));
+
+	REQUIRE(map.Deref(garbage) == nullptr);
+	REQUIRE(!map.IsLive(garbage));
+
+	// The real handle is unaffected.
+	REQUIRE(map.Deref(handle) == &widget);
+}
+
+TEST_CASE("adding null is rejected rather than occupying a slot", "[handle]")
+{
+	SlotMap<Widget> map;
+
+	auto handle = map.Add(nullptr);
+
+	REQUIRE(handle.IsNull());
+	REQUIRE(map.SlotCount() == 0);
+	REQUIRE(map.LiveCount() == 0);
+}
+
+TEST_CASE("freed slots are reused rather than growing the map", "[handle]")
+{
+	SlotMap<Widget> map;
+	std::vector<Widget> widgets(4);
+	std::vector<Handle<Widget>> handles;
+
+	for (auto &widget : widgets)
+		handles.push_back(map.Add(&widget));
+
+	REQUIRE(map.SlotCount() == 4);
+	REQUIRE(map.LiveCount() == 4);
+
+	map.Remove(handles[1]);
+	map.Remove(handles[2]);
+
+	REQUIRE(map.LiveCount() == 2);
+	REQUIRE(map.SlotCount() == 4);
+
+	Widget extra;
+	auto extraHandle = map.Add(&extra);
+
+	REQUIRE(map.SlotCount() == 4);
+	REQUIRE(map.LiveCount() == 3);
+	REQUIRE(map.Deref(extraHandle) == &extra);
+
+	// The survivors are untouched by all the churn around them.
+	REQUIRE(map.Deref(handles[0]) == &widgets[0]);
+	REQUIRE(map.Deref(handles[3]) == &widgets[3]);
+	REQUIRE(map.Deref(handles[1]) == nullptr);
+	REQUIRE(map.Deref(handles[2]) == nullptr);
+}
+
+//
+// The one failure mode a generational handle can still have: if a slot's
+// generation counter wraps, an ancient handle can start resolving to a live
+// entity -- the wrong one. Silent, and no sanitizer catches it. The fix is to
+// retire a slot permanently once its counter is spent rather than reissue a
+// colliding generation, so the miss stays a miss forever.
+//
+TEST_CASE("a slot is retired rather than wrapping its generation", "[handle]")
+{
+	NarrowMap map;
+	Widget widget;
+
+	NarrowHandle firstHandle = map.Add(&widget);
+
+	// Churn the single slot until its generation counter is spent. The bound
+	// is deliberate: an implementation that never retires the slot should fail
+	// an assertion here rather than spin forever.
+	const int recycleLimit = 4 * (std::numeric_limits<unsigned char>::max() + 1);
+	int recycles = 0;
+
+	NarrowHandle handle = firstHandle;
+	while (map.SlotCount() == 1 && recycles < recycleLimit)
+	{
+		map.Remove(handle);
+		handle = map.Add(&widget);
+		recycles++;
+	}
+
+	REQUIRE(recycles < recycleLimit);
+
+	// The slot was retired instead of reissuing firstHandle's generation.
+	REQUIRE(map.SlotCount() == 2);
+	REQUIRE(map.LiveCount() == 1);
+	REQUIRE(handle != firstHandle);
+	REQUIRE(map.Deref(firstHandle) == nullptr);
+	REQUIRE(map.Deref(handle) == &widget);
+
+	// And the retired slot stays retired -- it is never handed out again.
+	map.Remove(handle);
+	Widget another;
+	auto laterHandle = map.Add(&another);
+
+	REQUIRE(laterHandle != firstHandle);
+	REQUIRE(map.Deref(firstHandle) == nullptr);
+}
+
+TEST_CASE("every handle ever issued by a map stays distinct from every other", "[handle]")
+{
+	NarrowMap map;
+	std::vector<NarrowHandle> issued;
+	std::vector<Widget> widgets(3);
+
+	// Enough churn to exhaust and retire several slots.
+	for (int round = 0; round < 400; round++)
+	{
+		std::vector<NarrowHandle> live;
+
+		for (auto &widget : widgets)
+		{
+			auto handle = map.Add(&widget);
+			issued.push_back(handle);
+			live.push_back(handle);
+		}
+
+		for (auto handle : live)
+			map.Remove(handle);
+	}
+
+	REQUIRE(map.LiveCount() == 0);
+
+	// Repopulate, so the assertion below is about collision and not merely
+	// about an empty map. Every issued handle above has been removed, so none
+	// of them may resolve to any of these -- a wrapped generation is exactly
+	// how one would.
+	std::vector<Widget> survivors(8);
+	for (auto &widget : survivors)
+		map.Add(&widget);
+
+	REQUIRE(map.LiveCount() == 8);
+
+	for (auto handle : issued)
+		REQUIRE(map.Deref(handle) == nullptr);
+}
+
+//
+// Handles are stored inside the recycled entity structs, which are copied and
+// value-initialized wholesale. They must stay cheap and trivial to keep that
+// legal, and small enough that swapping a raw pointer for a handle does not
+// grow the structs.
+//
+TEST_CASE("a handle is a trivially copyable 64-bit value", "[handle]")
+{
+	REQUIRE(sizeof(Handle<Widget>) == 8);
+	REQUIRE(std::is_trivially_copyable<Handle<Widget>>::value);
+	REQUIRE(std::is_trivially_destructible<Handle<Widget>>::value);
+	REQUIRE(std::is_standard_layout<Handle<Widget>>::value);
+}

--- a/tests/handler_tests.c
+++ b/tests/handler_tests.c
@@ -813,6 +813,67 @@ SCENARIO("a recycled character address does not resurrect an old handle", "[hand
 	}
 }
 
+SCENARIO("freeing a character twice is a silent no-op", "[handles]")
+{
+	GIVEN("a character that has already been freed")
+	{
+		CHAR_DATA *ch = new_char();
+
+		free_char(ch);
+
+		WHEN("it is freed again, as the old `valid` bool used to allow")
+		{
+			// This is the half of `valid` that was never about weak references:
+			// it guarded free_char against running twice over the same struct,
+			// which would free its strings twice and put it on char_free twice.
+			// The handle answers the same question -- `Deref(ch->self) != ch`
+			// once the slot is retired -- so the bool became redundant rather
+			// than merely replaceable.
+			free_char(ch);
+
+			THEN("the character is on the free list exactly once")
+			{
+				// If the guard had failed, ch would be its own ->next and
+				// new_char would return the same address twice running.
+				CHAR_DATA *first = new_char();
+				CHAR_DATA *second = new_char();
+
+				REQUIRE(first == ch);
+				REQUIRE(second != first);
+
+				free_char(first);
+				free_char(second);
+			}
+		}
+	}
+}
+
+SCENARIO("freeing a character the slot maps never issued does nothing", "[handles]")
+{
+	GIVEN("a stack-built character, as a test factory produces")
+	{
+		CHAR_DATA ch;
+
+		WHEN("it is handed to free_char")
+		{
+			// It has a null self handle, so it never resolves to itself and the
+			// guard rejects it. The old bool did the same by being false, but
+			// only because value-initialisation happened to zero it; here it is
+			// the type's stated invariant rather than a coincidence.
+			free_char(&ch);
+
+			THEN("it is not adopted onto the free list")
+			{
+				CHAR_DATA *fresh = new_char();
+
+				REQUIRE(fresh != &ch);
+
+				free_char(fresh);
+			}
+		}
+	}
+}
+
 SCENARIO("new_obj registers an object and free_obj expires it", "[handles]")
 {
 	GIVEN("an object from new_obj")
@@ -935,7 +996,6 @@ SCENARIO("a character stops sitting on furniture that leaves the room", "[on]")
 			{
 				// This is the whole reason the clear above cannot be replaced
 				// by a liveness check: the object did not die, it moved.
-				REQUIRE(chair->valid);
 				REQUIRE(Deref(chair->self) == chair);
 			}
 		}
@@ -1152,7 +1212,6 @@ SCENARIO("a mob that gives up the hunt does not disturb the quarry", "[last_foug
 			THEN("the hunter is no longer tracking but the quarry is untouched")
 			{
 				REQUIRE(Tracking(hunter) == nullptr);
-				REQUIRE(quarry->valid);
 				REQUIRE(Deref(quarry->self) == quarry);
 			}
 		}
@@ -1268,7 +1327,6 @@ SCENARIO("the reply sweep does not disturb the character being replied to", "[re
 			THEN("the listener has no reply but the speaker is untouched")
 			{
 				REQUIRE(Replying(listener) == nullptr);
-				REQUIRE(speaker->valid);
 				REQUIRE(Deref(speaker->self) == speaker);
 			}
 		}
@@ -1404,7 +1462,6 @@ SCENARIO("die_follower detaches ordinary followers", "[follower]")
 
 			THEN("the master is still perfectly alive")
 			{
-				REQUIRE(master->valid);
 				REQUIRE(Deref(master->self) == master);
 			}
 		}
@@ -1498,7 +1555,6 @@ SCENARIO("stop_follower clears the master's pet when the pet stops following", "
 
 			THEN("the pet itself is still alive")
 			{
-				REQUIRE(pet->valid);
 				REQUIRE(Deref(pet->self) == pet);
 			}
 		}
@@ -1954,7 +2010,6 @@ SCENARIO("losing the link leaves the body in the world", "[chdesc]")
 			THEN("the body is still alive and simply has no connection")
 			{
 				REQUIRE(Connection(player) == nullptr);
-				REQUIRE(player->valid);
 				REQUIRE(Deref(player->self) == player);
 			}
 		}
@@ -2099,7 +2154,6 @@ SCENARIO("a slain player is still in the world, so extract_char is not a lifetim
 
 			THEN("the opponent is still alive")
 			{
-				REQUIRE(opponent->valid);
 				REQUIRE(Deref(opponent->self) == opponent);
 			}
 
@@ -2252,7 +2306,6 @@ SCENARIO("a slain player is still trustworthy as far as the world is concerned",
 
 			THEN("the trusted player is still alive")
 			{
-				REQUIRE(trusted->valid);
 				REQUIRE(Deref(trusted->self) == trusted);
 			}
 
@@ -2569,7 +2622,6 @@ SCENARIO("a slain player is still in the world, so their affects still name them
 
 			THEN("the caster is still alive")
 			{
-				REQUIRE(caster->valid);
 				REQUIRE(Deref(caster->self) == caster);
 			}
 

--- a/tests/handler_tests.c
+++ b/tests/handler_tests.c
@@ -2,6 +2,8 @@
 #include "../code/handler.h"
 #include "../code/entity/char_data.h"
 #include "../code/entity/obj_data.h"
+#include "../code/entity/room_index_data.h"
+#include "../code/entity/area_data.h"
 #include "../code/entity/handles.h"
 #include "../code/enums.h"
 #include "../code/db.h"
@@ -841,6 +843,183 @@ SCENARIO("an entity that never came from new_char is safe by default", "[handles
 		{
 			REQUIRE(ch->self.IsNull());
 			REQUIRE(Deref(ch->self) == nullptr);
+		}
+	}
+}
+
+//
+// ch->on -- what it means for the reference to go away.
+//
+// These pin the behavior of the two places that clear it today, because that
+// behavior is the specification against which any change is judged.
+//
+// Worth stating plainly, because it is easy to get backwards: the clear inside
+// obj_from_room is NOT lifetime bookkeeping. Nine of that function's ten
+// callers leave the object entirely alive -- a player picking it up, wind
+// blowing it to the next room, a portal being relocated. Only extract_obj is
+// about death. So the rule it encodes is "the furniture left the room", which
+// is a question about position, not about whether the object still exists.
+//
+// SittingOn is the single point that has to change if the field's type
+// changes; every assertion below is written through it and stays as-is.
+//
+
+namespace
+{
+	OBJ_DATA *SittingOn(CHAR_DATA *ch)
+	{
+		return Deref(ch->on);
+	}
+
+	ROOM_INDEX_DATA *MakeRoomForSitting()
+	{
+		auto room = new room_index_data();
+		room->area = new area_data();	// char_from_room decrements area->nplayer
+
+		return room;
+	}
+
+	void PutCharInRoomForSitting(CHAR_DATA *ch, ROOM_INDEX_DATA *room)
+	{
+		ch->in_room = room;
+		ch->next_in_room = room->people;
+		room->people = ch;
+	}
+
+	void PutObjInRoomForSitting(OBJ_DATA *obj, ROOM_INDEX_DATA *room)
+	{
+		obj->in_room = room;
+		obj->next_content = room->contents;
+		room->contents = obj;
+	}
+}
+
+SCENARIO("a character stops sitting on furniture that leaves the room", "[on]")
+{
+	GIVEN("two characters each sitting on a different object in one room")
+	{
+		auto room = MakeRoomForSitting();
+		OBJ_DATA *chair = new_obj();
+		OBJ_DATA *bench = new_obj();
+		auto sitter = new char_data();
+		auto bystander = new char_data();
+
+		PutObjInRoomForSitting(chair, room);
+		PutObjInRoomForSitting(bench, room);
+		PutCharInRoomForSitting(sitter, room);
+		PutCharInRoomForSitting(bystander, room);
+
+		sitter->on = chair->self;
+		bystander->on = bench->self;
+
+		WHEN("the chair is taken out of the room but not destroyed")
+		{
+			obj_from_room(chair);
+
+			THEN("whoever was on it no longer is")
+			{
+				REQUIRE(SittingOn(sitter) == nullptr);
+			}
+
+			THEN("someone on a different object is left alone")
+			{
+				REQUIRE(SittingOn(bystander) == bench);
+			}
+
+			THEN("the chair itself is still a perfectly live object")
+			{
+				// This is the whole reason the clear above cannot be replaced
+				// by a liveness check: the object did not die, it moved.
+				REQUIRE(chair->valid);
+				REQUIRE(Deref(chair->self) == chair);
+			}
+		}
+	}
+}
+
+SCENARIO("the on-clear reaches only the room the object left", "[on]")
+{
+	GIVEN("a character in another room referring to the object")
+	{
+		auto room = MakeRoomForSitting();
+		auto elsewhere = MakeRoomForSitting();
+		OBJ_DATA *chair = new_obj();
+		auto sitter = new char_data();
+		auto distant = new char_data();
+
+		PutObjInRoomForSitting(chair, room);
+		PutCharInRoomForSitting(sitter, room);
+		PutCharInRoomForSitting(distant, elsewhere);
+
+		sitter->on = chair->self;
+		distant->on = chair->self;
+
+		WHEN("the chair leaves the room")
+		{
+			obj_from_room(chair);
+
+			THEN("only the character in that room is cleared")
+			{
+				// Documents the mechanism's reach rather than a reachable game
+				// state: the walk is over in_room->people, so it is scoped to
+				// one room and is not a global sweep.
+				REQUIRE(SittingOn(sitter) == nullptr);
+				REQUIRE(SittingOn(distant) == chair);
+			}
+		}
+	}
+}
+
+SCENARIO("a character stops sitting on anything when it leaves the room", "[on]")
+{
+	GIVEN("a character sitting on an object")
+	{
+		auto room = MakeRoomForSitting();
+		OBJ_DATA *chair = new_obj();
+		auto sitter = new char_data();
+
+		PutObjInRoomForSitting(chair, room);
+		PutCharInRoomForSitting(sitter, room);
+		sitter->on = chair->self;
+
+		WHEN("the character leaves")
+		{
+			char_from_room(sitter);
+
+			THEN("it is no longer on anything")
+			{
+				REQUIRE(SittingOn(sitter) == nullptr);
+			}
+		}
+	}
+}
+
+SCENARIO("a character is not left pointing at furniture that was destroyed", "[on]")
+{
+	GIVEN("a character sitting on an object")
+	{
+		auto room = MakeRoomForSitting();
+		OBJ_DATA *chair = new_obj();
+		auto sitter = new char_data();
+
+		PutObjInRoomForSitting(chair, room);
+		PutCharInRoomForSitting(sitter, room);
+		sitter->on = chair->self;
+
+		REQUIRE(SittingOn(sitter) == chair);
+
+		WHEN("the object is destroyed without going through obj_from_room")
+		{
+			// obj_from_room clears the reference for anyone in the room, so it
+			// hides this case. The paths that do not run it -- extract_obj's
+			// not-found bail-out, or an object freed while held -- are the ones
+			// that used to leave a pointer into a recycled object behind.
+			free_obj(chair);
+
+			THEN("the reference reads as nothing rather than as freed memory")
+			{
+				REQUIRE(SittingOn(sitter) == nullptr);
+			}
 		}
 	}
 }

--- a/tests/handler_tests.c
+++ b/tests/handler_tests.c
@@ -2274,3 +2274,329 @@ SCENARIO("a slain player is still trustworthy as far as the world is concerned",
 		ClearTrackers();
 	}
 }
+
+//
+// The four affect `owner` fields -- AFFECT_DATA, ROOM_AFFECT_DATA,
+// AREA_AFFECT_DATA and OBJ_AFFECT_DATA.
+//
+// `owner` is "who caused this", and it is read for damage attribution, for
+// is_safe/is_same_group/is_same_cabal checks, for messaging, and in a handful
+// of places for "has the causer died". Four containers hold affects that carry
+// one -- ch->affected, room->affected, area->affected, obj->affected -- plus
+// obj->charaffs, which holds AFFECT_DATA on an object rather than a character.
+//
+// Only ONE of those five was ever scrubbed. extract_char walked char_list and
+// nulled `owner` in every ch->affected list; the room affects owned by the
+// dying character were removed outright by a second walk over
+// top_affected_room. Area affects, object affects and obj->charaffs were never
+// touched at all, so their owners simply dangled -- and free_char recycles
+// addresses, so "dangled" means "started naming whoever was allocated next".
+//
+// The two walks are not the same kind of thing, and the conversion treats them
+// differently. See the scenarios below.
+//
+
+namespace
+{
+	CHAR_DATA *AffectOwner(const AFFECT_DATA &af)
+	{
+		return Deref(af.owner);
+	}
+
+	CHAR_DATA *AffectOwner(const ROOM_AFFECT_DATA &raf)
+	{
+		return Deref(raf.owner);
+	}
+
+	CHAR_DATA *AffectOwner(const AREA_AFFECT_DATA &aaf)
+	{
+		return Deref(aaf.owner);
+	}
+
+	CHAR_DATA *AffectOwner(const OBJ_AFFECT_DATA &oaf)
+	{
+		return Deref(oaf.owner);
+	}
+
+	// The setter half of the pair. Every assignment in these scenarios goes
+	// through it for the same reason every read goes through AffectOwner: this
+	// file has to compile and run identically either side of the type flip, so
+	// the only things that may mention the field's type are these two bodies.
+	template <typename AffectT>
+	void SetAffectOwner(AffectT &af, CHAR_DATA *owner)
+	{
+		af.owner = owner->self;
+	}
+
+	AFFECT_DATA &GiveCharAffect(CHAR_DATA *victim, CHAR_DATA *owner, int type)
+	{
+		AFFECT_DATA af;
+		init_affect(&af);
+
+		af.type = static_cast<short>(type);
+		af.duration = 10;
+		SetAffectOwner(af, owner);
+
+		victim->affected.push_back(af);
+
+		return victim->affected.back();
+	}
+
+	OBJ_AFFECT_DATA &GiveObjAffect(OBJ_DATA *obj, CHAR_DATA *owner, int type)
+	{
+		OBJ_AFFECT_DATA oaf;
+		init_affect_obj(&oaf);
+
+		oaf.type = static_cast<short>(type);
+		oaf.duration = 10;
+		SetAffectOwner(oaf, owner);
+
+		obj->affected.push_back(oaf);
+
+		return obj->affected.back();
+	}
+
+	AREA_AFFECT_DATA &GiveAreaAffect(AREA_DATA *area, CHAR_DATA *owner, int type)
+	{
+		AREA_AFFECT_DATA aaf;
+		init_affect_area(&aaf);
+
+		aaf.type = static_cast<short>(type);
+		aaf.duration = 10;
+		SetAffectOwner(aaf, owner);
+
+		area->affected.push_back(aaf);
+
+		return area->affected.back();
+	}
+
+	ROOM_AFFECT_DATA &GiveRoomAffect(ROOM_INDEX_DATA *room, CHAR_DATA *owner, int type)
+	{
+		ROOM_AFFECT_DATA raf;
+		init_affect_room(&raf);
+
+		raf.type = static_cast<short>(type);
+		raf.duration = 10;
+		SetAffectOwner(raf, owner);
+
+		room->affected.push_back(raf);
+
+		// affect_to_room does this as a side effect of adding the first affect,
+		// and extract_char's second walk only visits rooms on this list.
+		if (top_affected_room != room && room->aff_next == nullptr)
+		{
+			room->aff_next = top_affected_room;
+			top_affected_room = room;
+		}
+
+		return room->affected.back();
+	}
+
+	void ClearAffectedRooms()
+	{
+		top_affected_room = nullptr;
+	}
+}
+
+SCENARIO("an affect does not remember a caster who has left the world", "[affectowner]")
+{
+	GIVEN("a mob carrying an affect cast by another")
+	{
+		auto room = MakeTrackingRoom();
+		CHAR_DATA *caster = MakeTracker(room);
+		CHAR_DATA *victim = MakeTracker(room);
+		CHAR_DATA *bystander = MakeTracker(room);
+
+		AFFECT_DATA &af = GiveCharAffect(victim, caster, 1);
+		AFFECT_DATA &unrelated = GiveCharAffect(bystander, victim, 1);
+
+		REQUIRE(AffectOwner(af) == caster);
+
+		WHEN("the caster is pulled from the world")
+		{
+			extract_char(caster, true);
+
+			THEN("the affect names nobody")
+			{
+				REQUIRE(AffectOwner(af) == nullptr);
+			}
+
+			THEN("an affect owned by somebody else is left alone")
+			{
+				REQUIRE(AffectOwner(unrelated) == victim);
+			}
+
+			THEN("it still names nobody once the address is reissued")
+			{
+				// The whole point. free_char pushes onto a free list, so the
+				// next new_char hands back the caster's address; a raw
+				// back-reference would silently start naming the newcomer.
+				CHAR_DATA *newcomer = new_char();
+
+				REQUIRE(newcomer == caster);
+				REQUIRE(AffectOwner(af) != newcomer);
+				REQUIRE(AffectOwner(af) == nullptr);
+			}
+		}
+
+		ClearTrackers();
+	}
+}
+
+SCENARIO("an object's affect does not remember a caster who has left the world", "[affectowner]")
+{
+	GIVEN("an object carrying an affect cast by a character")
+	{
+		auto room = MakeTrackingRoom();
+		CHAR_DATA *caster = MakeTracker(room);
+		OBJ_DATA *obj = new_obj();
+
+		OBJ_AFFECT_DATA &oaf = GiveObjAffect(obj, caster, 1);
+
+		REQUIRE(AffectOwner(oaf) == caster);
+
+		WHEN("the caster is pulled from the world")
+		{
+			// Nothing has ever scrubbed this one -- extract_char's walk only
+			// ever visited ch->affected -- so before the conversion the field
+			// held a freed pointer here, and named the next character to take
+			// the address.
+			extract_char(caster, true);
+
+			THEN("the affect names nobody")
+			{
+				REQUIRE(AffectOwner(oaf) == nullptr);
+			}
+
+			THEN("it still names nobody once the address is reissued")
+			{
+				CHAR_DATA *newcomer = new_char();
+
+				REQUIRE(newcomer == caster);
+				REQUIRE(AffectOwner(oaf) != newcomer);
+			}
+		}
+
+		free_obj(obj);
+		ClearTrackers();
+	}
+}
+
+SCENARIO("an area's affect does not remember a caster who has left the world", "[affectowner]")
+{
+	GIVEN("an area carrying an affect cast by a character")
+	{
+		auto room = MakeTrackingRoom();
+		CHAR_DATA *caster = MakeTracker(room);
+
+		AREA_AFFECT_DATA &aaf = GiveAreaAffect(room->area, caster, 1);
+
+		REQUIRE(AffectOwner(aaf) == caster);
+
+		WHEN("the caster is pulled from the world")
+		{
+			// Never scrubbed either, and area affects are the longest-lived of
+			// the four -- a zone-wide effect outlasts the fight that spawned it
+			// by design.
+			extract_char(caster, true);
+
+			THEN("the affect names nobody")
+			{
+				REQUIRE(AffectOwner(aaf) == nullptr);
+			}
+
+			THEN("it still names nobody once the address is reissued")
+			{
+				CHAR_DATA *newcomer = new_char();
+
+				REQUIRE(newcomer == caster);
+				REQUIRE(AffectOwner(aaf) != newcomer);
+			}
+		}
+
+		ClearTrackers();
+	}
+}
+
+SCENARIO("a room affect placed by a character dies with them", "[affectowner]")
+{
+	GIVEN("a room carrying an affect placed by a character")
+	{
+		auto room = MakeTrackingRoom();
+		CHAR_DATA *caster = MakeTracker(room);
+		CHAR_DATA *other = MakeTracker(room);
+
+		GiveRoomAffect(room, caster, 1);
+		GiveRoomAffect(room, other, 2);
+
+		REQUIRE(room->affected.size() == 2);
+
+		WHEN("the caster is pulled from the world")
+		{
+			extract_char(caster, true);
+
+			THEN("their room affect is removed outright, not merely disowned")
+			{
+				// This is the one walk in extract_char that survives the
+				// conversion, and it survives because it does not expire a
+				// reference -- it destroys the affect. A handle would leave the
+				// wall of fire burning in the room with nobody to attribute it
+				// to, and every consumer of raf->owner in act_move.c and
+				// update.c passes it straight to damage_new and is_safe.
+				REQUIRE(room->affected.size() == 1);
+				REQUIRE(AffectOwner(room->affected.front()) == other);
+			}
+		}
+
+		ClearAffectedRooms();
+		ClearTrackers();
+	}
+}
+
+SCENARIO("a slain player is still in the world, so their affects still name them", "[affectowner]")
+{
+	GIVEN("a mob carrying an affect cast by a player")
+	{
+		auto room = MakeTrackingRoom();
+		CHAR_DATA *caster = MakeNamedPlayer(room, "Alice");
+		CHAR_DATA *victim = MakeTracker(room);
+
+		AFFECT_DATA &af = GiveCharAffect(victim, caster, 1);
+
+		WHEN("the caster is extracted the way raw_kill does it, without pulling them")
+		{
+			extract_char(caster, false);
+
+			THEN("the caster is still alive")
+			{
+				REQUIRE(caster->valid);
+				REQUIRE(Deref(caster->self) == caster);
+			}
+
+			THEN("the affect still names them")
+			{
+				// This is the assertion that changes sides, and it is
+				// deliberate. extract_char's walk sat ABOVE the early return
+				// that sends a slain player to the altar without freeing them,
+				// so it nulled `owner` for a character who was still alive.
+				//
+				// Unlike last_fight_opponent and pcdata->trusting, that is not
+				// a game rule wearing lifetime clothing, and the evidence is
+				// that the readers disagree with it: update.c's mark of wrath
+				// asks `paf->owner->ghost > 0` -- literally "has my marked foe
+				// died" -- which can only be answered if `owner` still resolves
+				// after a death. The walk nulled it first, so that check was a
+				// null dereference rather than a rule. ap.c's burning_pulse
+				// (`owner->level`) and act_info.c's mark display
+				// (`af->owner->name`) are the same shape.
+				//
+				// So nothing is relocated to raw_kill for this field. The walk
+				// is deleted and the reference is left to expire on its own,
+				// which happens only when the caster is really gone.
+				REQUIRE(AffectOwner(af) == caster);
+			}
+		}
+
+		ClearTrackers();
+	}
+}

--- a/tests/handler_tests.c
+++ b/tests/handler_tests.c
@@ -1187,3 +1187,118 @@ SCENARIO("a hunter's reference to a freed quarry reads as nothing", "[last_fough
 		ClearTrackers();
 	}
 }
+
+//
+// Deref(ch->reply) -- who `reply` answers, and what clears it.
+//
+// Like last_fought, this field's expiry is genuine lifetime machinery: the
+// clear is a char_list pass written inline in extract_char, and that pass does
+// nothing else. The other two places that clear reply are game rules that
+// leave both characters alive -- do_noreply, where a player deliberately
+// closes their ears, and the wizard invis/incog commands, where cloaking drops
+// your own pending reply.
+//
+// Replying() is the single point that has to change if the field's type
+// changes; every assertion below is written through it and stays as-is.
+//
+
+namespace
+{
+	CHAR_DATA *Replying(CHAR_DATA *ch)
+	{
+		return Deref(ch->reply);
+	}
+}
+
+SCENARIO("extract_char clears every pending reply aimed at the extracted character", "[reply]")
+{
+	GIVEN("two characters holding a reply to a third and one replying elsewhere")
+	{
+		auto room = MakeTrackingRoom();
+		CHAR_DATA *speaker = MakeTracker(room);
+		CHAR_DATA *listener = MakeTracker(room);
+		CHAR_DATA *secondListener = MakeTracker(room);
+		CHAR_DATA *someoneElse = MakeTracker(room);
+		CHAR_DATA *unrelated = MakeTracker(room);
+
+		listener->reply = speaker->self;
+		secondListener->reply = speaker->self;
+		unrelated->reply = someoneElse->self;
+
+		WHEN("the speaker is extracted from the world")
+		{
+			extract_char(speaker, true);
+
+			THEN("nobody is left holding a reply to it")
+			{
+				REQUIRE(Replying(listener) == nullptr);
+				REQUIRE(Replying(secondListener) == nullptr);
+			}
+
+			THEN("a reply aimed at somebody else is left alone")
+			{
+				REQUIRE(Replying(unrelated) == someoneElse);
+			}
+		}
+
+		ClearTrackers();
+	}
+}
+
+SCENARIO("the reply sweep does not disturb the character being replied to", "[reply]")
+{
+	GIVEN("one character holding a reply to another")
+	{
+		auto room = MakeTrackingRoom();
+		CHAR_DATA *speaker = MakeTracker(room);
+		CHAR_DATA *listener = MakeTracker(room);
+
+		listener->reply = speaker->self;
+
+		WHEN("the listener drops the reply rather than the speaker dying")
+		{
+			// The other half of the contract, and the reason the clears
+			// outside extract_char stay: this one says "stop answering them",
+			// not "they are gone".
+			listener->reply = nullptr;
+
+			THEN("the listener has no reply but the speaker is untouched")
+			{
+				REQUIRE(Replying(listener) == nullptr);
+				REQUIRE(speaker->valid);
+				REQUIRE(Deref(speaker->self) == speaker);
+			}
+		}
+
+		ClearTrackers();
+	}
+}
+
+SCENARIO("a reply to a freed character reads as nothing", "[reply]")
+{
+	GIVEN("one character holding a reply to another")
+	{
+		auto room = MakeTrackingRoom();
+		CHAR_DATA *speaker = MakeTracker(room);
+		CHAR_DATA *listener = MakeTracker(room);
+
+		listener->reply = speaker->self;
+
+		REQUIRE(Replying(listener) == speaker);
+
+		WHEN("the speaker is freed without extract_char's sweep running")
+		{
+			// That sweep is gone now, so this is the only thing standing
+			// between `reply` and a pointer into a character struct the free
+			// list can hand straight back out to the next new_char.
+			free_char(speaker);
+
+			THEN("the reference reads as nothing rather than as recycled memory")
+			{
+				REQUIRE(Replying(listener) == nullptr);
+			}
+		}
+
+		ClearTrackers();
+	}
+}

--- a/tests/handler_tests.c
+++ b/tests/handler_tests.c
@@ -4,6 +4,8 @@
 #include "../code/entity/obj_data.h"
 #include "../code/entity/room_index_data.h"
 #include "../code/entity/area_data.h"
+#include "../code/entity/mob_index_data.h"
+#include "../code/macros.h"
 #include "../code/entity/handles.h"
 #include "../code/enums.h"
 #include "../code/db.h"
@@ -1021,5 +1023,167 @@ SCENARIO("a character is not left pointing at furniture that was destroyed", "[o
 				REQUIRE(SittingOn(sitter) == nullptr);
 			}
 		}
+	}
+}
+
+//
+// Deref(ch->last_fought) -- the mob hunt target, and what clears it.
+//
+// Unlike ch->on and ch->fighting, this field's scrub really is lifetime
+// machinery. The clear that matters lives inside extract_char itself, under a
+// "remove all tracking" comment, and extract_char is only ever reached when a
+// character is leaving the world for good. Every other place that clears
+// last_fought is a mob deciding to give up the hunt -- losing the trail,
+// a peace command, the quarry fleeing -- and those all leave both characters
+// alive.
+//
+// So this is the first field whose scrub loop clause can actually go. These
+// tests pin the behavior it provides, so that the handle can be shown to
+// provide the same thing.
+//
+// Tracking() is the single point that has to change if the field's type
+// changes; every assertion below is written through it and stays as-is.
+//
+
+namespace
+{
+	CHAR_DATA *Tracking(CHAR_DATA *ch)
+	{
+		return Deref(ch->last_fought);
+	}
+
+	/// extract_char takes the NPC path -- it decrements pIndexData->count and
+	/// skips the altar-room redirect that only applies to players -- so these
+	/// are mobs, with the index data that path requires.
+	CHAR_DATA *MakeTracker(ROOM_INDEX_DATA *room)
+	{
+		CHAR_DATA *mob = new_char();
+		mob->pIndexData = new mob_index_data();
+		SET_BIT(mob->act, ACT_IS_NPC);
+		mob->hit = 100;
+
+		mob->in_room = room;
+		mob->next_in_room = room->people;
+		room->people = mob;
+
+		mob->next = char_list;
+		char_list = mob;
+
+		return mob;
+	}
+
+	ROOM_INDEX_DATA *MakeTrackingRoom()
+	{
+		auto room = new room_index_data();
+		room->area = new area_data();
+
+		return room;
+	}
+
+	void ClearTrackers()
+	{
+		CHAR_DATA *next;
+
+		for (CHAR_DATA *ch = char_list; ch != nullptr; ch = next)
+		{
+			next = ch->next;
+			free_char(ch);
+		}
+
+		char_list = nullptr;
+	}
+}
+
+SCENARIO("extract_char clears every tracker's reference to the extracted character", "[last_fought]")
+{
+	GIVEN("two mobs hunting a third and one hunting someone else")
+	{
+		auto room = MakeTrackingRoom();
+		CHAR_DATA *quarry = MakeTracker(room);
+		CHAR_DATA *hunter = MakeTracker(room);
+		CHAR_DATA *secondHunter = MakeTracker(room);
+		CHAR_DATA *otherQuarry = MakeTracker(room);
+		CHAR_DATA *unrelated = MakeTracker(room);
+
+		hunter->last_fought = quarry->self;
+		secondHunter->last_fought = quarry->self;
+		unrelated->last_fought = otherQuarry->self;
+
+		WHEN("the quarry is extracted from the world")
+		{
+			extract_char(quarry, true);
+
+			THEN("nobody is left hunting it")
+			{
+				REQUIRE(Tracking(hunter) == nullptr);
+				REQUIRE(Tracking(secondHunter) == nullptr);
+			}
+
+			THEN("a mob hunting somebody else is left alone")
+			{
+				REQUIRE(Tracking(unrelated) == otherQuarry);
+			}
+		}
+
+		ClearTrackers();
+	}
+}
+
+SCENARIO("a mob that gives up the hunt does not disturb the quarry", "[last_fought]")
+{
+	GIVEN("a mob hunting another")
+	{
+		auto room = MakeTrackingRoom();
+		CHAR_DATA *quarry = MakeTracker(room);
+		CHAR_DATA *hunter = MakeTracker(room);
+
+		hunter->last_fought = quarry->self;
+
+		WHEN("the hunter loses interest rather than the quarry dying")
+		{
+			// The other half of the field's contract, and the reason the
+			// clears outside extract_char have to stay: this one says "stop
+			// hunting", not "the quarry is gone".
+			hunter->last_fought = nullptr;
+
+			THEN("the hunter is no longer tracking but the quarry is untouched")
+			{
+				REQUIRE(Tracking(hunter) == nullptr);
+				REQUIRE(quarry->valid);
+				REQUIRE(Deref(quarry->self) == quarry);
+			}
+		}
+
+		ClearTrackers();
+	}
+}
+
+SCENARIO("a hunter's reference to a freed quarry reads as nothing", "[last_fought]")
+{
+	GIVEN("a mob hunting another")
+	{
+		auto room = MakeTrackingRoom();
+		CHAR_DATA *quarry = MakeTracker(room);
+		CHAR_DATA *hunter = MakeTracker(room);
+
+		hunter->last_fought = quarry->self;
+
+		REQUIRE(Tracking(hunter) == quarry);
+
+		WHEN("the quarry is freed without extract_char's sweep running")
+		{
+			// extract_char used to clear this reference by walking char_list.
+			// The paths that never reach that walk -- its own not-found
+			// bail-out, say -- are the ones that used to leave a pointer into
+			// a character struct the free list can hand straight back out.
+			free_char(quarry);
+
+			THEN("the reference reads as nothing rather than as recycled memory")
+			{
+				REQUIRE(Tracking(hunter) == nullptr);
+			}
+		}
+
+		ClearTrackers();
 	}
 }

--- a/tests/handler_tests.c
+++ b/tests/handler_tests.c
@@ -2,8 +2,10 @@
 #include "../code/handler.h"
 #include "../code/entity/char_data.h"
 #include "../code/entity/obj_data.h"
+#include "../code/entity/handles.h"
 #include "../code/enums.h"
 #include "../code/db.h"
+#include "../code/recycle.h"
 
 // TEST_CASE("Test capitalization", "[string]" )
 // {
@@ -735,6 +737,110 @@ SCENARIO("affect_strip removes all affects of a type but leaves others", "[affec
 				REQUIRE(affect_find(ch->affected, 100) == nullptr);
 				REQUIRE(is_affected(ch, 101) == true);
 			}
+		}
+	}
+}
+
+//
+// The entity slot maps. These exercise the real new_char/free_char and
+// new_obj/free_obj rather than a stand-in, because the property that matters
+// is the interaction with the free lists: those functions hand the same
+// address back out, and the whole point of a handle is that reuse of an
+// address must not resurrect a reference to the thing that used to live there.
+//
+// (Handle and SlotMap are covered on their own terms in handle_tests.c; these
+// are about the wiring.)
+//
+
+SCENARIO("new_char registers a character and free_char expires it", "[handles]")
+{
+	GIVEN("a character from new_char")
+	{
+		CHAR_DATA *ch = new_char();
+
+		THEN("it has a live self handle that derefs back to itself")
+		{
+			REQUIRE(!ch->self.IsNull());
+			REQUIRE(Deref(ch->self) == ch);
+		}
+
+		WHEN("it is freed")
+		{
+			Handle<CHAR_DATA> stale = ch->self;
+			free_char(ch);
+
+			THEN("handles taken before the free no longer resolve")
+			{
+				REQUIRE(Deref(stale) == nullptr);
+			}
+		}
+	}
+}
+
+SCENARIO("a recycled character address does not resurrect an old handle", "[handles]")
+{
+	GIVEN("a character that has been freed back onto the free list")
+	{
+		CHAR_DATA *first = new_char();
+		Handle<CHAR_DATA> stale = first->self;
+		free_char(first);
+
+		WHEN("a new character is allocated, reusing that address")
+		{
+			CHAR_DATA *second = new_char();
+
+			THEN("the old handle stays expired even though the address matches")
+			{
+				// The free list really did hand back the same memory -- if it
+				// ever stops doing so this test is still correct, just less
+				// pointed, so it is asserted rather than assumed.
+				REQUIRE(second == first);
+
+				REQUIRE(Deref(stale) == nullptr);
+				REQUIRE(stale != second->self);
+				REQUIRE(Deref(second->self) == second);
+			}
+
+			free_char(second);
+		}
+	}
+}
+
+SCENARIO("new_obj registers an object and free_obj expires it", "[handles]")
+{
+	GIVEN("an object from new_obj")
+	{
+		OBJ_DATA *obj = new_obj();
+
+		THEN("it has a live self handle that derefs back to itself")
+		{
+			REQUIRE(!obj->self.IsNull());
+			REQUIRE(Deref(obj->self) == obj);
+		}
+
+		WHEN("it is freed")
+		{
+			Handle<OBJ_DATA> stale = obj->self;
+			free_obj(obj);
+
+			THEN("handles taken before the free no longer resolve")
+			{
+				REQUIRE(Deref(stale) == nullptr);
+			}
+		}
+	}
+}
+
+SCENARIO("an entity that never came from new_char is safe by default", "[handles]")
+{
+	GIVEN("a bare character built without new_char, as the tests do")
+	{
+		auto ch = new char_data();
+
+		THEN("its self handle is null and derefs to nothing rather than to junk")
+		{
+			REQUIRE(ch->self.IsNull());
+			REQUIRE(Deref(ch->self) == nullptr);
 		}
 	}
 }

--- a/tests/handler_tests.c
+++ b/tests/handler_tests.c
@@ -2080,6 +2080,52 @@ SCENARIO("the last opponent is forgotten when they leave the world", "[lastfight
 	}
 }
 
+SCENARIO("a slain player is still in the world, so extract_char is not a lifetime event for them", "[lastfight]")
+{
+	GIVEN("two players who have fought each other")
+	{
+		auto room = MakeTrackingRoom();
+		CHAR_DATA *fighter = MakeNamedPlayer(room, "Alice");
+		CHAR_DATA *opponent = MakeNamedPlayer(room, "Bob");
+
+		RecordFight(fighter, opponent);
+
+		WHEN("the opponent is extracted the way raw_kill does it, without pulling them")
+		{
+			// raw_kill is the only caller that passes fPull = false, and for a
+			// player extract_char then returns early to the altar without
+			// freeing anything. So this call leaves Bob alive and in char_list.
+			extract_char(opponent, false);
+
+			THEN("the opponent is still alive")
+			{
+				REQUIRE(opponent->valid);
+				REQUIRE(Deref(opponent->self) == opponent);
+			}
+
+			THEN("clearing the other side's record is raw_kill's job, not extract_char's")
+			{
+				// extract_char cannot be responsible for this: the reference is
+				// still perfectly live, because its target is. The record is
+				// reset on death because that is the game rule, and raw_kill is
+				// where the rule lives.
+				//
+				// NOT COVERED, deliberately: that raw_kill actually applies the
+				// rule. Reaching it needs a killer, a corpse, the ghost affect
+				// set, group and cabal state and a populated room index -- far
+				// more world than this suite stands up, and a mock of it would
+				// only assert that the mock was written correctly. The walk in
+				// raw_kill, immediately after its extract_char call, is checked
+				// by reading. If that walk is ever moved or dropped, nothing
+				// here will fail -- so treat it as load-bearing.
+				REQUIRE(LastOpponentName(fighter) != nullptr);
+			}
+		}
+
+		ClearTrackers();
+	}
+}
+
 SCENARIO("the last opponent survives a rename", "[lastfight]")
 {
 	GIVEN("two players who have fought each other")
@@ -2111,6 +2157,118 @@ SCENARIO("the last opponent survives a rename", "[lastfight]")
 			}
 
 			free_pstring(releasedInProduction);
+		}
+
+		ClearTrackers();
+	}
+}
+
+//
+// ch->pcdata->trusting -- who this player has authorised to take questionable
+// actions against them.
+//
+// A plain CHAR -> CHAR back-reference that happens to live on PC_DATA rather
+// than CHAR_DATA, which is the only reason §1's original table missed it. Set
+// only by do_trust, which rejects NPCs, so both ends are always players.
+//
+// Its clause in extract_char's walk is guarded !is_npc on both sides, and that
+// makes it half lifetime and half game rule -- see the scenarios below.
+//
+
+namespace
+{
+	CHAR_DATA *Trusting(CHAR_DATA *ch)
+	{
+		return Deref(ch->pcdata->trusting);
+	}
+
+	void Trust(CHAR_DATA *ch, CHAR_DATA *victim)
+	{
+		ch->pcdata->trusting = victim->self;
+	}
+}
+
+SCENARIO("trust does not outlive the trusted player", "[trusting]")
+{
+	GIVEN("a player trusting another")
+	{
+		auto room = MakeTrackingRoom();
+		CHAR_DATA *truster = MakeNamedPlayer(room, "Alice");
+		CHAR_DATA *trusted = MakeNamedPlayer(room, "Bob");
+		CHAR_DATA *bystander = MakeNamedPlayer(room, "Carol");
+
+		Trust(truster, trusted);
+
+		REQUIRE(Trusting(truster) == trusted);
+
+		WHEN("the trusted player is pulled from the world")
+		{
+			// fPull = true is the real removal -- quit, delete_char. This is
+			// the half of the clause that is lifetime, and the half a handle
+			// covers for free.
+			extract_char(trusted, true);
+
+			THEN("the trust reads as nothing")
+			{
+				REQUIRE(Trusting(truster) == nullptr);
+			}
+
+			THEN("it stays nothing once the address is reissued")
+			{
+				CHAR_DATA *newcomer = new_char();
+
+				REQUIRE(newcomer == trusted);
+				REQUIRE(Trusting(truster) != newcomer);
+			}
+		}
+
+		WHEN("somebody unrelated is pulled from the world")
+		{
+			extract_char(bystander, true);
+
+			THEN("the trust is untouched")
+			{
+				REQUIRE(Trusting(truster) == trusted);
+			}
+		}
+
+		ClearTrackers();
+	}
+}
+
+SCENARIO("a slain player is still trustworthy as far as the world is concerned", "[trusting]")
+{
+	GIVEN("a player trusting another")
+	{
+		auto room = MakeTrackingRoom();
+		CHAR_DATA *truster = MakeNamedPlayer(room, "Alice");
+		CHAR_DATA *trusted = MakeNamedPlayer(room, "Bob");
+
+		Trust(truster, trusted);
+
+		WHEN("the trusted player is slain, which does not pull them from the world")
+		{
+			extract_char(trusted, false);
+
+			THEN("the trusted player is still alive")
+			{
+				REQUIRE(trusted->valid);
+				REQUIRE(Deref(trusted->self) == trusted);
+			}
+
+			THEN("dropping the trust is the death rule's job, not extract_char's")
+			{
+				// The reference is still live because its target is. That
+				// death cancels trust is a rule, and rules belong where the
+				// death happens -- raw_kill -- not in the lifetime teardown.
+				//
+				// NOT COVERED, deliberately, and for the same reason as the
+				// [lastfight] scenario above: this suite does not execute
+				// raw_kill, so nothing here proves the rule still fires. Both
+				// clears live in one walk directly after raw_kill's
+				// extract_char call; that walk is verified by reading only.
+				REQUIRE(Trusting(truster) != nullptr);
+			}
 		}
 
 		ClearTrackers();

--- a/tests/handler_tests.c
+++ b/tests/handler_tests.c
@@ -1,5 +1,6 @@
 #include "catch.hpp"
 #include "../code/handler.h"
+#include "../code/act_comm.h"
 #include "../code/entity/char_data.h"
 #include "../code/entity/obj_data.h"
 #include "../code/entity/room_index_data.h"
@@ -1296,6 +1297,250 @@ SCENARIO("a reply to a freed character reads as nothing", "[reply]")
 			THEN("the reference reads as nothing rather than as recycled memory")
 			{
 				REQUIRE(Replying(listener) == nullptr);
+			}
+		}
+
+		ClearTrackers();
+	}
+}
+
+//
+// Deref(ch->master) / Deref(ch->leader) / Deref(ch->pet) -- the follower graph.
+//
+// These three differ from the fields above in that their clears live in
+// helpers -- stop_follower, die_follower, nuke_pets -- rather than inline in
+// extract_char, and those helpers are reached overwhelmingly for reasons that
+// have nothing to do with anyone dying. die_follower alone has four callers
+// and only one of them (extract_char) is a lifetime event; the others are a
+// player setting nofollow, a sphere of plasma, and an item prog putting its
+// owner to sleep. So the sweeps stay and the fields convert in place.
+//
+// Two behaviors here are deliberate game rules that a naive migration would
+// "fix" into regressions, and both are pinned below:
+//
+//   * A follower whose leader dies is made its OWN leader, not leaderless.
+//   * A follower secretly trailing via gsn_trail is exempt from the sweep and
+//     stays attached. That exemption is correct while the master is alive --
+//     the point of the skill is that the target cannot shake you -- and it is
+//     what makes `master` outlive its target when the master is extracted.
+//
+// Master()/Leader()/Pet() are the single points that have to change if the
+// field types change; every assertion below is written through them.
+//
+
+namespace
+{
+	CHAR_DATA *Master(CHAR_DATA *ch)
+	{
+		return Deref(ch->master);
+	}
+
+	CHAR_DATA *Leader(CHAR_DATA *ch)
+	{
+		return Deref(ch->leader);
+	}
+
+	CHAR_DATA *Pet(CHAR_DATA *ch)
+	{
+		return Deref(ch->pet);
+	}
+
+	/// gsn_trail and gsn_animate_dead are both zero in an unbooted test
+	/// binary, and die_follower branches on both -- an affect added for one
+	/// would answer for the other. Give trail a distinct value for the
+	/// duration of a test.
+	class ScopedTrailSkill
+	{
+	public:
+		ScopedTrailSkill() : saved(gsn_trail) { gsn_trail = 500; }
+		~ScopedTrailSkill() { gsn_trail = saved; }
+
+	private:
+		short saved;
+	};
+
+	void MakeTrailing(CHAR_DATA *ch)
+	{
+		AFFECT_DATA af;
+		init_affect(&af);
+		af.type = gsn_trail;
+		af.where = TO_AFFECTS;
+		af.duration = -1;
+		affect_to_char(ch, &af);
+	}
+}
+
+SCENARIO("die_follower detaches ordinary followers", "[follower]")
+{
+	GIVEN("a master with two followers and an unrelated pair")
+	{
+		auto room = MakeTrackingRoom();
+		CHAR_DATA *master = MakeTracker(room);
+		CHAR_DATA *followerOne = MakeTracker(room);
+		CHAR_DATA *followerTwo = MakeTracker(room);
+		CHAR_DATA *otherMaster = MakeTracker(room);
+		CHAR_DATA *otherFollower = MakeTracker(room);
+
+		followerOne->master = master->self;
+		followerTwo->master = master->self;
+		otherFollower->master = otherMaster->self;
+
+		WHEN("the master sheds its followers without dying")
+		{
+			die_follower(master);
+
+			THEN("its own followers are detached")
+			{
+				REQUIRE(Master(followerOne) == nullptr);
+				REQUIRE(Master(followerTwo) == nullptr);
+			}
+
+			THEN("somebody else's follower is left alone")
+			{
+				REQUIRE(Master(otherFollower) == otherMaster);
+			}
+
+			THEN("the master is still perfectly alive")
+			{
+				REQUIRE(master->valid);
+				REQUIRE(Deref(master->self) == master);
+			}
+		}
+
+		ClearTrackers();
+	}
+}
+
+SCENARIO("a follower whose leader dies becomes its own leader", "[follower]")
+{
+	GIVEN("a leader with a follower")
+	{
+		auto room = MakeTrackingRoom();
+		CHAR_DATA *leader = MakeTracker(room);
+		CHAR_DATA *follower = MakeTracker(room);
+
+		follower->leader = leader->self;
+
+		WHEN("the leader sheds its group")
+		{
+			die_follower(leader);
+
+			THEN("the follower leads itself rather than being left leaderless")
+			{
+				// Intentional game logic, not an oversight: a character with
+				// no group still leads one, consisting of itself. Turning this
+				// into a null would be a gameplay regression.
+				REQUIRE(Leader(follower) == follower);
+			}
+		}
+
+		ClearTrackers();
+	}
+}
+
+SCENARIO("a secret trailer survives the follower sweep", "[follower]")
+{
+	GIVEN("a master with one open follower and one trailing it secretly")
+	{
+		ScopedTrailSkill trailSkill;
+
+		auto room = MakeTrackingRoom();
+		CHAR_DATA *master = MakeTracker(room);
+		CHAR_DATA *openFollower = MakeTracker(room);
+		CHAR_DATA *trailer = MakeTracker(room);
+
+		openFollower->master = master->self;
+		trailer->master = master->self;
+		MakeTrailing(trailer);
+
+		REQUIRE(is_affected(trailer, gsn_trail) == true);
+
+		WHEN("the master sheds its followers while staying alive")
+		{
+			die_follower(master);
+
+			THEN("the open follower is detached but the trailer is not")
+			{
+				// The whole point of the skill: the target cannot shake
+				// someone who is trailing them. This exemption is correct
+				// here, and must survive the field becoming a handle.
+				REQUIRE(Master(openFollower) == nullptr);
+				REQUIRE(Master(trailer) == master);
+			}
+		}
+
+		ClearTrackers();
+	}
+}
+
+SCENARIO("stop_follower clears the master's pet when the pet stops following", "[follower]")
+{
+	GIVEN("a master with a pet")
+	{
+		auto room = MakeTrackingRoom();
+		CHAR_DATA *master = MakeTracker(room);
+		CHAR_DATA *pet = MakeTracker(room);
+
+		pet->master = master->self;
+		master->pet = pet->self;
+
+		WHEN("the pet stops following")
+		{
+			stop_follower(pet);
+
+			THEN("both ends of the relationship are cleared")
+			{
+				REQUIRE(Pet(master) == nullptr);
+				REQUIRE(Master(pet) == nullptr);
+			}
+
+			THEN("the pet itself is still alive")
+			{
+				REQUIRE(pet->valid);
+				REQUIRE(Deref(pet->self) == pet);
+			}
+		}
+
+		ClearTrackers();
+	}
+}
+
+SCENARIO("a secret trailer does not outlive the master it was trailing", "[follower]")
+{
+	GIVEN("a master being trailed secretly")
+	{
+		ScopedTrailSkill trailSkill;
+
+		auto room = MakeTrackingRoom();
+		CHAR_DATA *master = MakeTracker(room);
+		CHAR_DATA *trailer = MakeTracker(room);
+
+		trailer->master = master->self;
+		MakeTrailing(trailer);
+
+		REQUIRE(Master(trailer) == master);
+
+		WHEN("the master is extracted from the world")
+		{
+			// The sweep in die_follower deliberately skips trailers, and that
+			// is right while the master is alive. It is not right once the
+			// master has been freed: the reference used to survive into a
+			// character struct that the free list hands straight back out, so
+			// the trailer silently ended up attached to whoever was allocated
+			// next.
+			extract_char(master, true);
+
+			THEN("its reference reads as nothing rather than as recycled memory")
+			{
+				REQUIRE(Master(trailer) == nullptr);
+			}
+
+			THEN("the address really was reissued, which is what made this silent")
+			{
+				CHAR_DATA *newcomer = new_char();
+
+				REQUIRE(newcomer == master);
+				REQUIRE(Master(trailer) == nullptr);
 			}
 		}
 

--- a/tests/handler_tests.c
+++ b/tests/handler_tests.c
@@ -2652,3 +2652,99 @@ SCENARIO("a slain player is still in the world, so their affects still name them
 		ClearTrackers();
 	}
 }
+
+//
+// d->snoop_by -- the connection watching this one.
+//
+// The last raw cross-reference in the descriptor pair, and the only one whose
+// scrub loop was correct: close_socket swept descriptor_list clearing every
+// d->snoop_by that named the connection going away, and free_descriptor is
+// reached from nowhere else that a snooped connection could be looking at.
+//
+// So there is no defect here to demonstrate, and saying so matters -- the
+// scenarios below document the mechanism that replaces the sweep rather than a
+// bug that it missed.
+//
+
+namespace
+{
+	DESCRIPTOR_DATA *SnoopedBy(DESCRIPTOR_DATA *d)
+	{
+		return Deref(d->snoop_by);
+	}
+
+	void Snoop(DESCRIPTOR_DATA *snooper, DESCRIPTOR_DATA *target)
+	{
+		target->snoop_by = snooper->self;
+	}
+}
+
+SCENARIO("a snoop does not outlive the connection running it", "[snoop]")
+{
+	GIVEN("one connection snooping another")
+	{
+		DESCRIPTOR_DATA *snooper = new_descriptor();
+		DESCRIPTOR_DATA *watched = new_descriptor();
+
+		Snoop(snooper, watched);
+
+		REQUIRE(SnoopedBy(watched) == snooper);
+
+		WHEN("the snooping connection is freed")
+		{
+			// close_socket is where the sweep lived, and it is far more world
+			// than this suite stands up -- process_output, wiznet, the
+			// character teardown. What the sweep was *for* is this: once the
+			// snooper is gone, nothing may still name it.
+			free_descriptor(snooper);
+
+			THEN("the watched connection names no snooper")
+			{
+				REQUIRE(SnoopedBy(watched) == nullptr);
+			}
+
+			THEN("it still names none once the address is reissued")
+			{
+				// This is the part the sweep could not have given: a reused
+				// descriptor address would have satisfied a raw pointer, and
+				// every reader of this field writes the snooped output
+				// straight into whatever it names.
+				DESCRIPTOR_DATA *newcomer = new_descriptor();
+
+				REQUIRE(newcomer == snooper);
+				REQUIRE(SnoopedBy(watched) != newcomer);
+
+				free_descriptor(newcomer);
+			}
+		}
+
+		free_descriptor(watched);
+	}
+}
+
+SCENARIO("a connection that stops snooping leaves its target alone", "[snoop]")
+{
+	GIVEN("one connection snooping another")
+	{
+		DESCRIPTOR_DATA *snooper = new_descriptor();
+		DESCRIPTOR_DATA *watched = new_descriptor();
+
+		Snoop(snooper, watched);
+
+		WHEN("the snoop is dropped rather than the connection closing")
+		{
+			// do_snoop's own clear, which stays: "snoop self" means "drop every
+			// snoop I am running", and nobody has left the world.
+			watched->snoop_by = nullptr;
+
+			THEN("the snooper is untouched")
+			{
+				REQUIRE(SnoopedBy(watched) == nullptr);
+				REQUIRE(Deref(snooper->self) == snooper);
+			}
+		}
+
+		free_descriptor(snooper);
+		free_descriptor(watched);
+	}
+}

--- a/tests/handler_tests.c
+++ b/tests/handler_tests.c
@@ -1791,7 +1791,7 @@ namespace
 	void Connect(DESCRIPTOR_DATA *d, CHAR_DATA *ch)
 	{
 		d->character = ch->self;
-		ch->desc = d;
+		ch->desc = d->self;
 	}
 
 	/// The state do_switch leaves behind: the descriptor drives the mob, the
@@ -1800,7 +1800,7 @@ namespace
 	{
 		d->character = mob->self;
 		d->original = immortal->self;
-		mob->desc = d;
+		mob->desc = d->self;
 		immortal->desc = nullptr;
 	}
 }
@@ -1889,6 +1889,116 @@ SCENARIO("a switched immortal's original body does not outlive it", "[descriptor
 		}
 
 		free_descriptor(d);
+		ClearTrackers();
+	}
+}
+
+//
+// ch->desc -- the character half of the bidirectional pair.
+//
+// The inverse of d->character, and scrubbed far less carefully than it. The
+// only clear on a lifetime path is close_socket's, and it is guarded:
+//
+//     if (dclose->connected == CON_PLAYING && !merc_down)
+//         ch->desc = nullptr;                       // link-dead, body lives on
+//     else
+//         free_char(dclose->original ? dclose->original : dclose->character);
+//     ...
+//     free_descriptor(dclose);
+//
+// Take the else branch with an immortal switched into a mob and it frees the
+// immortal, never touches the mob, and then frees the descriptor -- leaving the
+// mob naming a descriptor on the free list. DESCRIPTOR_DATA is recycled through
+// descriptor_free, so the next connection gets that address and the mob is
+// suddenly holding a live player's socket.
+//
+// Narrow: it needs a shutdown or a non-CON_PLAYING close with a switch in
+// effect. It is the least severe dangle in the graph, not the worst.
+//
+
+namespace
+{
+	DESCRIPTOR_DATA *Connection(CHAR_DATA *ch)
+	{
+		return Deref(ch->desc);
+	}
+
+	void Attach(CHAR_DATA *ch, DESCRIPTOR_DATA *d)
+	{
+		ch->desc = d ? d->self : nullptr;
+	}
+}
+
+SCENARIO("losing the link leaves the body in the world", "[chdesc]")
+{
+	GIVEN("a player on a descriptor")
+	{
+		auto room = MakeTrackingRoom();
+		CHAR_DATA *player = MakeTracker(room);
+		DESCRIPTOR_DATA *d = new_descriptor();
+
+		Attach(player, d);
+
+		REQUIRE(Connection(player) == d);
+
+		WHEN("the socket closes but the body is left in the world")
+		{
+			// close_socket's CON_PLAYING branch. This is the half that must not
+			// change: it means "the connection went away", not "the body did".
+			// close_socket used to null ch->desc by hand just before freeing
+			// the descriptor; this asserts the free alone is enough, which is
+			// what makes that line deletable.
+			free_descriptor(d);
+
+			THEN("the body is still alive and simply has no connection")
+			{
+				REQUIRE(Connection(player) == nullptr);
+				REQUIRE(player->valid);
+				REQUIRE(Deref(player->self) == player);
+			}
+		}
+
+		ClearTrackers();
+	}
+}
+
+SCENARIO("a possessed mob does not outlive the connection driving it", "[chdesc]")
+{
+	GIVEN("an immortal switched into a mob")
+	{
+		auto room = MakeTrackingRoom();
+		CHAR_DATA *immortal = MakeTracker(room);
+		CHAR_DATA *mob = MakeTracker(room);
+		DESCRIPTOR_DATA *d = new_descriptor();
+
+		Possess(d, mob, immortal);
+
+		REQUIRE(Connection(mob) == d);
+		REQUIRE(Connection(immortal) == nullptr);
+
+		WHEN("the socket closes on the shutdown path, which frees only the immortal")
+		{
+			free_char(immortal);
+			free_descriptor(d);
+
+			THEN("the mob names no connection")
+			{
+				REQUIRE(Connection(mob) == nullptr);
+			}
+
+			THEN("the next connection to take the address is not adopted")
+			{
+				// Every reader of this field asks "is this a player with a live
+				// connection", so a recycled descriptor turns a mob into one.
+				DESCRIPTOR_DATA *newcomer = new_descriptor();
+
+				REQUIRE(newcomer == d);
+				REQUIRE(Connection(mob) != newcomer);
+
+				free_descriptor(newcomer);
+			}
+		}
+
 		ClearTrackers();
 	}
 }

--- a/tests/handler_tests.c
+++ b/tests/handler_tests.c
@@ -1,4 +1,5 @@
 #include "catch.hpp"
+#include "../code/merc.h"
 #include "../code/handler.h"
 #include "../code/act_comm.h"
 #include "../code/entity/char_data.h"
@@ -1745,6 +1746,149 @@ SCENARIO("a mob's quarry does not outlive it", "[hunting]")
 			}
 		}
 
+		ClearTrackers();
+	}
+}
+
+//
+// d->character / d->original -- the descriptor half of the bidirectional pair.
+//
+// This is the only two-way link in the graph: a connected player is
+// d->character == ch and ch->desc == d, and a switched immortal is
+// d->character == the possessed mob, d->original == the immortal, with the
+// mob holding the descriptor and the immortal's own desc null. Exactly one
+// character points back at a descriptor at any moment, and it is always
+// d->character.
+//
+// The two halves of the link are scrubbed very differently:
+//
+//   d->character  cleared inline right after the free, in five places --
+//                 extract_char, and four login-screen rejections in comm.c
+//                 that all read `free_char(d->character); d->character = 0`.
+//   d->original   cleared NOWHERE except do_return, which is a wizard
+//                 returning to their body, not a lifetime event.
+//
+// So `original` is the same shape as hunting and analyzePC -- except that it
+// is not merely compared. check_playing dereferences `dold->original->true_name`
+// for every descriptor in the list on every login attempt, so a stale original
+// is read by the next person to connect.
+//
+
+namespace
+{
+	// Reader and setter both, so this file compiles unchanged on either side of
+	// the type flip -- see the note on the hunting helpers above.
+	CHAR_DATA *Body(DESCRIPTOR_DATA *d)
+	{
+		return Deref(d->character);
+	}
+
+	CHAR_DATA *OriginalBody(DESCRIPTOR_DATA *d)
+	{
+		return Deref(d->original);
+	}
+
+	void Connect(DESCRIPTOR_DATA *d, CHAR_DATA *ch)
+	{
+		d->character = ch->self;
+		ch->desc = d;
+	}
+
+	/// The state do_switch leaves behind: the descriptor drives the mob, the
+	/// immortal is parked in `original`, and only the mob points back.
+	void Possess(DESCRIPTOR_DATA *d, CHAR_DATA *mob, CHAR_DATA *immortal)
+	{
+		d->character = mob->self;
+		d->original = immortal->self;
+		mob->desc = d;
+		immortal->desc = nullptr;
+	}
+}
+
+SCENARIO("a descriptor's body reference does not outlive the body", "[descriptor]")
+{
+	GIVEN("a character on a descriptor")
+	{
+		auto room = MakeTrackingRoom();
+		CHAR_DATA *player = MakeTracker(room);
+		DESCRIPTOR_DATA *d = new_descriptor();
+
+		// new_descriptor resets a recycled descriptor with `*d = d_zero`, an
+		// all-zero static. Both fields have to read as nothing after that, or a
+		// reused descriptor would inherit the previous connection's body.
+		REQUIRE(Body(d) == nullptr);
+		REQUIRE(OriginalBody(d) == nullptr);
+
+		Connect(d, player);
+
+		REQUIRE(Body(d) == player);
+
+		WHEN("the character is extracted")
+		{
+			extract_char(player, true);
+
+			THEN("the descriptor names nobody")
+			{
+				// Today this holds because extract_char clears it by hand on
+				// the line before free_char. That clear is inline in a lifetime
+				// path, so it is deletable -- and this assertion is what proves
+				// the deletion rather than merely surviving it.
+				REQUIRE(Body(d) == nullptr);
+			}
+
+			THEN("the next character to take the address is not adopted")
+			{
+				CHAR_DATA *newcomer = new_char();
+
+				REQUIRE(newcomer == player);
+				REQUIRE(Body(d) != newcomer);
+			}
+		}
+
+		free_descriptor(d);
+		ClearTrackers();
+	}
+}
+
+SCENARIO("a switched immortal's original body does not outlive it", "[descriptor]")
+{
+	GIVEN("an immortal switched into a mob")
+	{
+		auto room = MakeTrackingRoom();
+		CHAR_DATA *immortal = MakeTracker(room);
+		CHAR_DATA *mob = MakeTracker(room);
+		DESCRIPTOR_DATA *d = new_descriptor();
+
+		Possess(d, mob, immortal);
+
+		REQUIRE(Body(d) == mob);
+		REQUIRE(OriginalBody(d) == immortal);
+
+		WHEN("the original body is freed while the switch is still in effect")
+		{
+			// close_socket does exactly this -- `free_char(dclose->original ?
+			// dclose->original : dclose->character)` -- and extract_char clears
+			// only `character`, never `original`.
+			free_char(immortal);
+
+			THEN("the descriptor no longer names the original body")
+			{
+				REQUIRE(OriginalBody(d) == nullptr);
+			}
+
+			THEN("the next character to take the address is not adopted as the original")
+			{
+				// check_playing reads `dold->original->true_name` for every
+				// descriptor on every login, so this one is dereferenced, not
+				// just compared.
+				CHAR_DATA *newcomer = new_char();
+
+				REQUIRE(newcomer == immortal);
+				REQUIRE(OriginalBody(d) != newcomer);
+			}
+		}
+
+		free_descriptor(d);
 		ClearTrackers();
 	}
 }

--- a/tests/handler_tests.c
+++ b/tests/handler_tests.c
@@ -1547,3 +1547,106 @@ SCENARIO("a secret trailer does not outlive the master it was trailing", "[follo
 		ClearTrackers();
 	}
 }
+
+//
+// Deref(ch->defending) / Deref(ch->analyzePC).
+//
+// Neither is cleared by extract_char. `defending` is scrubbed only on the
+// voluntary-quit path (do_quit_new, just before it extracts the quitter) and
+// by do_defend when a character stops defending; `analyzePC` is never cleared
+// anywhere. So on any death that is not a quit -- which is most of them --
+// both were left pointing into a character struct the free list can hand
+// straight back out.
+//
+// That makes these the thinnest scrub story of any field in the graph: there
+// is almost nothing to characterize, because there was almost nothing there.
+// What is pinned below is the part that must not change (the reference is
+// scoped to its own target and unrelated deaths leave it alone) and the part
+// that does (it now expires).
+//
+
+namespace
+{
+	CHAR_DATA *Defending(CHAR_DATA *ch)
+	{
+		return Deref(ch->defending);
+	}
+
+	CHAR_DATA *Analyzing(CHAR_DATA *ch)
+	{
+		return Deref(ch->analyzePC);
+	}
+}
+
+SCENARIO("an unrelated death leaves defending and analyzePC alone", "[defending]")
+{
+	GIVEN("a defender and an analyzer, plus a bystander who dies")
+	{
+		auto room = MakeTrackingRoom();
+		CHAR_DATA *protector = MakeTracker(room);
+		CHAR_DATA *ward = MakeTracker(room);
+		CHAR_DATA *analyzer = MakeTracker(room);
+		CHAR_DATA *studied = MakeTracker(room);
+		CHAR_DATA *bystander = MakeTracker(room);
+
+		protector->defending = ward->self;
+		analyzer->analyzePC = studied->self;
+
+		WHEN("somebody else entirely is extracted")
+		{
+			extract_char(bystander, true);
+
+			THEN("both references are untouched")
+			{
+				REQUIRE(Defending(protector) == ward);
+				REQUIRE(Analyzing(analyzer) == studied);
+			}
+		}
+
+		ClearTrackers();
+	}
+}
+
+SCENARIO("defending and analyzePC do not outlive their target", "[defending]")
+{
+	GIVEN("a defender and an analyzer pointed at one character")
+	{
+		auto room = MakeTrackingRoom();
+		CHAR_DATA *protector = MakeTracker(room);
+		CHAR_DATA *analyzer = MakeTracker(room);
+		CHAR_DATA *target = MakeTracker(room);
+
+		protector->defending = target->self;
+		analyzer->analyzePC = target->self;
+
+		REQUIRE(Defending(protector) == target);
+		REQUIRE(Analyzing(analyzer) == target);
+
+		WHEN("the target dies")
+		{
+			// extract_char clears neither field -- it never did -- so before
+			// these became handles both references survived into a recycled
+			// character struct. analyzePC is the quieter of the two: every one
+			// of its uses is an identity compare, so a recycled address does
+			// not crash, it silently matches the wrong character.
+			extract_char(target, true);
+
+			THEN("both references read as nothing")
+			{
+				REQUIRE(Defending(protector) == nullptr);
+				REQUIRE(Analyzing(analyzer) == nullptr);
+			}
+
+			THEN("they stay nothing even once the address is reissued")
+			{
+				CHAR_DATA *newcomer = new_char();
+
+				REQUIRE(newcomer == target);
+				REQUIRE(Defending(protector) == nullptr);
+				REQUIRE(Analyzing(analyzer) == nullptr);
+			}
+		}
+
+		ClearTrackers();
+	}
+}

--- a/tests/handler_tests.c
+++ b/tests/handler_tests.c
@@ -1650,3 +1650,101 @@ SCENARIO("defending and analyzePC do not outlive their target", "[defending]")
 		ClearTrackers();
 	}
 }
+
+//
+// ch->hunting -- the mob-hunt-quarry link.
+//
+// The thinnest scrub story in the graph, thinner even than defending: this one
+// is never cleared anywhere at all. There are two setters -- the vnum-3002 face
+// sucker's greet prog and the sorcerer's aerial anchor -- and no clear on
+// extract, on quit, or on any other path.
+//
+// Nothing crashes, because every reachable reader is an identity compare
+// against a char_list walk rather than a dereference. That is what makes it
+// quiet: a fresh character that lands on a dead one's address silently
+// inherits the dead one's anchor and its face sucker. So the scenario that
+// matters is the reissued address, not the freed read.
+//
+
+namespace
+{
+	// Both helpers exist so the identical test source compiles against the raw
+	// pointer and against the handle -- when the field type flips, only these
+	// two bodies move.
+	CHAR_DATA *Hunting(CHAR_DATA *ch)
+	{
+		return Deref(ch->hunting);
+	}
+
+	void Hunt(CHAR_DATA *hunter, CHAR_DATA *quarry)
+	{
+		hunter->hunting = quarry->self;
+	}
+}
+
+SCENARIO("an unrelated death leaves a mob's quarry alone", "[hunting]")
+{
+	GIVEN("two mobs hunting one character, and a bystander")
+	{
+		auto room = MakeTrackingRoom();
+		CHAR_DATA *quarry = MakeTracker(room);
+		CHAR_DATA *sucker = MakeTracker(room);
+		CHAR_DATA *anchor = MakeTracker(room);
+		CHAR_DATA *bystander = MakeTracker(room);
+
+		Hunt(sucker, quarry);
+		Hunt(anchor, quarry);
+
+		WHEN("somebody else entirely is extracted")
+		{
+			extract_char(bystander, true);
+
+			THEN("both hunters still name their quarry")
+			{
+				REQUIRE(Hunting(sucker) == quarry);
+				REQUIRE(Hunting(anchor) == quarry);
+			}
+		}
+
+		ClearTrackers();
+	}
+}
+
+SCENARIO("a mob's quarry does not outlive it", "[hunting]")
+{
+	GIVEN("a mob hunting a character")
+	{
+		auto room = MakeTrackingRoom();
+		CHAR_DATA *quarry = MakeTracker(room);
+		CHAR_DATA *anchor = MakeTracker(room);
+
+		Hunt(anchor, quarry);
+
+		REQUIRE(Hunting(anchor) == quarry);
+
+		WHEN("the quarry dies")
+		{
+			extract_char(quarry, true);
+
+			THEN("the hunter names nothing")
+			{
+				REQUIRE(Hunting(anchor) == nullptr);
+			}
+
+			THEN("the next character to take the address is not mistaken for it")
+			{
+				// The whole defect, in three lines. Every reachable reader of
+				// this field walks char_list asking "is this the mob hunting
+				// me?" and answers with ==, so the newcomer used to inherit the
+				// dead character's anchor rather than crash on it.
+				CHAR_DATA *newcomer = new_char();
+
+				REQUIRE(newcomer == quarry);
+				REQUIRE(Hunting(anchor) != newcomer);
+				REQUIRE(Hunting(anchor) == nullptr);
+			}
+		}
+
+		ClearTrackers();
+	}
+}

--- a/tests/handler_tests.c
+++ b/tests/handler_tests.c
@@ -12,6 +12,7 @@
 #include "../code/enums.h"
 #include "../code/db.h"
 #include "../code/recycle.h"
+#include "../code/newmem.h"
 
 // TEST_CASE("Test capitalization", "[string]" )
 // {
@@ -1997,6 +1998,119 @@ SCENARIO("a possessed mob does not outlive the connection driving it", "[chdesc]
 
 				free_descriptor(newcomer);
 			}
+		}
+
+		ClearTrackers();
+	}
+}
+
+//
+// ch->last_fight_opponent -- "who did I last fight", for the lost-link wiznet and
+// do_stat.
+//
+// Not a string field. It is a `char *` holding the *other character's*
+// true_name allocation, compared by pointer identity, and the only setter is
+// update_pc_last_fight -- which early-returns unless both parties are players.
+// extract_char's scrub carries the identical !is_npc guard on both sides, so
+// the mismatch that guard could hide is unreachable by construction.
+//
+// The hole is somewhere else. `true_name` is free_pstring'd and reallocated on
+// two paths that leave the character *alive* -- do_rename, and update.c's
+// name-repair tick -- and after either, the alias points at released memory
+// that extract_char's scrub can never match, because it compares against the
+// character's current true_name and that buffer is no longer anyone's.
+//
+// free_pstring is a real delete[], not a free list, so unlike every other
+// defect in this graph this one is ordinary heap memory and ASAN sees it.
+//
+
+namespace
+{
+	const char *LastOpponentName(CHAR_DATA *ch)
+	{
+		CHAR_DATA *opponent = Deref(ch->last_fight_opponent);
+
+		return opponent ? opponent->true_name : nullptr;
+	}
+
+	void RecordFight(CHAR_DATA *a, CHAR_DATA *b)
+	{
+		a->last_fight_opponent = b->self;
+	}
+
+	CHAR_DATA *MakeNamedPlayer(ROOM_INDEX_DATA *room, const char *name)
+	{
+		CHAR_DATA *ch = MakeTracker(room);
+
+		REMOVE_BIT(ch->act, ACT_IS_NPC);
+		// extract_char's remaining scrub walk reads tch->pcdata->trusting for
+		// every player in char_list, so a test player needs real pcdata.
+		ch->pcdata = std::make_unique<pc_data>();
+		ch->true_name = palloc_string(name);
+		ch->name = palloc_string(name);
+
+		return ch;
+	}
+}
+
+SCENARIO("the last opponent is forgotten when they leave the world", "[lastfight]")
+{
+	GIVEN("two players who have fought each other")
+	{
+		auto room = MakeTrackingRoom();
+		CHAR_DATA *fighter = MakeNamedPlayer(room, "Alice");
+		CHAR_DATA *opponent = MakeNamedPlayer(room, "Bob");
+
+		RecordFight(fighter, opponent);
+
+		REQUIRE(LastOpponentName(fighter) != nullptr);
+		REQUIRE(strcmp(LastOpponentName(fighter), "Bob") == 0);
+
+		WHEN("the opponent is extracted")
+		{
+			extract_char(opponent, true);
+
+			THEN("the record reads as nothing rather than as a released buffer")
+			{
+				REQUIRE(LastOpponentName(fighter) == nullptr);
+			}
+		}
+
+		ClearTrackers();
+	}
+}
+
+SCENARIO("the last opponent survives a rename", "[lastfight]")
+{
+	GIVEN("two players who have fought each other")
+	{
+		auto room = MakeTrackingRoom();
+		CHAR_DATA *fighter = MakeNamedPlayer(room, "Alice");
+		CHAR_DATA *opponent = MakeNamedPlayer(room, "Bob");
+
+		RecordFight(fighter, opponent);
+
+		WHEN("the opponent is renamed")
+		{
+			// do_rename and update.c's name-repair tick both free_pstring the
+			// old true_name and allocate a new one, and both leave the
+			// character alive -- so extract_char's scrub never runs, and could
+			// not match the released buffer if it did.
+			//
+			// The old buffer is deliberately kept alive here rather than freed:
+			// reading a released one is undefined, and the question this asks
+			// is which *name* the record reports, not whether the read traps.
+			// The trap is real and ASAN sees it; that is demonstrated
+			// separately, because a permanently undefined test is a bad test.
+			char *releasedInProduction = opponent->true_name;
+			opponent->true_name = palloc_string("Robert");
+
+			THEN("the record names the opponent by their current name")
+			{
+				REQUIRE(strcmp(LastOpponentName(fighter), "Robert") == 0);
+			}
+
+			free_pstring(releasedInProduction);
 		}
 
 		ClearTrackers();

--- a/tests/mprog_tests.c
+++ b/tests/mprog_tests.c
@@ -94,7 +94,7 @@ SCENARIO("Testing a mob dropping an object", "[mprog_drop]")
 
 			THEN("the object leaves the mob and lies in the room")
 			{
-				REQUIRE(obj->carried_by == nullptr);
+				REQUIRE(Deref(obj->carried_by) == nullptr);
 				REQUIRE(obj->in_room == room);
 				REQUIRE(room->contents == obj);
 				REQUIRE(mob->carrying == nullptr);

--- a/tests/mprog_tests.c
+++ b/tests/mprog_tests.c
@@ -6,6 +6,8 @@
 #include "../code/entity/obj_data.h"
 #include "../code/entity/room_index_data.h"
 #include "../code/entity/area_data.h"
+#include "../code/entity/mob_index_data.h"
+#include "../code/macros.h"
 #include "../code/enums.h"
 #include "../code/mud.h"
 
@@ -98,6 +100,56 @@ SCENARIO("Testing a mob dropping an object", "[mprog_drop]")
 				REQUIRE(obj->in_room == room);
 				REQUIRE(room->contents == obj);
 				REQUIRE(mob->carrying == nullptr);
+			}
+		}
+	}
+}
+
+//
+// pulse_prog_demon -- the summoned demon's per-pulse behaviour.
+//
+// It gives up and returns to the Hells when its quarry is gone, and one of the
+// ways "gone" is spelled is `hunting` no longer resolving to anybody. The
+// give-up branch used to announce having taken the quarry's soul without
+// checking there was a quarry to read.
+//
+// Reachability, stated because it changes what this test is worth: nothing in
+// the tree spawns the mobs this prog is attached to (area/skills.are hangs it
+// on vnums 2935-2937, which no code creates and no area resets), so the crash
+// is latent rather than live. The guard is still wrong, and the call below is
+// the branch nothing else reaches.
+//
+
+SCENARIO("a demon whose quarry is gone gives up without reading it", "[mprog_demon]")
+{
+	GIVEN("a demon with a master and no quarry")
+	{
+		auto room = CreateTestRoom();
+		auto master = CreateTestChar((char *)"Summoner", room);
+		auto demon = CreateTestChar((char *)"Demon", room);
+
+		// Both NPCs: extract_char's die_follower walk reaches can_see, which
+		// reads pcdata on anything that is not one.
+		master->pIndexData = new mob_index_data();
+		SET_BIT(master->act, ACT_IS_NPC);
+
+		demon->pIndexData = new mob_index_data();
+		SET_BIT(demon->act, ACT_IS_NPC);
+		demon->master = master->self;
+
+		REQUIRE(Deref(demon->hunting) == nullptr);
+
+		WHEN("the pulse comes round")
+		{
+			pulse_prog_demon(demon);
+
+			THEN("it runs the give-up branch through instead of dereferencing the quarry it does not have")
+			{
+				// Reaching char_from_room is the observable end of that branch.
+				// The extract stops short of freeing here -- this demon was
+				// never linked into char_list, and free_char would try to
+				// release a string literal -- so the room is what to assert on.
+				REQUIRE(demon->in_room == nullptr);
 			}
 		}
 	}

--- a/tests/mprog_tests.c
+++ b/tests/mprog_tests.c
@@ -1,4 +1,5 @@
 #include "catch.hpp"
+#include "../code/entity/handles.h"
 #include "../code/mprog.h"
 #include "../code/handler.h"
 #include "../code/entity/char_data.h"
@@ -20,6 +21,10 @@ static room_index_data* CreateTestRoom()
 static obj_data* CreateTestItem()
 {
 	auto item = new obj_data();
+	// Registered the way new_obj would, so handle-typed references to it
+	// resolve. Without this its self handle stays null and every reference
+	// to it would read as "nothing", passing the assertions vacuously.
+	item->self = objectHandles.Add(item);
 	item->name = "test_trinket";
 	item->description = "A test item";
 	item->wear_loc = -1;
@@ -30,6 +35,7 @@ static obj_data* CreateTestItem()
 static char_data* CreateTestChar(char *name, room_index_data *room)
 {
 	auto ch = new char_data();
+	ch->self = charHandles.Add(ch);	// as new_char would
 	ch->name = name;
 	char_to_room(ch, room);
 
@@ -61,7 +67,7 @@ SCENARIO("Testing a mob handing an object to a character", "[mprog_give]")
 
 			THEN("the object leaves the mob and is carried by the character")
 			{
-				REQUIRE(obj->carried_by == ch);
+				REQUIRE(Deref(obj->carried_by) == ch);
 				REQUIRE(ch->carrying == obj);
 				REQUIRE(mob->carrying == nullptr);
 			}

--- a/tests/pathfind_tests.c
+++ b/tests/pathfind_tests.c
@@ -1,0 +1,178 @@
+#include "catch.hpp"
+#include "../code/merc.h"
+#include "../code/act_move.h"
+#include "../code/direction.h"
+#include "../code/entity/room_index_data.h"
+#include "../code/entity/exit_data.h"
+#include "../code/entity/area_data.h"
+#include "../code/db.h"
+#include "../code/recycle.h"
+
+//
+// PATHFIND_DATA -- the mob tracking search.
+//
+// The search is a recursive walk over an area's room graph. Each node it visits
+// is also hung off room->path, which is what stops it re-expanding a room it has
+// already reached by a shorter route. So room->path is a *visited marker for one
+// search*, and it has to be gone before the next search starts.
+//
+// That is the property these scenarios are about. The nodes themselves are a
+// plain tree -- every one is stored into exactly one dir_to[] slot -- so
+// ownership was never the interesting part; lifetime and leftover state were.
+//
+
+namespace
+{
+	std::vector<ROOM_INDEX_DATA *> builtRooms;
+	AREA_DATA *testArea = nullptr;
+
+	ROOM_INDEX_DATA *MakeRoom(int vnum)
+	{
+		auto room = new room_index_data();
+
+		room->vnum = vnum;
+		room->area = testArea;
+		room->path = nullptr;
+
+		room->next_room = room_list;
+		room_list = room;
+
+		builtRooms.push_back(room);
+
+		return room;
+	}
+
+	void Link(ROOM_INDEX_DATA *from, ROOM_INDEX_DATA *to, int dir, int back)
+	{
+		auto out = new exit_data();
+		out->u1.to_room = to;
+		from->exit[dir] = out;
+
+		auto in = new exit_data();
+		in->u1.to_room = from;
+		to->exit[back] = in;
+	}
+
+	void ClearRooms()
+	{
+		for (auto room : builtRooms)
+		{
+			for (auto i = 0; i < MAX_EXIT; i++)
+			{
+				if (room->exit[i] != nullptr)
+				{
+					delete room->exit[i];
+					room->exit[i] = nullptr;
+				}
+			}
+		}
+
+		for (auto room : builtRooms)
+			delete room;
+
+		builtRooms.clear();
+		room_list = nullptr;
+
+		delete testArea;
+		testArea = nullptr;
+	}
+
+	void StartWorld()
+	{
+		room_list = nullptr;
+		testArea = new area_data();
+	}
+}
+
+SCENARIO("a search finds the first step towards its goal", "[pathfind]")
+{
+	GIVEN("three rooms in a line, west to east")
+	{
+		StartWorld();
+
+		auto west = MakeRoom(100);
+		auto middle = MakeRoom(101);
+		auto east = MakeRoom(102);
+
+		Link(west, middle, Directions::East, Directions::West);
+		Link(middle, east, Directions::East, Directions::West);
+
+		WHEN("a search runs from the west end to the east end")
+		{
+			auto dir = find_first_step(west, east);
+
+			THEN("the first step is east")
+			{
+				REQUIRE(dir == Directions::East);
+			}
+		}
+
+		ClearRooms();
+	}
+}
+
+SCENARIO("a search leaves no visited markers behind it", "[pathfind]")
+{
+	GIVEN("three rooms in a line")
+	{
+		StartWorld();
+
+		auto west = MakeRoom(100);
+		auto middle = MakeRoom(101);
+		auto east = MakeRoom(102);
+
+		Link(west, middle, Directions::East, Directions::West);
+		Link(middle, east, Directions::East, Directions::West);
+
+		WHEN("a search has run to completion")
+		{
+			find_first_step(west, east);
+
+			THEN("no room still names a node from it")
+			{
+				// The markers point into a tree that has been freed by now, so
+				// leaving one set is not merely untidy.
+				REQUIRE(west->path == nullptr);
+				REQUIRE(middle->path == nullptr);
+				REQUIRE(east->path == nullptr);
+			}
+		}
+
+		ClearRooms();
+	}
+}
+
+SCENARIO("a search that finds nothing does not spoil the next one", "[pathfind]")
+{
+	GIVEN("two connected rooms and one unreachable room in the same area")
+	{
+		StartWorld();
+
+		auto west = MakeRoom(100);
+		auto middle = MakeRoom(101);
+		auto marooned = MakeRoom(200);
+
+		Link(west, middle, Directions::East, Directions::West);
+
+		WHEN("a search for the unreachable room fails, and then a reachable one runs")
+		{
+			// The failing search still walks west and middle, and marks both.
+			REQUIRE(find_first_step(west, marooned) == -1);
+
+			auto dir = find_first_step(west, middle);
+
+			THEN("the second search still works")
+			{
+				// It did not, before the search started owning its own state.
+				// The markers left behind by the failed search say "already
+				// reached in one step or fewer, and already evaluated", which
+				// is exactly the test used to decide a room is not worth
+				// expanding -- so the second search pruned the only route it
+				// had and reported no path.
+				REQUIRE(dir == Directions::East);
+			}
+		}
+
+		ClearRooms();
+	}
+}

--- a/tests/prof_tests.c
+++ b/tests/prof_tests.c
@@ -371,7 +371,7 @@ SCENARIO("retrieve the proficiencies taught by a trainer", "[GetProfsTaughtByTra
 			{
 				player->Profs()->GetProfsTaughtByTrainer(player, trainer);
 
-				auto result = !str_cmp(player->desc->outbuf, "\n\rcooking          | 13 points\n\rfirestarting     | 15 points\n\r");
+				auto result = !str_cmp(Deref(player->desc)->outbuf, "\n\rcooking          | 13 points\n\rfirestarting     | 15 points\n\r");
 				REQUIRE(result == true);
 			}
 
@@ -404,7 +404,7 @@ SCENARIO("a trainer tries to teach a character a procificiency", "[TrainProficie
 			{
 				player->Profs()->TrainProficiency(player, trainer, "moo");
 
-				auto result = !str_cmp(player->desc->outbuf,"\n\rSyntax: proficiencies train <proficiency>\n\r");
+				auto result = !str_cmp(Deref(player->desc)->outbuf,"\n\rSyntax: proficiencies train <proficiency>\n\r");
 				REQUIRE(result == true);
 			}
 
@@ -430,7 +430,7 @@ SCENARIO("a trainer tries to teach a character a procificiency", "[TrainProficie
 			{
 				player->Profs()->TrainProficiency(player, trainer, "train butchery");
 
-				auto result = !str_cmp(player->desc->outbuf,"\n\rYou can't study that here.\n\r");
+				auto result = !str_cmp(Deref(player->desc)->outbuf,"\n\rYou can't study that here.\n\r");
 				REQUIRE(result == true);
 			}
 
@@ -457,7 +457,7 @@ SCENARIO("a trainer tries to teach a character a procificiency", "[TrainProficie
 				player->Profs()->SetProf(6, 1); // cooking
 				player->Profs()->TrainProficiency(player, trainer, "train cooking");
 
-				auto result = !str_cmp(player->desc->outbuf,"\n\rYou are already familiar with that proficiency.\n\r");
+				auto result = !str_cmp(Deref(player->desc)->outbuf,"\n\rYou are already familiar with that proficiency.\n\r");
 				REQUIRE(result == true);
 			}
 
@@ -484,7 +484,7 @@ SCENARIO("a trainer tries to teach a character a procificiency", "[TrainProficie
 				player->Profs()->SetPoints(8);
 				player->Profs()->TrainProficiency(player, trainer, "train cooking");
 
-				auto result = !str_cmp(player->desc->outbuf,"\n\rYou don't have enough points to study that proficiency.\n\r");
+				auto result = !str_cmp(Deref(player->desc)->outbuf,"\n\rYou don't have enough points to study that proficiency.\n\r");
 				REQUIRE(result == true);
 			}
 
@@ -523,7 +523,7 @@ SCENARIO("a trainer tries to teach a character a procificiency", "[TrainProficie
 				player->Profs()->SetPoints(30);
 				player->Profs()->TrainProficiency(player, trainer, "train tracking");
 
-				auto result = !str_cmp(player->desc->outbuf,"\n\rYou are not advanced enough in your guild to learn that proficiency.\n\r");
+				auto result = !str_cmp(Deref(player->desc)->outbuf,"\n\rYou are not advanced enough in your guild to learn that proficiency.\n\r");
 				REQUIRE(result == true);
 			}
 
@@ -555,7 +555,7 @@ SCENARIO("a trainer tries to teach a character a procificiency", "[TrainProficie
 				//RS.Queue.ProcessQueue();
 
 				// TODO: this should be the trainers message to the character
-				//auto result = !str_cmp(player->desc->outbuf,"\n\r$N beckons you over to a nearby tree.\n\r");
+				//auto result = !str_cmp(Deref(player->desc)->outbuf,"\n\r$N beckons you over to a nearby tree.\n\r");
 				//REQUIRE(result == true);
 
 				REQUIRE(player->Profs()->GetPoints() == 0);
@@ -975,7 +975,7 @@ SCENARIO("testing outputting character known proficiencies", "[ListKnownProficie
 
 			THEN("it should send a single line of text to the player buffer")
 			{
-				auto result = !str_cmp(player->desc->outbuf, "\n\rYou currently have no proficiencies.\n\r");
+				auto result = !str_cmp(Deref(player->desc)->outbuf, "\n\rYou currently have no proficiencies.\n\r");
 
 				REQUIRE(result == true);
 			}
@@ -998,7 +998,7 @@ SCENARIO("testing outputting character known proficiencies", "[ListKnownProficie
 
 			THEN("it should send a listing of proficiencies to the player buffer")
 			{
-				auto result = !str_cmp(player->desc->outbuf, "\n\rYour proficiencies are:\n\rYou are proficient at cooking.\n\rYou are proficient at firestarting.\n\r");
+				auto result = !str_cmp(Deref(player->desc)->outbuf, "\n\rYour proficiencies are:\n\rYou are proficient at cooking.\n\rYou are proficient at firestarting.\n\r");
 
 				REQUIRE(result == true);
 			}
@@ -1030,7 +1030,7 @@ SCENARIO("testing outputting a list of basic proficiencies", "[ListBasicProficie
 				buffer += std::string("cooking               firestarting          \n\r");
 				buffer += std::string("Many other proficiencies are known to Shalaran adventurers, but you must first find a teacher.\n\r");
 
-				REQUIRE(!str_cmp(buffer.c_str(), player->desc->outbuf));
+				REQUIRE(!str_cmp(buffer.c_str(), Deref(player->desc)->outbuf));
 			}
 
 			TestHelperCleanupPlayerObject(player);
@@ -1057,7 +1057,7 @@ SCENARIO("testing outputting a list of known proficiencies and points", "[Displa
 			{
 				auto buffer = std::string("\n\rProficiencies (30 pts left): \n\r");
 
-				REQUIRE(!str_cmp(buffer.c_str(), player->desc->outbuf));
+				REQUIRE(!str_cmp(buffer.c_str(), Deref(player->desc)->outbuf));
 			}
 
 			TestHelperCleanupPlayerObject(player);
@@ -1082,7 +1082,7 @@ SCENARIO("testing outputting a list of known proficiencies and points", "[Displa
 			{
 				auto buffer = std::string("\n\rProficiencies (30 pts left): mountaineering (1) cooking (1) firestarting\n\r(1) \n\r");
 
-				REQUIRE(!str_cmp(buffer.data(), player->desc->outbuf));
+				REQUIRE(!str_cmp(buffer.data(), Deref(player->desc)->outbuf));
 			}
 
 			TestHelperCleanupPlayerObject(player);
@@ -1164,7 +1164,7 @@ SCENARIO("display a list of proficiencies and skill mastery the player has learn
 			{
 				auto buffer = std::string("\n\rYou are adept in mountaineering.\n\rYou are masterful in cooking.\n\r");
 
-				REQUIRE(!str_cmp(buffer.c_str(), player->desc->outbuf));
+				REQUIRE(!str_cmp(buffer.c_str(), Deref(player->desc)->outbuf));
 			}
 
 			TestHelperCleanupPlayerObject(player);
@@ -1189,7 +1189,7 @@ SCENARIO("update the players proficiency points and notify them", "[UpdateProfPo
 			THEN("it should display a message notifying the player")
 			{
 				auto buffer = std::string("\n\rYou feel ready to study new proficiencies.\n\r");
-				REQUIRE(!str_cmp(buffer.c_str(), player->desc->outbuf));
+				REQUIRE(!str_cmp(buffer.c_str(), Deref(player->desc)->outbuf));
 			}
 
 			TestHelperCleanupPlayerObject(player);
@@ -1213,7 +1213,7 @@ SCENARIO("check to see if player leveled a proficiency (int int)", "[CheckImprov
 			THEN("it should display a message notifying the player")
 			{
 				// TODO: figure out how to game the chance generator to test correct output
-				auto result = player->desc->outbuf;
+				auto result = Deref(player->desc)->outbuf;
 
 				REQUIRE(1 == 1);
 			}
@@ -1237,7 +1237,7 @@ SCENARIO("check to see if player leveled a proficiency (char* int)", "[CheckImpr
 			THEN("it should display a message notifying the player")
 			{
 				// TODO: figure out how to game the chance generator to test correct output
-				auto result = player->desc->outbuf;
+				auto result = Deref(player->desc)->outbuf;
 
 				REQUIRE(1 == 1);
 			}
@@ -1428,7 +1428,7 @@ SCENARIO("Attempt to track a character", "[prof_tracking]")
 				char_list = player2;
 				player->Profs()->InterpCommand("track", "player2");
 
-				auto result = !str_cmp(player->desc->outbuf,"\n\rTrack who?\n\r");
+				auto result = !str_cmp(Deref(player->desc)->outbuf,"\n\rTrack who?\n\r");
 
 				REQUIRE(result == true);
 			}
@@ -1455,7 +1455,7 @@ SCENARIO("Attempt to track a character", "[prof_tracking]")
 				char_list = player2;
 				player->Profs()->InterpCommand("track", "player2");
 
-				auto result = !str_cmp(player->desc->outbuf,"\n\rYou cannot attempt to track them again yet.\n\r");
+				auto result = !str_cmp(Deref(player->desc)->outbuf,"\n\rYou cannot attempt to track them again yet.\n\r");
 
 				REQUIRE(result == true);
 			}
@@ -1482,7 +1482,7 @@ SCENARIO("Attempt to track a character", "[prof_tracking]")
 				char_list = player2;
 				player->Profs()->InterpCommand("track", "player2");
 
-				auto result = !str_cmp(player->desc->outbuf,"\n\rEven if they had been here, there would be no suitable tracks left for you to follow.\n\r");
+				auto result = !str_cmp(Deref(player->desc)->outbuf,"\n\rEven if they had been here, there would be no suitable tracks left for you to follow.\n\r");
 
 				REQUIRE(result == true);
 			}
@@ -1512,7 +1512,7 @@ SCENARIO("Attempt to track a character", "[prof_tracking]")
 				char_list = player2;
 				player->Profs()->InterpCommand("track", "player2");
 
-				//auto result = !str_cmp(player->desc->outbuf,"\n\rYou were unable to find any sign of player2 here.\n\r");
+				//auto result = !str_cmp(Deref(player->desc)->outbuf,"\n\rYou were unable to find any sign of player2 here.\n\r");
 				// TODO: find out how act() writes to buffer
 				REQUIRE(1 == 1);
 			}
@@ -1669,7 +1669,7 @@ SCENARIO("Attempt to bandage a character", "[prof_bandage]")
 			THEN("it should display a message notifying the player")
 			{
 				player->Profs()->InterpCommand("bandage", "self");
-				auto result = !str_cmp(player->desc->outbuf,"\n\rYou can only bandage wounds that are bleeding.\n\r");
+				auto result = !str_cmp(Deref(player->desc)->outbuf,"\n\rYou can only bandage wounds that are bleeding.\n\r");
 
 				REQUIRE(result == true);
 			}
@@ -1689,7 +1689,7 @@ SCENARIO("Attempt to bandage a character", "[prof_bandage]")
 			THEN("it should display a message notifying the player")
 			{
 				player->Profs()->InterpCommand("bandage", "self");
-				auto result = !str_cmp(player->desc->outbuf,"\n\rThat wound has been bandaged too recently.\n\r");
+				auto result = !str_cmp(Deref(player->desc)->outbuf,"\n\rThat wound has been bandaged too recently.\n\r");
 
 				REQUIRE(result == true);
 			}
@@ -1721,7 +1721,7 @@ SCENARIO("Attempt to bandage a character", "[prof_bandage]")
 			THEN("it should display a message notifying the player")
 			{
 				player->Profs()->InterpCommand("bandage", "self");
-				auto result = !str_cmp(player->desc->outbuf,"\n\rYou bandage your wounds, staunching the worst of the bleeding.\n\r");
+				auto result = !str_cmp(Deref(player->desc)->outbuf,"\n\rYou bandage your wounds, staunching the worst of the bleeding.\n\r");
 
 				REQUIRE(result == true);
 			}

--- a/tests/rune_tests.c
+++ b/tests/rune_tests.c
@@ -10,6 +10,7 @@
 #include "../code/enums.h"
 #include "../code/db.h"
 #include "../code/recycle.h"
+#include "../code/mem.h"
 
 //
 // RUNE_DATA, and the two lists every rune is on at once.
@@ -98,7 +99,6 @@ namespace
 			extract_rune(rune_list);
 
 		obj->rune = nullptr;
-		obj->has_rune = false;
 	}
 }
 
@@ -114,7 +114,6 @@ SCENARIO("a rune is reachable from both of the lists it is placed on", "[rune]")
 		{
 			REQUIRE(GlobalListLength() == 1);
 			REQUIRE(ChainTypes(obj) == std::vector<int>{11});
-			REQUIRE(obj->has_rune);
 		}
 
 		THEN("find_rune matches it by trigger")
@@ -169,15 +168,14 @@ SCENARIO("extracting the oldest rune does not hide the newer ones", "[rune]")
 
 		WHEN("the oldest expires")
 		{
-			// It is the tail, so its next_content is null -- and that is the
-			// branch that clears has_rune outright regardless of what else is
-			// still on the chain.
+			// It is the tail, so its next_content is null -- the case the old
+			// unlink treated as "this container has no runes left", whatever
+			// else was still on the chain.
 			extract_rune(oldest);
 
 			THEN("the newer rune is still there and still visible")
 			{
 				REQUIRE(ChainTypes(obj) == std::vector<int>{22});
-				REQUIRE(obj->has_rune);
 				REQUIRE(find_rune(obj, RUNE_TO_WEAPON, RUNE_TRIGGER_EXIT, nullptr) != nullptr);
 			}
 		}
@@ -233,7 +231,6 @@ SCENARIO("extracting the last rune leaves the container naming nothing", "[rune]
 				// pointing at an extracted rune is pointing at something
 				// new_rune can hand straight back out.
 				REQUIRE(obj->rune == nullptr);
-				REQUIRE(!obj->has_rune);
 				REQUIRE(GlobalListLength() == 0);
 			}
 		}
@@ -287,5 +284,39 @@ SCENARIO("a rune does not remember a caster who has left the world", "[rune]")
 
 		ClearRunes(obj);
 		free_obj(obj);
+	}
+}
+
+SCENARIO("a recycled exit does not inherit the last one's rune", "[rune]")
+{
+	GIVEN("an exit that carried a rune and has been freed")
+	{
+		EXIT_DATA *pexit = new_exit();
+
+		REQUIRE(pexit->rune == nullptr);
+
+		// Stand in for a rune having been placed on the door. The pointer is
+		// never followed here -- what matters is that new_exit clears it.
+		pexit->rune = (RUNE_DATA *)0xdeadbeef;
+
+		free_exit(pexit);
+
+		WHEN("the exit allocator hands the same struct back out")
+		{
+			EXIT_DATA *reused = new_exit();
+
+			THEN("it names no rune")
+			{
+				// new_exit resets every other field it hands back and used to
+				// skip this one, so a recycled exit inherited both the stale
+				// pointer and the stale flag that made it readable. The area
+				// loader had the same hole from the other direction: it built
+				// exits with an uninitialised rune pointer entirely.
+				REQUIRE(reused == pexit);
+				REQUIRE(reused->rune == nullptr);
+			}
+
+			free_exit(reused);
+		}
 	}
 }

--- a/tests/rune_tests.c
+++ b/tests/rune_tests.c
@@ -320,3 +320,40 @@ SCENARIO("a recycled exit does not inherit the last one's rune", "[rune]")
 		}
 	}
 }
+
+//
+// The rune spell_stasis_wall hands to the queue.
+//
+// A drawn rune waits nine ticks before draw_rune finalises it. It used to live
+// in the temp-struct pool, which is a bump allocator over a fixed buffer that
+// wraps without regard for outstanding pointers -- so the queue entry named
+// memory any other pool caller could take back. It comes from new_rune now, and
+// the queue owns it until draw_rune runs.
+//
+
+SCENARIO("a drawn rune is returned to the recycler however the draw ends", "[rune]")
+{
+	GIVEN("a rune queued for drawing whose caster then leaves")
+	{
+		CHAR_DATA *caster = new_char();
+		RUNE_DATA *drawn = new_rune();
+
+		drawn->owner = caster->self;
+		drawn->drawn_in = 1;
+
+		free_char(caster);
+
+		WHEN("the draw comes due with nobody left to complete it")
+		{
+			draw_rune(drawn, nullptr);
+
+			THEN("the rune is back on the free list rather than stranded")
+			{
+				// The bail-out paths are the ones worth pinning: the queue held
+				// the only reference, so an early return that skips the free
+				// strands the struct for the rest of the run.
+				REQUIRE(new_rune() == drawn);
+			}
+		}
+	}
+}

--- a/tests/rune_tests.c
+++ b/tests/rune_tests.c
@@ -27,15 +27,31 @@
 
 namespace
 {
+	// The one reader and the one writer of rune->owner, so the rest of this
+	// file compiles unchanged either side of the field's type flip.
+	CHAR_DATA *RuneOwner(const RUNE_DATA *rune)
+	{
+		return Deref(rune->owner);
+	}
+
+	void SetRuneOwner(RUNE_DATA &rune, CHAR_DATA *owner)
+	{
+		rune.owner = owner->self;
+	}
+
 	// apply_rune copies its argument into a fresh new_rune(), so the caller's
 	// struct is a template rather than the thing that ends up on the lists.
-	RUNE_DATA *PlaceRuneOnObj(OBJ_DATA *obj, int type, int trigger)
+	RUNE_DATA *PlaceRuneOnObj(OBJ_DATA *obj, int type, int trigger, CHAR_DATA *owner = nullptr)
 	{
 		RUNE_DATA temp;
 
 		temp.function = nullptr;
 		temp.placed_on = obj;
 		temp.owner = nullptr;
+
+		if (owner != nullptr)
+			SetRuneOwner(temp, owner);
+
 		temp.target_type = RUNE_TO_WEAPON;
 		temp.trigger_type = trigger;
 		temp.level = 30;
@@ -219,6 +235,53 @@ SCENARIO("extracting the last rune leaves the container naming nothing", "[rune]
 				REQUIRE(obj->rune == nullptr);
 				REQUIRE(!obj->has_rune);
 				REQUIRE(GlobalListLength() == 0);
+			}
+		}
+
+		ClearRunes(obj);
+		free_obj(obj);
+	}
+}
+
+//
+// rune->owner -- the caster. §0.6 found it late: it is a fifth `owner`, on a
+// type nobody counted as part of the entity graph, and it is the only one that
+// was scrubbed by literally nothing. Runes are placed on doors and rooms
+// precisely so they outlive the moment they were cast in, so a caster leaving
+// while their rune stands is the ordinary case rather than an edge one.
+//
+
+SCENARIO("a rune does not remember a caster who has left the world", "[rune]")
+{
+	GIVEN("a rune placed by a character")
+	{
+		OBJ_DATA *obj = new_obj();
+		CHAR_DATA *caster = new_char();
+		RUNE_DATA *rune = PlaceRuneOnObj(obj, 11, RUNE_TRIGGER_EXIT, caster);
+
+		REQUIRE(RuneOwner(rune) == caster);
+
+		WHEN("the caster is freed while the rune still stands")
+		{
+			free_char(caster);
+
+			THEN("the rune names nobody")
+			{
+				REQUIRE(RuneOwner(rune) == nullptr);
+			}
+
+			THEN("it still names nobody once the address is reissued")
+			{
+				// The damage this does is misattribution rather than a crash:
+				// the readers pass the owner to is_safe_new and damage_new, so
+				// a recycled address makes an unrelated character the author of
+				// a stasis wall they never cast.
+				CHAR_DATA *newcomer = new_char();
+
+				REQUIRE(newcomer == caster);
+				REQUIRE(RuneOwner(rune) != newcomer);
+
+				free_char(newcomer);
 			}
 		}
 

--- a/tests/rune_tests.c
+++ b/tests/rune_tests.c
@@ -1,0 +1,228 @@
+#include "catch.hpp"
+#include "../code/merc.h"
+#include "../code/handler.h"
+#include "../code/characterClasses/chrono.h"
+#include "../code/entity/char_data.h"
+#include "../code/entity/obj_data.h"
+#include "../code/entity/exit_data.h"
+#include "../code/entity/room_index_data.h"
+#include "../code/entity/handles.h"
+#include "../code/enums.h"
+#include "../code/db.h"
+#include "../code/recycle.h"
+
+//
+// RUNE_DATA, and the two lists every rune is on at once.
+//
+// apply_rune puts a rune on the global `rune_list` (via `next`) AND on a
+// per-container chain hanging off obj->rune / exit->rune / room->rune (via
+// `next_content`). update.c ticks runes off the global list and calls
+// extract_rune when one expires; find_rune walks the per-container chain to
+// decide whether entering a room or opening a door should trigger anything.
+//
+// So the global list decides *when* a rune fires and the container chain
+// decides *whether*, and extract_rune has to unlink from both. These scenarios
+// are about the container half, because that is the half it gets wrong.
+//
+
+namespace
+{
+	// apply_rune copies its argument into a fresh new_rune(), so the caller's
+	// struct is a template rather than the thing that ends up on the lists.
+	RUNE_DATA *PlaceRuneOnObj(OBJ_DATA *obj, int type, int trigger)
+	{
+		RUNE_DATA temp;
+
+		temp.function = nullptr;
+		temp.placed_on = obj;
+		temp.owner = nullptr;
+		temp.target_type = RUNE_TO_WEAPON;
+		temp.trigger_type = trigger;
+		temp.level = 30;
+		temp.duration = 5;
+		temp.type = type;
+		temp.extra = 0;
+		temp.drawn_in = 0;
+		temp.next = nullptr;
+		temp.next_content = nullptr;
+		temp.end_fun = nullptr;
+
+		apply_rune(&temp);
+
+		// apply_rune pushes onto both heads, so the rune it just made is the
+		// head of the global list.
+		return rune_list;
+	}
+
+	// The container chain as a list of rune `type`s, read the way find_rune
+	// reads it. A rune that has been unlinked correctly does not appear here.
+	std::vector<int> ChainTypes(OBJ_DATA *obj)
+	{
+		std::vector<int> types;
+
+		for (RUNE_DATA *rune = obj->rune; rune != nullptr; rune = rune->next_content)
+			types.push_back(rune->type);
+
+		return types;
+	}
+
+	int GlobalListLength()
+	{
+		int count = 0;
+
+		for (RUNE_DATA *rune = rune_list; rune != nullptr; rune = rune->next)
+			count++;
+
+		return count;
+	}
+
+	void ClearRunes(OBJ_DATA *obj)
+	{
+		while (rune_list != nullptr)
+			extract_rune(rune_list);
+
+		obj->rune = nullptr;
+		obj->has_rune = false;
+	}
+}
+
+SCENARIO("a rune is reachable from both of the lists it is placed on", "[rune]")
+{
+	GIVEN("an object with one rune on it")
+	{
+		OBJ_DATA *obj = new_obj();
+
+		PlaceRuneOnObj(obj, 11, RUNE_TRIGGER_EXIT);
+
+		THEN("it is on the global tick list and on the object's own chain")
+		{
+			REQUIRE(GlobalListLength() == 1);
+			REQUIRE(ChainTypes(obj) == std::vector<int>{11});
+			REQUIRE(obj->has_rune);
+		}
+
+		THEN("find_rune matches it by trigger")
+		{
+			REQUIRE(find_rune(obj, RUNE_TO_WEAPON, RUNE_TRIGGER_EXIT, nullptr) != nullptr);
+			REQUIRE(find_rune(obj, RUNE_TO_WEAPON, RUNE_TRIGGER_ENTRY, nullptr) == nullptr);
+		}
+
+		ClearRunes(obj);
+		free_obj(obj);
+	}
+}
+
+SCENARIO("extracting the newest rune leaves the older ones in place", "[rune]")
+{
+	GIVEN("an object with three runes, newest first")
+	{
+		OBJ_DATA *obj = new_obj();
+
+		PlaceRuneOnObj(obj, 11, RUNE_TRIGGER_EXIT);
+		PlaceRuneOnObj(obj, 22, RUNE_TRIGGER_EXIT);
+		RUNE_DATA *newest = PlaceRuneOnObj(obj, 33, RUNE_TRIGGER_EXIT);
+
+		REQUIRE(ChainTypes(obj) == std::vector<int>({33, 22, 11}));
+
+		WHEN("the newest expires")
+		{
+			// The head case, and the only one extract_rune has ever handled.
+			extract_rune(newest);
+
+			THEN("the other two are still on the chain, in order")
+			{
+				REQUIRE(ChainTypes(obj) == std::vector<int>({22, 11}));
+				REQUIRE(GlobalListLength() == 2);
+			}
+		}
+
+		ClearRunes(obj);
+		free_obj(obj);
+	}
+}
+
+SCENARIO("extracting the oldest rune does not hide the newer ones", "[rune]")
+{
+	GIVEN("an object with two runes on it")
+	{
+		OBJ_DATA *obj = new_obj();
+
+		RUNE_DATA *oldest = PlaceRuneOnObj(obj, 11, RUNE_TRIGGER_EXIT);
+
+		PlaceRuneOnObj(obj, 22, RUNE_TRIGGER_EXIT);
+
+		WHEN("the oldest expires")
+		{
+			// It is the tail, so its next_content is null -- and that is the
+			// branch that clears has_rune outright regardless of what else is
+			// still on the chain.
+			extract_rune(oldest);
+
+			THEN("the newer rune is still there and still visible")
+			{
+				REQUIRE(ChainTypes(obj) == std::vector<int>{22});
+				REQUIRE(obj->has_rune);
+				REQUIRE(find_rune(obj, RUNE_TO_WEAPON, RUNE_TRIGGER_EXIT, nullptr) != nullptr);
+			}
+		}
+
+		ClearRunes(obj);
+		free_obj(obj);
+	}
+}
+
+SCENARIO("extracting a rune from the middle of the chain keeps the rest", "[rune]")
+{
+	GIVEN("an object with three runes on it")
+	{
+		OBJ_DATA *obj = new_obj();
+
+		PlaceRuneOnObj(obj, 11, RUNE_TRIGGER_EXIT);
+
+		RUNE_DATA *middle = PlaceRuneOnObj(obj, 22, RUNE_TRIGGER_EXIT);
+
+		PlaceRuneOnObj(obj, 33, RUNE_TRIGGER_EXIT);
+
+		WHEN("the middle one expires")
+		{
+			extract_rune(middle);
+
+			THEN("the newest is still the head and the oldest still follows it")
+			{
+				REQUIRE(ChainTypes(obj) == std::vector<int>({33, 11}));
+				REQUIRE(GlobalListLength() == 2);
+			}
+		}
+
+		ClearRunes(obj);
+		free_obj(obj);
+	}
+}
+
+SCENARIO("extracting the last rune leaves the container naming nothing", "[rune]")
+{
+	GIVEN("an object with a single rune on it")
+	{
+		OBJ_DATA *obj = new_obj();
+
+		RUNE_DATA *only = PlaceRuneOnObj(obj, 11, RUNE_TRIGGER_EXIT);
+
+		WHEN("it expires")
+		{
+			extract_rune(only);
+
+			THEN("the object names no rune at all")
+			{
+				// free_rune pushes onto the rune free list, so a container left
+				// pointing at an extracted rune is pointing at something
+				// new_rune can hand straight back out.
+				REQUIRE(obj->rune == nullptr);
+				REQUIRE(!obj->has_rune);
+				REQUIRE(GlobalListLength() == 0);
+			}
+		}
+
+		ClearRunes(obj);
+		free_obj(obj);
+	}
+}

--- a/tests/test_helpers.c
+++ b/tests/test_helpers.c
@@ -5,11 +5,13 @@ void TestHelperSetupPlayerBuffer(CHAR_DATA *player, char *name = "player1", char
 {
 	player->name = name;
 	player->pcdata = std::make_unique<pc_data>();
-	player->desc = new descriptor_data();
-	player->desc->outbuf = new char[2];
-	player->desc->outtop = 0;
-	player->desc->fcommand = false;
-	player->desc->outsize = 2;
+	auto dnew = new descriptor_data();
+	dnew->self = descriptorHandles.Add(dnew);	// as new_descriptor would
+	player->desc = dnew->self;
+	dnew->outbuf = new char[2];
+	dnew->outtop = 0;
+	dnew->fcommand = false;
+	dnew->outsize = 2;
 	player->in_room = new room_index_data();
 	player->in_room->name = room_name;
 }
@@ -26,12 +28,12 @@ void TestHelperCleanupPlayerObject(CHAR_DATA *player)
 	if (player == nullptr)
 		return;
 
-	if (player->desc != nullptr)
+	if (Deref(player->desc) != nullptr)
 	{
-		if (player->desc->outbuf != nullptr)
-			delete[] player->desc->outbuf;
+		if (Deref(player->desc)->outbuf != nullptr)
+			delete[] Deref(player->desc)->outbuf;
 		
-		delete player->desc;
+		delete Deref(player->desc);
 	}
 
 	if(player->pIndexData != nullptr)


### PR DESCRIPTION
This PR is a hefty one. It's taking a lot of the raw long-lived pointers in the code and converting them into generational handles. Because of the way certain C++ objects travel throughout the game, a straight _ptr conversion (unique_ptr, shared_ptr, weak_ptr) is not possible without seriously affecting the game.

Entities used free lists which parks a struct for reuse rather than returning memory. Every cross-entity reference was a raw pointer into that pool. When the target was extracted the pointer stayed valid-looking and could hand the same address back out, thus causing silent corruptions. (Ex: A fresh player landing on a dead one's address inherits its hunter, its aerial anchor, or authorship of a stasis wall they never cast.)

> Note: Handle has no `operator->` and no `operator bool` on purpose. Their absence is what
> forced the compiler to enumerate every call site, and it's why the diff is full of 
> `Deref(x)`.

### Behavior changes
- `extract_char`'s affect-owner nulling walk was deleted: the most important change here. That walk sat above the early return that sends a slain player to the altar without freeing them, so it nulled `owner` for characters who were still alive. The readers demonstrably disagreed: `mark of wrath` asks `paf->owner->ghost > 0` which means "has my marked foe died". This only works if owner still resolves after a death. With this fix, `mark of wrath`, `burning pulse`, and the `mark` display should now behave correctly.

- `RUNE_DATA` re-linking rewritten: `extract_rune` only rewrote the container head when removing the head, so mid-chain removal left a chain pointing at a recycled struct. Affects stasis wall and runes on weapons/armor/portals/rooms.

- `PATHFIND_DATA` restructured: affects mob smart-tracking.

- `snoop_by` chain walked differently: affects immortal snoop.

### Bugs found and fixed
- a null deref in `pulse_prog_demon`
- a `CHAR_DATA` leaked per login
- `hunting`/`defending`/`analyzePC` never being cleared on extract.

