### PR TITLE
Convert free lists of entities into their own owned lists

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -78,14 +78,12 @@ jobs:
       # ASAN halts on memory errors by default
       # detect_leaks=0: the codebase intentionally never frees; leak reports
       #   would be pure noise for now.
-      # detect_odr_violation=0: tolerates the one known ODR violation
-      #   (db_tests.c includes db.c); revisit after the merc.h split.
       # UBSAN halt_on_error=1: the known UB this waited on was the queue
       #   re-entrancy UAF, fixed in the queue safety commit. UB now gates CI.
       - name: Test under sanitizers
         run: ctest --test-dir build-asan --output-on-failure
         env:
-          ASAN_OPTIONS: detect_leaks=0:detect_odr_violation=0
+          ASAN_OPTIONS: detect_leaks=0
           UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=1
 
   smoke:
@@ -137,7 +135,7 @@ jobs:
         run: tests/smoke/boot_test.sh
         env:
           RIFT_BIN: ${{ github.workspace }}/build-asan/code/rift
-          ASAN_OPTIONS: detect_leaks=0:detect_odr_violation=0
+          ASAN_OPTIONS: detect_leaks=0
           UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=1
 
       # Goes past the greeting: creates a character, keeps it in the world while
@@ -147,7 +145,7 @@ jobs:
         env:
           RIFT_BIN: ${{ github.workspace }}/build-asan/code/rift
           RIFT_SMOKE_BOOT_TIMEOUT: 240
-          ASAN_OPTIONS: detect_leaks=0:detect_odr_violation=0
+          ASAN_OPTIONS: detect_leaks=0
           UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=1
 
       # And again unsanitized. Not redundant: the heap overrun that motivated

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -76,8 +76,13 @@ jobs:
         run: cmake --build build-asan
 
       # ASAN halts on memory errors by default
-      # detect_leaks=0: the codebase intentionally never frees; leak reports
-      #   would be pure noise for now.
+      # detect_leaks=0: entity teardown really frees now that the free lists are
+      #   gone, so LeakSanitizer has become informative. It reports a standing
+      #   backlog of roughly 1.3 MB across 232 reports, and every one of them is
+      #   test-fixture memory that the fixtures allocate and never release. That
+      #   backlog is pre-existing and tracked, so turning this on would gate CI
+      #   on test hygiene rather than on the code under test. Revisit once the
+      #   fixtures clean up after themselves.
       # UBSAN halt_on_error=1: the known UB this waited on was the queue
       #   re-entrancy UAF, fixed in the queue safety commit. UB now gates CI.
       - name: Test under sanitizers

--- a/code/act_comm.c
+++ b/code/act_comm.c
@@ -336,8 +336,10 @@ void do_cb(CHAR_DATA *ch, char *argument)
 
 	send_to_char(buf, ch);
 
-	for (auto d = descriptor_list; d != nullptr; d = d->next)
+	for (OwningListWalk<DESCRIPTOR_DATA> walk(descriptor_list); !walk.Done(); walk.Step())
 	{
+		DESCRIPTOR_DATA *d = walk.Current();
+
 		// Read once: this loop only formats and sends, and nothing in it can
 		// extract a listener.
 		CHAR_DATA *listener = Deref(d->character);
@@ -1131,8 +1133,10 @@ void do_pray(CHAR_DATA *ch, char *argument)
 		fclose(fp);
 	}
 
-	for (auto d = descriptor_list; d != nullptr; d = d->next)
+	for (OwningListWalk<DESCRIPTOR_DATA> walk(descriptor_list); !walk.Done(); walk.Step())
 	{
+		DESCRIPTOR_DATA *d = walk.Current();
+
 		auto victim = Deref(d->original) ? Deref(d->original) : Deref(d->character);
 
 		if (d->connected == CON_PLAYING && Deref(d->character) != ch && !IS_SET(victim->comm, COMM_SHOUTSOFF) && !IS_SET(victim->comm, COMM_QUIET) && victim->level >= 52)
@@ -1462,8 +1466,10 @@ void do_yell(CHAR_DATA *ch, char *argument)
 		act("You yell '$t'", ch, argument, nullptr, TO_CHAR);
 	}
 
-	for (auto d = descriptor_list; d != nullptr; d = d->next)
+	for (OwningListWalk<DESCRIPTOR_DATA> walk(descriptor_list); !walk.Done(); walk.Step())
 	{
+		DESCRIPTOR_DATA *d = walk.Current();
+
 		// Read once: command_execute below can extract the listener, but it is
 		// the last thing this iteration does with it.
 		CHAR_DATA *listener = Deref(d->character);
@@ -1494,8 +1500,10 @@ void do_myell(CHAR_DATA *ch, char *argument, CHAR_DATA *attacker)
 	/*
 	if(is_shifted(ch))
 	{
-		for (d = descriptor_list; d; d = d->next)
+		for (OwningListWalk<DESCRIPTOR_DATA> walk(descriptor_list); !walk.Done(); walk.Step())
 		{
+			DESCRIPTOR_DATA *d = walk.Current();
+
 			if (d->connected == CON_PLAYING
 				&&  Deref(d->character)->in_room != nullptr && ch->in_room != nullptr
 				&&  Deref(d->character)->in_room->area == ch->in_room->area
@@ -1922,13 +1930,9 @@ void do_quit_new(CHAR_DATA *ch, char *argument, bool autoq)
 		close_socket(d);
 
 	/* toast evil cheating bastards */
-	// The successor has to be read before the body: close_socket frees d, and the
-	// loop advances through it.
-	DESCRIPTOR_DATA *d_after;
-
-	for (d = descriptor_list; d != nullptr; d = d_after)
+	for (OwningListWalk<DESCRIPTOR_DATA> walk(descriptor_list); !walk.Done(); walk.Step())
 	{
-		d_after = d->next;
+		DESCRIPTOR_DATA *d = walk.Current();
 
 		auto tch = Deref(d->original) ? Deref(d->original) : Deref(d->character);
 		if (tch && tch->id == id)

--- a/code/act_comm.c
+++ b/code/act_comm.c
@@ -40,6 +40,7 @@
 #include <time.h>
 #include "merc.h"
 #include "entity/handles.h"
+#include "entity/list_cursor.h"
 #include "act_comm.h"
 #include "rift.h"
 #include "recycle.h"
@@ -1802,8 +1803,10 @@ void do_quit_new(CHAR_DATA *ch, char *argument, bool autoq)
 			return;
 		}
 
-		for (auto obj = object_list; obj != nullptr; obj = obj->next)
+		for (auto &owned : object_list)
 		{
+			OBJ_DATA *obj = owned.get();
+
 			if (isCabalItem(obj))
 			{
 				if (obj->carried_by == ch->self)
@@ -1855,10 +1858,10 @@ void do_quit_new(CHAR_DATA *ch, char *argument, bool autoq)
 	/* Remove any Cabal items first , also owners
 		and any limiteds on levels 10 and below
 	*/
-	OBJ_DATA *obj_next;
-	for (auto obj = object_list; obj != nullptr; obj = obj_next)
+	for (OwningListWalk<OBJ_DATA> walk(object_list); !walk.Done(); walk.Step())
 	{
-		obj_next = obj->next;
+		OBJ_DATA *obj = walk.Current();
+
 		if (isCabalItem(obj))
 		{
 			if (obj->carried_by == ch->self)
@@ -1919,8 +1922,14 @@ void do_quit_new(CHAR_DATA *ch, char *argument, bool autoq)
 		close_socket(d);
 
 	/* toast evil cheating bastards */
-	for (d = descriptor_list; d != nullptr; d = d->next)
+	// The successor has to be read before the body: close_socket frees d, and the
+	// loop advances through it.
+	DESCRIPTOR_DATA *d_after;
+
+	for (d = descriptor_list; d != nullptr; d = d_after)
 	{
+		d_after = d->next;
+
 		auto tch = Deref(d->original) ? Deref(d->original) : Deref(d->character);
 		if (tch && tch->id == id)
 		{

--- a/code/act_comm.c
+++ b/code/act_comm.c
@@ -429,8 +429,10 @@ void do_newbie(CHAR_DATA *ch, char *argument)
 		act_new("[NEWBIE] $n$t", ch, buf, 0, TO_CHAR, POS_DEAD);
 	}
 
-	for (auto wch = char_list; wch != nullptr; wch = wch->next)
+	for (OwningListWalk<CHAR_DATA> walk(char_list); !walk.Done(); walk.Step())
 	{
+		CHAR_DATA *wch = walk.Current();
+
 		DESCRIPTOR_DATA *connection = Deref(wch->desc);
 
 		if (is_npc(wch) && connection == nullptr)
@@ -499,8 +501,10 @@ void do_builder(CHAR_DATA *ch, char *argument)
 		act_new("[BUILDER] $n$t", ch, buf, 0, TO_CHAR, POS_DEAD);
 	}
 
-	for (auto wch = char_list; wch != nullptr; wch = wch->next)
+	for (OwningListWalk<CHAR_DATA> walk(char_list); !walk.Done(); walk.Step())
 	{
+		CHAR_DATA *wch = walk.Current();
+
 		DESCRIPTOR_DATA *connection = Deref(wch->desc);
 
 		if (is_npc(wch) && connection == nullptr)
@@ -590,8 +594,10 @@ void do_immtalk(CHAR_DATA *ch, char *argument)
 		act_new("[IMM] $n$t", ch, buffer.data(), 0, TO_CHAR, POS_DEAD);
 	}
 
-	for (auto wch = char_list; wch != nullptr; wch = wch->next)
+	for (OwningListWalk<CHAR_DATA> walk(char_list); !walk.Done(); walk.Step())
 	{
+		CHAR_DATA *wch = walk.Current();
+
 		DESCRIPTOR_DATA *connection = Deref(wch->desc);
 
 		if (is_npc(wch) && connection == nullptr)
@@ -1210,17 +1216,25 @@ void do_tell(CHAR_DATA *ch, char *argument)
 
 	auto number = number_argument(arg2, arg);
 	auto count = 0;
-	auto victim = char_list;
-	for (; victim != nullptr; victim = victim->next)
+	// A pure search, so a plain walk is enough. The result has to outlive the
+	// loop, which is why the match is captured rather than left in the cursor.
+	CHAR_DATA *victim = nullptr;
+
+	for (auto &owned : char_list)
 	{
-		if (is_name(victim->name, arg) && (is_npc(victim) && victim->pIndexData->vnum == MOB_VNUM_DECOY))
+		CHAR_DATA *candidate = owned.get();
+
+		if (is_name(candidate->name, arg) && (is_npc(candidate) && candidate->pIndexData->vnum == MOB_VNUM_DECOY))
 			continue;
 
-		if (victim->in_room == nullptr || (is_immortal(ch) ? !is_name(arg, (victim->true_name ? victim->true_name : victim->name)) : !is_name(arg, victim->name)) || !can_see(ch, victim))
+		if (candidate->in_room == nullptr || (is_immortal(ch) ? !is_name(arg, (candidate->true_name ? candidate->true_name : candidate->name)) : !is_name(arg, candidate->name)) || !can_see(ch, candidate))
 			continue;
 
 		if (++count == number)
+		{
+			victim = candidate;
 			break;
+		}
 	}
 
 	if (victim == nullptr || (is_npc(victim) && victim->in_room != ch->in_room))
@@ -1299,8 +1313,10 @@ void do_noreply(CHAR_DATA *ch, char *argument)
 {
 	send_to_char("You concentrate and momentarily close your ears to the replies of others.\n\r", ch);
 
-	for (auto vch = char_list; vch; vch = vch->next)
+	for (OwningListWalk<CHAR_DATA> walk(char_list); !walk.Done(); walk.Step())
 	{
+		CHAR_DATA *vch = walk.Current();
+
 		if (!is_npc(vch) && Deref(vch->reply) == ch)
 			vch->reply = nullptr;
 	}
@@ -1883,10 +1899,9 @@ void do_quit_new(CHAR_DATA *ch, char *argument, bool autoq)
 	}
 
 	/* extract all decoys */
-	CHAR_DATA *wch_next;
-	for (auto wch = char_list; wch != nullptr; wch = wch_next)
+	for (OwningListWalk<CHAR_DATA> walk(char_list); !walk.Done(); walk.Step())
 	{
-		wch_next = wch->next;
+		CHAR_DATA *wch = walk.Current();
 
 		if (is_affected(wch, gsn_empathy))
 		{
@@ -2136,10 +2151,10 @@ void die_follower(CHAR_DATA *ch)
 
 	ch->leader = nullptr;
 
-	CHAR_DATA *fch_next;
-	for (auto fch = char_list; fch != nullptr; fch = fch_next)
+	for (OwningListWalk<CHAR_DATA> walk(char_list); !walk.Done(); walk.Step())
 	{
-		fch_next = fch->next;
+		CHAR_DATA *fch = walk.Current();
+
 		/*if(!fch->in_room && is_npc(fch))
 		{
 			RS.Logger.Debug("Error: Mob {} in room is nullptr!",fch->pIndexData->vnum);
@@ -2273,8 +2288,10 @@ void do_group(CHAR_DATA *ch, char *argument)
 		buffer = fmt::format("{}'s group:\n\r", pers(leader, ch));
 		send_to_char(buffer.c_str(), ch);
 
-		for (auto gch = char_list; gch != nullptr; gch = gch->next)
+		for (OwningListWalk<CHAR_DATA> walk(char_list); !walk.Done(); walk.Step())
 		{
+			CHAR_DATA *gch = walk.Current();
+
 			if (is_same_group(gch, ch))
 			{
 				if (!is_npc(gch))
@@ -2391,8 +2408,10 @@ void do_group(CHAR_DATA *ch, char *argument)
 		af.location = 0;
 		af.pulse_fun = traitor_pulse;
 
-		for (auto vch = char_list; vch; vch = vch->next)
+		for (OwningListWalk<CHAR_DATA> walk(char_list); !walk.Done(); walk.Step())
 		{
+			CHAR_DATA *vch = walk.Current();
+
 			if (vch != ch && is_same_group(vch, ch))
 				new_affect_to_char(vch, &af);
 		}
@@ -2527,8 +2546,10 @@ void do_gtell(CHAR_DATA *ch, char *argument)
 	sprintf(buf, "You tell the group '%s$t%s'", get_char_color(ch, "grouptells"), END_COLOR(ch));
 	act_new(buf, ch, argument, nullptr, TO_CHAR, POS_SLEEPING);
 
-	for (auto gch = char_list; gch != nullptr; gch = gch->next)
+	for (OwningListWalk<CHAR_DATA> walk(char_list); !walk.Done(); walk.Step())
 	{
+		CHAR_DATA *gch = walk.Current();
+
 		if (is_same_group(gch, ch) && !is_affected(gch, gsn_deafen))
 		{
 			sprintf(buf, "$n tells the group '%s$t%s'", get_char_color(gch, "grouptells"), END_COLOR(gch));

--- a/code/act_info.c
+++ b/code/act_info.c
@@ -2962,8 +2962,10 @@ void do_whois(CHAR_DATA *ch, char *argument)
 
 	BUFFER output;
 	auto found = false;
-	for (auto d = descriptor_list; d != nullptr; d = d->next)
+	for (OwningListWalk<DESCRIPTOR_DATA> walk(descriptor_list); !walk.Done(); walk.Step())
 	{
+		DESCRIPTOR_DATA *d = walk.Current();
+
 		char const *class_name;
 		char const *imm_lvl;
 
@@ -3309,8 +3311,10 @@ void do_who(CHAR_DATA *ch, char *argument)
 
 	auto nMatch = 0;
 	BUFFER output;
-	for (auto d = descriptor_list; d != nullptr; d = d->next)
+	for (OwningListWalk<DESCRIPTOR_DATA> walk(descriptor_list); !walk.Done(); walk.Step())
 	{
+		DESCRIPTOR_DATA *d = walk.Current();
+
 		/*
 		 * Check for match against restrictions.
 		 * Don't use trust as that exposes trusted mortals.
@@ -3513,8 +3517,10 @@ void do_count(CHAR_DATA *ch, char *argument)
 	auto not_seen = 0;
 	auto count = 0;
 
-	for (auto d = descriptor_list; d != nullptr; d = d->next)
+	for (OwningListWalk<DESCRIPTOR_DATA> walk(descriptor_list); !walk.Done(); walk.Step())
 	{
+		DESCRIPTOR_DATA *d = walk.Current();
+
 		if (d->connected == CON_PLAYING)
 		{
 			if (can_see(ch, Deref(d->character)) && !is_switched(Deref(d->character)))
@@ -3712,8 +3718,10 @@ void do_where(CHAR_DATA *ch, char *argument)
 	{
 		send_to_char("Players near you:\n\r", ch);
 
-		for (auto d = descriptor_list; d; d = d->next)
+		for (OwningListWalk<DESCRIPTOR_DATA> walk(descriptor_list); !walk.Done(); walk.Step())
 		{
+			DESCRIPTOR_DATA *d = walk.Current();
+
 			auto victim = Deref(d->character);
 			if (d->connected == CON_PLAYING
 				&& victim != nullptr
@@ -3747,8 +3755,10 @@ void do_where(CHAR_DATA *ch, char *argument)
 	}
 	else if (!str_prefix(arg, "pk"))
 	{
-		for (auto d = descriptor_list; d; d = d->next)
+		for (OwningListWalk<DESCRIPTOR_DATA> walk(descriptor_list); !walk.Done(); walk.Step())
 		{
+			DESCRIPTOR_DATA *d = walk.Current();
+
 			auto victim = Deref(d->character);
 			if (d->connected == CON_PLAYING
 				&& victim != nullptr

--- a/code/act_info.c
+++ b/code/act_info.c
@@ -3790,8 +3790,10 @@ void do_where(CHAR_DATA *ch, char *argument)
 	}
 	else
 	{
-		for (auto victim = char_list; victim != nullptr; victim = victim->next)
+		for (OwningListWalk<CHAR_DATA> walk(char_list); !walk.Done(); walk.Step())
 		{
+			CHAR_DATA *victim = walk.Current();
+
 			if (victim->in_room != nullptr
 				&& (victim->in_room->area == ch->in_room->area
 					|| (is_adjacent_area(victim->in_room->area, ch->in_room->area) && is_immortal(ch)))
@@ -4921,8 +4923,10 @@ void do_records(CHAR_DATA *ch, char *argument)
 	sprintf(buf, "Listing of current active players :\n\r");
 
 	auto count = 0;
-	for (auto victim = char_list; victim != nullptr; victim = victim->next)
+	for (OwningListWalk<CHAR_DATA> walk(char_list); !walk.Done(); walk.Step())
 	{
+		CHAR_DATA *victim = walk.Current();
+
 		if (is_npc(victim))
 			continue;
 

--- a/code/act_move.c
+++ b/code/act_move.c
@@ -604,8 +604,10 @@ void move_char(CHAR_DATA *ch, int door, bool automatic, bool fcharm)
 
 	if (in_room->area != to_room->area)
 	{
-		for (auto d = descriptor_list; d; d = d->next)
+		for (OwningListWalk<DESCRIPTOR_DATA> walk(descriptor_list); !walk.Done(); walk.Step())
 		{
+			DESCRIPTOR_DATA *d = walk.Current();
+
 			auto victim = Deref(d->character);
 			if (d->connected == CON_PLAYING
 				&& victim != nullptr

--- a/code/act_move.c
+++ b/code/act_move.c
@@ -3472,8 +3472,10 @@ void do_bear_call(CHAR_DATA *ch, char *argument)
 	}
 
 	auto found = false;
-	for (auto check = char_list; check != nullptr; check = check->next)
+	for (OwningListWalk<CHAR_DATA> walk(char_list); !walk.Done(); walk.Step())
 	{
+		CHAR_DATA *check = walk.Current();
+
 		if (Deref(check->master) == ch && check->pIndexData->vnum == MOB_VNUM_BEAR)
 			found = true;
 	}
@@ -3613,17 +3615,23 @@ void do_animal_call(CHAR_DATA *ch, char *argument)
 		return;
 	}
 
-	auto mob = char_list;
-	for (; mob != nullptr; mob = mob->next)
+	// A pure search, so a plain walk is enough. The result has to outlive the
+	// loop, which is why the match is captured rather than left in the cursor.
+	CHAR_DATA *mob = nullptr;
+
+	for (auto &owned : char_list)
 	{
-		if (is_npc(mob)
-			&& is_affected_by(mob, AFF_CHARM)
-			&& (Deref(mob->master) == ch)
-			&& ((mob->pIndexData->vnum == MOB_VNUM_FALCON)
-				|| (mob->pIndexData->vnum == MOB_VNUM_WOLF)
-				|| (mob->pIndexData->vnum == MOB_VNUM_BEAR)
-				|| (mob->pIndexData->vnum == MOB_VNUM_LION)))
+		CHAR_DATA *candidate = owned.get();
+
+		if (is_npc(candidate)
+			&& is_affected_by(candidate, AFF_CHARM)
+			&& (Deref(candidate->master) == ch)
+			&& ((candidate->pIndexData->vnum == MOB_VNUM_FALCON)
+				|| (candidate->pIndexData->vnum == MOB_VNUM_WOLF)
+				|| (candidate->pIndexData->vnum == MOB_VNUM_BEAR)
+				|| (candidate->pIndexData->vnum == MOB_VNUM_LION)))
 		{
+			mob = candidate;
 			break;
 		}
 	}

--- a/code/act_move.c
+++ b/code/act_move.c
@@ -403,14 +403,18 @@ void move_char(CHAR_DATA *ch, int door, bool automatic, bool fcharm)
 
 			auto gravroom = to_room;
 
-			auto well = object_list;
-			for (; well; well = well->next)
+			OBJ_DATA *well = nullptr;
+
+			for (auto &owned : object_list)
 			{
-				if (well->item_type == ITEM_GRAVITYWELL && well->in_room && well->in_room->area == in_room->area)
+				if (owned->item_type == ITEM_GRAVITYWELL && owned->in_room && owned->in_room->area == in_room->area)
+				{
+					well = owned.get();
 					break;
+				}
 			}
 
-			if (!well)
+			if (well == nullptr)
 				return;
 
 			for (auto distance = 0; distance <= get_grav_distance(well); distance++)

--- a/code/act_obj.c
+++ b/code/act_obj.c
@@ -4515,10 +4515,15 @@ bool cabal_down_new(CHAR_DATA *ch, int cabal, bool show)
 	bool is_down= false;
 	int objvnum = cabal_table[ch->cabal].item_vnum;
 
-	for (obj = object_list; obj != nullptr; obj = obj->next)
+	obj = nullptr;
+
+	for (auto &owned : object_list)
 	{
-		if (obj->pIndexData->vnum == objvnum)
+		if (owned->pIndexData->vnum == objvnum)
+		{
+			obj = owned.get();
 			break;
+		}
 	}
 
 	CHAR_DATA *carrier = obj != nullptr ? Deref(obj->carried_by) : nullptr;
@@ -4937,8 +4942,10 @@ void save_cabal_items(void)
 		if (vnum == 0)
 			continue;
 
-		for (obj = object_list; obj != nullptr; obj = obj->next)
+		for (auto &owned : object_list)
 		{
+			obj = owned.get();
+
 			if (obj->pIndexData->vnum == vnum)
 			{
 				CHAR_DATA *carrier = Deref(obj->carried_by);

--- a/code/act_obj.c
+++ b/code/act_obj.c
@@ -103,7 +103,7 @@ bool check_arms(CHAR_DATA *ch, OBJ_DATA *obj)
 
 bool can_loot(CHAR_DATA *ch, OBJ_DATA *obj)
 {
-	CHAR_DATA *owner, *wch;
+	CHAR_DATA *owner;
 
 	if (obj->item_type == ITEM_CORPSE_PC
 		&& (!is_npc(ch) || is_affected_by(ch, AFF_CHARM)))
@@ -138,8 +138,10 @@ bool can_loot(CHAR_DATA *ch, OBJ_DATA *obj)
 	}
 
 	owner = nullptr;
-	for (wch = char_list; wch != nullptr; wch = wch->next)
+	for (OwningListWalk<CHAR_DATA> walk(char_list); !walk.Done(); walk.Step())
 	{
+		CHAR_DATA *wch = walk.Current();
+
 		if (!is_npc(wch) && obj->owner && !str_cmp(wch->true_name, obj->owner))
 			owner = wch;
 	}
@@ -4490,8 +4492,10 @@ void do_embalm(CHAR_DATA *ch, char *argument)
 
 void cabal_shudder(int cabal, bool itemloss)
 {
-	for (CHAR_DATA *ch = char_list; ch != nullptr; ch = ch->next)
+	for (OwningListWalk<CHAR_DATA> walk(char_list); !walk.Done(); walk.Step())
 	{
+		CHAR_DATA *ch = walk.Current();
+
 		if (ch->cabal == cabal)
 		{
 			if (IS_SET(ch->comm, COMM_ANSI) && itemloss)

--- a/code/act_wiz.c
+++ b/code/act_wiz.c
@@ -3273,8 +3273,10 @@ void do_owhere(CHAR_DATA *ch, char *argument)
 		return;
 	}
 
-	for (obj = object_list; obj != nullptr; obj = obj->next)
+	for (auto &owned : object_list)
 	{
+		obj = owned.get();
+
 		if (!can_see_obj(ch, obj) || !is_name(argument, obj->name) || ch->level < obj->level)
 			continue;
 
@@ -7966,10 +7968,18 @@ void do_memtest(CHAR_DATA *ch, char *argument)
 	}
 	if(!str_cmp(buf,"end"))
 	{
-		for(qch = char_list; qch; qch = qch->next)
+		// The successor has to be read before the body: extract_char frees qch,
+		// and the loop advances through it.
+		CHAR_DATA *qch_next;
+
+		for(qch = char_list; qch; qch = qch_next)
+		{
+			qch_next = qch->next;
+
 			if(is_npc(qch) && qch->pIndexData->vnum == 3001 && qch->in_room->vnum > 2399 &&
 			   qch->in_room->vnum < 2801)
 				extract_char(qch, true);
+		}
 		send_to_char("It has.. ENDED!\n\r",ch);
 	}
 }

--- a/code/act_wiz.c
+++ b/code/act_wiz.c
@@ -1445,7 +1445,6 @@ void do_at(CHAR_DATA *ch, char *argument)
 	// one that destroys this object. A handle that outlives what it names simply
 	// stops resolving, where the pointer this replaced would have dangled.
 	Handle<OBJ_DATA> on;
-	CHAR_DATA *wch;
 
 	argument = one_argument(argument, arg);
 
@@ -1486,8 +1485,10 @@ void do_at(CHAR_DATA *ch, char *argument)
 	 * See if 'ch' still exists before continuing!
 	 * Handles 'at XXXX quit' case.
 	 */
-	for (wch = char_list; wch != nullptr; wch = wch->next)
+	for (OwningListWalk<CHAR_DATA> walk(char_list); !walk.Done(); walk.Step())
 	{
+		CHAR_DATA *wch = walk.Current();
+
 		if (wch == ch)
 		{
 			char_from_room(ch);
@@ -3391,8 +3392,10 @@ void do_mwhere(CHAR_DATA *ch, char *argument)
 
 	found = false;
 
-	for (victim = char_list; victim != nullptr; victim = victim->next)
+	for (OwningListWalk<CHAR_DATA> walk(char_list); !walk.Done(); walk.Step())
 	{
+		CHAR_DATA *victim = walk.Current();
+
 		if (victim->in_room != nullptr && can_see(ch, victim) && is_name(argument, victim->name))
 		{
 			found = true;
@@ -6087,7 +6090,6 @@ void do_lagout(CHAR_DATA *ch, char *argument)
  */
 void do_force(CHAR_DATA *ch, char *argument)
 {
-	CHAR_DATA *vch, *vch_next;
 	char buf[MAX_STRING_LENGTH];
 	char arg[MAX_INPUT_LENGTH];
 	char arg2[MAX_INPUT_LENGTH];
@@ -6118,9 +6120,9 @@ void do_force(CHAR_DATA *ch, char *argument)
 			return;
 		}
 
-		for (vch = char_list; vch != nullptr; vch = vch_next)
+		for (OwningListWalk<CHAR_DATA> walk(char_list); !walk.Done(); walk.Step())
 		{
-			vch_next = vch->next;
+			CHAR_DATA *vch = walk.Current();
 
 			if (!is_npc(vch) && get_trust(vch) < get_trust(ch))
 			{
@@ -6140,9 +6142,9 @@ void do_force(CHAR_DATA *ch, char *argument)
 			return;
 		}
 
-		for (vch = char_list; vch != nullptr; vch = vch_next)
+		for (OwningListWalk<CHAR_DATA> walk(char_list); !walk.Done(); walk.Step())
 		{
-			vch_next = vch->next;
+			CHAR_DATA *vch = walk.Current();
 
 			if (!is_npc(vch) && get_trust(vch) < get_trust(ch) && vch->level < LEVEL_HERO)
 			{
@@ -6159,9 +6161,9 @@ void do_force(CHAR_DATA *ch, char *argument)
 			return;
 		}
 
-		for (vch = char_list; vch != nullptr; vch = vch_next)
+		for (OwningListWalk<CHAR_DATA> walk(char_list); !walk.Done(); walk.Step())
 		{
-			vch_next = vch->next;
+			CHAR_DATA *vch = walk.Current();
 
 			if (!is_npc(vch) && get_trust(vch) < get_trust(ch) && vch->level >= LEVEL_HERO)
 			{
@@ -7947,7 +7949,6 @@ void do_racedump(CHAR_DATA *ch, char *argument)
 void do_memtest(CHAR_DATA *ch, char *argument)
 {
 	char buf[MSL];
-	CHAR_DATA *qch;
 	argument = one_argument(argument, buf);
 	RS.Queue.AddToQueue(6, "do_memtest", "do_bash_queue", do_bash_queue, ch, "Calenduil");
 	return;
@@ -7964,34 +7965,30 @@ void do_memtest(CHAR_DATA *ch, char *argument)
 	return;
 	if(!str_cmp(buf,"dammod"))
 	{
-		for(qch = char_list; qch; qch = qch->next)
-			if(is_npc(qch) && qch->pIndexData->vnum == 3001)
-				qch->dam_mod = atoi(argument);
+		for (auto &owned : char_list)
+			if(is_npc(owned.get()) && owned->pIndexData->vnum == 3001)
+				owned->dam_mod = atoi(argument);
 		send_to_char("Dammod changed.\n\r",ch);
 	}
 	if(!str_cmp(buf,"hp"))
 	{
-		for(qch = char_list; qch; qch = qch->next)
-			if(is_npc(qch) && qch->pIndexData->vnum == 3001)
-				qch->max_hit = std::max(qch->max_hit - atoi(argument), 100);
+		for (auto &owned : char_list)
+			if(is_npc(owned.get()) && owned->pIndexData->vnum == 3001)
+				owned->max_hit = std::max(owned->max_hit - atoi(argument), 100);
 		send_to_char("Maxhit changed.\n\r",ch);
 	}
 	if(!str_cmp(buf,"begin"))
 	{
-		for(qch = char_list; qch; qch = qch->next)
-			if(is_npc(qch) && qch->pIndexData->vnum == 3001 && !is_affected_by(qch, AFF_DETECT_MAGIC))
-				SET_BIT(qch->affected_by, AFF_DETECT_MAGIC);
+		for (auto &owned : char_list)
+			if(is_npc(owned.get()) && owned->pIndexData->vnum == 3001 && !is_affected_by(owned.get(), AFF_DETECT_MAGIC))
+				SET_BIT(owned->affected_by, AFF_DETECT_MAGIC);
 		send_to_char("It HAS BEGUN!\n\r",ch);
 	}
 	if(!str_cmp(buf,"end"))
 	{
-		// The successor has to be read before the body: extract_char frees qch,
-		// and the loop advances through it.
-		CHAR_DATA *qch_next;
-
-		for(qch = char_list; qch; qch = qch_next)
+		for (OwningListWalk<CHAR_DATA> walk(char_list); !walk.Done(); walk.Step())
 		{
-			qch_next = qch->next;
+			CHAR_DATA *qch = walk.Current();
 
 			if(is_npc(qch) && qch->pIndexData->vnum == 3001 && qch->in_room->vnum > 2399 &&
 			   qch->in_room->vnum < 2801)

--- a/code/act_wiz.c
+++ b/code/act_wiz.c
@@ -192,8 +192,10 @@ void wiznet(char *string, CHAR_DATA *ch, OBJ_DATA *obj, long flag, long flag_ski
 {
 	char str[MAX_STRING_LENGTH];
 
-	for (DESCRIPTOR_DATA *d = descriptor_list; d != nullptr; d = d->next)
+	for (OwningListWalk<DESCRIPTOR_DATA> walk(descriptor_list); !walk.Done(); walk.Step())
 	{
+		DESCRIPTOR_DATA *d = walk.Current();
+
 		CHAR_DATA *wch = Deref(d->character);
 
 		if (d->connected == CON_PLAYING
@@ -1035,7 +1037,6 @@ void do_deny(CHAR_DATA *ch, char *argument)
 void do_disconnect(CHAR_DATA *ch, char *argument)
 {
 	char arg[MAX_INPUT_LENGTH];
-	DESCRIPTOR_DATA *d;
 	CHAR_DATA *victim;
 
 	one_argument(argument, arg);
@@ -1049,8 +1050,10 @@ void do_disconnect(CHAR_DATA *ch, char *argument)
 	if (is_number(arg))
 	{
 		int desc = atoi(arg);
-		for (d = descriptor_list; d != nullptr; d = d->next)
+		for (OwningListWalk<DESCRIPTOR_DATA> walk(descriptor_list); !walk.Done(); walk.Step())
 		{
+			DESCRIPTOR_DATA *d = walk.Current();
+
 			if (d->descriptor == desc)
 			{
 				close_socket(d);
@@ -1080,8 +1083,10 @@ void do_disconnect(CHAR_DATA *ch, char *argument)
 		return;
 	}
 
-	for (d = descriptor_list; d != nullptr; d = d->next)
+	for (OwningListWalk<DESCRIPTOR_DATA> walk(descriptor_list); !walk.Done(); walk.Step())
 	{
+		DESCRIPTOR_DATA *d = walk.Current();
+
 		if (d == Deref(victim->desc))
 		{
 			close_socket(d);
@@ -1154,7 +1159,6 @@ void do_pardon(CHAR_DATA *ch, char *argument)
 
 void do_echo(CHAR_DATA *ch, char *argument)
 {
-	DESCRIPTOR_DATA *d;
 	char buffer[MAX_STRING_LENGTH * 2];
 
 	if (argument[0] == '\0')
@@ -1163,8 +1167,10 @@ void do_echo(CHAR_DATA *ch, char *argument)
 		return;
 	}
 
-	for (d = descriptor_list; d; d = d->next)
+	for (OwningListWalk<DESCRIPTOR_DATA> walk(descriptor_list); !walk.Done(); walk.Step())
 	{
+		DESCRIPTOR_DATA *d = walk.Current();
+
 		CHAR_DATA *wch = Deref(d->character);
 
 		if (d->connected == CON_PLAYING)
@@ -1185,7 +1191,6 @@ void do_echo(CHAR_DATA *ch, char *argument)
 
 void do_immecho(CHAR_DATA *ch, char *argument)
 {
-	DESCRIPTOR_DATA *d;
 	char buffer[MAX_STRING_LENGTH * 2];
 
 	if (argument[0] == '\0')
@@ -1194,8 +1199,10 @@ void do_immecho(CHAR_DATA *ch, char *argument)
 		return;
 	}
 
-	for (d = descriptor_list; d; d = d->next)
+	for (OwningListWalk<DESCRIPTOR_DATA> walk(descriptor_list); !walk.Done(); walk.Step())
 	{
+		DESCRIPTOR_DATA *d = walk.Current();
+
 		CHAR_DATA *wch = Deref(d->character);
 
 		if (d->connected == CON_PLAYING && (wch->level > 51))
@@ -1209,7 +1216,6 @@ void do_immecho(CHAR_DATA *ch, char *argument)
 
 void do_recho(CHAR_DATA *ch, char *argument)
 {
-	DESCRIPTOR_DATA *d;
 	char buffer[MAX_STRING_LENGTH * 2];
 
 	if (argument[0] == '\0')
@@ -1218,8 +1224,10 @@ void do_recho(CHAR_DATA *ch, char *argument)
 		return;
 	}
 
-	for (d = descriptor_list; d; d = d->next)
+	for (OwningListWalk<DESCRIPTOR_DATA> walk(descriptor_list); !walk.Done(); walk.Step())
 	{
+		DESCRIPTOR_DATA *d = walk.Current();
+
 		CHAR_DATA *wch = Deref(d->character);
 
 		if (d->connected == CON_PLAYING && wch->in_room == ch->in_room)
@@ -1238,7 +1246,6 @@ void do_recho(CHAR_DATA *ch, char *argument)
 void do_zecho(CHAR_DATA *ch, char *argument)
 {
 	char buffer[MAX_STRING_LENGTH * 2];
-	DESCRIPTOR_DATA *d;
 
 	if (argument[0] == '\0')
 	{
@@ -1246,8 +1253,10 @@ void do_zecho(CHAR_DATA *ch, char *argument)
 		return;
 	}
 
-	for (d = descriptor_list; d; d = d->next)
+	for (OwningListWalk<DESCRIPTOR_DATA> walk(descriptor_list); !walk.Done(); walk.Step())
 	{
+		DESCRIPTOR_DATA *d = walk.Current();
+
 		CHAR_DATA *wch = Deref(d->character);
 
 		if (d->connected == CON_PLAYING
@@ -1327,7 +1336,6 @@ void do_transfer(CHAR_DATA *ch, char *argument)
 	char arg1[MAX_INPUT_LENGTH];
 	char arg2[MAX_INPUT_LENGTH];
 	ROOM_INDEX_DATA *location;
-	DESCRIPTOR_DATA *d;
 	CHAR_DATA *victim;
 
 	argument = one_argument(argument, arg1);
@@ -1341,8 +1349,10 @@ void do_transfer(CHAR_DATA *ch, char *argument)
 
 	if (!str_cmp(arg1, "all"))
 	{
-		for (d = descriptor_list; d != nullptr; d = d->next)
+		for (OwningListWalk<DESCRIPTOR_DATA> walk(descriptor_list); !walk.Done(); walk.Step())
 		{
+			DESCRIPTOR_DATA *d = walk.Current();
+
 			CHAR_DATA *wch = Deref(d->character);
 
 			if (d->connected == CON_PLAYING
@@ -3334,12 +3344,13 @@ void do_mwhere(CHAR_DATA *ch, char *argument)
 
 	if (argument[0] == '\0')
 	{
-		DESCRIPTOR_DATA *d;
 
 		/* show characters logged */
 
-		for (d = descriptor_list; d != nullptr; d = d->next)
+		for (OwningListWalk<DESCRIPTOR_DATA> walk(descriptor_list); !walk.Done(); walk.Step())
 		{
+			DESCRIPTOR_DATA *d = walk.Current();
+
 			victim = Deref(d->character);
 
 			if (victim != nullptr
@@ -3412,7 +3423,6 @@ void do_reboo(CHAR_DATA *ch, char *argument)
 
 void reboot_now(CHAR_DATA *ch)
 {
-	DESCRIPTOR_DATA *d, *d_next;
 	CHAR_DATA *vch;
 
 	/*
@@ -3453,9 +3463,11 @@ void reboot_now(CHAR_DATA *ch)
 	do_force(ch, "all save");
 	do_echo(ch, "*** REBOOTING NOW ***");
 
-	for (d = descriptor_list; d != nullptr; d = d_next)
+	// Closes every connection in the list as it goes, so the walk has to be one
+	// extraction can steer.
+	for (OwningListWalk<DESCRIPTOR_DATA> walk(descriptor_list); !walk.Done(); walk.Step())
 	{
-		d_next = d->next;
+		DESCRIPTOR_DATA *d = walk.Current();
 		CHAR_DATA *original = Deref(d->original);
 
 		vch = original ? original : Deref(d->character);
@@ -3629,8 +3641,10 @@ void do_snoop(CHAR_DATA *ch, char *argument)
 
 		// A game rule, not lifetime: "snoop self" means "drop every snoop I am
 		// running", and nobody is leaving the world.
-		for (d = descriptor_list; d != nullptr; d = d->next)
+		for (OwningListWalk<DESCRIPTOR_DATA> walk(descriptor_list); !walk.Done(); walk.Step())
 		{
+			DESCRIPTOR_DATA *d = walk.Current();
+
 			if (Deref(d->snoop_by) == Deref(ch->desc))
 				d->snoop_by = nullptr;
 		}
@@ -4312,7 +4326,6 @@ void do_restore(CHAR_DATA *ch, char *argument)
 	char arg[MAX_INPUT_LENGTH], buf[MAX_STRING_LENGTH];
 	CHAR_DATA *victim;
 	CHAR_DATA *vch;
-	DESCRIPTOR_DATA *d;
 
 	argument = one_argument(argument, arg);
 
@@ -4349,8 +4362,10 @@ void do_restore(CHAR_DATA *ch, char *argument)
 	{
 		/* cure all */
 
-		for (d = descriptor_list; d != nullptr; d = d->next)
+		for (OwningListWalk<DESCRIPTOR_DATA> walk(descriptor_list); !walk.Done(); walk.Step())
 		{
+			DESCRIPTOR_DATA *d = walk.Current();
+
 			victim = Deref(d->character);
 
 			if (victim == nullptr || is_npc(victim))
@@ -5852,7 +5867,6 @@ void do_sockets(CHAR_DATA *ch, char *argument)
 	char buf[2 * MAX_STRING_LENGTH];
 	char buf2[MAX_STRING_LENGTH];
 	char arg[MAX_INPUT_LENGTH];
-	DESCRIPTOR_DATA *d;
 	int count;
 	bool bDis = false; // displinary
 
@@ -5864,8 +5878,10 @@ void do_sockets(CHAR_DATA *ch, char *argument)
 
 	one_argument(argument, arg);
 
-	for (d = descriptor_list; d != nullptr; d = d->next)
+	for (OwningListWalk<DESCRIPTOR_DATA> walk(descriptor_list); !walk.Done(); walk.Step())
 	{
+		DESCRIPTOR_DATA *d = walk.Current();
+
 		CHAR_DATA *wch = Deref(d->character);
 		CHAR_DATA *original = Deref(d->original);
 
@@ -5952,14 +5968,15 @@ void do_multicheck(CHAR_DATA *ch, char *argument)
 {
 	char buf[2 * MAX_STRING_LENGTH];
 	char buf2[MAX_STRING_LENGTH];
-	DESCRIPTOR_DATA *d;
 	int count = 0, i = 0, j = 0;
 	MULTDATA CHARLIST[80];
 
 	buf[0] = '\0';
 
-	for (d = descriptor_list; d != nullptr; d = d->next)
+	for (OwningListWalk<DESCRIPTOR_DATA> walk(descriptor_list); !walk.Done(); walk.Step())
 	{
+		DESCRIPTOR_DATA *d = walk.Current();
+
 		CHAR_DATA *wch = Deref(d->character);
 
 		if (wch != nullptr && can_see(ch, wch))

--- a/code/aprog.c
+++ b/code/aprog.c
@@ -359,7 +359,6 @@ void reset_prog_cimsewer(AREA_DATA *area)
 
 void pulse_prog_ruins_shark(AREA_DATA *area)
 {
-	DESCRIPTOR_DATA *d;
 	CHAR_DATA *shark, *ch = nullptr;
 	int count = 0;
 
@@ -389,8 +388,10 @@ void pulse_prog_ruins_shark(AREA_DATA *area)
 	if (count > 5)
 		return;
 
-	for (d = descriptor_list; d; d = d->next)
+	for (OwningListWalk<DESCRIPTOR_DATA> walk(descriptor_list); !walk.Done(); walk.Step())
 	{
+		DESCRIPTOR_DATA *d = walk.Current();
+
 		if (d->connected == CON_PLAYING
 			&& Deref(d->character)->in_room != nullptr
 			&& Deref(d->character)->in_room->area == area

--- a/code/aprog.c
+++ b/code/aprog.c
@@ -366,8 +366,14 @@ void pulse_prog_ruins_shark(AREA_DATA *area)
 	if (area->nplayer == 0)
 		return;
 
-	for (shark = char_list; shark; shark = shark->next)
+	// The successor has to be read before the body: extract_char frees shark, and
+	// the loop advances through it.
+	CHAR_DATA *shark_next;
+
+	for (shark = char_list; shark; shark = shark_next)
 	{
+		shark_next = shark->next;
+
 		if (!is_npc(shark))
 			continue;
 

--- a/code/aprog.c
+++ b/code/aprog.c
@@ -164,10 +164,11 @@ void aprog_set(AREA_DATA *area, const char *progtype, const char *name)
 
 void tick_prog_academy_reset(AREA_DATA *area)
 {
-	CHAR_DATA *ch;
 
-	for (ch = char_list; ch; ch = ch->next)
+	for (OwningListWalk<CHAR_DATA> walk(char_list); !walk.Done(); walk.Step())
 	{
+		CHAR_DATA *ch = walk.Current();
+
 		if (!is_npc(ch) && ch->in_room->area == area && ch->level > 10 && !Deref(ch->fighting) && !is_immortal(ch))
 		{
 			char buf[MSL];
@@ -367,11 +368,10 @@ void pulse_prog_ruins_shark(AREA_DATA *area)
 
 	// The successor has to be read before the body: extract_char frees shark, and
 	// the loop advances through it.
-	CHAR_DATA *shark_next;
 
-	for (shark = char_list; shark; shark = shark_next)
+	for (OwningListWalk<CHAR_DATA> walk(char_list); !walk.Done(); walk.Step())
 	{
-		shark_next = shark->next;
+		CHAR_DATA *shark = walk.Current();
 
 		if (!is_npc(shark))
 			continue;

--- a/code/cabal.c
+++ b/code/cabal.c
@@ -712,8 +712,10 @@ void spell_hire_mercenary(int sn, int level, CHAR_DATA *ch, void *vo, int target
 		return;
 	}
 
-	for (merc = char_list; merc != nullptr; merc = merc->next)
+	for (OwningListWalk<CHAR_DATA> walk(char_list); !walk.Done(); walk.Step())
 	{
+		CHAR_DATA *merc = walk.Current();
+
 		if (is_npc(merc)
 			&& merc->pIndexData->vnum >= MOB_VNUM_WARRIOR_MERCENARY
 			&& merc->pIndexData->vnum <= MOB_VNUM_SHAMAN_MERCENARY

--- a/code/characterClasses/ap.c
+++ b/code/characterClasses/ap.c
@@ -983,7 +983,7 @@ void traitor_pulse(CHAR_DATA *ch, AFFECT_DATA *af)
 
 void spell_dark_familiar(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 {
-	CHAR_DATA *fam, *check;
+	CHAR_DATA *fam;
 	AFFECT_DATA af;
 	char buf[MSL];
 	int devil = -1;
@@ -992,8 +992,10 @@ void spell_dark_familiar(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 	float hp_mod = 1;
 	bool found = false;
 
-	for (check = char_list; check != nullptr; check = check->next)
+	for (OwningListWalk<CHAR_DATA> walk(char_list); !walk.Done(); walk.Step())
 	{
+		CHAR_DATA *check = walk.Current();
+
 		if (is_npc(check) && Deref(check->leader) == ch)
 		{
 			found = true;

--- a/code/characterClasses/ap.c
+++ b/code/characterClasses/ap.c
@@ -1155,7 +1155,6 @@ void communion_end(CHAR_DATA *ch, AFFECT_DATA *af)
 
 void check_unholy_communion(CHAR_DATA *ch, char *argument)
 {
-	DESCRIPTOR_DATA *d;
 	AFFECT_DATA *af;
 	int demon = -1, type = -1;
 	int i;
@@ -1209,8 +1208,10 @@ void check_unholy_communion(CHAR_DATA *ch, char *argument)
 		return;
 	}
 
-	for (d = descriptor_list; d; d = d->next)
+	for (OwningListWalk<DESCRIPTOR_DATA> walk(descriptor_list); !walk.Done(); walk.Step())
 	{
+		DESCRIPTOR_DATA *d = walk.Current();
+
 		if (d->connected == CON_PLAYING 
 			&& !is_immortal(Deref(d->character))
 			&& !is_npc(Deref(d->character))

--- a/code/characterClasses/chrono.c
+++ b/code/characterClasses/chrono.c
@@ -4,6 +4,7 @@
 #include <string.h>
 #include <time.h>
 #include <math.h>
+#include <algorithm>
 #include "../merc.h"
 #include "chrono.h"
 #include "../magic.h"
@@ -436,9 +437,11 @@ void extract_rune(RUNE_DATA *rune)
 {
 	RUNE_DATA *rune_prev;
 
-	// Unlink from the container's chain. Every rune is on two lists and this is
-	// the one keyed by what it was placed on, so a rune that stays linked here
-	// after free_rune has recycled it is a chain find_rune will walk into.
+	// Unlink from the container's chain first. Every rune is on two lists, and
+	// erasing it from rune_list below destroys it. This has to happen while
+	// the node is still readable, or the chain find_rune walks is left pointing
+	// at freed memory. The ordering was load-bearing by accident before
+	// rune_list owned its runes; it is load-bearing on purpose now.
 	RUNE_DATA **head = rune_container_head(rune);
 
 	if (head != nullptr)
@@ -460,34 +463,26 @@ void extract_rune(RUNE_DATA *rune)
 		}
 	}
 
-	if (rune_list == rune)
-	{
-		rune_list = rune_list->next;
-	}
-	else
-	{
-		for (rune_prev = rune_list; rune_prev; rune_prev = rune_prev->next)
-		{
-			if (rune_prev->next == rune)
-			{
-				rune_prev->next = rune->next;
-				break;
-			}
-		}
-	}
+	// And this is the destruction point.
+	auto owned = std::find_if(rune_list.begin(), rune_list.end(),
+		[rune](const std::unique_ptr<RUNE_DATA> &candidate) { return candidate.get() == rune; });
 
-	free_rune(rune);
+	if (owned != rune_list.end())
+		rune_list.erase(owned);
 }
+
 void apply_rune(RUNE_DATA *rune)
 {
-	RUNE_DATA *rune_new;
 	OBJ_DATA *obj;
 	EXIT_DATA *pexit;
 	ROOM_INDEX_DATA *room;
-	rune_new = new_rune();
-	*rune_new = *rune;
-	rune_new->next = rune_list;
-	rune_list = rune_new;
+
+	// The caller's rune is a template it owns itself, often a stack struct,
+	// so the copy is what goes on the lists. push_front keeps the order the
+	// hand-rolled link had.
+	rune_list.push_front(std::make_unique<RUNE_DATA>(*rune));
+
+	RUNE_DATA *rune_new = rune_list.front().get();
 	rune_new->next_content = nullptr;
 
 	switch (rune_new->target_type)

--- a/code/characterClasses/chrono.c
+++ b/code/characterClasses/chrono.c
@@ -126,7 +126,11 @@ bool trigger_stasis_wall(void *vo, void *vo2, void *vo3, void *vo4)
 
 bool activate_stasis_wall(void *vo, void *vo2, void *vo3, void *vo4)
 {
-	RUNE_DATA *rune = (RUNE_DATA *)vo, new_rune;
+	// Zero-initialized, like the sibling template in spell_stasis_wall: this sets
+	// nine of the twelve fields and apply_rune copies the whole struct, so
+	// leaving it default-initialized handed `extra`, `drawn_in` and
+	// `next_content` to the copy as indeterminate values.
+	RUNE_DATA *rune = (RUNE_DATA *)vo, new_rune = {};
 	CHAR_DATA *victim = (CHAR_DATA *)vo2, *ch = Deref(rune->owner);
 	int dir = reverse_d((int)*(int *)vo3);
 

--- a/code/characterClasses/chrono.c
+++ b/code/characterClasses/chrono.c
@@ -76,12 +76,17 @@ void spell_stasis_wall(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 	// finalises it, so it needs a lifetime of its own rather than any kind of
 	// scratch storage the next caller can reuse.
 	//
-	// new_rune gives it that lifetime, and draw_rune ends that lifetime on
-	// every path out. The one hole left is a queue entry cancelled rather than
-	// run (DeleteQueuedEventsInvolving, which extract_char calls for NPCs):
-	// that leaks the struct, because the queue cancels with a tombstone and has
-	// no hook to run on the way. A leaked rune is the better failure.
-	RUNE_DATA *rune = new_rune();
+	// The queue captures its arguments by value into a std::function, so it
+	// cannot hold a move-only type: ownership is released into it here and
+	// adopted back by draw_rune, whose signature takes the unique_ptr so that
+	// every path out of it frees by scope.
+	//
+	// The one hole left is a queue entry cancelled rather than run
+	// (DeleteQueuedEventsInvolving, which extract_char calls for NPCs): that
+	// leaks the struct, because the queue cancels with a tombstone and has no
+	// hook to run on the way. A leaked rune is the better failure and it is
+	// now a leak LeakSanitizer can see rather than an orphan on a free list.
+	auto rune = std::make_unique<RUNE_DATA>();
 
 	rune->level = level;
 	rune->placed_on = (ROOM_INDEX_DATA *)ch->in_room;
@@ -95,12 +100,10 @@ void spell_stasis_wall(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 	rune->drawn_in = ch->in_room->vnum;
 	rune->function = activate_stasis_wall;
 
-	/*
-		this checks lose_conc and stuff before finalizing the rune,
-		usually make sure the lag on the rune
-		is at least as long as the lag on the draw_rune queue
-	*/
-	RS.Queue.AddToQueue(9, "spell_stasis_wall", "draw_rune_queue", draw_rune_queue, rune, ch);
+	// this checks lose_conc and stuff before finalizing the rune,
+	// usually make sure the lag on the rune is at least as long 
+	// as the lag on the draw_rune queue
+	RS.Queue.AddToQueue(9, "spell_stasis_wall", "draw_rune_queue", draw_rune_queue, rune.release(), ch);
 }
 
 bool trigger_stasis_wall(void *vo, void *vo2, void *vo3, void *vo4)
@@ -158,28 +161,24 @@ bool activate_stasis_wall(void *vo, void *vo2, void *vo3, void *vo4)
 	return false;
 }
 
-// Consumes the rune spell_stasis_wall queued. Every path out of here frees it,
-// including the ones that decide the draw failed: the queue held the only
-// reference, and apply_rune takes a copy rather than the struct itself.
-void draw_rune(void *vo, void *vo2)
+// Consumes the rune spell_stasis_wall queued. Taking the unique_ptr by value is
+// the point: the queue held the only reference, so every path out of here has to
+// end the rune's life, and now the ones that decide the draw failed do it by
+// returning. apply_rune takes a copy rather than the struct itself.
+void draw_rune(std::unique_ptr<RUNE_DATA> rune)
 {
-	RUNE_DATA *rune = (RUNE_DATA *)vo;
 	CHAR_DATA *ch = Deref(rune->owner);
 
 	// Nine ticks pass between the queue entry being made and this running, and
 	// extract_char only cancels pending events for NPCs -- so the caster may
 	// simply be gone by now.
 	if (ch == nullptr)
-	{
-		free_rune(rune);
 		return;
-	}
 
 	if (ch->in_room->vnum != rune->drawn_in)
 	{
 		send_to_char("A backlash of energy whips through you as your uncompleted rune overloads!\n\r", ch);
 		damage_new(ch, ch, dice(rune->level, 4), TYPE_UNDEFINED, DAM_ENERGY, true, HIT_UNBLOCKABLE, 0, 1, "mana surge");
-		free_rune(rune);
 		return;
 	}
 
@@ -187,18 +186,20 @@ void draw_rune(void *vo, void *vo2)
 	{
 		act("The rune flares brightly before vanishing!", ch, 0, 0, TO_ROOM);
 		send_to_char("The improperly scribed rune flares brightly before vanishing!\n\r", ch);
-		free_rune(rune);
 		return;
 	}
 
 	act("The rune flares $t!", ch, skill_table[rune->type].msg_off, 0, TO_ALL);
-	apply_rune(rune);
-	free_rune(rune);
+	apply_rune(rune.get());
 }
 
+// The queue's entry point. `ch` is unused here but has to stay in the signature:
+// CQueue::GetCharacterData scrapes the argument list for CHAR_DATA pointers to
+// build the cancellation index, so dropping it would make this entry
+// uncancellable by DeleteQueuedEventsInvolving.
 void draw_rune_queue(RUNE_DATA *rune, CHAR_DATA *ch)
 {
-	draw_rune(rune, nullptr);
+	draw_rune(std::unique_ptr<RUNE_DATA>(rune));
 }
 
 void do_rune(CHAR_DATA *ch, char *argument)

--- a/code/characterClasses/chrono.h
+++ b/code/characterClasses/chrono.h
@@ -1,6 +1,8 @@
 #ifndef CHRONO_H
 #define CHRONO_H
 
+#include <memory>
+
 #include "../entity/fwd.h"
 
 //
@@ -10,7 +12,7 @@
 void spell_stasis_wall (int sn, int level, CHAR_DATA *ch, void *vo,int target );
 bool trigger_stasis_wall (void *vo,void *vo2,void *vo3,void *vo4);
 bool activate_stasis_wall (void *vo,void *vo2,void *vo3,void *vo4);	//list your rune trigs here for good reference
-void draw_rune (void *vo, void *vo2); //attempt to add a rune that's just been initiated
+void draw_rune (std::unique_ptr<RUNE_DATA> rune); //attempt to add a rune that's just been initiated; consumes it
 void draw_rune_queue(RUNE_DATA *rune, CHAR_DATA *ch);
 void do_rune (CHAR_DATA *ch, char *argument );
 RUNE_DATA *find_rune (void *vo, int target_type, int trigger_type, RUNE_DATA *rune_prev);

--- a/code/characterClasses/necro.c
+++ b/code/characterClasses/necro.c
@@ -331,7 +331,6 @@ void spell_hex(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 
 void spell_animate_dead(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 {
-	CHAR_DATA *search;
 	OBJ_DATA *corpse;
 	char *obj_name;
 	int chance, control = 0;
@@ -345,8 +344,10 @@ void spell_animate_dead(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 		return;
 	}
 
-	for (search = char_list; search != nullptr; search = search->next)
+	for (OwningListWalk<CHAR_DATA> walk(char_list); !walk.Done(); walk.Step())
 	{
+		CHAR_DATA *search = walk.Current();
+
 		if (is_npc(search)
 			&& Deref(search->master) == ch
 			&& (search->pIndexData->vnum == MOB_VNUM_ZOMBIE
@@ -596,7 +597,6 @@ void spell_vampiric_touch(int sn, int level, CHAR_DATA *ch, void *vo, int target
 
 void spell_black_circle(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 {
-	CHAR_DATA *pet;
 	AFFECT_DATA af;
 	bool found= false;
 	if (is_affected(ch, sn))
@@ -605,8 +605,10 @@ void spell_black_circle(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 	act("$n draws a black circle on the ground and falls into deep concentration.", ch, 0, 0, TO_ROOM);
 	act("You draw a black circle on the ground and fall into deep concentration.", ch, 0, 0, TO_CHAR);
 
-	for (pet = char_list; pet != nullptr; pet = pet->next)
+	for (OwningListWalk<CHAR_DATA> walk(char_list); !walk.Done(); walk.Step())
 	{
+		CHAR_DATA *pet = walk.Current();
+
 		if (is_npc(pet) && is_affected_by(pet, AFF_CHARM) && Deref(pet->master) && Deref(pet->master) == ch)
 		{
 			stop_fighting(pet, true);
@@ -783,8 +785,10 @@ void spell_ritual_soul(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 {
 	CHAR_DATA *search, *victim = (CHAR_DATA *)vo;
 
-	for (search = char_list; search != nullptr; search = search->next)
+	for (OwningListWalk<CHAR_DATA> walk(char_list); !walk.Done(); walk.Step())
 	{
+		CHAR_DATA *search = walk.Current();
+
 		if (is_npc(search)
 			&& Deref(search->master) == ch
 			&& search->pIndexData->vnum > 2939
@@ -913,8 +917,10 @@ void spell_ritual_flesh(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 {
 	CHAR_DATA *search, *victim = (CHAR_DATA *)vo;
 
-	for (search = char_list; search != nullptr; search = search->next)
+	for (OwningListWalk<CHAR_DATA> walk(char_list); !walk.Done(); walk.Step())
 	{
+		CHAR_DATA *search = walk.Current();
+
 		if (is_npc(search)
 			&& Deref(search->master) == ch
 			&& search->pIndexData->vnum > 2944
@@ -1340,7 +1346,6 @@ void spell_lesser_golem(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 	float dmgMultiplier = 1;
 	char type[MSL];
 	int num;
-	CHAR_DATA *check;
 	AFFECT_DATA af;
 
 	target_name = one_argument(target_name, type);
@@ -1378,8 +1383,10 @@ void spell_lesser_golem(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 		return;
 	}
 
-	for (check = char_list; check != nullptr; check = check->next)
+	for (OwningListWalk<CHAR_DATA> walk(char_list); !walk.Done(); walk.Step())
 	{
+		CHAR_DATA *check = walk.Current();
+
 		if (is_npc(check)
 			&& Deref(check->master) == ch
 			&& (check->pIndexData->vnum == 2955 || check->pIndexData->vnum == 2956 || check->pIndexData->vnum == 2957))
@@ -1447,7 +1454,7 @@ void spell_lesser_golem(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 
 void spell_greater_golem(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 {
-	CHAR_DATA *mob, *check;
+	CHAR_DATA *mob;
 	AFFECT_DATA af;
 	char type[MSL];
 	char arg[MSL];
@@ -1469,8 +1476,10 @@ void spell_greater_golem(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 		return;
 	}
 
-	for (check = char_list; check != nullptr; check = check->next)
+	for (OwningListWalk<CHAR_DATA> walk(char_list); !walk.Done(); walk.Step())
 	{
+		CHAR_DATA *check = walk.Current();
+
 		if (is_npc(check)
 			&& Deref(check->master) == ch
 			&& (check->pIndexData->vnum == 2959 || check->pIndexData->vnum == 2960 || check->pIndexData->vnum == 2961))
@@ -1681,13 +1690,14 @@ bool check_bond(CHAR_DATA *ch, CHAR_DATA *mob)
 
 bool check_zombie_summon(CHAR_DATA *ch)
 {
-	CHAR_DATA *mob;
 
 	if (get_skill(ch, gsn_unholy_bond) < 1)
 		return false;
 
-	for (mob = char_list; mob != nullptr; mob = mob->next)
+	for (OwningListWalk<CHAR_DATA> walk(char_list); !walk.Done(); walk.Step())
 	{
+		CHAR_DATA *mob = walk.Current();
+
 		if (is_npc(mob)
 			&& is_affected_by(mob, AFF_CHARM)
 			&& Deref(mob->master)

--- a/code/characterClasses/necro.c
+++ b/code/characterClasses/necro.c
@@ -653,8 +653,13 @@ void spell_visceral(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 		return;
 	}
 
-	for (corpse = object_list; corpse != nullptr && corpses < 3; corpse = corpse->next)
+	for (auto &owned : object_list)
 	{
+		if (corpses >= 3)
+			break;
+
+		corpse = owned.get();
+
 		if (corpse->in_room
 			&& corpse->in_room == ch->in_room
 			&& corpse->level >= ch->level

--- a/code/characterClasses/sorcerer.c
+++ b/code/characterClasses/sorcerer.c
@@ -2805,9 +2805,9 @@ void spell_anchor(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 		return;
 	}
 
-	for (wch = char_list; wch != nullptr; wch = wch_next)
+	for (OwningListWalk<CHAR_DATA> walk(char_list); !walk.Done(); walk.Step())
 	{
-		wch_next = wch->next;
+		CHAR_DATA *wch = walk.Current();
 
 		if (is_npc(wch) && wch->pIndexData->vnum == MOB_VNUM_ANCHOR && Deref(wch->hunting) == ch)
 		{
@@ -2850,9 +2850,9 @@ void spell_aerial_transferrence(int sn, int level, CHAR_DATA *ch, void *vo, int 
 		return;
 	}
 
-	for (wch = char_list; wch != nullptr; wch = wch_next)
+	for (OwningListWalk<CHAR_DATA> walk(char_list); !walk.Done(); walk.Step())
 	{
-		wch_next = wch->next;
+		CHAR_DATA *wch = walk.Current();
 
 		if (is_npc(wch) && wch->pIndexData->vnum == MOB_VNUM_ANCHOR && Deref(wch->hunting) == ch)
 		{

--- a/code/characterClasses/sorcerer.c
+++ b/code/characterClasses/sorcerer.c
@@ -227,13 +227,18 @@ void gravity_well_explode(ROOM_INDEX_DATA *room, ROOM_AFFECT_DATA *af)
 
 	affect_strip_area(room->area, gsn_gravity_well);
 
-	for (well = object_list; well != nullptr; well = well->next)
+	well = nullptr;
+
+	for (auto &owned : object_list)
 	{
-		if (well->item_type == ITEM_GRAVITYWELL && well->in_room && well->in_room == room)
+		if (owned->item_type == ITEM_GRAVITYWELL && owned->in_room && owned->in_room == room)
+		{
+			well = owned.get();
 			break;
+		}
 	}
 
-	if (!well)
+	if (well == nullptr)
 		return;
 
 	send_to_char("You lose control of your gravity well and it ruptures violently!\n\r", ch);

--- a/code/characterClasses/thief.c
+++ b/code/characterClasses/thief.c
@@ -1474,7 +1474,7 @@ void do_disguise(CHAR_DATA *ch, char *argument)
 
 	if (number_percent() < skill)
 	{
-		ch->pcdata->old = new_oldchar();
+		ch->pcdata->old = std::make_unique<OLD_CHAR>();
 		ch->pcdata->old->name = palloc_string(ch->true_name);
 		ch->pcdata->old->short_descr = palloc_string(ch->short_descr);
 		ch->pcdata->old->long_descr = palloc_string(ch->long_descr);
@@ -1551,8 +1551,7 @@ void disguise_remove(CHAR_DATA *ch)
 	free_pstring(ch->description);
 	ch->description = palloc_string(ch->pcdata->old->description);
 
-	free_oldchar(ch->pcdata->old);
-	ch->pcdata->old = nullptr;
+	ch->pcdata->old.reset();
 }
 
 void do_undisguise(CHAR_DATA *ch, char *argument)

--- a/code/characterClasses/warrior.c
+++ b/code/characterClasses/warrior.c
@@ -4758,7 +4758,7 @@ void execute_retreat(CHAR_DATA *ch, int dir)
 void do_disrupt_formation(CHAR_DATA *ch, char *arg)
 {
 	int skill, percent;
-	CHAR_DATA *vch, *vch_next, *gch;
+	CHAR_DATA *vch, *vch_next;
 	bool grouped = false;
 	CHAR_DATA *victim = nullptr;
 
@@ -4803,8 +4803,10 @@ void do_disrupt_formation(CHAR_DATA *ch, char *arg)
 		return;
 	}
 
-	for (gch = char_list; gch != nullptr; gch = gch->next)
+	for (OwningListWalk<CHAR_DATA> walk(char_list); !walk.Done(); walk.Step())
 	{
+		CHAR_DATA *gch = walk.Current();
+
 		if (is_same_group(gch, ch) && gch != ch)
 		{
 			grouped = true;

--- a/code/comm.c
+++ b/code/comm.c
@@ -2855,11 +2855,10 @@ void nanny(DESCRIPTOR_DATA *d, char *argument)
 			another one exists.
 			*/
 			{
-				OBJ_DATA *obj;
-				OBJ_DATA *obj_next;
-				for (obj = object_list; obj != nullptr; obj = obj_next)
+				for (OwningListWalk<OBJ_DATA> walk(object_list); !walk.Done(); walk.Step())
 				{
-					obj_next = obj->next;
+					OBJ_DATA *obj = walk.Current();
+
 					if (obj->carried_by == ch->self)
 					{
 						if (isCabalItem(obj))

--- a/code/comm.c
+++ b/code/comm.c
@@ -97,8 +97,7 @@
 /*
  * Global variables.
  */
-DESCRIPTOR_DATA *descriptor_list; /* All open descriptors		*/
-DESCRIPTOR_DATA *d_next;		  /* Next descriptor in loop	*/
+DescriptorList descriptor_list;	/* All open descriptors		*/
 bool god;						  /* All new chars are gods!	*/
 bool merc_down;					  /* Shutdown					*/
 bool rebooting= false;
@@ -197,7 +196,6 @@ void game_loop_unix(int control)
 		fd_set in_set;
 		fd_set out_set;
 		fd_set exc_set;
-		DESCRIPTOR_DATA *d;
 		int maxdesc;
 
 #ifdef MALLOC_DEBUG
@@ -215,12 +213,13 @@ void game_loop_unix(int control)
 
 		maxdesc = control;
 
-		for (d = descriptor_list; d; d = d->next)
+		for (auto &owned : descriptor_list)
 		{
-			maxdesc = std::max(maxdesc, (int)d->descriptor);
-			FD_SET(d->descriptor, &in_set);
-			FD_SET(d->descriptor, &out_set);
-			FD_SET(d->descriptor, &exc_set);
+			// Nothing here can close a connection, so a plain walk is enough.
+			maxdesc = std::max(maxdesc, (int)owned->descriptor);
+			FD_SET(owned->descriptor, &in_set);
+			FD_SET(owned->descriptor, &out_set);
+			FD_SET(owned->descriptor, &exc_set);
 		}
 
 		if (select(maxdesc + 1, &in_set, &out_set, &exc_set, &null_time) < 0)
@@ -238,9 +237,9 @@ void game_loop_unix(int control)
 		/*
 		 * Kick out the freaky folks.
 		 */
-		for (d = descriptor_list; d != nullptr; d = d_next)
+		for (OwningListWalk<DESCRIPTOR_DATA> walk(descriptor_list); !walk.Done(); walk.Step())
 		{
-			d_next = d->next;
+			DESCRIPTOR_DATA *d = walk.Current();
 
 			if (FD_ISSET(d->descriptor, &exc_set))
 			{
@@ -260,9 +259,10 @@ void game_loop_unix(int control)
 		/*
 		 * Process input.
 		 */
-		for (d = descriptor_list; d != nullptr; d = d_next)
+		for (OwningListWalk<DESCRIPTOR_DATA> walk(descriptor_list); !walk.Done(); walk.Step())
 		{
-			d_next = d->next;
+			DESCRIPTOR_DATA *d = walk.Current();
+
 			d->fcommand= false;
 
 			// Nothing between here and the interpret() below can free the
@@ -390,9 +390,9 @@ void game_loop_unix(int control)
 		/*
 		 * Output.
 		 */
-		for (d = descriptor_list; d != nullptr; d = d_next)
+		for (OwningListWalk<DESCRIPTOR_DATA> walk(descriptor_list); !walk.Done(); walk.Step())
 		{
-			d_next = d->next;
+			DESCRIPTOR_DATA *d = walk.Current();
 
 			if ((d->fcommand || d->outtop > 0) && FD_ISSET(d->descriptor, &out_set))
 			{
@@ -570,8 +570,10 @@ void init_descriptor(int control)
 	/*
 	 * Init descriptor data.
 	 */
-	dnew->next = descriptor_list;
-	descriptor_list = dnew;
+	// Ownership moves to the list here, not in new_descriptor: everything above
+	// this point can still reject the connection and delete it outright.
+	descriptor_list.push_back(std::unique_ptr<DESCRIPTOR_DATA>(dnew));
+	dnew->globalNode = std::prev(descriptor_list.end());
 
 	/*
 	 * Send the greeting.
@@ -624,32 +626,25 @@ void close_socket(DESCRIPTOR_DATA *dclose)
 		}
 	}
 
-	// The hand-rolled version of what CursorRegistry does, kept until the
-	// descriptor loops stop using the d_next global.
-	if (d_next == dclose)
-		d_next = d_next->next;
-
-	CursorRegistry<DESCRIPTOR_DATA>::Advance(dclose);
-
-	if (dclose == descriptor_list)
-	{
-		descriptor_list = descriptor_list->next;
-	}
-	else
-	{
-		DESCRIPTOR_DATA *d;
-
-		for (d = descriptor_list; d && d->next != dclose; d = d->next);
-
-		if (d != nullptr)
-			d->next = dclose->next;
-		else
-			RS.Logger.Warn("Close_socket: dclose not found.");
-	}
-
 	close(dclose->descriptor);
-	free_descriptor(dclose);
-	return;
+
+	// A descriptor that was never linked (init_descriptor's ban paths build
+	// these, as do the test fixtures) has no node to erase. Nothing owns it
+	// either, so it is the caller's to delete.
+	if (dclose->globalNode == DescriptorList::iterator{})
+	{
+		RS.Logger.Warn("Close_socket: dclose was not on the descriptor list.");
+		return;
+	}
+
+	// Advance the walks before the erase, while the node still links to its
+	// successor. The erase is also the destruction point, so this is the last
+	// moment `dclose` is readable. This subsumes the hand-written
+	// `if (d_next == dclose) d_next = d_next->next;` that guarded exactly one
+	// loop. Every walk over descriptor_list is covered now.
+	OwningCursorRegistry<DESCRIPTOR_DATA>::Advance(dclose->globalNode);
+
+	descriptor_list.erase(dclose->globalNode);
 }
 
 bool read_from_descriptor(DESCRIPTOR_DATA *d)
@@ -938,7 +933,6 @@ void bust_a_prompt(CHAR_DATA *ch)
 	bool found;
 	const char *dir_name[] = {"N", "E", "S", "W", "U", "D"};
 	int door;
-	DESCRIPTOR_DATA *d;
 	point = buf;
 
 	if (is_npc(ch)
@@ -1111,11 +1105,12 @@ void bust_a_prompt(CHAR_DATA *ch)
 				{
 					number_people = 0;
 
-					for (d = descriptor_list; d != nullptr; d = d->next)
+					// Counting only. Nothing here can close a connection.
+					for (auto &owned : descriptor_list)
 					{
-						CHAR_DATA *wch = Deref(d->character);
+						CHAR_DATA *wch = Deref(owned->character);
 
-						if (d->connected == CON_PLAYING
+						if (owned->connected == CON_PLAYING
 							&& wch->in_room != nullptr
 							&& wch->in_room->area == ch->in_room->area
 							&& !is_immortal(wch))
@@ -1137,11 +1132,11 @@ void bust_a_prompt(CHAR_DATA *ch)
 				if (is_immortal(ch) && ch->in_room != nullptr)
 				{
 					number_people = 0;
-					for (d = descriptor_list; d != nullptr; d = d->next)
+					for (auto &owned : descriptor_list)
 					{
-						CHAR_DATA *wch = Deref(d->character);
+						CHAR_DATA *wch = Deref(owned->character);
 
-						if (d->connected == CON_PLAYING
+						if (owned->connected == CON_PLAYING
 							&& wch->in_room != nullptr
 							&& wch->in_room->area == ch->in_room->area
 							&& can_see(ch, wch))
@@ -1164,9 +1159,9 @@ void bust_a_prompt(CHAR_DATA *ch)
 				{
 					number_people = 0;
 
-					for (d = descriptor_list; d != nullptr; d = d->next)
+					for (auto &owned : descriptor_list)
 					{
-						if (d->connected == CON_PLAYING && can_see(ch, Deref(d->character)))
+						if (owned->connected == CON_PLAYING && can_see(ch, Deref(owned->character)))
 							number_people++;
 					}
 
@@ -1483,7 +1478,6 @@ bool write_to_descriptor(int desc, char *txt, int length)
  */
 void nanny(DESCRIPTOR_DATA *d, char *argument)
 {
-	DESCRIPTOR_DATA *d_old, *d_next;
 	char buf[MAX_STRING_LENGTH], word[200], tword[200], cword[200];
 	std::string buffer, namebuf;
 	char arg[MAX_INPUT_LENGTH];
@@ -1704,9 +1698,9 @@ void nanny(DESCRIPTOR_DATA *d, char *argument)
 				case 'y':
 				case 'Y':
 				{
-					for (d_old = descriptor_list; d_old != nullptr; d_old = d_next)
+					for (OwningListWalk<DESCRIPTOR_DATA> walk(descriptor_list); !walk.Done(); walk.Step())
 					{
-						d_next = d_old->next;
+						DESCRIPTOR_DATA *d_old = walk.Current();
 						CHAR_DATA *oldDriving = Deref(d_old->character);
 						CHAR_DATA *oldSwitchedFrom = Deref(d_old->original);
 						char *oldName;
@@ -3076,10 +3070,12 @@ bool check_reconnect(DESCRIPTOR_DATA *d, char *name, bool fConn)
  */
 bool check_playing(DESCRIPTOR_DATA *d, char *name)
 {
-	DESCRIPTOR_DATA *dold;
-
-	for (dold = descriptor_list; dold; dold = dold->next)
+	// Protected rather than plain: the write_to_buffer below can overflow and
+	// close a connection, which erases a node in the list being walked.
+	for (OwningListWalk<DESCRIPTOR_DATA> walk(descriptor_list); !walk.Done(); walk.Step())
 	{
+		DESCRIPTOR_DATA *dold = walk.Current();
+
 		// A switched immortal answers to the name of their own body, not the
 		// mob they are driving -- hence the original-first pick. The guard
 		// stays on `character`, as it always has: this loop is looking for
@@ -3254,7 +3250,6 @@ void act_area(const char *format, CHAR_DATA *ch, CHAR_DATA *victim)
 	const char *str;
 	const char *i;
 	char *point;
-	DESCRIPTOR_DATA *d;
 
 	/*
 	 * Discard null and zero-length messages.
@@ -3263,8 +3258,12 @@ void act_area(const char *format, CHAR_DATA *ch, CHAR_DATA *victim)
 		return;
 
 	/*colorconv(format, format, ch);*/
-	for (d = descriptor_list; d != nullptr; d = d->next)
+	// Protected rather than plain: the write_to_buffer below can overflow and
+	// close the connection it is writing to, which erases a node in this list.
+	for (OwningListWalk<DESCRIPTOR_DATA> walk(descriptor_list); !walk.Done(); walk.Step())
 	{
+		DESCRIPTOR_DATA *d = walk.Current();
+
 		to = Deref(d->character);
 
 		if (d->connected == CON_PLAYING

--- a/code/comm.c
+++ b/code/comm.c
@@ -58,6 +58,7 @@
 #include <algorithm>
 #include "merc.h"
 #include "entity/handles.h"
+#include "entity/list_cursor.h"
 #include "comm.h"
 #include "recycle.h"
 #include "tables.h"
@@ -623,8 +624,12 @@ void close_socket(DESCRIPTOR_DATA *dclose)
 		}
 	}
 
+	// The hand-rolled version of what CursorRegistry does, kept until the
+	// descriptor loops stop using the d_next global.
 	if (d_next == dclose)
 		d_next = d_next->next;
+
+	CursorRegistry<DESCRIPTOR_DATA>::Advance(dclose);
 
 	if (dclose == descriptor_list)
 	{

--- a/code/comm.c
+++ b/code/comm.c
@@ -2715,8 +2715,11 @@ void nanny(DESCRIPTOR_DATA *d, char *argument)
 			}
 
 			write_to_buffer(d, "\n\rWelcome to Riftshadow! Remember to wipe your feet!\n\r\n\r", 0);
-			ch->next = char_list;
-			char_list = ch;
+			// The login hands the character over to the world here. Everything
+			// before this point can still reject it and free it outright.
+			char_list.push_front(std::unique_ptr<CHAR_DATA>(ch));
+			ch->globalNode = char_list.begin();
+
 			d->connected = CON_PLAYING;
 			reset_char(ch);
 
@@ -3001,7 +3004,6 @@ bool check_parse_name(char *name)
  */
 bool check_reconnect(DESCRIPTOR_DATA *d, char *name, bool fConn)
 {
-	CHAR_DATA *ch, *fch, *fch_next;
 	OBJ_DATA *obj;
 
 	// The half-built character sitting on the login screen, which this function
@@ -3010,8 +3012,10 @@ bool check_reconnect(DESCRIPTOR_DATA *d, char *name, bool fConn)
 	// life, and nothing reads it after that.
 	CHAR_DATA *pending = Deref(d->character);
 
-	for (ch = char_list; ch != nullptr; ch = ch->next)
+	for (OwningListWalk<CHAR_DATA> walk(char_list); !walk.Done(); walk.Step())
 	{
+		CHAR_DATA *ch = walk.Current();
+
 		if (!is_npc(ch)
 			&& (!fConn || Deref(ch->desc) == nullptr)
 			&& !str_cmp((pending->true_name ? pending->true_name : pending->name), (ch->true_name ? ch->true_name : ch->name)))
@@ -3023,9 +3027,10 @@ bool check_reconnect(DESCRIPTOR_DATA *d, char *name, bool fConn)
 			}
 			else
 			{
-				for (fch = char_list; fch; fch = fch_next)
+				for (OwningListWalk<CHAR_DATA> walk(char_list); !walk.Done(); walk.Step())
 				{
-					fch_next = fch->next;
+					CHAR_DATA *fch = walk.Current();
+
 					if (is_npc(fch)
 						&& (is_affected(fch, gsn_animate_dead) || is_affected_by(fch, AFF_CHARM))
 						&& Deref(fch->master) == pending)

--- a/code/comm.h
+++ b/code/comm.h
@@ -23,6 +23,8 @@
 
 #include "entity/fwd.h"
 #include "entity/limits.h"
+#include "entity/descriptor_data.h"	// DescriptorList: descriptor_list owns its connections
+#include "entity/list_cursor.h"		// walking descriptor_list while connections close
 #include "telnet.h"
 
 #define CHAR_WRAP			85
@@ -69,7 +71,10 @@
 	int	socket (int domain, int type, int protocol);
 #endif
 
-extern DESCRIPTOR_DATA *descriptor_list;
+// Owns every open connection. A descriptor is put here by init_descriptor once
+// it has survived the ban checks, and destroyed by close_socket erasing its
+// node. ch->desc and d->snoop_by name a connection without owning it.
+extern DescriptorList descriptor_list;
 extern bool merc_down;
 extern bool rebooting;
 extern int reboot_num;

--- a/code/db.c
+++ b/code/db.c
@@ -85,7 +85,7 @@ SHOP_DATA *shop_first;
 SHOP_DATA *shop_last;
 
 char bug_buf[2 * MAX_INPUT_LENGTH];
-CHAR_DATA *char_list;
+CharacterList char_list;
 // The same entities as char_list/object_list, indexed so a cross-reference can
 // be checked for liveness instead of trusted. See entity/handles.h.
 SlotMap<CHAR_DATA> charHandles;
@@ -1182,7 +1182,6 @@ void load_cabal_items(void)
 {
 	FILE *fp;
 	OBJ_DATA *obj;
-	CHAR_DATA *mob;
 
 	int inum, vnum;
 
@@ -1201,8 +1200,10 @@ void load_cabal_items(void)
 
 		if (!vnum)
 		{
-			for (mob = char_list; mob; mob = mob->next)
+			for (OwningListWalk<CHAR_DATA> walk(char_list); !walk.Done(); walk.Step())
 			{
+				CHAR_DATA *mob = walk.Current();
+
 				if (mob->cabal == inum && is_cabal_guard(mob))
 					obj_to_char(obj, mob);
 			}
@@ -1210,8 +1211,10 @@ void load_cabal_items(void)
 			continue;
 		}
 
-		for (mob = char_list; mob; mob = mob->next)
+		for (OwningListWalk<CHAR_DATA> walk(char_list); !walk.Done(); walk.Step())
 		{
+			CHAR_DATA *mob = walk.Current();
+
 			if (mob->pIndexData->vnum == vnum)
 				obj_to_char(obj, mob);
 		}
@@ -2090,9 +2093,11 @@ CHAR_DATA *create_mobile(MOB_INDEX_DATA *pMobIndex)
 	mob->home_room = nullptr;
 
 	/* link the mob to the world list */
-	mob->next = char_list;
+	// Ownership moves to the list here, not in new_char. A mob exists unlinked
+	// between the two, and the test fixtures build ones that never link at all.
+	char_list.push_front(std::unique_ptr<CHAR_DATA>(mob));
+	mob->globalNode = char_list.begin();
 
-	char_list = mob;
 	pMobIndex->count++;
 
 	return mob;
@@ -3162,7 +3167,6 @@ void do_memory(CHAR_DATA *ch, char *argument)
 void do_dump(CHAR_DATA *ch, char *argument)
 {
 	int count, count2, num_pcs, aff_count;
-	CHAR_DATA *fch;
 	MOB_INDEX_DATA *pMobIndex;
 	OBJ_DATA *obj;
 	OBJ_INDEX_DATA *pObjIndex;
@@ -3191,22 +3195,19 @@ void do_dump(CHAR_DATA *ch, char *argument)
 	count = 0;
 	count2 = 0;
 
-	for (fch = char_list; fch != nullptr; fch = fch->next)
+	for (auto &owned : char_list)
 	{
 		count++;
 
-		if (fch->pcdata != nullptr)
+		if (owned->pcdata != nullptr)
 			num_pcs++;
 
-		aff_count += fch->affected.size();
+		aff_count += owned->affected.size();
 	}
 
-	for (fch = char_free; fch != nullptr; fch = fch->next)
-	{
-		count2++;
-	}
-
-	fprintf(fp, "Mobs	%4d (%8lu bytes), %2d free (%lu bytes)\n", count, count * (sizeof(*fch)), count2, count2 * (sizeof(*fch)));
+	// No free list any more. char_list owns its characters, so an extracted one
+	// is destroyed rather than parked for reuse.
+	fprintf(fp, "Mobs	%4d (%8lu bytes), %2d free (%lu bytes)\n", count, count * (sizeof(CHAR_DATA)), count2, count2 * (sizeof(CHAR_DATA)));
 
 	/* pcdata — no free list any more (pcdata is owned by unique_ptr) */
 	count = 0;
@@ -3691,7 +3692,6 @@ void do_force_reset(CHAR_DATA *ch, char *argument)
 {
 	AREA_DATA *pArea;
 	char buf[MAX_STRING_LENGTH];
-	CHAR_DATA *ich, *ich_next;
 
 	if (get_trust(ch) < LEVEL_IMMORTAL && !is_heroimm(ch))
 	{
@@ -3707,9 +3707,9 @@ void do_force_reset(CHAR_DATA *ch, char *argument)
 
 	pArea = ch->in_room->area;
 
-	for (ich = char_list; ich; ich = ich_next)
+	for (OwningListWalk<CHAR_DATA> walk(char_list); !walk.Done(); walk.Step())
 	{
-		ich_next = ich->next;
+		CHAR_DATA *ich = walk.Current();
 
 		if (is_npc(ich) && ich->in_room && ich->in_room->area == pArea && pArea->area_type == ARE_UNOPENED)
 			extract_char(ich, true);

--- a/code/db.c
+++ b/code/db.c
@@ -104,7 +104,7 @@ short moon_calabren;
 short calabren_pos;
 ROOM_INDEX_DATA *room_list = nullptr;
 ROOM_INDEX_DATA *top_affected_room;
-RUNE_DATA *rune_list = nullptr;
+std::list<std::unique_ptr<RUNE_DATA>> rune_list;
 MOB_INDEX_DATA *mindex_list = nullptr;
 OBJ_INDEX_DATA *oIndex_list = nullptr;
 long gold_constant = 0;

--- a/code/db.c
+++ b/code/db.c
@@ -3168,7 +3168,6 @@ void do_dump(CHAR_DATA *ch, char *argument)
 	OBJ_INDEX_DATA *pObjIndex;
 	ROOM_INDEX_DATA *room;
 	EXIT_DATA *exit;
-	DESCRIPTOR_DATA *d;
 	FILE *fp;
 	int vnum, nMatch = 0;
 
@@ -3215,20 +3214,12 @@ void do_dump(CHAR_DATA *ch, char *argument)
 	fprintf(fp, "Pcdata	%4d (%8lu bytes), %2d free (%lu bytes)\n", num_pcs, num_pcs * (sizeof(PC_DATA)), count, count * (sizeof(PC_DATA)));
 
 	/* descriptors */
-	count = 0;
+	// No free list any more. descriptor_list owns its connections, so a closed
+	// one is destroyed rather than parked for reuse.
+	count = descriptor_list.size();
 	count2 = 0;
 
-	for (d = descriptor_list; d != nullptr; d = d->next)
-	{
-		count++;
-	}
-
-	for (d = descriptor_free; d != nullptr; d = d->next)
-	{
-		count2++;
-	}
-
-	fprintf(fp, "Descs	%4d (%8lu bytes), %2d free (%lu bytes)\n", count, count * (sizeof(*d)), count2, count2 * (sizeof(*d)));
+	fprintf(fp, "Descs	%4d (%8lu bytes), %2d free (%lu bytes)\n", count, count * (sizeof(DESCRIPTOR_DATA)), count2, count2 * (sizeof(DESCRIPTOR_DATA)));
 
 	/* object prototypes */
 	for (vnum = 0; nMatch < top_obj_index; vnum++)

--- a/code/db.c
+++ b/code/db.c
@@ -95,7 +95,7 @@ char *help_greeting;
 char log_buf[2 * MAX_INPUT_LENGTH];
 KILL_DATA kill_table[MAX_LEVEL];
 NOTE_DATA *note_list;
-OBJ_DATA *object_list;
+ObjectList object_list;
 TIME_INFO_DATA time_info;
 short sun;
 short moon_berus;
@@ -1404,7 +1404,7 @@ void reset_room(ROOM_INDEX_DATA *pRoom)
 	RESET_DATA *pReset;
 	CHAR_DATA *pMob;
 	CHAR_DATA *mob;
-	OBJ_DATA *pObj, *pObj2;
+	OBJ_DATA *pObj, *pObj2, *pObj2_next;
 	CHAR_DATA *LastMob = nullptr;
 	OBJ_DATA *LastObj = nullptr;
 	EXIT_DATA *pexit = nullptr;
@@ -1520,8 +1520,12 @@ void reset_room(ROOM_INDEX_DATA *pRoom)
 					continue;
 				}
 
-				for (pObj2 = pRoomIndex->contents; pObj2; pObj2 = pObj2->next_content)
+				// The successor has to be read before the body: extract_obj frees
+				// pObj2, and the loop advances through it.
+				for (pObj2 = pRoomIndex->contents; pObj2; pObj2 = pObj2_next)
 				{
+					pObj2_next = pObj2->next_content;
+
 					if (pObj2->pIndexData->vnum == pObjIndex->vnum
 						&& !is_obj_stat(pObj2, ITEM_DONATION_PIT)
 						&& !is_obj_stat(pObj2, ITEM_CORPSE_PC)
@@ -2358,8 +2362,13 @@ OBJ_DATA *create_object(OBJ_INDEX_DATA *pObjIndex, int level)
 	}
 
 	obj->owner = palloc_string("none");
-	obj->next = object_list;
-	object_list = obj;
+
+	// The list takes ownership here, not in new_obj: an object exists unlinked
+	// between the two, and the test fixtures build objects that never get linked
+	// at all.
+	object_list.push_front(std::unique_ptr<OBJ_DATA>(obj));
+	obj->globalNode = object_list.begin();
+
 	pObjIndex->limcount += 1;
 
 	return obj;
@@ -3240,19 +3249,16 @@ void do_dump(CHAR_DATA *ch, char *argument)
 	count = 0;
 	count2 = 0;
 
-	for (obj = object_list; obj != nullptr; obj = obj->next)
+	for (auto &owned : object_list)
 	{
 		count++;
 
-		aff_count += obj->affected.size();
+		aff_count += owned->affected.size();
 	}
 
-	for (obj = obj_free; obj != nullptr; obj = obj->next)
-	{
-		count2++;
-	}
-
-	fprintf(fp, "Objs	%4d (%8lu bytes), %2d free (%lu bytes)\n", count, count * (sizeof(*obj)), count2, count2 * (sizeof(*obj)));
+	// No free list any more -- object_list owns its objects, so a freed one is
+	// returned to the allocator rather than parked for reuse.
+	fprintf(fp, "Objs	%4d (%8lu bytes), %2d free (%lu bytes)\n", count, count * (sizeof(OBJ_DATA)), count2, count2 * (sizeof(OBJ_DATA)));
 
 	/* affects — no free list any more (affects are owned by value) */
 	count = 0;
@@ -3822,8 +3828,9 @@ void do_llimit(CHAR_DATA *ch, char *argument)
 	send_to_char("Counts set to zero....\n\r", ch);
 	send_to_char("Loading all in-game counts now (excluding PC objects).\n\r", ch);
 
-	for (obj = object_list; obj != nullptr; obj = obj->next)
+	for (auto &owned : object_list)
 	{
+		obj = owned.get();
 		carrier = Deref(obj->carried_by);
 
 		if (carrier != nullptr && !is_npc(carrier))

--- a/code/db.h
+++ b/code/db.h
@@ -43,6 +43,8 @@
 #include <unistd.h>		// getpid -- replaces the OLD_RAND hand declarations
 
 #include "entity/obj_data.h"		// ObjectList: object_list owns its objects
+#include "entity/char_data.h"		// CharacterList: char_list owns its characters
+#include "entity/list_cursor.h"	// walking char_list while characters are extracted
 #include "entity/extra_descr.h"		// get_extra_descr takes a std::list<EXTRA_DESCR_DATA>&
 
 #include "entity/fwd.h"
@@ -68,7 +70,10 @@ extern SHOP_DATA *shop_last;
 extern char bug_buf[];
 extern char *help_greeting;
 extern char log_buf[];
-extern CHAR_DATA *char_list;
+// Owns every character in the world. A character is put here by create_mobile
+// and by the login handing over at CON_READ_MOTD, and destroyed by extract_char
+// erasing its node. room->people and ch->carrying are containment, and stay raw.
+extern CharacterList char_list;
 extern KILL_DATA kill_table[];
 extern MOB_INDEX_DATA *mindex_list;
 extern OBJ_INDEX_DATA *oIndex_list;

--- a/code/db.h
+++ b/code/db.h
@@ -42,6 +42,7 @@
 #include <stdlib.h>		// srandom
 #include <unistd.h>		// getpid -- replaces the OLD_RAND hand declarations
 
+#include "entity/obj_data.h"		// ObjectList: object_list owns its objects
 #include "entity/extra_descr.h"		// get_extra_descr takes a std::list<EXTRA_DESCR_DATA>&
 
 #include "entity/fwd.h"
@@ -71,7 +72,10 @@ extern CHAR_DATA *char_list;
 extern KILL_DATA kill_table[];
 extern MOB_INDEX_DATA *mindex_list;
 extern OBJ_INDEX_DATA *oIndex_list;
-extern OBJ_DATA *object_list;
+// Owns every object in the world. An object is put here by create_object (and by
+// fread_obj for the legacy format) and destroyed by extract_obj erasing its
+// node; obj_data::contains and ch->carrying are containment, and stay raw.
+extern ObjectList object_list;
 extern TIME_INFO_DATA time_info;
 extern short sun;
 extern short moon_berus;

--- a/code/db.h
+++ b/code/db.h
@@ -36,6 +36,7 @@
 
 #include <cstddef>
 #include <list>
+#include <memory>
 #include <time.h>
 #include <stdio.h>
 #include <stdlib.h>		// srandom
@@ -79,7 +80,12 @@ extern short moon_calabren;
 extern short calabren_pos;
 extern ROOM_INDEX_DATA *room_list;
 extern ROOM_INDEX_DATA *top_affected_room;
-extern RUNE_DATA *rune_list;
+// Owns every applied rune. A rune is on two lists at once: this one, which
+// decides when it expires and holds it alive, and a per-container chain off
+// obj->rune / exit->rune / room->rune, which decides whether it triggers and is
+// non-owning. Erasing from here is the destruction point, so extract_rune has
+// to unlink the container chain strictly first.
+extern std::list<std::unique_ptr<RUNE_DATA>> rune_list;
 extern long gold_constant;
 extern long total_gold;
 extern long player_gold;

--- a/code/devextra.c
+++ b/code/devextra.c
@@ -111,8 +111,8 @@ void do_pswitch(CHAR_DATA *ch, char *argument)
 	victim = Deref(d->character);
 
 	victim->desc = nullptr;
-	victim->next = char_list;
-	char_list = victim;
+	char_list.push_front(std::unique_ptr<CHAR_DATA>(victim));
+	victim->globalNode = char_list.begin();
 	d->outsize = 2000;
 	d->outbuf = new char[d->outsize];
 	d->connected = CON_PLAYING;
@@ -3098,8 +3098,10 @@ OBJ_DATA *make_cosmetic(char *name, char *wearloc, char *underloc, char *cosmeti
 	CHAR_DATA *ch;
 	OBJ_DATA *obj;
 
-	for (ch = char_list; ch->next; ch = ch->next)
+	for (OwningListWalk<CHAR_DATA> walk(char_list); !walk.Done(); walk.Step())
 	{
+		CHAR_DATA *ch = walk.Current();
+
 		if (is_npc(ch))
 			break;
 	}

--- a/code/devextra.c
+++ b/code/devextra.c
@@ -366,10 +366,15 @@ void do_offer(CHAR_DATA *ch, char *argument)
 	auto offerings = OfferingRepository(RS.DbRift);
 
 	// status: 0 unread 1 rejected 2 accepted
-	for (altar = object_list; altar; altar = altar->next)
+	altar = nullptr;
+
+	for (auto &owned : object_list)
 	{
-		if (altar->in_room && altar->item_type == ITEM_ALTAR && altar->in_room == ch->in_room)
+		if (owned->in_room && owned->item_type == ITEM_ALTAR && owned->in_room == ch->in_room)
+		{
+			altar = owned.get();
 			break;
+		}
 	}
 
 	if (!altar || !altar->in_room->owner || !str_cmp(altar->in_room->owner, ""))

--- a/code/devextra.c
+++ b/code/devextra.c
@@ -1048,8 +1048,10 @@ void mob_recho(CHAR_DATA *ch, char *argument)
 		return;
 	}
 
-	for (DESCRIPTOR_DATA *d = descriptor_list; d; d = d->next)
+	for (OwningListWalk<DESCRIPTOR_DATA> walk(descriptor_list); !walk.Done(); walk.Step())
 	{
+		DESCRIPTOR_DATA *d = walk.Current();
+
 		CHAR_DATA *wch = Deref(d->character);
 
 		if (d->connected == CON_PLAYING
@@ -1070,8 +1072,10 @@ void area_echo(CHAR_DATA *ch, char *echo)
 {
 	char buffer[MAX_STRING_LENGTH * 2];
 
-	for (DESCRIPTOR_DATA *d = descriptor_list; d; d = d->next)
+	for (OwningListWalk<DESCRIPTOR_DATA> walk(descriptor_list); !walk.Done(); walk.Step())
 	{
+		DESCRIPTOR_DATA *d = walk.Current();
+
 		CHAR_DATA *wch = Deref(d->character);
 
 		if (d->connected == CON_PLAYING
@@ -1090,8 +1094,10 @@ void rarea_echo(ROOM_INDEX_DATA *room, char *echo)
 {
 	char buffer[MAX_STRING_LENGTH * 2];
 
-	for (DESCRIPTOR_DATA *d = descriptor_list; d; d = d->next)
+	for (OwningListWalk<DESCRIPTOR_DATA> walk(descriptor_list); !walk.Done(); walk.Step())
 	{
+		DESCRIPTOR_DATA *d = walk.Current();
+
 		CHAR_DATA *wch = Deref(d->character);
 
 		if (d->connected == CON_PLAYING
@@ -1110,8 +1116,10 @@ void outdoors_echo(AREA_DATA *area, char *echo)
 {
 	char buffer[MSL * 2];
 
-	for (DESCRIPTOR_DATA *d = descriptor_list; d; d = d->next)
+	for (OwningListWalk<DESCRIPTOR_DATA> walk(descriptor_list); !walk.Done(); walk.Step())
 	{
+		DESCRIPTOR_DATA *d = walk.Current();
+
 		CHAR_DATA *wch = Deref(d->character);
 
 		if (d->connected == CON_PLAYING

--- a/code/dioextra.c
+++ b/code/dioextra.c
@@ -132,7 +132,6 @@ void do_ghost(CHAR_DATA *ch, char *argument)
 	char arg1[MAX_INPUT_LENGTH];
 	char arg2[MAX_INPUT_LENGTH];
 	CHAR_DATA *victim;
-	DESCRIPTOR_DATA *d;
 
 	argument = one_argument(argument, arg1);
 	argument = one_argument(argument, arg2);
@@ -153,8 +152,10 @@ void do_ghost(CHAR_DATA *ch, char *argument)
 
 	if (!str_cmp(arg1, "all"))
 	{
-		for (d = descriptor_list; d; d = d->next)
+		for (OwningListWalk<DESCRIPTOR_DATA> walk(descriptor_list); !walk.Done(); walk.Step())
 		{
+			DESCRIPTOR_DATA *d = walk.Current();
+
 			CHAR_DATA *wch = Deref(d->character);
 
 			if (d->connected == CON_PLAYING
@@ -181,8 +182,10 @@ void do_ghost(CHAR_DATA *ch, char *argument)
 
 	if (!str_cmp(arg1, "zone"))
 	{
-		for (d = descriptor_list; d; d = d->next)
+		for (OwningListWalk<DESCRIPTOR_DATA> walk(descriptor_list); !walk.Done(); walk.Step())
 		{
+			DESCRIPTOR_DATA *d = walk.Current();
+
 			CHAR_DATA *wch = Deref(d->character);
 
 			if (d->connected == CON_PLAYING
@@ -495,7 +498,6 @@ void do_ccb(CHAR_DATA *ch, char *argument)
 	char arg1[MAX_STRING_LENGTH];
 	char arg2[MAX_STRING_LENGTH];
 	int cabal;
-	DESCRIPTOR_DATA *d;
 
 	/*
 	if (!is_immortal(ch))
@@ -536,8 +538,10 @@ void do_ccb(CHAR_DATA *ch, char *argument)
 
 	send_to_char(buffer.c_str(), ch);
 
-	for (d = descriptor_list; d != nullptr; d = d->next)
+	for (OwningListWalk<DESCRIPTOR_DATA> walk(descriptor_list); !walk.Done(); walk.Step())
 	{
+		DESCRIPTOR_DATA *d = walk.Current();
+
 		if (d->connected == CON_PLAYING)
 		{
 			CHAR_DATA *wch = Deref(d->character);
@@ -1613,8 +1617,10 @@ int count_carried(CHAR_DATA *ch, bool limited)
 
 bool auto_check_multi(DESCRIPTOR_DATA *d_check, char *host)
 {
-	for (DESCRIPTOR_DATA *d = descriptor_list; d != nullptr; d = d->next)
+	for (OwningListWalk<DESCRIPTOR_DATA> walk(descriptor_list); !walk.Done(); walk.Step())
 	{
+		DESCRIPTOR_DATA *d = walk.Current();
+
 		if (d == d_check || Deref(d->character) == nullptr)
 			continue;
 
@@ -1732,8 +1738,10 @@ void zone_echo(AREA_DATA *area, char *echo)
 {
 	char buffer[MSL * 2];
 
-	for (DESCRIPTOR_DATA *d = descriptor_list; d; d = d->next)
+	for (OwningListWalk<DESCRIPTOR_DATA> walk(descriptor_list); !walk.Done(); walk.Step())
 	{
+		DESCRIPTOR_DATA *d = walk.Current();
+
 		CHAR_DATA *wch = Deref(d->character);
 
 		if (d->connected == CON_PLAYING && wch->in_room != nullptr && wch->in_room->area == area)

--- a/code/dioextra.c
+++ b/code/dioextra.c
@@ -896,8 +896,10 @@ void report_cabal_items(CHAR_DATA *ch, char *argument)
 		sprintf(buf1, "%s is the guardian.", guardian->short_descr);
 		wiznet(buf1, 0, nullptr, WIZ_DEBUG, 0, 0);
 
-		for (obj = object_list; obj != nullptr; obj = obj->next)
+		for (auto &owned : object_list)
 		{
+			obj = owned.get();
+
 			if (obj->pIndexData->cabal != guardian->cabal)
 				continue;
 

--- a/code/dioextra.c
+++ b/code/dioextra.c
@@ -1670,9 +1670,11 @@ void do_pload(CHAR_DATA *ch, char *argument)
 	victim = Deref(d->character);
 
 	victim->desc = nullptr;
-	victim->next = char_list;
 
-	char_list = victim;
+	// The loaded character joins the world here, so the list takes it over from
+	// the descriptor that loaded it.
+	char_list.push_front(std::unique_ptr<CHAR_DATA>(victim));
+	victim->globalNode = char_list.begin();
 
 	d->outsize = 2000;
 	d->outbuf = new char[d->outsize];

--- a/code/entity/char_data.h
+++ b/code/entity/char_data.h
@@ -23,15 +23,28 @@
 
 extern CProficiencies prof_none; //empty proficiencies for jackasses who are going to ref ch->Profs() without checking IS_NPC
 
+/// The global character list owns every character in the world. Declared here
+/// rather than in db.h because a character caches its own node in it.
+using CharacterList = std::list<std::unique_ptr<CHAR_DATA>>;
+
 class	char_data
 {
 public:
-	// A handle naming this character, issued by new_char and retired by
-	// free_char. It is how another entity refers to this one without risking a
-	// pointer into a recycled slot; null for a character that never came from
-	// new_char.
+	// Releases the carried objects and the affects, frees the owned strings and
+	// expires every handle to this character. Runs when char_list erases the
+	// node, which is how a real character dies, or when free_char destroys one
+	// that was never linked.
+	~char_data();
+
+	// A handle naming this character, issued by new_char and retired when the
+	// character is destroyed. It is how another entity refers to this one
+	// without risking a pointer into a recycled slot. Null for a character that
+	// never came from new_char.
 	Handle<CHAR_DATA> self;
-	CHAR_DATA *next;
+	// This character's node in the global character list, valid while it is on
+	// it. Caching it is what makes extraction O(1) instead of a scan for the
+	// predecessor, and erasing it is what destroys the character.
+	CharacterList::iterator globalNode {};
 	CHAR_DATA *next_in_room;
 	// The follower graph. All non-owning, and any of the three can be
 	// extracted independently of the others, so they are handles rather than

--- a/code/entity/descriptor_data.h
+++ b/code/entity/descriptor_data.h
@@ -1,0 +1,67 @@
+#ifndef ENTITY_DESCRIPTOR_DATA_H
+#define ENTITY_DESCRIPTOR_DATA_H
+
+#include <list>
+#include <memory>
+
+#include "fwd.h"
+#include "limits.h"
+#include "handles.h"	// self, and the handle-typed cross-references
+
+//
+// One player connection.
+//
+
+/// The global descriptor list owns every open connection. Declared here rather
+/// than in comm.h because a descriptor caches its own node in it.
+using DescriptorList = std::list<std::unique_ptr<DESCRIPTOR_DATA>>;
+
+struct descriptor_data
+{
+	// Frees the owned strings and the output buffer, and expires every handle to
+	// this connection. Runs when descriptor_list erases the node (which is how a
+	// real connection dies) or when free_descriptor deletes a descriptor that
+	// was never linked.
+	~descriptor_data();
+
+	// This connection's node in the global descriptor list, valid while it is on
+	// it. Caching it is what makes close_socket O(1) instead of a scan for the
+	// predecessor, and erasing it is what closes the connection.
+	DescriptorList::iterator globalNode {};
+	// This connection's own handle, handed out so a character can name it
+	// without holding a pointer into a recycled struct. Registered by
+	// new_descriptor and retired when the descriptor is destroyed.
+	Handle<DESCRIPTOR_DATA> self;
+	// The connection watching this one, if any. Non-owning. It expires by
+	// itself when that connection closes, which is what close_socket's
+	// hand-written sweep over descriptor_list used to do.
+	Handle<DESCRIPTOR_DATA> snoop_by;
+	// The body this connection drives. While an immortal is switched into a
+	// mob, `original` is the immortal's own body parked behind it. Non-owning
+	// both ways: a character can be extracted while the connection lives on, so
+	// these are handles rather than pointers. `character` used to be nulled by
+	// hand on each of the five paths that free it. `original` was nulled on
+	// none of them, and check_playing reads its `true_name` for every open
+	// connection on every login attempt.
+	Handle<CHAR_DATA> character;
+	Handle<CHAR_DATA> original;
+	char *host;
+	short descriptor;
+	short connected;
+	bool fcommand;
+	char inbuf[4 * MAX_INPUT_LENGTH];
+	char incomm[MAX_INPUT_LENGTH];
+	char inlast[MAX_INPUT_LENGTH];
+	int repeat;
+	char *outbuf;
+	int outsize;
+	int outtop;
+	char *showstr_head;
+	char *showstr_point;
+	void *pEdit;	// OLC
+	char **pString;	// OLC
+	int editor;		// OLC
+	short type;
+};
+
+#endif /* ENTITY_DESCRIPTOR_DATA_H */

--- a/code/entity/list_cursor.h
+++ b/code/entity/list_cursor.h
@@ -1,0 +1,133 @@
+#ifndef ENTITY_LIST_CURSOR_H
+#define ENTITY_LIST_CURSOR_H
+
+#include <algorithm>
+#include <vector>
+
+//
+// Walking a global entity list while things are being extracted from it.
+//
+// The hazard: a loop body that extracts something other than the element it was
+// handed. Every walk in the game saves its successor before running the body:
+//
+//     for (ch = char_list; ch != nullptr; ch = ch_next)
+//     {
+//         ch_next = ch->next;
+//         ...                     // may extract ch      -- fine
+//         ...                     // may extract ch_next -- not fine
+//     }
+//
+// so extracting the successor leaves the loop holding a pointer to an entity
+// that has just been freed. That is worse than reading a stale entity, because
+// the free lists are threaded through the very same `next` field the global
+// lists use: free_char ends with `ch->next = char_free`, so the saved successor
+// stops naming anything on the live list. With an empty free list the walk ends
+// early and silently skips every remaining entity; with a non-empty one it
+// walks off into the free list and hands the loop body one corpse after
+// another. Neither is visible at runtime today, because the memory stays mapped.
+//
+// close_socket has coped with this by hand since forever, for one of the three
+// lists:
+//
+//     if (d_next == dclose)
+//         d_next = d_next->next;
+//
+// That is the whole idea, and it is correct. It just only protects the one
+// loop that happens to use the `d_next` global. This generalizes it: a walk
+// registers where it keeps its successor, and extraction advances any
+// registered successor that names the entity going away. The loop then carries
+// on with the next live entity, which is what every one of those loops meant.
+//
+// Two rules for anything that removes an entity from a global list:
+//
+//   1. Call CursorRegistry<T>::Advance(entity) BEFORE unlinking it and before
+//      freeing it. Both of those destroy the `next` the advance needs to read.
+//   2. Do it for every removal path, or the loops go back to being on their own.
+//
+
+/// Where the walks in flight are keeping their successors, per entity type.
+///
+/// One vector per T, holding the address of each active walk's successor
+/// variable rather than its value. The walk keeps updating that variable as it
+/// steps, and registration has to survive it doing so. Walks nest a few deep at
+/// most, so a linear scan is the right shape.
+template <class T>
+class CursorRegistry
+{
+public:
+	static void Add(T **cursor) { cursors.push_back(cursor); }
+
+	static void Remove(T **cursor)
+	{
+		cursors.erase(std::remove(cursors.begin(), cursors.end(), cursor), cursors.end());
+	}
+
+	/// Moves any walk that was about to visit `removed` past it. Must be called
+	/// while `removed` is still linked, since that is where the answer comes from.
+	static void Advance(T *removed)
+	{
+		if (removed == nullptr)
+			return;
+
+		for (T **cursor : cursors)
+		{
+			if (*cursor == removed)
+				*cursor = removed->next;
+		}
+	}
+
+	/// Walks in flight. For tests and for asserting a walk cleaned up after
+	/// itself.
+	static std::size_t ActiveCount() { return cursors.size(); }
+
+private:
+	inline static std::vector<T **> cursors;
+};
+
+/// A walk over a global entity list that extraction knows about.
+///
+/// Replaces the hand-rolled save-the-successor loop:
+///
+///     for (ListWalk<CHAR_DATA> walk(char_list); !walk.Done(); walk.Step())
+///     {
+///         CHAR_DATA *ch = walk.Current();
+///         ...
+///     }
+///
+/// The body may extract the current entity, the next one, or any other, and the
+/// walk still visits exactly the entities that are still on the list when it
+/// reaches them.
+template <class T>
+class ListWalk
+{
+public:
+	explicit ListWalk(T *head)
+		: current(head)
+		, next(head != nullptr ? head->next : nullptr)
+	{
+		CursorRegistry<T>::Add(&next);
+	}
+
+	~ListWalk() { CursorRegistry<T>::Remove(&next); }
+
+	// The registry holds the address of `next`, so this object has to stay put.
+	ListWalk(const ListWalk &) = delete;
+	ListWalk &operator=(const ListWalk &) = delete;
+	ListWalk(ListWalk &&) = delete;
+	ListWalk &operator=(ListWalk &&) = delete;
+
+	bool Done() const { return current == nullptr; }
+	T *Current() const { return current; }
+
+	void Step()
+	{
+		current = next;
+		next = current != nullptr ? current->next : nullptr;
+	}
+
+private:
+	T *current;
+	T *next;		// registered; extraction may rewrite this mid-body
+};
+
+#endif /* ENTITY_LIST_CURSOR_H */

--- a/code/entity/list_cursor.h
+++ b/code/entity/list_cursor.h
@@ -12,138 +12,41 @@
 // The hazard: a loop body that extracts something other than the element it was
 // handed. Every walk in the game saves its successor before running the body:
 //
-//     for (ch = char_list; ch != nullptr; ch = ch_next)
+//     for (OwningListWalk<OBJ_DATA> walk(object_list); !walk.Done(); walk.Step())
 //     {
-//         ch_next = ch->next;
-//         ...                     // may extract ch      -- fine
-//         ...                     // may extract ch_next -- not fine
+//         OBJ_DATA *obj = walk.Current();
+//         ...                     // may extract obj, fine
+//         ...                     // may extract the successor, not fine
 //     }
 //
-// so extracting the successor leaves the loop holding a pointer to an entity
-// that has just been freed. That is worse than reading a stale entity, because
-// the free lists are threaded through the very same `next` field the global
-// lists use: free_char ends with `ch->next = char_free`, so the saved successor
-// stops naming anything on the live list. With an empty free list the walk ends
-// early and silently skips every remaining entity; with a non-empty one it
-// walks off into the free list and hands the loop body one corpse after
-// another. Neither is visible at runtime today, because the memory stays mapped.
+// A global list owns what it holds, so extracting an entity erases its node and
+// destroys it. Any saved successor naming that node is left pointing into a
+// destroyed element, and stepping onto it reads freed memory.
 //
-// close_socket has coped with this by hand since forever, for one of the three
-// lists:
+// close_socket has coped with this by hand since forever, for one of the lists:
 //
 //     if (d_next == dclose)
 //         d_next = d_next->next;
 //
-// That is the whole idea, and it is correct. It just only protects the one
-// loop that happens to use the `d_next` global. This generalizes it: a walk
+// That is the whole idea, and it is correct. It just only protected the one loop
+// that happened to use the `d_next` global. This generalizes it: a walk
 // registers where it keeps its successor, and extraction advances any
 // registered successor that names the entity going away. The loop then carries
 // on with the next live entity, which is what every one of those loops meant.
 //
 // Two rules for anything that removes an entity from a global list:
 //
-//   1. Call CursorRegistry<T>::Advance(entity) BEFORE unlinking it and before
-//      freeing it. Both of those destroy the `next` the advance needs to read.
+//   1. Call OwningCursorRegistry<T>::Advance(node) BEFORE erasing that node.
+//      The erase is what destroys the link the advance needs to read.
 //   2. Do it for every removal path, or the loops go back to being on their own.
 //
 
 /// Where the walks in flight are keeping their successors, per entity type.
 ///
 /// One vector per T, holding the address of each active walk's successor
-/// variable rather than its value. The walk keeps updating that variable as it
+/// iterator rather than its value. The walk keeps updating that iterator as it
 /// steps, and registration has to survive it doing so. Walks nest a few deep at
 /// most, so a linear scan is the right shape.
-template <class T>
-class CursorRegistry
-{
-public:
-	static void Add(T **cursor) { cursors.push_back(cursor); }
-
-	static void Remove(T **cursor)
-	{
-		cursors.erase(std::remove(cursors.begin(), cursors.end(), cursor), cursors.end());
-	}
-
-	/// Moves any walk that was about to visit `removed` past it. Must be called
-	/// while `removed` is still linked, since that is where the answer comes from.
-	static void Advance(T *removed)
-	{
-		if (removed == nullptr)
-			return;
-
-		for (T **cursor : cursors)
-		{
-			if (*cursor == removed)
-				*cursor = removed->next;
-		}
-	}
-
-	/// Walks in flight. For tests and for asserting a walk cleaned up after
-	/// itself.
-	static std::size_t ActiveCount() { return cursors.size(); }
-
-private:
-	inline static std::vector<T **> cursors;
-};
-
-/// A walk over a global entity list that extraction knows about.
-///
-/// Replaces the hand-rolled save-the-successor loop:
-///
-///     for (ListWalk<CHAR_DATA> walk(char_list); !walk.Done(); walk.Step())
-///     {
-///         CHAR_DATA *ch = walk.Current();
-///         ...
-///     }
-///
-/// The body may extract the current entity, the next one, or any other, and the
-/// walk still visits exactly the entities that are still on the list when it
-/// reaches them.
-template <class T>
-class ListWalk
-{
-public:
-	explicit ListWalk(T *head)
-		: current(head)
-		, next(head != nullptr ? head->next : nullptr)
-	{
-		CursorRegistry<T>::Add(&next);
-	}
-
-	~ListWalk() { CursorRegistry<T>::Remove(&next); }
-
-	// The registry holds the address of `next`, so this object has to stay put.
-	ListWalk(const ListWalk &) = delete;
-	ListWalk &operator=(const ListWalk &) = delete;
-	ListWalk(ListWalk &&) = delete;
-	ListWalk &operator=(ListWalk &&) = delete;
-
-	bool Done() const { return current == nullptr; }
-	T *Current() const { return current; }
-
-	void Step()
-	{
-		current = next;
-		next = current != nullptr ? current->next : nullptr;
-	}
-
-private:
-	T *current;
-	T *next;		// registered; extraction may rewrite this mid-body
-};
-
-//
-// The same idea for a list that owns what it holds.
-//
-// Once a global list is std::list<std::unique_ptr<T>>, erasing an element both
-// destroys the entity and invalidates iterators to that element. So a walk's
-// saved successor is an iterator rather than a pointer, and it needs the same
-// protection for the same reason. The hazard is if anything sharper here: the
-// entity is really freed, so a walk that carried on regardless would be reading
-// poisoned memory rather than an intact corpse.
-//
-
-/// The owning-container counterpart to CursorRegistry.
 template <class T>
 class OwningCursorRegistry
 {
@@ -169,19 +72,27 @@ public:
 		}
 	}
 
+	/// Walks in flight. For tests and for asserting a walk cleaned up after
+	/// itself.
 	static std::size_t ActiveCount() { return cursors.size(); }
 
 private:
 	inline static std::vector<Iterator *> cursors;
 };
 
-/// A walk over an owning global entity list that extraction knows about.
+/// A walk over a global entity list that extraction knows about.
+///
+/// Replaces the hand-rolled save-the-successor loop:
 ///
 ///     for (OwningListWalk<OBJ_DATA> walk(object_list); !walk.Done(); walk.Step())
 ///     {
 ///         OBJ_DATA *obj = walk.Current();
 ///         ...
 ///     }
+///
+/// The body may extract the current entity, the next one, or any other, and the
+/// walk still visits exactly the entities that are still on the list when it
+/// reaches them.
 ///
 /// `Done` is only ever asked about the *new* current, because the loop runs
 /// Step before it, so the body is free to extract the entity it was handed.

--- a/code/entity/list_cursor.h
+++ b/code/entity/list_cursor.h
@@ -2,6 +2,8 @@
 #define ENTITY_LIST_CURSOR_H
 
 #include <algorithm>
+#include <list>
+#include <memory>
 #include <vector>
 
 //
@@ -128,6 +130,97 @@ public:
 private:
 	T *current;
 	T *next;		// registered; extraction may rewrite this mid-body
+};
+
+//
+// The same idea for a list that owns what it holds.
+//
+// Once a global list is std::list<std::unique_ptr<T>>, erasing an element both
+// destroys the entity and invalidates iterators to that element. So a walk's
+// saved successor is an iterator rather than a pointer, and it needs the same
+// protection for the same reason. The hazard is if anything sharper here: the
+// entity is really freed, so a walk that carried on regardless would be reading
+// poisoned memory rather than an intact corpse.
+//
+
+/// The owning-container counterpart to CursorRegistry.
+template <class T>
+class OwningCursorRegistry
+{
+public:
+	using ListType = std::list<std::unique_ptr<T>>;
+	using Iterator = typename ListType::iterator;
+
+	static void Add(Iterator *cursor) { cursors.push_back(cursor); }
+
+	static void Remove(Iterator *cursor)
+	{
+		cursors.erase(std::remove(cursors.begin(), cursors.end(), cursor), cursors.end());
+	}
+
+	/// Moves any walk that was about to visit `erased` past it. Must be called
+	/// before the erase, while the node still links to its successor.
+	static void Advance(Iterator erased)
+	{
+		for (Iterator *cursor : cursors)
+		{
+			if (*cursor == erased)
+				*cursor = std::next(erased);
+		}
+	}
+
+	static std::size_t ActiveCount() { return cursors.size(); }
+
+private:
+	inline static std::vector<Iterator *> cursors;
+};
+
+/// A walk over an owning global entity list that extraction knows about.
+///
+///     for (OwningListWalk<OBJ_DATA> walk(object_list); !walk.Done(); walk.Step())
+///     {
+///         OBJ_DATA *obj = walk.Current();
+///         ...
+///     }
+///
+/// `Done` is only ever asked about the *new* current, because the loop runs
+/// Step before it, so the body is free to extract the entity it was handed.
+template <class T>
+class OwningListWalk
+{
+public:
+	using ListType = std::list<std::unique_ptr<T>>;
+	using Iterator = typename ListType::iterator;
+
+	explicit OwningListWalk(ListType &list)
+		: list(list)
+		, current(list.begin())
+		, next(current == list.end() ? current : std::next(current))
+	{
+		OwningCursorRegistry<T>::Add(&next);
+	}
+
+	~OwningListWalk() { OwningCursorRegistry<T>::Remove(&next); }
+
+	// The registry holds the address of `next`, so this object has to stay put.
+	OwningListWalk(const OwningListWalk &) = delete;
+	OwningListWalk &operator=(const OwningListWalk &) = delete;
+	OwningListWalk(OwningListWalk &&) = delete;
+	OwningListWalk &operator=(OwningListWalk &&) = delete;
+
+	bool Done() const { return current == list.end(); }
+	T *Current() const { return current->get(); }
+
+	void Step()
+	{
+		current = next;
+		next = current == list.end() ? current : std::next(current);
+	}
+
+private:
+	ListType &list;
+	Iterator current;
+	Iterator next;		// registered; extraction may rewrite this mid-body
 };
 
 #endif /* ENTITY_LIST_CURSOR_H */

--- a/code/entity/obj_data.h
+++ b/code/entity/obj_data.h
@@ -2,6 +2,7 @@
 #define ENTITY_OBJ_DATA_H
 
 #include <list>
+#include <memory>
 
 #include "fwd.h"
 #include "limits.h"
@@ -13,13 +14,25 @@
 // One object.
 //
 
+/// The global object list owns every object in the world. Declared here rather
+/// than in db.h because an object caches its own node in it.
+using ObjectList = std::list<std::unique_ptr<OBJ_DATA>>;
+
 struct obj_data
 {
+	// Frees the owned strings and expires every handle to this object. Runs when
+	// object_list erases the node (which is how a real object dies) or when
+	// free_obj deletes an object that was never linked.
+	~obj_data();
+
 	// A handle naming this object, issued by new_obj and retired by free_obj.
 	// It is how another entity refers to this one without risking a pointer
 	// into a recycled slot; null for an object that never came from new_obj.
 	Handle<OBJ_DATA> self;
-	OBJ_DATA *next;
+	// This object's node in the global object list, valid while it is on it.
+	// Caching it is what makes extraction O(1) instead of a scan for the
+	// predecessor, and erasing it is what destroys the object.
+	ObjectList::iterator globalNode {};
 	OBJ_DATA *next_content;
 	OBJ_DATA *contains;
 	// The container this object sits inside, if any. Kept in step with in_room

--- a/code/entity/pc_data.h
+++ b/code/entity/pc_data.h
@@ -3,6 +3,7 @@
 
 #include <time.h>
 #include <list>
+#include <memory>
 
 #include "fwd.h"
 #include "limits.h"
@@ -78,7 +79,12 @@ struct pc_data
 	char *logon_time;
 	char *color_scheme[MAX_EVENTS];
 	long shifted;
-	OLD_CHAR *old;
+	// The player's real identity while they are disguised, null otherwise.
+	// This is the sole owner since nothing else holds an old_char. Only 
+	// `disguise_remove` ever freed it and this destructor never did, so 
+	// a player who left the world still disguised leaked one plus its four
+	// strings. Owning it closes that.
+	std::unique_ptr<OLD_CHAR> old;
 	bool entering_text;
 	char *entered_text;
 	DO_FUN *end_fun;

--- a/code/fight.c
+++ b/code/fight.c
@@ -84,17 +84,16 @@
  */
 void violence_update(void)
 {
-	CHAR_DATA *ch;
-	CHAR_DATA *ch_next;
 	CHAR_DATA *victim;
 	CHAR_DATA *opponent;
 	int regen = 0;
 	OBJ_DATA *obj;
 	AFFECT_DATA *af;
 
-	for (ch = char_list; ch != nullptr; ch = ch->next)
+	for (OwningListWalk<CHAR_DATA> walk(char_list); !walk.Done(); walk.Step())
 	{
-		ch_next = ch->next;
+		CHAR_DATA *ch = walk.Current();
+
 		if (ch->regen_rate != 0)
 		{
 			if (ch->regen_rate > 0)
@@ -305,7 +304,7 @@ void check_assist(CHAR_DATA *ch, CHAR_DATA *victim)
 					if (number_bits(1) == 0)
 						continue;
 
-					for (vch = ch->in_room->people; vch; vch = vch->next)
+					for (vch = ch->in_room->people; vch; vch = vch->next_in_room)
 					{
 						if (can_see(rch, vch) && is_same_group(vch, victim))
 							number++;
@@ -314,7 +313,7 @@ void check_assist(CHAR_DATA *ch, CHAR_DATA *victim)
 					tnumber = number_range(1, number);
 					number = 1;
 
-					for (vch = ch->in_room->people; vch; vch = vch->next)
+					for (vch = ch->in_room->people; vch; vch = vch->next_in_room)
 					{
 						if (can_see(rch, vch) && is_same_group(vch, victim) && number++ == tnumber)
 							target = vch;
@@ -672,7 +671,7 @@ void mob_hit(CHAR_DATA *ch, CHAR_DATA *victim, int dt)
 	{
 		for (vch = ch->in_room->people; vch != nullptr; vch = vch_next)
 		{
-			vch_next = vch->next;
+			vch_next = vch->next_in_room;
 
 			if (vch != victim && Deref(vch->fighting) == ch)
 				one_hit(ch, vch, dt);
@@ -2983,10 +2982,11 @@ void combat_alert(CHAR_DATA *victim, int type, CHAR_DATA *ch)
  */
 void stop_fighting(CHAR_DATA *ch, bool fBoth)
 {
-	CHAR_DATA *fch;
 
-	for (fch = char_list; fch != nullptr; fch = fch->next)
+	for (OwningListWalk<CHAR_DATA> walk(char_list); !walk.Done(); walk.Step())
 	{
+		CHAR_DATA *fch = walk.Current();
+
 		if (fch == ch || (fBoth && Deref(fch->fighting) == ch))
 		{
 			fch->fighting = nullptr;
@@ -3307,7 +3307,6 @@ void raw_kill(CHAR_DATA *ch, CHAR_DATA *victim)
 	AFFECT_DATA af;
 	ROOM_AFFECT_DATA raf;
 	AREA_AFFECT_DATA aaf;
-	CHAR_DATA *gch, *gch_next;
 	OBJ_DATA *obj, *obj2, *corpse;
 	char wizbuf[MSL], *cname, buf[MSL], buf2[MSL];
 	bool infidels = false;
@@ -3415,9 +3414,9 @@ void raw_kill(CHAR_DATA *ch, CHAR_DATA *victim)
 			wiznet(wizbuf, nullptr, nullptr, WIZ_DEATHS, 0, 0);
 	}
 
-	for (gch = char_list; gch != nullptr; gch = gch_next)
+	for (OwningListWalk<CHAR_DATA> walk(char_list); !walk.Done(); walk.Step())
 	{
-		gch_next = gch->next;
+		CHAR_DATA *gch = walk.Current();
 
 		if (is_npc(gch) && Deref(gch->master) == victim && gch->pIndexData->vnum != ACADEMY_PET && !is_npc(victim))
 			extract_char(gch, true);
@@ -3463,8 +3462,10 @@ void raw_kill(CHAR_DATA *ch, CHAR_DATA *victim)
 	// leaves a slain player alive, so the references stay live and something
 	// else has to drop them); this is the half that answers it. Deleting it
 	// will not fail a build or a test, it will quietly restore a bug.
-	for (CHAR_DATA *wch = char_list; wch != nullptr; wch = wch->next)
+	for (OwningListWalk<CHAR_DATA> walk(char_list); !walk.Done(); walk.Step())
 	{
+		CHAR_DATA *wch = walk.Current();
+
 		if (Deref(wch->last_fight_opponent) == victim)
 			wch->last_fight_opponent = nullptr;
 
@@ -3630,7 +3631,6 @@ void raw_kill(CHAR_DATA *ch, CHAR_DATA *victim)
 
 void pk_record(CHAR_DATA *ch, CHAR_DATA *victim)
 {
-	CHAR_DATA *wch;
 	int killer_group = 0, victim_group = 0;
 	int killer_in_room = 0;
 	float killer_credit, victim_credit;
@@ -3639,8 +3639,10 @@ void pk_record(CHAR_DATA *ch, CHAR_DATA *victim)
 	if (is_npc(victim) || is_npc(ch))
 		return;
 
-	for (wch = char_list; wch; wch = wch->next)
+	for (OwningListWalk<CHAR_DATA> walk(char_list); !walk.Done(); walk.Step())
 	{
+		CHAR_DATA *wch = walk.Current();
+
 		if (is_same_group(wch, ch) && !is_npc(wch) && (wch->in_room == ch->in_room || wch->ghost > 0))
 		{
 			RS.Logger.Info("Adding {} to killer_group", wch->name);
@@ -3669,8 +3671,10 @@ void pk_record(CHAR_DATA *ch, CHAR_DATA *victim)
 	killer_credit = killer_credit / killer_in_room;
 	victim->pcdata->fragged += victim_credit;
 
-	for (wch = char_list; wch; wch = wch->next)
+	for (OwningListWalk<CHAR_DATA> walk(char_list); !walk.Done(); walk.Step())
 	{
+		CHAR_DATA *wch = walk.Current();
+
 		if (is_same_group(wch, ch) && can_pk(wch, victim) && !is_npc(wch) && wch->in_room == ch->in_room)
 		{
 			wch->pcdata->frags[PK_KILLS] += killer_credit;
@@ -4035,8 +4039,10 @@ int xp_compute(CHAR_DATA *gch, CHAR_DATA *victim, int group_amount, int glevel)
 
 	if (!is_npc(gch))
 	{
-		for (cPeers = char_list; cPeers; cPeers = cPeers->next)
+		for (OwningListWalk<CHAR_DATA> walk(char_list); !walk.Done(); walk.Step())
 		{
+			CHAR_DATA *cPeers = walk.Current();
+
 			if (!is_npc(cPeers)
 				&& cPeers != gch
 				&& cPeers->level > gch->level - PEER_BALANCE_DISTANCE
@@ -7431,7 +7437,6 @@ void do_enlist(CHAR_DATA *ch, char *argument)
 	char buf[MAX_STRING_LENGTH];
 	AFFECT_DATA af;
 	int chance;
-	CHAR_DATA *check;
 
 	chance = get_skill(ch, gsn_enlist);
 
@@ -7475,8 +7480,10 @@ void do_enlist(CHAR_DATA *ch, char *argument)
 		return;
 	}
 
-	for (check = char_list; check != nullptr; check = check->next)
+	for (OwningListWalk<CHAR_DATA> walk(char_list); !walk.Done(); walk.Step())
 	{
+		CHAR_DATA *check = walk.Current();
+
 		if (is_affected(check, gsn_enlist) && Deref(check->master) == ch)
 		{
 			send_to_char("You already have a devoted recruit following you.\n\r", ch);
@@ -8816,8 +8823,10 @@ bool check_parting_blow(CHAR_DATA *ch, CHAR_DATA *victim)
 
 CHAR_DATA *get_cabal_guardian(int cabal)
 {
-	for (CHAR_DATA *cabalguardian = char_list; cabalguardian != nullptr; cabalguardian = cabalguardian->next)
+	for (OwningListWalk<CHAR_DATA> walk(char_list); !walk.Done(); walk.Step())
 	{
+		CHAR_DATA *cabalguardian = walk.Current();
+
 		if (is_npc(cabalguardian) && cabalguardian->cabal == cabal && is_cabal_guard(cabalguardian))
 			return cabalguardian;
 	}

--- a/code/handler.c
+++ b/code/handler.c
@@ -40,6 +40,7 @@
 #include "merc.h"
 #include "handler.h"
 #include "entity/handles.h"
+#include "entity/list_cursor.h"
 #include "magic.h"
 #include "recycle.h"
 #include "tables.h"
@@ -2198,6 +2199,9 @@ void extract_obj(OBJ_DATA *obj)
 		extract_obj(obj_content);
 	}
 
+	// See extract_char: advance the walks before the link they are holding goes.
+	CursorRegistry<OBJ_DATA>::Advance(obj);
+
 	if (object_list == obj)
 	{
 		object_list = obj->next;
@@ -2318,6 +2322,11 @@ void extract_char(CHAR_DATA *ch, bool fPull)
 			it = next;
 		}
 	}
+
+	// Before the unlink, and before the free below it: any walk in flight that
+	// was about to visit this character moves past it instead. Both of those
+	// steps destroy the `next` the advance reads.
+	CursorRegistry<CHAR_DATA>::Advance(ch);
 
 	if (ch == char_list)
 	{

--- a/code/handler.c
+++ b/code/handler.c
@@ -2309,34 +2309,18 @@ void extract_char(CHAR_DATA *ch, bool fPull)
 		}
 	}
 
-	// Before the unlink, and before the free below it: any walk in flight that
-	// was about to visit this character moves past it instead. Both of those
-	// steps destroy the `next` the advance reads.
-	CursorRegistry<CHAR_DATA>::Advance(ch);
-
-	if (ch == char_list)
+	// A character that was never linked has no node to erase. Nothing owns it
+	// either, so it is the caller's to destroy, and extracting it stops here
+	// rather than freeing something it does not own. This is the early return
+	// the predecessor scan used to take when it fell off the end of the list.
+	if (ch->globalNode == CharacterList::iterator{})
 	{
-		char_list = ch->next;
-	}
-	else
-	{
-		CHAR_DATA *prev;
-		for (prev = char_list; prev != nullptr; prev = prev->next)
-		{
-			if (prev->next == ch)
-			{
-				prev->next = ch->next;
-				break;
-			}
-		}
-
-		if (prev == nullptr)
-		{
-			RS.Logger.Warn("Extract_char: char not found.");
-			return;
-		}
+		RS.Logger.Warn("Extract_char: char not found.");
+		return;
 	}
 
+	// Advances the walks in flight and then erases the node, which is what
+	// destroys the character.
 	free_char(ch);
 }
 
@@ -2385,8 +2369,10 @@ CHAR_DATA *get_char_world(CHAR_DATA *ch, char *argument)
 	number = number_argument(argument, arg);
 	count = 0;
 
-	for (wch = char_list; wch != nullptr; wch = wch->next)
+	for (OwningListWalk<CHAR_DATA> walk(char_list); !walk.Done(); walk.Step())
 	{
+		CHAR_DATA *wch = walk.Current();
+
 		if (is_immortal(ch) && !is_npc(wch))
 			sprintf(name, "%s", wch->true_name);
 		else

--- a/code/handler.c
+++ b/code/handler.c
@@ -2199,34 +2199,20 @@ void extract_obj(OBJ_DATA *obj)
 		extract_obj(obj_content);
 	}
 
-	// See extract_char: advance the walks before the link they are holding goes.
-	CursorRegistry<OBJ_DATA>::Advance(obj);
-
-	if (object_list == obj)
+	// An object that was never linked (the test fixtures build these) has no node
+	// to erase. Nothing owns it either, so it is the caller's to delete.
+	if (obj->globalNode == ObjectList::iterator{})
 	{
-		object_list = obj->next;
-	}
-	else
-	{
-		OBJ_DATA *prev;
-
-		for (prev = object_list; prev != nullptr; prev = prev->next)
-		{
-			if (prev->next == obj)
-			{
-				prev->next = obj->next;
-				break;
-			}
-		}
-
-		if (prev == nullptr)
-		{
-			RS.Logger.Warn("Extract_obj: obj {} not found.", obj->pIndexData->vnum);
-			return;
-		}
+		RS.Logger.Warn("Extract_obj: obj {} was not on the object list.", obj->pIndexData->vnum);
+		return;
 	}
 
-	free_obj(obj);
+	// Advance the walks before the erase, while the node still links to its
+	// successor. The erase is also the destruction point, so this is the
+	// last moment `obj` is readable.
+	OwningCursorRegistry<OBJ_DATA>::Advance(obj->globalNode);
+
+	object_list.erase(obj->globalNode);
 }
 
 void delay_extract(CHAR_DATA *ch)
@@ -2303,7 +2289,7 @@ void extract_char(CHAR_DATA *ch, bool fPull)
 	}
 
 	// A character's room affects end with them. This is not the reference
-	// expiring -- that happens on its own now -- it is the effect itself being
+	// expiring, that happens on its own now, it is the effect itself being
 	// destroyed, which a handle cannot do: a disowned wall of fire goes on
 	// burning everyone who walks in, and every consumer of raf->owner in
 	// act_move.c and update.c hands it straight to damage_new and is_safe.
@@ -2425,12 +2411,10 @@ CHAR_DATA *get_char_world(CHAR_DATA *ch, char *argument)
  */
 OBJ_DATA *get_obj_type(OBJ_INDEX_DATA *pObjIndex)
 {
-	OBJ_DATA *obj;
-
-	for (obj = object_list; obj != nullptr; obj = obj->next)
+	for (auto &owned : object_list)
 	{
-		if (obj->pIndexData == pObjIndex)
-			return obj;
+		if (owned->pIndexData == pObjIndex)
+			return owned.get();
 	}
 
 	return nullptr;
@@ -2563,8 +2547,10 @@ OBJ_DATA *get_obj_world(CHAR_DATA *ch, char *argument)
 	number = number_argument(argument, arg);
 	count = 0;
 
-	for (obj = object_list; obj != nullptr; obj = obj->next)
+	for (auto &owned : object_list)
 	{
+		OBJ_DATA *obj = owned.get();
+
 		if (can_see_obj(ch, obj) && is_name(arg, obj->name))
 		{
 			if (++count == number)

--- a/code/iprog.c
+++ b/code/iprog.c
@@ -1449,7 +1449,6 @@ void fight_prog_ruins_sword(OBJ_DATA *obj, CHAR_DATA *ch)
 
 void verb_prog_check_bounties(OBJ_DATA *obj, CHAR_DATA *ch, char *argument)
 {
-	DESCRIPTOR_DATA *d;
 	char buf[MSL];
 	bool found= false;
 	CHAR_DATA *mob;
@@ -1489,8 +1488,10 @@ void verb_prog_check_bounties(OBJ_DATA *obj, CHAR_DATA *ch, char *argument)
 	do_say(mob, "Now then..");
 	do_emote(mob, "studies his list of bounties.");
 
-	for (d = descriptor_list; d != nullptr; d = d->next)
+	for (OwningListWalk<DESCRIPTOR_DATA> walk(descriptor_list); !walk.Done(); walk.Step())
 	{
+		DESCRIPTOR_DATA *d = walk.Current();
+
 		if (d->connected == CON_PLAYING && Deref(d->character) && Deref(d->character)->in_room != nullptr)
 		{
 			if (Deref(d->character)->pcdata && Deref(d->character)->pcdata->bounty)

--- a/code/iprog.c
+++ b/code/iprog.c
@@ -1238,8 +1238,10 @@ void greet_prog_corpse_explode(OBJ_DATA *obj, CHAR_DATA *ch)
 {
 	CHAR_DATA *owner;
 
-	for (owner = char_list; owner != nullptr; owner = owner->next)
+	for (OwningListWalk<CHAR_DATA> walk(char_list); !walk.Done(); walk.Step())
 	{
+		CHAR_DATA *owner = walk.Current();
+
 		if (!is_npc(owner) && (!str_cmp(owner->true_name, obj->owner)))
 			break;
 	}
@@ -3271,15 +3273,14 @@ void verb_prog_pull_book(OBJ_DATA *obj, CHAR_DATA *ch, char *argument)
 void trapdoor_end(ROOM_INDEX_DATA *room, ROOM_AFFECT_DATA *af)
 {
 	EXIT_DATA *pexit = room->exit[Directions::Down];
-	CHAR_DATA *ch, *ch_next;
 
 	SET_BIT(pexit->exit_info, EX_CLOSED);
 	SET_BIT(pexit->exit_info, EX_LOCKED);
 	SET_BIT(pexit->exit_info, EX_NONOBVIOUS);
 
-	for (ch = char_list; ch != nullptr; ch = ch_next)
+	for (OwningListWalk<CHAR_DATA> walk(char_list); !walk.Done(); walk.Step())
 	{
-		ch_next = ch->next;
+		CHAR_DATA *ch = walk.Current();
 
 		if (ch->in_room == room)
 			act("A creaking sound fills the air, and a trap door in the floor swings shut.", ch, 0, 0, TO_CHAR);
@@ -3291,8 +3292,10 @@ bool open_prog_beef_balls(OBJ_DATA *obj, CHAR_DATA *ch)
 	CHAR_DATA *mob;
 	bool found= false;
 
-	for (mob = char_list; mob != nullptr; mob = mob->next)
+	for (OwningListWalk<CHAR_DATA> walk(char_list); !walk.Done(); walk.Step())
 	{
+		CHAR_DATA *mob = walk.Current();
+
 		if (is_npc(mob))
 		{
 			if (mob->pIndexData->vnum == 24549)
@@ -3472,13 +3475,15 @@ void verb_prog_join_guild(OBJ_DATA *obj, CHAR_DATA *ch, char *argument)
 
 void verb_prog_pull_lever(OBJ_DATA *obj, CHAR_DATA *ch, char *argument)
 {
-	CHAR_DATA *mob, *check;
+	CHAR_DATA *mob;
 	int vnum = 0;
 	char buf[MSL], buf2[MSL];
 	bool found= false;
 
-	for (check = char_list; check != nullptr; check = check->next)
+	for (OwningListWalk<CHAR_DATA> walk(char_list); !walk.Done(); walk.Step())
 	{
+		CHAR_DATA *check = walk.Current();
+
 		if (is_npc(check) && check->in_room == ch->in_room &&
 			(check->pIndexData->vnum == 24538 || check->pIndexData->vnum == 24539 || check->pIndexData->vnum == 24540))
 		{

--- a/code/magic.c
+++ b/code/magic.c
@@ -3515,8 +3515,10 @@ void spell_locate_object(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 	number = 0;
 	max_found = is_immortal(ch) ? 200 : 2 * level;
 
-	for (obj = object_list; obj != nullptr; obj = obj->next)
+	for (auto &owned : object_list)
 	{
+		obj = owned.get();
+
 		if (!can_see_obj(ch, obj)
 			|| !is_name(target_name, obj->name)
 			|| is_obj_stat(obj, ITEM_NOLOCATE)

--- a/code/magic.c
+++ b/code/magic.c
@@ -1700,7 +1700,6 @@ void spell_charm_person(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 {
 	CHAR_DATA *victim = (CHAR_DATA *)vo;
 	AFFECT_DATA af;
-	CHAR_DATA *check;
 	int count;
 
 	count = 0;
@@ -1724,8 +1723,10 @@ void spell_charm_person(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 		return;
 	}
 
-	for (check = char_list; check != nullptr; check = check->next)
+	for (OwningListWalk<CHAR_DATA> walk(char_list); !walk.Done(); walk.Step())
 	{
+		CHAR_DATA *check = walk.Current();
+
 		if (Deref(check->leader) == ch && is_affected_by(check, AFF_CHARM))
 			count++;
 	}
@@ -4545,8 +4546,10 @@ void spell_turn_undead(int sn, int level, CHAR_DATA *ch, void *vo, int target)
 	}
 	else
 	{
-		for (follower = char_list; follower != nullptr; follower = follower->next)
+		for (OwningListWalk<CHAR_DATA> walk(char_list); !walk.Done(); walk.Step())
 		{
+			CHAR_DATA *follower = walk.Current();
+
 			if (Deref(follower->master) == ch && IS_SET(follower->act, ACT_UNDEAD) && follower != ch)
 			{
 				num++;

--- a/code/merc.h
+++ b/code/merc.h
@@ -302,7 +302,8 @@ struct rune_data
 	int type;
 	int extra;
 	int drawn_in;
-	RUNE_DATA *next;
+	// The per-container chain off obj->rune / exit->rune / room->rune.
+	// Non-owning containment: rune_list owns every applied rune.
 	RUNE_DATA *next_content;
 	RUNE_END *end_fun;
 };

--- a/code/merc.h
+++ b/code/merc.h
@@ -438,24 +438,38 @@ struct race_data
 	int legs;
 };
 
+//
+// A disguised player's real identity. `disguise` stashes the true name and
+// descriptions here and `disguise_remove` puts them back; save_char_obj reads
+// them so a player's file records who they really are rather than the mob they
+// are wearing. Held by exactly one field, pcdata->old, which owns it as a
+// unique_ptr. The destructor below frees the four strings and there is no
+// free list and no `next` link.
+//
+// `carrying` is a non-owning borrow of an object owned by the global object
+// list. Nothing assigns it, so it is always null and save.c's read of it never
+// fires. It is left in place because removing it changes what gets saved, which
+// is a separate question from who owns this struct.
+//
 struct old_char
 {
-	char *name;
-	char *short_descr;
-	char *long_descr;
-	char *description;
-	short perm_stats[MAX_STATS];
-	short armor[4];
-	float dam_mod;
-	short carry_weight;
-	short carry_number;
-	short saving_throw;
-	long affected_by[MAX_BITVECTOR];
-	long res_flags[MAX_BITVECTOR];
-	long vuln_flags[MAX_BITVECTOR];
-	long imm_flags[MAX_BITVECTOR];
-	OLD_CHAR *next;
-	OBJ_DATA *carrying;
+	char *name = nullptr;
+	char *short_descr = nullptr;
+	char *long_descr = nullptr;
+	char *description = nullptr;
+	short perm_stats[MAX_STATS] = {};
+	short armor[4] = {};
+	float dam_mod = 0.0f;
+	short carry_weight = 0;
+	short carry_number = 0;
+	short saving_throw = 0;
+	long affected_by[MAX_BITVECTOR] = {};
+	long res_flags[MAX_BITVECTOR] = {};
+	long vuln_flags[MAX_BITVECTOR] = {};
+	long imm_flags[MAX_BITVECTOR] = {};
+	OBJ_DATA *carrying = nullptr;
+
+	~old_char();		// frees the four owned strings (body in recycle.c)
 };
 
 #include "entity/affect_data.h"

--- a/code/merc.h
+++ b/code/merc.h
@@ -308,44 +308,7 @@ struct rune_data
 	RUNE_END *end_fun;
 };
 
-struct descriptor_data
-{
-	DESCRIPTOR_DATA *next;
-	// This connection's own handle, handed out so a character can name it
-	// without holding a pointer into a recycled struct. Registered by
-	// new_descriptor and retired by free_descriptor.
-	Handle<DESCRIPTOR_DATA> self;
-	// The connection watching this one, if any. Non-owning; it expires by
-	// itself when that connection closes, which is what close_socket's
-	// hand-written sweep over descriptor_list used to do.
-	Handle<DESCRIPTOR_DATA> snoop_by;
-	// The body this connection drives, and -- while an immortal is switched
-	// into a mob -- the immortal's own body parked behind it. Non-owning both
-	// ways: a character can be extracted while the connection lives on, so
-	// these are handles rather than pointers. `character` used to be nulled by
-	// hand on each of the five paths that free it; `original` was nulled on
-	// none of them, and check_playing reads its `true_name` for every open
-	// connection on every login attempt.
-	Handle<CHAR_DATA> character;
-	Handle<CHAR_DATA> original;
-	char *host;
-	short descriptor;
-	short connected;
-	bool fcommand;
-	char inbuf[4 * MAX_INPUT_LENGTH];
-	char incomm[MAX_INPUT_LENGTH];
-	char inlast[MAX_INPUT_LENGTH];
-	int repeat;
-	char *outbuf;
-	int outsize;
-	int outtop;
-	char *showstr_head;
-	char *showstr_point;
-	void *pEdit;	// OLC
-	char **pString;	// OLC
-	int editor;		// OLC
-	short type;
-};
+#include "entity/descriptor_data.h"
 
 struct bounty
 {

--- a/code/mprog.c
+++ b/code/mprog.c
@@ -1300,14 +1300,15 @@ bool death_prog_inner_guardian(CHAR_DATA *mob, CHAR_DATA *killer)
 
 void pulse_prog_tahlu_mist_ward(CHAR_DATA *mob)
 {
-	DESCRIPTOR_DATA *d;
 	CHAR_DATA *mist, *ch;
 
 	if (!mob->in_room->area->nplayer || number_percent() <= 90)
 		return;
 
-	for (d = descriptor_list; d != nullptr; d = d->next)
+	for (OwningListWalk<DESCRIPTOR_DATA> walk(descriptor_list); !walk.Done(); walk.Step())
 	{
+		DESCRIPTOR_DATA *d = walk.Current();
+
 		if (d->connected == CON_PLAYING
 			&& Deref(d->character)->in_room != nullptr
 			&& Deref(d->character)->in_room->area == mob->in_room->area
@@ -3212,7 +3213,6 @@ void pulse_prog_troopers(CHAR_DATA *mob)
 
 void pulse_prog_area_echo_ward(CHAR_DATA *mob)
 {
-	DESCRIPTOR_DATA *d;
 
 	// hightime = armor[3] lowtime = armor[0]
 	if (!mob->in_room->area->nplayer || time_info.hour < mob->armor[2] || time_info.hour > mob->armor[3])
@@ -3229,8 +3229,10 @@ void pulse_prog_area_echo_ward(CHAR_DATA *mob)
 	if (mob->regen_rate)
 		return;
 
-	for (d = descriptor_list; d; d = d->next)
+	for (OwningListWalk<DESCRIPTOR_DATA> walk(descriptor_list); !walk.Done(); walk.Step())
 	{
+		DESCRIPTOR_DATA *d = walk.Current();
+
 		if (d->connected != CON_PLAYING
 			|| !Deref(d->character)->in_room
 			|| Deref(d->character)->in_room->area != mob->in_room->area

--- a/code/mprog.c
+++ b/code/mprog.c
@@ -3570,8 +3570,10 @@ void sucker_pulse(CHAR_DATA *ch, AFFECT_DATA *af)
 {
 	CHAR_DATA *owner;
 
-	for (owner = char_list; owner; owner = owner->next)
+	for (OwningListWalk<CHAR_DATA> walk(char_list); !walk.Done(); walk.Step())
 	{
+		CHAR_DATA *owner = walk.Current();
+
 		if (is_npc(owner) && owner->pIndexData->vnum == 3002 && Deref(owner->hunting) == ch)
 			break;
 	}

--- a/code/quest.c
+++ b/code/quest.c
@@ -807,14 +807,15 @@ bool aggress_prog_ilopheth_hermit(CHAR_DATA *mob, CHAR_DATA *attacker)
 
 void pulse_prog_ilopheth_hermit(CHAR_DATA *mob)
 {
-	DESCRIPTOR_DATA *d;
 	char buf[MSL];
 
 	if (mob->in_room->area->nplayer == 0)
 		return;
 
-	for (d = descriptor_list; d; d = d->next)
+	for (OwningListWalk<DESCRIPTOR_DATA> walk(descriptor_list); !walk.Done(); walk.Step())
 	{
+		DESCRIPTOR_DATA *d = walk.Current();
+
 		if (d->connected == CON_PLAYING && !is_npc(Deref(d->character)) && Deref(d->character)->in_room != nullptr &&
 			Deref(d->character)->in_room->area != nullptr && Deref(d->character)->in_room->area == mob->in_room->area &&
 			Deref(d->character)->pcdata->quests[TALISMANIC_QUEST] == 5 && number_percent() < 5)

--- a/code/queue.c
+++ b/code/queue.c
@@ -3,11 +3,13 @@
 #include <algorithm>
 
 /// Registers a new entry against every character it names.
-void CQueue::RegisterEntry(const std::vector<CHAR_DATA*>& chars, entryRef ref)
+/// @param chars: The characters the entry affects.
+/// @param ref: The entry's ref, which is what the index holds.
+void CQueue::RegisterEntry(const std::vector<Handle<CHAR_DATA>>& chars, entryRef ref)
 {
-	for (auto *ch : chars)
+	for (auto ch : chars)
 	{
-		if (ch != nullptr)
+		if (!ch.IsNull())
 			charIndex[ch].push_back(ref);
 	}
 }
@@ -15,9 +17,11 @@ void CQueue::RegisterEntry(const std::vector<CHAR_DATA*>& chars, entryRef ref)
 /// Removes an entry's refs from every character it names.
 /// Done for all of the entry's characters, not just the one being cancelled, so that
 /// charIndex only ever holds refs to entries that can still run.
+/// @param entry: The entry to remove from the index.
+/// @param ref: The entry's ref, which is what the index holds.
 void CQueue::DropEntryRefs(const queueEntry_t& entry, entryRef ref)
 {
-	for (auto *ch : entry.charList)
+	for (auto ch : entry.charList)
 	{
 		auto it = charIndex.find(ch);
 
@@ -32,6 +36,8 @@ void CQueue::DropEntryRefs(const queueEntry_t& entry, entryRef ref)
 	}
 }
 
+/// Resolves a ref to the entry it points at, or nullptr if the entry is gone.
+/// @param ref: The entry's ref, which is what the index holds.
 /// @return the entry a ref points at, or nullptr if its bucket is already gone.
 CQueue::queueEntry_t* CQueue::ResolveEntry(entryRef ref)
 {
@@ -86,7 +92,10 @@ void CQueue::ProcessQueue()
 /// @return true if there are entries related to the character in the queue; otherwise false.
 bool CQueue::HasQueuePending(CHAR_DATA *qChar)
 {
-	auto it = charIndex.find(qChar);
+	if (qChar == nullptr)
+		return false;
+
+	auto it = charIndex.find(qChar->self);
 
 	return it != charIndex.end() && !it->second.empty();
 }
@@ -99,7 +108,13 @@ bool CQueue::HasQueuePending(CHAR_DATA *qChar)
 /// @param qChar: The character to lookup in the queue.
 void CQueue::DeleteQueuedEventsInvolving(CHAR_DATA *qChar)
 {
-	auto it = charIndex.find(qChar);
+	if (qChar == nullptr)
+		return;
+
+	// Read qChar->self while the character is still registered. extract_char
+	// calls this before free_char clears the handle, which is the only ordering
+	// that lets a departing character cancel its own pending events.
+	auto it = charIndex.find(qChar->self);
 
 	if (it == charIndex.end())
 		return;

--- a/code/queue.h
+++ b/code/queue.h
@@ -14,6 +14,7 @@
 #include <vector>
 
 #include "entity/fwd.h"
+#include "entity/handles.h"
 
 class CQueue
 {
@@ -68,7 +69,11 @@ private:
 	{
 		std::string callerFuncName;
 		std::string calleeFuncName;
-		std::vector<CHAR_DATA*> charList;
+		/// Every character this entry names as handles. An entry can outlive
+		/// any of them so a raw pointer here would go stale, and a stale pointer
+		/// is worse than a dangling one while the free lists recycle addresses: 
+		/// it names whichever character next lands on that address.
+		std::vector<Handle<CHAR_DATA>> charList;
 		std::function<void()> function;
 
 		/// tombstone flag
@@ -99,9 +104,14 @@ private:
 	/// Reverse lookup for cancellation. Holds refs to *live* entries only: refs are
 	/// dropped when an entry is cancelled or executed, so a non-empty entry here
 	/// means the character genuinely has work pending.
-	std::unordered_map<CHAR_DATA*, std::vector<entryRef>> charIndex;
+	///
+	/// Keyed by handle rather than by pointer. A character who leaves the world
+	/// with entries still queued leaves its key behind until those entries run or
+	/// are cancelled; keyed by pointer, the next character to be handed that
+	/// address would inherit them.
+	std::unordered_map<Handle<CHAR_DATA>, std::vector<entryRef>> charIndex;
 
-	void RegisterEntry(const std::vector<CHAR_DATA*>& chars, entryRef ref);
+	void RegisterEntry(const std::vector<Handle<CHAR_DATA>>& chars, entryRef ref);
 	void DropEntryRefs(const queueEntry_t& entry, entryRef ref);
 	queueEntry_t* ResolveEntry(entryRef ref);
 
@@ -109,11 +119,11 @@ private:
 	/// @note Main use is for extracting character data sent to the AddToQueue method.
 	/// @tparam ...Tp: Template parameter pack used to specify the variadic arguments. 
 	/// @param t: Variadic arguments containing the values of the tuple.
-	/// @return A list containing character data from the tuple.
+	/// @return Handles to the characters named in the tuple.
 	template<class... Tp>
-	std::vector<CHAR_DATA*> GetCharacterData(std::tuple<Tp...>& t)
+	std::vector<Handle<CHAR_DATA>> GetCharacterData(std::tuple<Tp...>& t)
 	{
-		std::vector<CHAR_DATA*> accumulator;
+		std::vector<Handle<CHAR_DATA>> accumulator;
 
 		std::apply([&] (const auto&... tupleArgs) 
 		{
@@ -121,7 +131,13 @@ private:
 			{
 				// decay x to get the actual argument type to compare to our character data type 
 		 		if constexpr (std::is_same<typename std::decay<decltype(x)>::type,CHAR_DATA*>::value)
-					accumulator.push_back(x);
+				{
+					// A character built outside the slot map has a null handle,
+					// and cannot be indexed or cancelled. That is the same answer
+					// the old pointer version gave for a null argument.
+					if (x != nullptr)
+						accumulator.push_back(x->self);
+				}
 			};
 			(processTuple(tupleArgs), ...);  // fold expression - calls processTuple for each argument in tupleArgs
 		}, t);

--- a/code/recycle.c
+++ b/code/recycle.c
@@ -61,7 +61,6 @@ DESCRIPTOR_DATA *descriptor_free;
 RUNE_DATA *rune_free;
 OBJ_DATA *obj_free;
 CHAR_DATA *char_free;
-OLD_CHAR *oldtype_free;
 
 long last_pc_id;
 long last_mob_id;
@@ -577,34 +576,12 @@ std::unique_ptr<PC_DATA> new_pcdata(void)
 	return pcdata;
 }
 
-OLD_CHAR *new_oldchar(void)
+old_char::~old_char()
 {
-	static OLD_CHAR oldtype_zero;
-	OLD_CHAR *oldtype;
-
-	if (oldtype_free == nullptr)
-	{
-		oldtype = new OLD_CHAR;
-	}
-	else
-	{
-		oldtype = oldtype_free;
-		oldtype_free = oldtype_free->next;
-	}
-
-	*oldtype = oldtype_zero;
-	return oldtype;
-}
-
-void free_oldchar(OLD_CHAR *old)
-{
-	free_pstring(old->name);
-	free_pstring(old->short_descr);
-	free_pstring(old->long_descr);
-	free_pstring(old->description);
-
-	old->next = oldtype_free;
-	oldtype_free = old;
+	free_pstring(name);
+	free_pstring(short_descr);
+	free_pstring(long_descr);
+	free_pstring(description);
 }
 
 pc_data::~pc_data()

--- a/code/recycle.c
+++ b/code/recycle.c
@@ -58,7 +58,6 @@
 const int buf_size[MAX_BUF_LIST] = {16, 32, 64, 128, 256, 1024, 2048, 4096, 8192, 16384};
 
 DESCRIPTOR_DATA *descriptor_free;
-OBJ_DATA *obj_free;
 CHAR_DATA *char_free;
 
 long last_pc_id;
@@ -376,50 +375,44 @@ void free_trap(TRAP_DATA *trap)
 
 OBJ_DATA *new_obj(void)
 {
-	static OBJ_DATA obj_zero;
-	OBJ_DATA *obj;
+	// The parentheses matter: obj_data has no user-provided constructor, so
+	// value-initialization zeroes every POD member before the implicit one runs.
+	// That is what `*obj = obj_zero` used to do.
+	//
+	// The object is not on object_list yet. create_object and fread_obj link it
+	// once they have filled it in, and the test fixtures never link theirs.
+	OBJ_DATA *obj = new OBJ_DATA();
 
-	if (obj_free == nullptr)
-	{
-		obj = new OBJ_DATA;
-	}
-	else
-	{
-		obj = obj_free;
-		obj_free = obj_free->next;
-	}
-
-	*obj = obj_zero;
-
-	// After the reset, which zeroes the old handle along with everything else.
 	obj->self = objectHandles.Add(obj);
 
 	return obj;
 }
 
+obj_data::~obj_data()
+{
+	// affected/charaffs/extra_descr/apply are std::lists of value types and
+	// destruct themselves; the obj owns its charaffs and apply copies, which were
+	// once shared with the index.
+
+	free_pstring(name);
+	free_pstring(description);
+	free_pstring(short_descr);
+
+	// free_pstring( owner );
+
+	// Expires every handle to this object.
+	objectHandles.Remove(self);
+}
+
+/// Destroys an object that never made it onto object_list. The list owns the
+/// ones that did, and extract_obj erasing the node is what destroys those.
+/// @param obj The object to destroy.
 void free_obj(OBJ_DATA *obj)
 {
 	if (obj == nullptr || Deref(obj->self) != obj)
 		return;
 
-	obj->affected.clear();
-	obj->charaffs.clear();	// obj owns its charaffs copy now (was shared with the index)
-	obj->extra_descr.clear();
-	obj->apply.clear();		// obj owns its apply copy now (was shared with the index)
-
-	free_pstring(obj->name);
-	free_pstring(obj->description);
-	free_pstring(obj->short_descr);
-
-	// free_pstring( obj->owner     );
-
-	// Expires every handle to this object. Must happen before it goes on the
-	// free list, since new_obj can hand the same address straight back out.
-	objectHandles.Remove(obj->self);
-	obj->self = nullptr;
-
-	obj->next = obj_free;
-	obj_free = obj;
+	delete obj;
 }
 
 /* stuff for recycling characters */

--- a/code/recycle.c
+++ b/code/recycle.c
@@ -58,7 +58,6 @@
 const int buf_size[MAX_BUF_LIST] = {16, 32, 64, 128, 256, 1024, 2048, 4096, 8192, 16384};
 
 DESCRIPTOR_DATA *descriptor_free;
-RUNE_DATA *rune_free;
 OBJ_DATA *obj_free;
 CHAR_DATA *char_free;
 
@@ -371,31 +370,6 @@ void free_trap(TRAP_DATA *trap)
 	free_pstring(trap->trig_echo);
 
 	delete trap;
-}
-
-RUNE_DATA *new_rune(void)
-{
-	static RUNE_DATA rune_zero;
-	RUNE_DATA *rune;
-
-	if (rune_free == nullptr)
-	{
-		rune = new RUNE_DATA;
-	}
-	else
-	{
-		rune = rune_free;
-		rune_free = rune->next;
-	}
-
-	*rune = rune_zero;
-	return rune;
-}
-
-void free_rune(RUNE_DATA *rune)
-{
-	rune->next = rune_free;
-	rune_free = rune;
 }
 
 /* stuff for recycling objects */

--- a/code/recycle.c
+++ b/code/recycle.c
@@ -57,7 +57,6 @@
 /* buffer sizes */
 const int buf_size[MAX_BUF_LIST] = {16, 32, 64, 128, 256, 1024, 2048, 4096, 8192, 16384};
 
-CHAR_DATA *char_free;
 
 long last_pc_id;
 long last_mob_id;
@@ -418,25 +417,15 @@ CHAR_DATA *new_char(void)
 	CHAR_DATA *ch;
 	int i;
 
-	if (char_free == nullptr)
-	{
-		ch = new CHAR_DATA;
+	// The parentheses matter. char_data has no user-provided constructor, so
+	// value-initialization zeroes every POD member before the implicit one
+	// runs. That is what `*ch = CHAR_DATA()` used to do to a recycled struct.
+	//
+	// The character is not on char_list yet. create_mobile links it, and the
+	// login hands it over at CON_READ_MOTD once the player is really playing.
+	// A character loaded for the login prompt is never linked at all.
+	ch = new CHAR_DATA();
 
-		// if (bDebug)
-		// 	RS.Logger.Debug("Char free is null.  . . . . !");
-	}
-	else
-	{
-		ch = char_free;
-		char_free = char_free->next;
-	}
-
-	// Reset to a pristine char. A unique_ptr member rules out the old
-	// `*ch = ch_zero` copy-assign; move-assigning a value-initialized
-	// temporary zeroes the PODs and frees/clears the owned members.
-	*ch = CHAR_DATA();
-
-	// After the reset, which zeroes the old handle along with everything else.
 	ch->self = charHandles.Add(ch);
 
 	ch->name = &str_empty[0];
@@ -481,53 +470,83 @@ CHAR_DATA *new_char(void)
 	return ch;
 }
 
-void free_char(CHAR_DATA *ch)
+char_data::~char_data()
 {
 	OBJ_DATA *obj;
 	OBJ_DATA *obj_next;
 
-	if (ch == nullptr || Deref(ch->self) != ch)
+	// The guard free_char carried, and it has to stay here rather than move to
+	// the callers. It answers "is this a character this module handed out",
+	// which is what decides whether the strings below are owned at all. The
+	// test fixtures build characters directly and point `name` at string
+	// literals, so running this body over one of those would free a literal.
+	if (Deref(self) != this)
 		return;
 
-	if (is_npc(ch))
+	if (is_npc(this))
 		mobile_count--;
 
-	for (obj = ch->carrying; obj != nullptr; obj = obj_next)
+	for (obj = carrying; obj != nullptr; obj = obj_next)
 	{
 		obj_next = obj->next_content;
 		extract_obj(obj);
 	}
 
-	for (auto it = ch->affected.begin(); it != ch->affected.end(); )
+	for (auto it = affected.begin(); it != affected.end(); )
 	{
 		auto next = std::next(it);
 		it->pulse_fun = nullptr;
 		it->tick_fun = nullptr;
 		it->end_fun = nullptr;
-		affect_remove(ch, &*it);
+		affect_remove(this, &*it);
 		it = next;
 	}
 
-	ch->memory.clear();
+	memory.clear();
 
-	free_pstring(ch->name);
-	free_pstring(ch->short_descr);
-	free_pstring(ch->long_descr);
-	free_pstring(ch->true_name);
-	free_pstring(ch->description);
-	free_pstring(ch->prompt);
-	free_pstring(ch->prefix);
+	free_pstring(name);
+	free_pstring(short_descr);
+	free_pstring(long_descr);
+	free_pstring(true_name);
+	free_pstring(description);
+	free_pstring(prompt);
+	free_pstring(prefix);
 
-	ch->pcdata.reset();
-	ch->gen_data.reset();
+	// pcdata and gen_data are unique_ptrs and destruct themselves.
 
-	// Expires every handle to this character. Must happen before it goes on the
-	// free list, since new_char can hand the same address straight back out.
-	charHandles.Remove(ch->self);
-	ch->self = nullptr;
+	// Expires every handle to this character, which is what makes d->character,
+	// ch->master and the rest read as nothing from here on.
+	charHandles.Remove(self);
+}
 
-	ch->next = char_free;
-	char_free = ch;
+/// Destroys a character. The list owns the ones that were linked, so those are
+/// destroyed by erasing the node. The login builds characters that never make it
+/// onto char_list, and those are deleted outright.
+///
+/// Unlike free_obj and free_descriptor, this handles both cases rather than
+/// warning on the linked one. Eight of its nine call sites are login teardown
+/// paths that free a character before CON_READ_MOTD ever links it, and the ninth
+/// is extract_char. Keeping the linked case correct means a caller cannot arm a
+/// double free by freeing a character that turned out to be in the world.
+/// @param ch The character to destroy.
+void free_char(CHAR_DATA *ch)
+{
+	// A character that was never registered has a null handle, so a stack-built
+	// one cannot be destroyed by mistake.
+	if (ch == nullptr || Deref(ch->self) != ch)
+		return;
+
+	if (ch->globalNode != CharacterList::iterator{})
+	{
+		// Advance the walks before the erase, while the node still links to its
+		// successor. The erase is also the destruction point, so this is the
+		// last moment `ch` is readable.
+		OwningCursorRegistry<CHAR_DATA>::Advance(ch->globalNode);
+		char_list.erase(ch->globalNode);
+		return;
+	}
+
+	delete ch;
 }
 
 std::unique_ptr<PC_DATA> new_pcdata(void)

--- a/code/recycle.c
+++ b/code/recycle.c
@@ -57,56 +57,52 @@
 /* buffer sizes */
 const int buf_size[MAX_BUF_LIST] = {16, 32, 64, 128, 256, 1024, 2048, 4096, 8192, 16384};
 
-DESCRIPTOR_DATA *descriptor_free;
 CHAR_DATA *char_free;
 
 long last_pc_id;
 long last_mob_id;
 
-/* stuff for recycling descriptors */
 DESCRIPTOR_DATA *new_descriptor(void)
 {
-	static DESCRIPTOR_DATA d_zero;
-	DESCRIPTOR_DATA *d;
+	// The parentheses matter: descriptor_data has no user-provided constructor,
+	// so value-initialization zeroes every POD member before the implicit one
+	// runs. That is what `*d = d_zero` used to do.
+	//
+	// The descriptor is not on descriptor_list yet. init_descriptor links it
+	// once it has survived the ban checks, and the test fixtures never link
+	// theirs.
+	DESCRIPTOR_DATA *d = new DESCRIPTOR_DATA();
 
-	if (descriptor_free == nullptr)
-		d = new DESCRIPTOR_DATA;
-	else
-	{
-		d = descriptor_free;
-		descriptor_free = descriptor_free->next;
-	}
-
-	*d = d_zero;
-
-	// After the reset, which zeroes the old handle along with everything else.
 	d->self = descriptorHandles.Add(d);
 
 	return d;
 }
 
+descriptor_data::~descriptor_data()
+{
+	free_pstring(host);
+
+	if (outbuf)
+		delete[] outbuf;
+
+	// Expires every handle to this connection, which is what makes ch->desc and
+	// another descriptor's snoop_by read as nothing from here on.
+	descriptorHandles.Remove(self);
+}
+
+/// Destroys a descriptor that never made it onto descriptor_list. The list owns
+/// the ones that did, and close_socket erasing the node is what destroys those.
+/// @param d The descriptor to destroy.
 void free_descriptor(DESCRIPTOR_DATA *d)
 {
 	// The slot map answers "is this a live connection this module handed out",
 	// which is what the old `valid` bool was for and one thing more: a
 	// descriptor that was never registered has a null handle, so a stack-built
-	// one cannot be pushed onto the free list by mistake.
+	// one cannot be deleted by mistake.
 	if (d == nullptr || Deref(d->self) != d)
 		return;
 
-	free_pstring(d->host);
-
-	if (d->outbuf)
-		delete[] d->outbuf;
-
-	// Expires every handle to this connection. Must happen before it goes on
-	// the free list, since new_descriptor can hand the same address straight
-	// back out.
-	descriptorHandles.Remove(d->self);
-	d->self = nullptr;
-
-	d->next = descriptor_free;
-	descriptor_free = d;
+	delete d;
 }
 
 /* Trophy list elements own their victname string (rule-of-5). */

--- a/code/recycle.h
+++ b/code/recycle.h
@@ -39,7 +39,6 @@
 #include "entity/fwd.h"
 
 /* externals for counting purposes */
-extern CHAR_DATA *char_free;
 
 
 /* stuff for providing a crash-proof buffer */

--- a/code/recycle.h
+++ b/code/recycle.h
@@ -40,7 +40,6 @@
 
 /* externals for counting purposes */
 extern DESCRIPTOR_DATA *descriptor_free;
-extern OBJ_DATA *obj_free;
 extern CHAR_DATA *char_free;
 
 

--- a/code/recycle.h
+++ b/code/recycle.h
@@ -39,7 +39,6 @@
 #include "entity/fwd.h"
 
 /* externals for counting purposes */
-extern DESCRIPTOR_DATA *descriptor_free;
 extern CHAR_DATA *char_free;
 
 

--- a/code/recycle.h
+++ b/code/recycle.h
@@ -72,8 +72,6 @@ void free_race_data(RACE_DATA *race_specs);
 /* apply — value type owned by parents in std::list; see entity/affect_data.h */
 TRAP_DATA *new_trap(void);
 void free_trap(TRAP_DATA *trap);
-RUNE_DATA *new_rune(void);
-void free_rune(RUNE_DATA *rune);
 /* object recycling */
 OBJ_DATA *new_obj(void);
 void free_obj(OBJ_DATA *obj);

--- a/code/recycle.h
+++ b/code/recycle.h
@@ -81,8 +81,6 @@ void free_obj(OBJ_DATA *obj);
 CHAR_DATA *new_char(void);
 void free_char(CHAR_DATA *ch);
 std::unique_ptr<PC_DATA> new_pcdata(void);
-OLD_CHAR *new_oldchar(void);
-void free_oldchar(OLD_CHAR *old);
 /* mob id procedures */
 long get_pc_id(void);
 long get_mob_id(void);

--- a/code/rprog.c
+++ b/code/rprog.c
@@ -310,7 +310,7 @@ bool move_prog_mudschool_key(ROOM_INDEX_DATA *room, CHAR_DATA *ch, int dir)
 	OBJ_DATA *obj;
 	bool found= false;
 
-	for (obj = ch->carrying; obj != nullptr; obj = obj->next)
+	for (obj = ch->carrying; obj != nullptr; obj = obj->next_content)
 	{
 		if (obj->pIndexData->vnum == 24596)
 		{
@@ -440,7 +440,7 @@ bool move_prog_stone_roll(ROOM_INDEX_DATA *room, CHAR_DATA *ch, int dir)
 
 	act("As you pass through, the stone rolls violently back into place!", ch, 0, 0, TO_CHAR);
 
-	for (corpse = room->contents; corpse != nullptr; corpse = corpse->next)
+	for (corpse = room->contents; corpse != nullptr; corpse = corpse->next_content)
 	{
 		if (corpse->pIndexData->vnum == 24558)
 		{

--- a/code/save.c
+++ b/code/save.c
@@ -2217,8 +2217,11 @@ void fread_obj(CHAR_DATA *ch, FILE *fp)
 
 						if (!new_format)
 						{
-							obj->next = object_list;
-							object_list = obj;
+							// The legacy path builds its object with new_obj rather
+							// than create_object, so this is where the list takes
+							// ownership of it.
+							object_list.push_front(std::unique_ptr<OBJ_DATA>(obj));
+							obj->globalNode = object_list.begin();
 							obj->pIndexData->count++;
 						}
 

--- a/code/save.c
+++ b/code/save.c
@@ -2204,23 +2204,14 @@ void fread_obj(CHAR_DATA *ch, FILE *fp)
 					if (!fNest || (fVnum && obj->pIndexData == nullptr))
 					{
 						RS.Logger.Warn("Fread_obj: incomplete object.");
-						free_pstring(obj->name);
-						free_pstring(obj->description);
-						free_pstring(obj->short_descr);
-						obj->next = obj_free;
-						obj_free = obj;
+						free_obj(obj);
 						return;
 					}
 					else
 					{
 						if (!fVnum)
 						{
-							free_pstring(obj->name);
-							free_pstring(obj->description);
-							free_pstring(obj->short_descr);
-							obj->next = obj_free;
-							obj_free = obj;
-
+							free_obj(obj);
 							obj = create_object(get_obj_index(OBJ_VNUM_DUMMY), 0);
 						}
 

--- a/code/save.c
+++ b/code/save.c
@@ -94,7 +94,6 @@ void save_char_obj(CHAR_DATA *ch)
 {
 	char strsave[MAX_INPUT_LENGTH], filenm[MSL], query[MSL * 2];
 	FILE *fp;
-	CHAR_DATA *search;
 
 	if (is_npc(ch) || mPort == 4000) // do not save, sir!!!
 		return;
@@ -152,8 +151,10 @@ void save_char_obj(CHAR_DATA *ch)
 		if (pet != nullptr && pet->in_room == ch->in_room)
 			fwrite_pet(pet, fp);
 
-		for (search = char_list; search != nullptr; search = search->next)
+		for (OwningListWalk<CHAR_DATA> walk(char_list); !walk.Done(); walk.Step())
 		{
+			CHAR_DATA *search = walk.Current();
+
 			if (is_npc(search)
 				&& Deref(search->master) == ch
 				&& (IS_SET(search->act, ACT_UNDEAD)
@@ -1243,7 +1244,6 @@ void fread_char(CHAR_DATA *ch, FILE *fp)
 				if (!str_cmp(word, "Affc"))
 				{
 					AFFECT_DATA paf;
-					CHAR_DATA *wch;
 					char *owner;
 					char *afname;
 					int sn;
@@ -1265,8 +1265,10 @@ void fread_char(CHAR_DATA *ch, FILE *fp)
 					paf.aftype = fread_number(fp);
 
 					owner = fread_word(fp);
-					for (wch = char_list; wch; wch = wch->next)
+					for (OwningListWalk<CHAR_DATA> walk(char_list); !walk.Done(); walk.Step())
 					{
+						CHAR_DATA *wch = walk.Current();
+
 						if (!str_cmp(wch->name, owner))
 						{
 							paf.owner = wch->self;
@@ -1921,8 +1923,10 @@ void fread_pet(CHAR_DATA *ch, FILE *fp)
 					if (strcmp(owner, "none")) // safe default
 						paf.owner = ch->self;
 
-					for (wch = char_list; wch; wch = wch->next)
+					for (OwningListWalk<CHAR_DATA> walk(char_list); !walk.Done(); walk.Step())
 					{
+						CHAR_DATA *wch = walk.Current();
+
 						if (!str_cmp(wch->name, owner))
 						{
 							paf.owner = wch->self;
@@ -2112,7 +2116,6 @@ void fread_obj(CHAR_DATA *ch, FILE *fp)
 			case 'A':
 				if (!str_cmp(word, "Affc"))
 				{
-					CHAR_DATA *wch;
 					char *owner;
 					OBJ_AFFECT_DATA paf;
 					int sn;
@@ -2136,8 +2139,10 @@ void fread_obj(CHAR_DATA *ch, FILE *fp)
 
 					owner = fread_word(fp);
 
-					for (wch = char_list; wch; wch = wch->next)
+					for (OwningListWalk<CHAR_DATA> walk(char_list); !walk.Done(); walk.Step())
 					{
+						CHAR_DATA *wch = walk.Current();
+
 						if (!str_cmp(wch->name, owner))
 						{
 							paf.owner = wch->self;

--- a/code/stdlibs/handle.h
+++ b/code/stdlibs/handle.h
@@ -12,7 +12,7 @@
 // The problem this solves: the recycled entity types hand out reused
 // addresses. When one is freed it goes onto a free list and the very next
 // allocation can return the same address, so a raw back-reference to a dead
-// entity does not merely dangle -- it can silently start pointing at whatever
+// entity does not merely dangle. It can silently start pointing at whatever
 // took its place. Today that is policed by a `valid` bool plus hand-written
 // scrub loops that walk every entity nulling inbound references to the one
 // being freed.
@@ -20,7 +20,7 @@
 // A handle is that `valid` check folded into the reference itself. It names a
 // slot and the generation of that slot at the moment the handle was made.
 // Deref compares generations, so a handle to a freed entity resolves to null
-// forever -- no scrub loop required, and no chance of resolving to the
+// forever. No scrub loop required, and no chance of resolving to the
 // entity's replacement.
 //
 // Two invariants carry most of the weight:
@@ -32,7 +32,7 @@
 //
 //   * A slot whose generation counter is spent is retired permanently rather
 //     than wrapped. Wrapping is the one way a generational handle can still
-//     resolve to the wrong object, and it is silent -- no sanitizer sees it.
+//     resolve to the wrong object, and it is silent. No sanitizer sees it.
 //     Burning a slot is far cheaper than that.
 //
 // Note there is deliberately no `operator bool` and no `operator->`. A handle
@@ -58,7 +58,7 @@ public:
 	Handle(std::nullptr_t) {}
 
 	/// True when this handle names nothing at all. Says nothing about whether
-	/// the entity it names is still alive -- only Deref answers that.
+	/// the entity it names is still alive. Only Deref answers that.
 	bool IsNull() const { return generation == 0; }
 
 	bool operator==(const Handle &other) const
@@ -81,6 +81,24 @@ public:
 	bool operator==(std::nullptr_t) const = delete;
 	bool operator!=(std::nullptr_t) const = delete;
 
+	/// Hashes the handle's identity, so a handle can key an unordered_map.
+	///
+	/// This is the one thing worth having that a raw pointer key does not do:
+	/// a handle to a freed entity never compares equal to a handle to whatever
+	/// entity later takes its address, because the generation differs. A map
+	/// keyed on pointers silently answers the old entity's questions with the
+	/// new entity's entry.
+	///
+	/// Says nothing about liveness. An expired handle keeps its hash, which is
+	/// what makes stale entries findable and droppable rather than confusable.
+	/// Exposing this does not weaken the deliberate omissions above: it yields a
+	/// number, not a way to reach the entity, so every read still goes through
+	/// Deref.
+	std::size_t Hash() const
+	{
+		return (static_cast<std::size_t>(index) << 32) ^ static_cast<std::size_t>(generation);
+	}
+
 private:
 	friend class SlotMap<T, GenT>;
 
@@ -90,7 +108,7 @@ private:
 
 /// Issues handles for entities and answers whether a handle is still good.
 ///
-/// The map does not own the entities and never moves them -- it stores plain
+/// The map does not own the entities and never moves them. It stores plain
 /// pointers to objects allocated elsewhere. That is not an oversight: the
 /// codebase caches raw entity pointers across list mutations all over the
 /// place, so storage that relocates its elements would break those callers.
@@ -138,8 +156,8 @@ public:
 	}
 
 	/// Expires every handle to this entity. Removing something already removed
-	/// is a silent no-op, matching how the free_X functions behave today --
-	/// and it matters, because bumping the generation on a stray call would
+	/// is a silent no-op, matching how the free_X functions behave today.
+	/// It matters because bumping the generation on a stray call would
 	/// spend the slot's counter for nothing.
 	void Remove(HandleType handle)
 	{
@@ -205,5 +223,16 @@ private:
 	std::uint32_t		freeHead = NO_SLOT;
 	std::size_t			liveCount = 0;
 };
+
+/// Lets a handle be an unordered_map key. See Handle::Hash for why that is
+/// worth having over a raw pointer key.
+namespace std
+{
+	template <typename T, typename GenT>
+	struct hash<Handle<T, GenT>>
+	{
+		std::size_t operator()(const Handle<T, GenT> &handle) const { return handle.Hash(); }
+	};
+}
 
 #endif /* STDLIBS_HANDLE_H */

--- a/code/update.c
+++ b/code/update.c
@@ -39,6 +39,7 @@
 #include <iterator>
 #include <algorithm>
 #include "merc.h"
+#include "entity/list_cursor.h"
 #include "update.h"
 #include "entity/handles.h"
 #include "weather_enums.h"
@@ -1506,8 +1507,10 @@ void obj_update(void)
 	OBJ_DATA *obj_next;
 	CHAR_DATA *owner, *cguard;
 
-	for (obj = object_list; obj != nullptr; obj = obj_next)
+	for (OwningListWalk<OBJ_DATA> walk(object_list); !walk.Done(); walk.Step())
 	{
+		obj = walk.Current();
+
 		CHAR_DATA *rch;
 		// Re-read from obj->carried_by before each use below, never cached across
 		// them: the cabal-item branch calls obj_from_char/obj_to_char, which move
@@ -1515,8 +1518,6 @@ void obj_update(void)
 		// is stale from that point on.
 		CHAR_DATA *carrier;
 		char *message;
-
-		obj_next = obj->next;
 
 		if (obj->moved)
 			obj->moved= false;
@@ -2394,9 +2395,9 @@ void affect_update(void)
 		}
 	}
 
-	for (obj = object_list; obj; obj = obj_next)
+	for (OwningListWalk<OBJ_DATA> walk(object_list); !walk.Done(); walk.Step())
 	{
-		obj_next = obj->next;
+		obj = walk.Current();
 
 		for (auto it = obj->affected.begin(); it != obj->affected.end(); )
 		{
@@ -2495,13 +2496,18 @@ void room_affect_update(void)
 
 			af = affect_find_room(room->affected, gsn_gravity_well);
 
-			for (well = object_list; well != nullptr; well = well->next)
+			well = nullptr;
+
+			for (auto &owned : object_list)
 			{
-				if (well->item_type == ITEM_GRAVITYWELL && well->in_room && well->in_room == room)
+				if (owned->item_type == ITEM_GRAVITYWELL && owned->in_room && owned->in_room == room)
+				{
+					well = owned.get();
 					break;
+				}
 			}
 
-			if (!well)
+			if (well == nullptr)
 				continue;
 
 			auto room_exit_size = std::size(room->exit);
@@ -2936,9 +2942,9 @@ void iprog_pulse_update(bool isTick)
 	EXIT_DATA *pexit;
 	int door;
 
-	for (obj = object_list; obj != nullptr; obj = obj_next)
+	for (OwningListWalk<OBJ_DATA> walk(object_list); !walk.Done(); walk.Step())
 	{
-		obj_next = obj->next;
+		obj = walk.Current();
 
 		/* items drifting/sinking in water -- Dioxide */
 		if (obj->in_room

--- a/code/update.c
+++ b/code/update.c
@@ -3317,11 +3317,14 @@ void save_demos()
 
 void rune_update()
 {
-	RUNE_DATA *rune, *rune_next;
-
-	for (rune = rune_list; rune; rune = rune_next)
+	// Advance before the body runs: extract_rune erases the rune it is given, so
+	// the cursor has to be off it already. Same reason the old walk saved
+	// rune->next first.
+	for (auto it = rune_list.begin(); it != rune_list.end(); )
 	{
-		rune_next = rune->next;
+		RUNE_DATA *rune = it->get();
+		++it;
+
 		rune->duration--;
 
 		if (rune->duration <= 0)

--- a/code/update.c
+++ b/code/update.c
@@ -751,7 +751,6 @@ void time_update(void)
 {
 	char buf[MSL], colbuf[MSL];
 	char bw1[MSL], bw2[MSL], bw3[MSL], bw4[MSL];
-	DESCRIPTOR_DATA *d;
 	AREA_DATA *area;
 
 	buf[0] = '\0';
@@ -901,8 +900,10 @@ void time_update(void)
 
 	if (buf[0] != '\0')
 	{
-		for (d = descriptor_list; d != nullptr; d = d->next)
+		for (OwningListWalk<DESCRIPTOR_DATA> walk(descriptor_list); !walk.Done(); walk.Step())
 		{
+			DESCRIPTOR_DATA *d = walk.Current();
+
 			CHAR_DATA *wch = Deref(d->character);
 
 			if (d->connected == CON_PLAYING

--- a/code/update.c
+++ b/code/update.c
@@ -631,15 +631,13 @@ void gain_condition(CHAR_DATA *ch, int iCond, int value)
  */
 void mobile_update(void)
 {
-	CHAR_DATA *ch;
-	CHAR_DATA *ch_next;
 	EXIT_DATA *pexit = nullptr;
 	int door;
 
 	/* Examine all mobs. */
-	for (ch = char_list; ch != nullptr; ch = ch_next)
+	for (OwningListWalk<CHAR_DATA> walk(char_list); !walk.Done(); walk.Step())
 	{
-		ch_next = ch->next;
+		CHAR_DATA *ch = walk.Current();
 
 		if (!is_npc(ch) || ch->in_room == nullptr)
 			continue;
@@ -935,15 +933,16 @@ void time_update(void)
 
 void gold_update(void)
 {
-	CHAR_DATA *mob;
 	long mob_gold;
 	long gold;
 
 	if (total_wealth == 0)
 		return;
 
-	for (mob = char_list; mob; mob = mob->next)
+	for (OwningListWalk<CHAR_DATA> walk(char_list); !walk.Done(); walk.Step())
 	{
+		CHAR_DATA *mob = walk.Current();
+
 		if (!is_npc(mob) || mob->stolen_from)
 			continue;
 
@@ -1162,8 +1161,6 @@ void calabren_update(void)
  */
 void char_update(void)
 {
-	CHAR_DATA *ch;
-	CHAR_DATA *ch_next;
 	CHAR_DATA *ch_quit;
 	int hgain;
 	bool ghost= false;
@@ -1176,12 +1173,13 @@ void char_update(void)
 	if (save_number > 2)
 		save_number = 0;
 
-	for (ch = char_list; ch != nullptr; ch = ch_next)
+	for (OwningListWalk<CHAR_DATA> walk(char_list); !walk.Done(); walk.Step())
 	{
+		CHAR_DATA *ch = walk.Current();
+
 		CHAR_DATA *master;
 		bool charm_gone;
 
-		ch_next = ch->next;
 		master = nullptr;
 
 		if (is_npc(ch)
@@ -1487,9 +1485,9 @@ void char_update(void)
 	 * Autosave and autoquit.
 	 * Check that these chars still exist.
 	 */
-	for (ch = char_list; ch != nullptr; ch = ch_next)
+	for (OwningListWalk<CHAR_DATA> walk(char_list); !walk.Done(); walk.Step())
 	{
-		ch_next = ch->next;
+		CHAR_DATA *ch = walk.Current();
 
 		DESCRIPTOR_DATA *connection = Deref(ch->desc);
 
@@ -1506,7 +1504,7 @@ void obj_update(void)
 {
 	OBJ_DATA *obj;
 	OBJ_DATA *obj_next;
-	CHAR_DATA *owner, *cguard;
+	CHAR_DATA *cguard;
 
 	for (OwningListWalk<OBJ_DATA> walk(object_list); !walk.Done(); walk.Step())
 	{
@@ -1698,8 +1696,10 @@ void obj_update(void)
 			if (obj->in_room != nullptr && is_explore(obj->in_room))
 			{
 				// Gear to char
-				for (owner = char_list; owner != nullptr; owner = owner->next)
+				for (OwningListWalk<CHAR_DATA> walk(char_list); !walk.Done(); walk.Step())
 				{
+					CHAR_DATA *owner = walk.Current();
+
 					if (!is_npc(owner) && !str_cmp(owner->true_name, obj->owner))
 					{
 						if (obj->contains)
@@ -1773,13 +1773,11 @@ void track_attack(CHAR_DATA *mob, CHAR_DATA *victim)
 
 void track_update(void)
 {
-	CHAR_DATA *tch;
-	CHAR_DATA *tch_next;
 	char buf[MAX_STRING_LENGTH];
 
-	for (tch = char_list; tch != nullptr; tch = tch_next)
+	for (OwningListWalk<CHAR_DATA> walk(char_list); !walk.Done(); walk.Step())
 	{
-		tch_next = tch->next;
+		CHAR_DATA *tch = walk.Current();
 
 		if (!is_npc(tch))
 			continue;
@@ -1853,8 +1851,6 @@ void track_update(void)
  */
 void aggr_update(void)
 {
-	CHAR_DATA *wch;
-	CHAR_DATA *wch_next;
 	CHAR_DATA *ch;
 	CHAR_DATA *ch_next;
 	CHAR_DATA *vch;
@@ -1864,9 +1860,9 @@ void aggr_update(void)
 	int timer;
 	char buf[MAX_STRING_LENGTH];
 
-	for (wch = char_list; wch != nullptr; wch = wch_next)
+	for (OwningListWalk<CHAR_DATA> walk(char_list); !walk.Done(); walk.Step())
 	{
-		wch_next = wch->next;
+		CHAR_DATA *wch = walk.Current();
 
 		if (!wch->name)
 			continue;
@@ -2167,14 +2163,12 @@ char *get_age_name(CHAR_DATA *ch)
 void age_update(void)
 {
 
-	CHAR_DATA *ch;
-	CHAR_DATA *ch_next;
 	bool timedied= false;
 	std::string cname;
 
-	for (ch = char_list; ch != nullptr; ch = ch_next)
+	for (OwningListWalk<CHAR_DATA> walk(char_list); !walk.Done(); walk.Step())
 	{
-		ch_next = ch->next;
+		CHAR_DATA *ch = walk.Current();
 
 		if (is_npc(ch))
 			continue;
@@ -2361,14 +2355,13 @@ void do_forcetick(CHAR_DATA *ch, char *argument)
 
 void affect_update(void)
 {
-	CHAR_DATA *ch, *ch_next;
 	OBJ_DATA *obj, *obj_next;
 	ROOM_INDEX_DATA *room;
 	AREA_DATA *area;
 
-	for (ch = char_list; ch; ch = ch_next)
+	for (OwningListWalk<CHAR_DATA> walk(char_list); !walk.Done(); walk.Step())
 	{
-		ch_next = ch->next;
+		CHAR_DATA *ch = walk.Current();
 
 		// Dev's super-fly cheap name hax!
 		if (!is_npc(ch) && strcmp(ch->true_name, ch->backup_true_name))
@@ -2477,7 +2470,7 @@ void room_update(void)
 void room_affect_update(void)
 {
 	ROOM_INDEX_DATA *room, *to_room;
-	CHAR_DATA *victim, *v_next, *vch, *ch;
+	CHAR_DATA *victim, *v_next, *vch;
 	int i, dam, chance, roomcount = 0;
 	AREA_AFFECT_DATA *aaf;
 	ROOM_AFFECT_DATA *af, *af2;
@@ -2911,8 +2904,10 @@ void room_affect_update(void)
 			}
 		}
 	}
-	for (ch = char_list; ch != nullptr; ch = ch->next)
+	for (OwningListWalk<CHAR_DATA> walk(char_list); !walk.Done(); walk.Step())
 	{
+		CHAR_DATA *ch = walk.Current();
+
 		dam = 0;
 
 		for (obj = ch->carrying; obj != nullptr; obj = obj->next_content)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -11,6 +11,7 @@ set_target_properties(TestMain PROPERTIES LINKER_LANGUAGE CXX)
 
 set(TEST_SRC_FILES act_obj_tests.c
 	ban_tests.c
+	entity_storage_tests.c
 	bitflag_tests.c
 	bug_tests.c
 	cabal_tests.c

--- a/tests/db_tests.c
+++ b/tests/db_tests.c
@@ -1,5 +1,7 @@
+#include <cstring>
+
 #include "catch.hpp"
-#include "../code/db.c"
+#include "../code/db.h"
 
 // TEST_CASE("Test capitalization", "[string]" )
 // {
@@ -119,13 +121,13 @@ SCENARIO("Testing random number generator", "[random_mm]")
 	{
 		WHEN("rgiState has not been initialized properly")
 		{
-			THEN("init_mm() should be called to ensure rgiState is not filled with zeros")
+			THEN("number_mm() should self-initialize instead of streaming zeros")
 			{
-				auto number = number_mm();
 				bool anyNonZero = false;
-				for(auto i = 0; i < std::size(rgiState); i++)
+
+				for (auto i = 0; i < 8; i++)
 				{
-					if(rgiState[i] != 0)
+					if (number_mm() != 0)
 					{
 						anyNonZero = true;
 						break;

--- a/tests/entity_storage_tests.c
+++ b/tests/entity_storage_tests.c
@@ -20,10 +20,11 @@
 //
 // These lists are what decides an entity's lifetime. The containment chains
 // (room->people, ch->carrying, obj->contains) are a game rule about where
-// things are, not about when they die. Today each global list is an intrusive
-// singly-linked chain through an entity's `next` field, and `free_char` and
-// friends push the entity onto a free list rather than returning its memory,
-// so an address is handed straight back out to the next allocation.
+// things are, not about when they die. `char_list` is still an intrusive
+// singly-linked chain through an entity's `next` field, and `free_char` pushes
+// the entity onto a free list rather than returning its memory, so an address is
+// handed straight back out to the next allocation. `object_list` and
+// `descriptor_list` are owning containers and no longer do either.
 //
 // This file characterises the storage behaviour the game currently depends on,
 // so that the same assertions can be run after the lists become owning
@@ -53,7 +54,6 @@ namespace
 	template <class T> T *&ListHead();
 
 	template <> CHAR_DATA *&ListHead<CHAR_DATA>() { return char_list; }
-	template <> DESCRIPTOR_DATA *&ListHead<DESCRIPTOR_DATA>() { return descriptor_list; }
 
 	/// Puts an entity on its global list, the way db.c/comm.c do it: push front.
 	template <class T>
@@ -154,6 +154,43 @@ namespace
 		}
 	}
 
+	//
+	// descriptor_list is an owning container now too, and the same collapse
+	// applies: close_socket erasing the node is the destruction, so there is no
+	// "off the list but still alive" state left for a test to construct.
+	//
+
+	template <>
+	void Link<DESCRIPTOR_DATA>(DESCRIPTOR_DATA *d)
+	{
+		descriptor_list.push_front(std::unique_ptr<DESCRIPTOR_DATA>(d));
+		d->globalNode = descriptor_list.begin();
+	}
+
+	template <>
+	std::vector<DESCRIPTOR_DATA *> Collect<DESCRIPTOR_DATA>()
+	{
+		std::vector<DESCRIPTOR_DATA *> out;
+
+		for (auto &owned : descriptor_list)
+			out.push_back(owned.get());
+
+		return out;
+	}
+
+	/// The unprotected walk, for the same reason the raw and object ones exist.
+	template <>
+	void Walk<DESCRIPTOR_DATA>(const std::function<void(DESCRIPTOR_DATA *)> &body)
+	{
+		for (auto it = descriptor_list.begin(); it != descriptor_list.end(); )
+		{
+			DESCRIPTOR_DATA *d = it->get();
+			++it;
+
+			body(d);
+		}
+	}
+
 	// ─── end of shim ───────────────────────────────────────────────────────
 
 	//
@@ -204,17 +241,17 @@ namespace
 		object_list.erase(obj->globalNode);
 	}
 
+	/// One operation now, as for objects: the erase runs ~descriptor_data.
 	void ExtractDescriptor(DESCRIPTOR_DATA *d)
 	{
-		CursorRegistry<DESCRIPTOR_DATA>::Advance(d);
-		Unlink(d);
-		free_descriptor(d);
+		OwningCursorRegistry<DESCRIPTOR_DATA>::Advance(d->globalNode);
+		descriptor_list.erase(d->globalNode);
 	}
 
 	/// Leaves the list empty however a scenario ended.
 	void DrainChars()       { while (char_list != nullptr) ExtractChar(char_list); }
 	void DrainObjs()        { while (!object_list.empty()) ExtractObj(object_list.front().get()); }
-	void DrainDescriptors() { while (descriptor_list != nullptr) ExtractDescriptor(descriptor_list); }
+	void DrainDescriptors() { while (!descriptor_list.empty()) ExtractDescriptor(descriptor_list.front().get()); }
 }
 
 //

--- a/tests/entity_storage_tests.c
+++ b/tests/entity_storage_tests.c
@@ -7,9 +7,11 @@
 #include "../code/entity/char_data.h"
 #include "../code/entity/obj_data.h"
 #include "../code/entity/handles.h"
+#include "../code/entity/list_cursor.h"
 
 #include <algorithm>
 #include <functional>
+#include <stdexcept>
 #include <vector>
 
 //
@@ -142,9 +144,30 @@ namespace
 		return d;
 	}
 
-	void ExtractChar(CHAR_DATA *ch)   { Unlink(ch); free_char(ch); }
-	void ExtractObj(OBJ_DATA *obj)    { Unlink(obj); free_obj(obj); }
-	void ExtractDescriptor(DESCRIPTOR_DATA *d) { Unlink(d); free_descriptor(d); }
+	// Mirrors the order the real extract_char/extract_obj/close_socket use:
+	// advance any walk in flight first, because both the unlink and the free
+	// destroy the link that answer comes from. A walk that registered no cursor
+	// is unaffected, which is what makes section 3 and section 5 differ.
+	void ExtractChar(CHAR_DATA *ch)
+	{
+		CursorRegistry<CHAR_DATA>::Advance(ch);
+		Unlink(ch);
+		free_char(ch);
+	}
+
+	void ExtractObj(OBJ_DATA *obj)
+	{
+		CursorRegistry<OBJ_DATA>::Advance(obj);
+		Unlink(obj);
+		free_obj(obj);
+	}
+
+	void ExtractDescriptor(DESCRIPTOR_DATA *d)
+	{
+		CursorRegistry<DESCRIPTOR_DATA>::Advance(d);
+		Unlink(d);
+		free_descriptor(d);
+	}
 
 	/// Leaves the list empty however a scenario ended.
 	void DrainChars()       { while (char_list != nullptr) ExtractChar(char_list); }
@@ -372,14 +395,16 @@ SCENARIO("a walk may extract the entity it was handed", "[entity_storage]")
 // │ These two scenarios assert *today's* broken behaviour on purpose, because │
 // │ that is what "no behaviour change" would mean. They are the only          │
 // │ assertions in this file expected to need editing, and editing them is the │
-// │ record of the semantic change. After conversion the same code cannot      │
-// │ silently continue. A saved iterator to an erased node is a hard failure   │
-// │ and a sanitizer report, which is the improvement being bought.            │
+// │ record of the semantic change.                                            │
 // │                                                                           │
-// │ Note this is NOT fixed by keeping the entity alive past the extract: the  │
-// │ entity's lifetime is not what the walk is following, the list node is.    │
-// │ Preserving these semantics needs the *unlink* deferred, not just the      │
-// │ free, ie. the node tombstoned in place and erased later.                  │
+// │ The replacement is tombstone-and-sweep: extraction marks the entity and   │
+// │ leaves it linked where it is, and a sweep at the end of the pulse does the│
+// │ unlink and the free. Keeping the entity *alive* past the extract would not│
+// │ have been enough on its own. The walk is not following the entity, it is  │
+// │ following the pointer inside the list node, so the node is what has to    │
+// │ stay put. The price is that iteration has to skip tombstones, and these   │
+// │ two scenarios become: the walk visits the living, skips the marked entity,│
+// │ and reaches the end of the list.                                          │
 // └───────────────────────────────────────────────────────────────────────────┘
 //
 
@@ -585,6 +610,181 @@ SCENARIO("a handle survives list mutation and expires exactly at extract", "[ent
 			THEN("the handle is expired")
 			{
 				REQUIRE(Deref(handle) == nullptr);
+			}
+		}
+
+		DrainObjs();
+	}
+}
+
+//
+// 5. The cursor-aware walk.
+//
+// Section 3 pins what a hand-rolled walk does when its successor is extracted:
+// it leaves the live list. ListWalk registers where it keeps that successor, so
+// extraction can move it along instead. These scenarios are the same setups as
+// section 3 with the walk swapped, and they are what the walks in the game
+// become as each list converts.
+//
+// The extraction is the same shim section 3 uses, and it advances registered
+// cursors exactly as the real extract_char/extract_obj/close_socket do. So the
+// difference between the two sections is only which walk is running: the fix is
+// opt-in at the walk, and a hand-rolled loop gets nothing.
+//
+
+namespace
+{
+	/// The section 3 walk, rewritten against ListWalk. Same contract: the body
+	/// sees each entity the walk lands on.
+	template <class T>
+	void CursorWalk(T *head, const std::function<void(T *)> &body)
+	{
+		for (ListWalk<T> walk(head); !walk.Done(); walk.Step())
+			body(walk.Current());
+	}
+}
+
+SCENARIO("a cursor-aware walk survives having its successor extracted", "[entity_storage]")
+{
+	GIVEN("three objects on the list and two corpses on the free list")
+	{
+		OBJ_DATA *oldest = MakeObj();
+		OBJ_DATA *middle = MakeObj();
+		OBJ_DATA *newest = MakeObj();
+
+		// Seeded after the live list: freeing first would just hand these
+		// addresses back to the MakeObj calls above.
+		OBJ_DATA *corpseA = new_obj();
+		OBJ_DATA *corpseB = new_obj();
+
+		free_obj(corpseA);
+		free_obj(corpseB);
+
+		WHEN("the first body call extracts the entity the walk was about to reach")
+		{
+			std::vector<OBJ_DATA *> visited;
+
+			CursorWalk<OBJ_DATA>(object_list, [&](OBJ_DATA *obj)
+			{
+				visited.push_back(obj);
+
+				if (obj == newest)
+					ExtractObj(middle);
+			});
+
+			THEN("the walk skips the extracted entity and finishes the live list")
+			{
+				// The comparison that matters: section 3's identical setup with
+				// a hand-rolled walk visits four entities, three of them dead,
+				// and never reaches `oldest`.
+				REQUIRE(visited == std::vector<OBJ_DATA *>({newest, oldest}));
+			}
+
+			THEN("nothing from the free list was handed to the body")
+			{
+				REQUIRE(std::find(visited.begin(), visited.end(), corpseA) == visited.end());
+				REQUIRE(std::find(visited.begin(), visited.end(), corpseB) == visited.end());
+
+				for (OBJ_DATA *seen : visited)
+					REQUIRE(Deref(seen->self) == seen);
+			}
+		}
+
+		WHEN("the body extracts the entity it was handed")
+		{
+			std::vector<OBJ_DATA *> visited;
+
+			CursorWalk<OBJ_DATA>(object_list, [&](OBJ_DATA *obj)
+			{
+				visited.push_back(obj);
+				ExtractObj(obj);
+			});
+
+			THEN("the walk still visits all three and empties the list")
+			{
+				REQUIRE(visited == std::vector<OBJ_DATA *>({newest, middle, oldest}));
+				REQUIRE(Collect<OBJ_DATA>().empty());
+			}
+		}
+
+		WHEN("the body extracts an entity the walk has not reached yet")
+		{
+			std::vector<OBJ_DATA *> visited;
+
+			CursorWalk<OBJ_DATA>(object_list, [&](OBJ_DATA *obj)
+			{
+				visited.push_back(obj);
+
+				if (obj == newest)
+					ExtractObj(oldest);
+			});
+
+			THEN("the walk simply never sees it")
+			{
+				REQUIRE(visited == std::vector<OBJ_DATA *>({newest, middle}));
+			}
+		}
+
+		DrainObjs();
+	}
+}
+
+SCENARIO("a walk deregisters its cursor however it ends", "[entity_storage]")
+{
+	GIVEN("no walks in flight")
+	{
+		REQUIRE(CursorRegistry<OBJ_DATA>::ActiveCount() == 0);
+
+		MakeObj();		// something for the walks to land on
+
+		WHEN("a walk runs to completion")
+		{
+			CursorWalk<OBJ_DATA>(object_list, [](OBJ_DATA *) {});
+
+			THEN("the registry is empty again")
+			{
+				REQUIRE(CursorRegistry<OBJ_DATA>::ActiveCount() == 0);
+			}
+		}
+
+		WHEN("walks are nested over the same list")
+		{
+			std::size_t innerDepth = 0;
+
+			CursorWalk<OBJ_DATA>(object_list, [&](OBJ_DATA *)
+			{
+				CursorWalk<OBJ_DATA>(object_list, [&](OBJ_DATA *)
+				{
+					innerDepth = CursorRegistry<OBJ_DATA>::ActiveCount();
+				});
+			});
+
+			THEN("both were registered at once, and both cleaned up")
+			{
+				REQUIRE(innerDepth == 2);
+				REQUIRE(CursorRegistry<OBJ_DATA>::ActiveCount() == 0);
+			}
+		}
+
+		WHEN("a walk is abandoned by an exception")
+		{
+			// The destructor is what deregisters, so an early exit out of a walk
+			// must not strand a dangling T** in the registry -- it would be
+			// written through by the next extraction.
+			try
+			{
+				CursorWalk<OBJ_DATA>(object_list, [](OBJ_DATA *)
+				{
+					throw std::runtime_error("abandon the walk");
+				});
+			}
+			catch (const std::runtime_error &)
+			{
+			}
+
+			THEN("the registry is empty again")
+			{
+				REQUIRE(CursorRegistry<OBJ_DATA>::ActiveCount() == 0);
 			}
 		}
 

--- a/tests/entity_storage_tests.c
+++ b/tests/entity_storage_tests.c
@@ -53,7 +53,6 @@ namespace
 	template <class T> T *&ListHead();
 
 	template <> CHAR_DATA *&ListHead<CHAR_DATA>() { return char_list; }
-	template <> OBJ_DATA *&ListHead<OBJ_DATA>() { return object_list; }
 	template <> DESCRIPTOR_DATA *&ListHead<DESCRIPTOR_DATA>() { return descriptor_list; }
 
 	/// Puts an entity on its global list, the way db.c/comm.c do it: push front.
@@ -113,6 +112,48 @@ namespace
 		}
 	}
 
+	//
+	// object_list is an owning container now, so the OBJ_DATA half of the shim is
+	// specialized. Note what collapsed: on a raw list, "take it off the list" and
+	// "free it" are two steps, and a test can do one without the other. Here
+	// erasing the node *is* the destruction, so Unlink and free_obj have no
+	// separate meaning and ExtractObj is a single operation. That collapse is the
+	// behaviour change, and this is where the file records it.
+	//
+
+	template <>
+	void Link<OBJ_DATA>(OBJ_DATA *obj)
+	{
+		object_list.push_front(std::unique_ptr<OBJ_DATA>(obj));
+		obj->globalNode = object_list.begin();
+	}
+
+	template <>
+	std::vector<OBJ_DATA *> Collect<OBJ_DATA>()
+	{
+		std::vector<OBJ_DATA *> out;
+
+		for (auto &owned : object_list)
+			out.push_back(owned.get());
+
+		return out;
+	}
+
+	/// The unprotected walk, for the same reason the raw one exists: it is what a
+	/// hand-written loop does, and section 2 needs it to show that extracting the
+	/// current element is the safe case either way.
+	template <>
+	void Walk<OBJ_DATA>(const std::function<void(OBJ_DATA *)> &body)
+	{
+		for (auto it = object_list.begin(); it != object_list.end(); )
+		{
+			OBJ_DATA *obj = it->get();
+			++it;
+
+			body(obj);
+		}
+	}
+
 	// ─── end of shim ───────────────────────────────────────────────────────
 
 	//
@@ -155,11 +196,12 @@ namespace
 		free_char(ch);
 	}
 
+	/// One operation now: the erase runs ~obj_data. Advancing the walks has to
+	/// come first, while the node still links to its successor.
 	void ExtractObj(OBJ_DATA *obj)
 	{
-		CursorRegistry<OBJ_DATA>::Advance(obj);
-		Unlink(obj);
-		free_obj(obj);
+		OwningCursorRegistry<OBJ_DATA>::Advance(obj->globalNode);
+		object_list.erase(obj->globalNode);
 	}
 
 	void ExtractDescriptor(DESCRIPTOR_DATA *d)
@@ -171,7 +213,7 @@ namespace
 
 	/// Leaves the list empty however a scenario ended.
 	void DrainChars()       { while (char_list != nullptr) ExtractChar(char_list); }
-	void DrainObjs()        { while (object_list != nullptr) ExtractObj(object_list); }
+	void DrainObjs()        { while (!object_list.empty()) ExtractObj(object_list.front().get()); }
 	void DrainDescriptors() { while (descriptor_list != nullptr) ExtractDescriptor(descriptor_list); }
 }
 
@@ -621,15 +663,16 @@ SCENARIO("a handle survives list mutation and expires exactly at extract", "[ent
 // 5. The cursor-aware walk.
 //
 // Section 3 pins what a hand-rolled walk does when its successor is extracted:
-// it leaves the live list. ListWalk registers where it keeps that successor, so
-// extraction can move it along instead. These scenarios are the same setups as
-// section 3 with the walk swapped, and they are what the walks in the game
-// become as each list converts.
+// it leaves the live list. A registered walk hands extraction somewhere to move
+// that successor to instead. These are section 3's setups with the walk swapped,
+// and they are what the walks in the game become as each list converts.
 //
-// The extraction is the same shim section 3 uses, and it advances registered
-// cursors exactly as the real extract_char/extract_obj/close_socket do. So the
-// difference between the two sections is only which walk is running: the fix is
-// opt-in at the walk, and a hand-rolled loop gets nothing.
+// object_list is converted, so its walk is OwningListWalk and its successor is a
+// list iterator. The hazard is sharper here than on the raw lists rather than
+// milder: erasing the node really frees the object, so a walk that carried on
+// regardless would be reading freed memory rather than an intact corpse. What
+// makes these pass is the same thing in both cases -- extraction advancing the
+// cursor before it destroys what the cursor names.
 //
 
 namespace
@@ -642,29 +685,33 @@ namespace
 		for (ListWalk<T> walk(head); !walk.Done(); walk.Step())
 			body(walk.Current());
 	}
+
+	/// The owning-container form. It takes the list rather than a head pointer,
+	/// which is the one call-site change the conversion forces here.
+	void CursorWalk(ObjectList &list, const std::function<void(OBJ_DATA *)> &body)
+	{
+		for (OwningListWalk<OBJ_DATA> walk(list); !walk.Done(); walk.Step())
+			body(walk.Current());
+	}
 }
 
 SCENARIO("a cursor-aware walk survives having its successor extracted", "[entity_storage]")
 {
-	GIVEN("three objects on the list and two corpses on the free list")
+	GIVEN("three objects on the list")
 	{
 		OBJ_DATA *oldest = MakeObj();
 		OBJ_DATA *middle = MakeObj();
 		OBJ_DATA *newest = MakeObj();
 
-		// Seeded after the live list: freeing first would just hand these
-		// addresses back to the MakeObj calls above.
-		OBJ_DATA *corpseA = new_obj();
-		OBJ_DATA *corpseB = new_obj();
-
-		free_obj(corpseA);
-		free_obj(corpseB);
+		// No free list to seed any more: object_list owns its objects, so
+		// extraction returns the memory to the allocator. Section 3's char_list
+		// scenarios still seed one, because char_free is still there.
 
 		WHEN("the first body call extracts the entity the walk was about to reach")
 		{
 			std::vector<OBJ_DATA *> visited;
 
-			CursorWalk<OBJ_DATA>(object_list, [&](OBJ_DATA *obj)
+			CursorWalk(object_list, [&](OBJ_DATA *obj)
 			{
 				visited.push_back(obj);
 
@@ -674,17 +721,14 @@ SCENARIO("a cursor-aware walk survives having its successor extracted", "[entity
 
 			THEN("the walk skips the extracted entity and finishes the live list")
 			{
-				// The comparison that matters: section 3's identical setup with
-				// a hand-rolled walk visits four entities, three of them dead,
-				// and never reaches `oldest`.
+				// The comparison that matters: section 3's equivalent setup on
+				// char_list, walked by hand, visits four entities of which three
+				// are dead and never reaches the last live one.
 				REQUIRE(visited == std::vector<OBJ_DATA *>({newest, oldest}));
 			}
 
-			THEN("nothing from the free list was handed to the body")
+			THEN("everything the body was handed was alive when it got it")
 			{
-				REQUIRE(std::find(visited.begin(), visited.end(), corpseA) == visited.end());
-				REQUIRE(std::find(visited.begin(), visited.end(), corpseB) == visited.end());
-
 				for (OBJ_DATA *seen : visited)
 					REQUIRE(Deref(seen->self) == seen);
 			}
@@ -694,7 +738,7 @@ SCENARIO("a cursor-aware walk survives having its successor extracted", "[entity
 		{
 			std::vector<OBJ_DATA *> visited;
 
-			CursorWalk<OBJ_DATA>(object_list, [&](OBJ_DATA *obj)
+			CursorWalk(object_list, [&](OBJ_DATA *obj)
 			{
 				visited.push_back(obj);
 				ExtractObj(obj);
@@ -711,7 +755,7 @@ SCENARIO("a cursor-aware walk survives having its successor extracted", "[entity
 		{
 			std::vector<OBJ_DATA *> visited;
 
-			CursorWalk<OBJ_DATA>(object_list, [&](OBJ_DATA *obj)
+			CursorWalk(object_list, [&](OBJ_DATA *obj)
 			{
 				visited.push_back(obj);
 
@@ -733,17 +777,17 @@ SCENARIO("a walk deregisters its cursor however it ends", "[entity_storage]")
 {
 	GIVEN("no walks in flight")
 	{
-		REQUIRE(CursorRegistry<OBJ_DATA>::ActiveCount() == 0);
+		REQUIRE(OwningCursorRegistry<OBJ_DATA>::ActiveCount() == 0);
 
 		MakeObj();		// something for the walks to land on
 
 		WHEN("a walk runs to completion")
 		{
-			CursorWalk<OBJ_DATA>(object_list, [](OBJ_DATA *) {});
+			CursorWalk(object_list, [](OBJ_DATA *) {});
 
 			THEN("the registry is empty again")
 			{
-				REQUIRE(CursorRegistry<OBJ_DATA>::ActiveCount() == 0);
+				REQUIRE(OwningCursorRegistry<OBJ_DATA>::ActiveCount() == 0);
 			}
 		}
 
@@ -751,18 +795,18 @@ SCENARIO("a walk deregisters its cursor however it ends", "[entity_storage]")
 		{
 			std::size_t innerDepth = 0;
 
-			CursorWalk<OBJ_DATA>(object_list, [&](OBJ_DATA *)
+			CursorWalk(object_list, [&](OBJ_DATA *)
 			{
-				CursorWalk<OBJ_DATA>(object_list, [&](OBJ_DATA *)
+				CursorWalk(object_list, [&](OBJ_DATA *)
 				{
-					innerDepth = CursorRegistry<OBJ_DATA>::ActiveCount();
+					innerDepth = OwningCursorRegistry<OBJ_DATA>::ActiveCount();
 				});
 			});
 
 			THEN("both were registered at once, and both cleaned up")
 			{
 				REQUIRE(innerDepth == 2);
-				REQUIRE(CursorRegistry<OBJ_DATA>::ActiveCount() == 0);
+				REQUIRE(OwningCursorRegistry<OBJ_DATA>::ActiveCount() == 0);
 			}
 		}
 
@@ -773,7 +817,7 @@ SCENARIO("a walk deregisters its cursor however it ends", "[entity_storage]")
 			// written through by the next extraction.
 			try
 			{
-				CursorWalk<OBJ_DATA>(object_list, [](OBJ_DATA *)
+				CursorWalk(object_list, [](OBJ_DATA *)
 				{
 					throw std::runtime_error("abandon the walk");
 				});
@@ -784,7 +828,7 @@ SCENARIO("a walk deregisters its cursor however it ends", "[entity_storage]")
 
 			THEN("the registry is empty again")
 			{
-				REQUIRE(CursorRegistry<OBJ_DATA>::ActiveCount() == 0);
+				REQUIRE(OwningCursorRegistry<OBJ_DATA>::ActiveCount() == 0);
 			}
 		}
 

--- a/tests/entity_storage_tests.c
+++ b/tests/entity_storage_tests.c
@@ -20,68 +20,50 @@
 //
 // These lists are what decides an entity's lifetime. The containment chains
 // (room->people, ch->carrying, obj->contains) are a game rule about where
-// things are, not about when they die. `char_list` is still an intrusive
-// singly-linked chain through an entity's `next` field, and `free_char` pushes
-// the entity onto a free list rather than returning its memory, so an address is
-// handed straight back out to the next allocation. `object_list` and
-// `descriptor_list` are owning containers and no longer do either.
+// things are, not about when they die. All three are owning containers now, so
+// an entity's node is what holds it and erasing that node is what destroys it.
 //
-// This file characterises the storage behaviour the game currently depends on,
-// so that the same assertions can be run after the lists become owning
-// containers. Every scenario is written against the five-function shim below;
-// converting the containers means rewriting those five bodies. Anything
-// *outside* the shim that has to be edited to keep this file compiling and
-// green is a behaviour change, and finding those is the whole point.
+// This file characterised the storage behaviour the game depended on before
+// that conversion, so that the same assertions could be run after it. Every
+// scenario is written against the shim below. Anything *outside* the shim that
+// had to be edited to keep this file compiling and green was a behaviour
+// change, and finding those was the whole point.
 //
-// The interesting case is the last two scenarios. A walk that unlinks the
-// element it is looking at is safe by construction, because every walk in the
-// game captures the successor before running its body. A walk that unlinks the
-// *successor* is not, and the damage is bigger than reading stale bytes: the
-// free lists are threaded through the very same `next` field, so freeing an
-// entity overwrites the successor the walk had already saved. The walk stops
-// following the live list and starts following the free list. Section 3 pins
-// both halves of that.
+// It found three, all recorded where they happened: Unlink collapsing into the
+// erase (the shim), section 3 losing its premise with the last free list, and
+// section 5 becoming the only place the successor hazard is still observable.
 //
 
 namespace
 {
 	// ─── the storage shim ──────────────────────────────────────────────────
 	//
-	// One head accessor and four operations. These are the only bodies in this
+	// One list accessor and four operations. These are the only bodies in this
 	// file that know how the lists are built.
 	//
+	// All three lists are owning containers now, so what used to be a generic
+	// raw-list implementation plus three specializations is one generic body
+	// again. Note what fell out of it: Unlink is gone. On a raw list "take it
+	// off the list" and "free it" were two steps and a test could do one
+	// without the other. Here erasing the node *is* the destruction, so there
+	// is no "off the list but still alive" state left to construct. That
+	// collapse is the behaviour change this phase made, and this is where the
+	// file records it.
+	//
 
-	template <class T> T *&ListHead();
+	template <class T> std::list<std::unique_ptr<T>> &GlobalList();
 
-	template <> CHAR_DATA *&ListHead<CHAR_DATA>() { return char_list; }
+	template <> CharacterList &GlobalList<CHAR_DATA>() { return char_list; }
+	template <> ObjectList &GlobalList<OBJ_DATA>() { return object_list; }
+	template <> DescriptorList &GlobalList<DESCRIPTOR_DATA>() { return descriptor_list; }
 
 	/// Puts an entity on its global list, the way db.c/comm.c do it: push front.
+	/// Ownership moves to the list here, which is what the real link sites do.
 	template <class T>
 	void Link(T *entity)
 	{
-		entity->next = ListHead<T>();
-		ListHead<T>() = entity;
-	}
-
-	/// Takes an entity off its global list. Mirrors extract_char/extract_obj/
-	/// close_socket, including the linear scan for the predecessor.
-	template <class T>
-	void Unlink(T *entity)
-	{
-		if (ListHead<T>() == entity)
-		{
-			ListHead<T>() = entity->next;
-			return;
-		}
-
-		for (T *prev = ListHead<T>(); prev != nullptr; prev = prev->next)
-		{
-			if (prev->next == entity)
-			{
-				prev->next = entity->next;
-				return;
-			}
-		}
+		GlobalList<T>().push_front(std::unique_ptr<T>(entity));
+		entity->globalNode = GlobalList<T>().begin();
 	}
 
 	/// The list as a vector, head first.
@@ -90,105 +72,37 @@ namespace
 	{
 		std::vector<T *> out;
 
-		for (T *entity = ListHead<T>(); entity != nullptr; entity = entity->next)
-			out.push_back(entity);
+		for (auto &owned : GlobalList<T>())
+			out.push_back(owned.get());
 
 		return out;
 	}
 
-	/// Walks the live list the way the game does in 164 places: the successor is
-	/// read before the body runs, so the body is free to unlink the element it
-	/// was handed. `body` sees each entity the cursor lands on, including any it
-	/// should not have.
+	/// The unprotected walk. It is what a hand-written loop does, and section 2
+	/// needs it to show that extracting the current element is the safe case.
+	/// It reads its successor before running the body, exactly as the old
+	/// intrusive loops did.
 	template <class T>
 	void Walk(const std::function<void(T *)> &body)
 	{
-		T *next;
+		auto &list = GlobalList<T>();
 
-		for (T *entity = ListHead<T>(); entity != nullptr; entity = next)
+		for (auto it = list.begin(); it != list.end(); )
 		{
-			next = entity->next;
+			T *entity = it->get();
+			++it;
+
 			body(entity);
 		}
 	}
 
-	//
-	// object_list is an owning container now, so the OBJ_DATA half of the shim is
-	// specialized. Note what collapsed: on a raw list, "take it off the list" and
-	// "free it" are two steps, and a test can do one without the other. Here
-	// erasing the node *is* the destruction, so Unlink and free_obj have no
-	// separate meaning and ExtractObj is a single operation. That collapse is the
-	// behaviour change, and this is where the file records it.
-	//
-
-	template <>
-	void Link<OBJ_DATA>(OBJ_DATA *obj)
+	/// One operation now: advancing the walks has to come first, while the node
+	/// still links to its successor, and the erase runs the destructor.
+	template <class T>
+	void Extract(T *entity)
 	{
-		object_list.push_front(std::unique_ptr<OBJ_DATA>(obj));
-		obj->globalNode = object_list.begin();
-	}
-
-	template <>
-	std::vector<OBJ_DATA *> Collect<OBJ_DATA>()
-	{
-		std::vector<OBJ_DATA *> out;
-
-		for (auto &owned : object_list)
-			out.push_back(owned.get());
-
-		return out;
-	}
-
-	/// The unprotected walk, for the same reason the raw one exists: it is what a
-	/// hand-written loop does, and section 2 needs it to show that extracting the
-	/// current element is the safe case either way.
-	template <>
-	void Walk<OBJ_DATA>(const std::function<void(OBJ_DATA *)> &body)
-	{
-		for (auto it = object_list.begin(); it != object_list.end(); )
-		{
-			OBJ_DATA *obj = it->get();
-			++it;
-
-			body(obj);
-		}
-	}
-
-	//
-	// descriptor_list is an owning container now too, and the same collapse
-	// applies: close_socket erasing the node is the destruction, so there is no
-	// "off the list but still alive" state left for a test to construct.
-	//
-
-	template <>
-	void Link<DESCRIPTOR_DATA>(DESCRIPTOR_DATA *d)
-	{
-		descriptor_list.push_front(std::unique_ptr<DESCRIPTOR_DATA>(d));
-		d->globalNode = descriptor_list.begin();
-	}
-
-	template <>
-	std::vector<DESCRIPTOR_DATA *> Collect<DESCRIPTOR_DATA>()
-	{
-		std::vector<DESCRIPTOR_DATA *> out;
-
-		for (auto &owned : descriptor_list)
-			out.push_back(owned.get());
-
-		return out;
-	}
-
-	/// The unprotected walk, for the same reason the raw and object ones exist.
-	template <>
-	void Walk<DESCRIPTOR_DATA>(const std::function<void(DESCRIPTOR_DATA *)> &body)
-	{
-		for (auto it = descriptor_list.begin(); it != descriptor_list.end(); )
-		{
-			DESCRIPTOR_DATA *d = it->get();
-			++it;
-
-			body(d);
-		}
+		OwningCursorRegistry<T>::Advance(entity->globalNode);
+		GlobalList<T>().erase(entity->globalNode);
 	}
 
 	// ─── end of shim ───────────────────────────────────────────────────────
@@ -223,33 +137,15 @@ namespace
 	}
 
 	// Mirrors the order the real extract_char/extract_obj/close_socket use:
-	// advance any walk in flight first, because both the unlink and the free
-	// destroy the link that answer comes from. A walk that registered no cursor
-	// is unaffected, which is what makes section 3 and section 5 differ.
-	void ExtractChar(CHAR_DATA *ch)
-	{
-		CursorRegistry<CHAR_DATA>::Advance(ch);
-		Unlink(ch);
-		free_char(ch);
-	}
-
-	/// One operation now: the erase runs ~obj_data. Advancing the walks has to
-	/// come first, while the node still links to its successor.
-	void ExtractObj(OBJ_DATA *obj)
-	{
-		OwningCursorRegistry<OBJ_DATA>::Advance(obj->globalNode);
-		object_list.erase(obj->globalNode);
-	}
-
-	/// One operation now, as for objects: the erase runs ~descriptor_data.
-	void ExtractDescriptor(DESCRIPTOR_DATA *d)
-	{
-		OwningCursorRegistry<DESCRIPTOR_DATA>::Advance(d->globalNode);
-		descriptor_list.erase(d->globalNode);
-	}
+	// advance any walk in flight first, because the erase destroys the link
+	// that answer comes from. A walk that registered no cursor is unaffected,
+	// which is what makes section 3 and section 5 differ.
+	void ExtractChar(CHAR_DATA *ch)        { Extract(ch); }
+	void ExtractObj(OBJ_DATA *obj)         { Extract(obj); }
+	void ExtractDescriptor(DESCRIPTOR_DATA *d) { Extract(d); }
 
 	/// Leaves the list empty however a scenario ended.
-	void DrainChars()       { while (char_list != nullptr) ExtractChar(char_list); }
+	void DrainChars()       { while (!char_list.empty()) ExtractChar(char_list.front().get()); }
 	void DrainObjs()        { while (!object_list.empty()) ExtractObj(object_list.front().get()); }
 	void DrainDescriptors() { while (!descriptor_list.empty()) ExtractDescriptor(descriptor_list.front().get()); }
 }
@@ -452,161 +348,35 @@ SCENARIO("a walk may extract the entity it was handed", "[entity_storage]")
 //
 // 3. The hazard, and this file's oracle. Extracting the successor mid-walk.
 //
-// Nothing in the game documents that a walk must not extract anything but its
-// current element, and nothing enforces it. When it happens, the cursor is left
-// holding an entity that has already been freed. The damage is not that
-// the walk reads stale bytes. It is that `free_char` *overwrites* `ch->next`
-// with the free-list head on its way out, so the walk's saved successor is a
-// pointer into the free list.
+// RETIRED. This section held two scenarios that asserted the pre-conversion
+// behaviour on purpose, because that is what "no behaviour change" would have
+// meant:
 //
-// The consequences, both pinned below:
+//   - "a walk that extracts its successor abandons the rest of the list", and
+//   - "a walk that extracts its successor continues into the free list".
 //
-//   - the walk leaves the live list at that point and never comes back, so
-//     every entity after the extracted one is silently skipped;
-//   - if the free list is not empty, the walk continues *through it*, handing
-//     the loop body one dead entity after another until the free list runs out.
+// Both rested on the same mechanism. The free lists were threaded through the
+// very `next` field the global lists used, so freeing an entity overwrote the
+// successor a walk had already saved, and the walk left the live list at that
+// point. With char_list converted there is no free list left in the tree and no
+// `next` field to overwrite, so neither scenario has a premise to assert. They
+// were removed rather than rewritten because the rewrite is not a variation on
+// them: an unprotected walk over an owning list holds an iterator to an erased
+// node, which is undefined rather than merely wrong, and there is nothing a
+// test may legally observe about it.
 //
-// So a single misplaced extraction turns one pass over the living into a
-// partial pass plus a full pass over the dead. That is invisible today: the
-// memory is mapped, the fields are readable, and nothing crashes.
+// What replaced them is section 5. The hazard is not gone, it is answered, and
+// answered somewhere a test can watch: extraction advances the cursor before it
+// destroys what the cursor names. Section 5 asserts that directly, which is the
+// assertion these two were standing in for.
 //
-// ┌─ WHEN THE CONTAINERS CONVERT, THIS IS WHERE IT SHOWS ─────────────────────┐
-// │ These two scenarios assert *today's* broken behaviour on purpose, because │
-// │ that is what "no behaviour change" would mean. They are the only          │
-// │ assertions in this file expected to need editing, and editing them is the │
-// │ record of the semantic change.                                            │
-// │                                                                           │
-// │ The replacement is tombstone-and-sweep: extraction marks the entity and   │
-// │ leaves it linked where it is, and a sweep at the end of the pulse does the│
-// │ unlink and the free. Keeping the entity *alive* past the extract would not│
-// │ have been enough on its own. The walk is not following the entity, it is  │
-// │ following the pointer inside the list node, so the node is what has to    │
-// │ stay put. The price is that iteration has to skip tombstones, and these   │
-// │ two scenarios become: the walk visits the living, skips the marked entity,│
-// │ and reaches the end of the list.                                          │
-// └───────────────────────────────────────────────────────────────────────────┘
+// The box that used to sit here predicted tombstone-and-sweep as the
+// replacement. That design was costed during execution and rejected in favour
+// of cursor patching. The prediction being wrong is why it is worth recording:
+// the section named a mechanism rather than the property it wanted, and the
+// property ("keep the pointer the cursor is about to follow valid") is what
+// survived into section 5.
 //
-
-SCENARIO("a walk that extracts its successor abandons the rest of the list", "[entity_storage]")
-{
-	GIVEN("three characters on the list and an empty free list")
-	{
-		CHAR_DATA *oldest = MakeChar();
-		CHAR_DATA *middle = MakeChar();
-		CHAR_DATA *newest = MakeChar();
-
-		Handle<CHAR_DATA> middleHandle = middle->self;
-
-		REQUIRE(Deref(middleHandle) == middle);
-
-		WHEN("the first body call extracts the entity the cursor is about to reach")
-		{
-			std::vector<CHAR_DATA *> visited;
-			bool middleWasLiveWhenVisited = true;
-
-			Walk<CHAR_DATA>([&](CHAR_DATA *ch)
-			{
-				visited.push_back(ch);
-
-				if (ch == newest)
-					ExtractChar(middle);
-
-				if (ch == middle)
-					middleWasLiveWhenVisited = (Deref(middleHandle) != nullptr);
-			});
-
-			THEN("the cursor still lands on the freed entity")
-			{
-				REQUIRE(visited.size() >= 2);
-				REQUIRE(visited[0] == newest);
-				REQUIRE(visited[1] == middle);
-			}
-
-			THEN("its handle was already dead when the walk got there")
-			{
-				// Extraction expires the handle, so no supported reference can
-				// follow the raw cursor here. This is the one guarantee that
-				// does hold, and it is Phase 5's doing rather than the list's.
-				REQUIRE(middleWasLiveWhenVisited == false);
-				REQUIRE(Deref(middleHandle) == nullptr);
-			}
-
-			THEN("and the rest of the live list is never visited at all")
-			{
-				// free_char set middle->next to the free-list head, which was
-				// null, so the walk ended there. `oldest` is still linked and
-				// still alive -- it was simply skipped.
-				REQUIRE(visited.size() == 2);
-				REQUIRE(std::find(visited.begin(), visited.end(), oldest) == visited.end());
-				REQUIRE(Collect<CHAR_DATA>() == std::vector<CHAR_DATA *>({newest, oldest}));
-				REQUIRE(Deref(oldest->self) == oldest);
-			}
-		}
-
-		DrainChars();
-	}
-}
-
-SCENARIO("a walk that extracts its successor continues into the free list", "[entity_storage]")
-{
-	GIVEN("three characters on the list and two corpses on the free list")
-	{
-		CHAR_DATA *oldest = MakeChar();
-		CHAR_DATA *middle = MakeChar();
-		CHAR_DATA *newest = MakeChar();
-
-		// Seeded *after* the live list on purpose. Freeing first does not work:
-		// the MakeChar calls above would pop the corpses straight back off and
-		// reuse their addresses, which is the recycling this phase is removing.
-		CHAR_DATA *corpseA = new_char();
-		CHAR_DATA *corpseB = new_char();
-
-		free_char(corpseA);
-		free_char(corpseB);
-
-		WHEN("the first body call extracts the entity the cursor is about to reach")
-		{
-			std::vector<CHAR_DATA *> visited;
-
-			// Bounded, because the thing being characterised is a walk that has
-			// left the container it thought it was walking.
-			int guard = 0;
-
-			CHAR_DATA *next;
-
-			for (CHAR_DATA *ch = char_list; ch != nullptr && guard < 20; ch = next, guard++)
-			{
-				next = ch->next;
-				visited.push_back(ch);
-
-				if (ch == newest)
-					ExtractChar(middle);
-			}
-
-			THEN("the loop body is handed the free list's contents as if they were live")
-			{
-				// newest (live), middle (just freed), then both corpses, in
-				// free-list order. Four entities for a three-entity list.
-				REQUIRE(visited.size() == 4);
-				REQUIRE(visited[0] == newest);
-				REQUIRE(visited[1] == middle);
-				REQUIRE(visited[2] == corpseB);
-				REQUIRE(visited[3] == corpseA);
-			}
-
-			THEN("three of the four are dead, and the one live straggler was skipped")
-			{
-				REQUIRE(Deref(visited[1]->self) == nullptr);
-				REQUIRE(Deref(visited[2]->self) == nullptr);
-				REQUIRE(Deref(visited[3]->self) == nullptr);
-				REQUIRE(std::find(visited.begin(), visited.end(), oldest) == visited.end());
-				REQUIRE(Deref(oldest->self) == oldest);
-			}
-		}
-
-		DrainChars();
-	}
-}
 
 //
 // 4. Handles across list mutation.
@@ -704,27 +474,21 @@ SCENARIO("a handle survives list mutation and expires exactly at extract", "[ent
 // that successor to instead. These are section 3's setups with the walk swapped,
 // and they are what the walks in the game become as each list converts.
 //
-// object_list is converted, so its walk is OwningListWalk and its successor is a
-// list iterator. The hazard is sharper here than on the raw lists rather than
-// milder: erasing the node really frees the object, so a walk that carried on
-// regardless would be reading freed memory rather than an intact corpse. What
-// makes these pass is the same thing in both cases -- extraction advancing the
-// cursor before it destroys what the cursor names.
+// All four global lists are owning containers, so every walk here is an
+// OwningListWalk and every successor is a list iterator. The hazard is sharper
+// than it was on the raw lists rather than milder: erasing the node really frees
+// the entity, so a walk that carried on regardless would be reading freed memory
+// rather than an intact corpse. What makes these pass is extraction advancing
+// the cursor before it destroys what the cursor names.
+//
+// The raw-list form of this helper is gone with the last raw list. ListWalk and
+// CursorRegistry survive in list_cursor.h with no caller left in the tree.
 //
 
 namespace
 {
-	/// The section 3 walk, rewritten against ListWalk. Same contract: the body
-	/// sees each entity the walk lands on.
-	template <class T>
-	void CursorWalk(T *head, const std::function<void(T *)> &body)
-	{
-		for (ListWalk<T> walk(head); !walk.Done(); walk.Step())
-			body(walk.Current());
-	}
-
-	/// The owning-container form. It takes the list rather than a head pointer,
-	/// which is the one call-site change the conversion forces here.
+	/// The walk under test. Same contract as the unprotected one in the shim:
+	/// the body sees each entity the walk lands on.
 	void CursorWalk(ObjectList &list, const std::function<void(OBJ_DATA *)> &body)
 	{
 		for (OwningListWalk<OBJ_DATA> walk(list); !walk.Done(); walk.Step())

--- a/tests/entity_storage_tests.c
+++ b/tests/entity_storage_tests.c
@@ -1,0 +1,593 @@
+#include "catch.hpp"
+#include "../code/merc.h"
+#include "../code/db.h"
+#include "../code/comm.h"
+#include "../code/recycle.h"
+#include "../code/handler.h"
+#include "../code/entity/char_data.h"
+#include "../code/entity/obj_data.h"
+#include "../code/entity/handles.h"
+
+#include <algorithm>
+#include <functional>
+#include <vector>
+
+//
+// Storage for the three global entity lists: char_list, object_list and
+// descriptor_list.
+//
+// These lists are what decides an entity's lifetime. The containment chains
+// (room->people, ch->carrying, obj->contains) are a game rule about where
+// things are, not about when they die. Today each global list is an intrusive
+// singly-linked chain through an entity's `next` field, and `free_char` and
+// friends push the entity onto a free list rather than returning its memory,
+// so an address is handed straight back out to the next allocation.
+//
+// This file characterises the storage behaviour the game currently depends on,
+// so that the same assertions can be run after the lists become owning
+// containers. Every scenario is written against the five-function shim below;
+// converting the containers means rewriting those five bodies. Anything
+// *outside* the shim that has to be edited to keep this file compiling and
+// green is a behaviour change, and finding those is the whole point.
+//
+// The interesting case is the last two scenarios. A walk that unlinks the
+// element it is looking at is safe by construction, because every walk in the
+// game captures the successor before running its body. A walk that unlinks the
+// *successor* is not, and the damage is bigger than reading stale bytes: the
+// free lists are threaded through the very same `next` field, so freeing an
+// entity overwrites the successor the walk had already saved. The walk stops
+// following the live list and starts following the free list. Section 3 pins
+// both halves of that.
+//
+
+namespace
+{
+	// ─── the storage shim ──────────────────────────────────────────────────
+	//
+	// One head accessor and four operations. These are the only bodies in this
+	// file that know how the lists are built.
+	//
+
+	template <class T> T *&ListHead();
+
+	template <> CHAR_DATA *&ListHead<CHAR_DATA>() { return char_list; }
+	template <> OBJ_DATA *&ListHead<OBJ_DATA>() { return object_list; }
+	template <> DESCRIPTOR_DATA *&ListHead<DESCRIPTOR_DATA>() { return descriptor_list; }
+
+	/// Puts an entity on its global list, the way db.c/comm.c do it: push front.
+	template <class T>
+	void Link(T *entity)
+	{
+		entity->next = ListHead<T>();
+		ListHead<T>() = entity;
+	}
+
+	/// Takes an entity off its global list. Mirrors extract_char/extract_obj/
+	/// close_socket, including the linear scan for the predecessor.
+	template <class T>
+	void Unlink(T *entity)
+	{
+		if (ListHead<T>() == entity)
+		{
+			ListHead<T>() = entity->next;
+			return;
+		}
+
+		for (T *prev = ListHead<T>(); prev != nullptr; prev = prev->next)
+		{
+			if (prev->next == entity)
+			{
+				prev->next = entity->next;
+				return;
+			}
+		}
+	}
+
+	/// The list as a vector, head first.
+	template <class T>
+	std::vector<T *> Collect()
+	{
+		std::vector<T *> out;
+
+		for (T *entity = ListHead<T>(); entity != nullptr; entity = entity->next)
+			out.push_back(entity);
+
+		return out;
+	}
+
+	/// Walks the live list the way the game does in 164 places: the successor is
+	/// read before the body runs, so the body is free to unlink the element it
+	/// was handed. `body` sees each entity the cursor lands on, including any it
+	/// should not have.
+	template <class T>
+	void Walk(const std::function<void(T *)> &body)
+	{
+		T *next;
+
+		for (T *entity = ListHead<T>(); entity != nullptr; entity = next)
+		{
+			next = entity->next;
+			body(entity);
+		}
+	}
+
+	// ─── end of shim ───────────────────────────────────────────────────────
+
+	//
+	// Entities come from the real allocators so that they are registered in the
+	// slot map and their liveness is something a test can assert on. Extract*
+	// pairs the list unlink with the free, which is what extract_char and
+	// extract_obj do for storage purposes -- without dragging in rooms, carried
+	// objects or the event queue, none of which this file is about.
+	//
+
+	CHAR_DATA *MakeChar()
+	{
+		CHAR_DATA *ch = new_char();
+		Link(ch);
+		return ch;
+	}
+
+	OBJ_DATA *MakeObj()
+	{
+		OBJ_DATA *obj = new_obj();
+		Link(obj);
+		return obj;
+	}
+
+	DESCRIPTOR_DATA *MakeDescriptor()
+	{
+		DESCRIPTOR_DATA *d = new_descriptor();
+		Link(d);
+		return d;
+	}
+
+	void ExtractChar(CHAR_DATA *ch)   { Unlink(ch); free_char(ch); }
+	void ExtractObj(OBJ_DATA *obj)    { Unlink(obj); free_obj(obj); }
+	void ExtractDescriptor(DESCRIPTOR_DATA *d) { Unlink(d); free_descriptor(d); }
+
+	/// Leaves the list empty however a scenario ended.
+	void DrainChars()       { while (char_list != nullptr) ExtractChar(char_list); }
+	void DrainObjs()        { while (object_list != nullptr) ExtractObj(object_list); }
+	void DrainDescriptors() { while (descriptor_list != nullptr) ExtractDescriptor(descriptor_list); }
+}
+
+//
+// 1. Link, walk, unlink -- order and count, for each of the three lists.
+//
+
+SCENARIO("a global list hands entities back in the order they were linked", "[entity_storage]")
+{
+	GIVEN("three characters linked one after another")
+	{
+		CHAR_DATA *first = MakeChar();
+		CHAR_DATA *second = MakeChar();
+		CHAR_DATA *third = MakeChar();
+
+		THEN("the list reads newest first")
+		{
+			REQUIRE(Collect<CHAR_DATA>() == std::vector<CHAR_DATA *>({third, second, first}));
+		}
+
+		DrainChars();
+	}
+
+	GIVEN("three objects linked one after another")
+	{
+		OBJ_DATA *first = MakeObj();
+		OBJ_DATA *second = MakeObj();
+		OBJ_DATA *third = MakeObj();
+
+		THEN("the list reads newest first")
+		{
+			REQUIRE(Collect<OBJ_DATA>() == std::vector<OBJ_DATA *>({third, second, first}));
+		}
+
+		DrainObjs();
+	}
+
+	GIVEN("three descriptors linked one after another")
+	{
+		DESCRIPTOR_DATA *first = MakeDescriptor();
+		DESCRIPTOR_DATA *second = MakeDescriptor();
+		DESCRIPTOR_DATA *third = MakeDescriptor();
+
+		THEN("the list reads newest first")
+		{
+			REQUIRE(Collect<DESCRIPTOR_DATA>() == std::vector<DESCRIPTOR_DATA *>({third, second, first}));
+		}
+
+		DrainDescriptors();
+	}
+}
+
+SCENARIO("unlinking leaves the rest of the list intact wherever it happened", "[entity_storage]")
+{
+	GIVEN("three characters on the list, newest first")
+	{
+		CHAR_DATA *oldest = MakeChar();
+		CHAR_DATA *middle = MakeChar();
+		CHAR_DATA *newest = MakeChar();
+
+		WHEN("the head is unlinked")
+		{
+			ExtractChar(newest);
+
+			THEN("the other two remain in order")
+			{
+				REQUIRE(Collect<CHAR_DATA>() == std::vector<CHAR_DATA *>({middle, oldest}));
+			}
+		}
+
+		WHEN("the middle is unlinked")
+		{
+			ExtractChar(middle);
+
+			THEN("the head and tail close up")
+			{
+				REQUIRE(Collect<CHAR_DATA>() == std::vector<CHAR_DATA *>({newest, oldest}));
+			}
+		}
+
+		WHEN("the tail is unlinked")
+		{
+			ExtractChar(oldest);
+
+			THEN("the other two remain in order")
+			{
+				REQUIRE(Collect<CHAR_DATA>() == std::vector<CHAR_DATA *>({newest, middle}));
+			}
+		}
+
+		WHEN("the only remaining entity is unlinked")
+		{
+			ExtractChar(newest);
+			ExtractChar(middle);
+			ExtractChar(oldest);
+
+			THEN("the list is empty")
+			{
+				REQUIRE(Collect<CHAR_DATA>().empty());
+			}
+		}
+
+		DrainChars();
+	}
+}
+
+//
+// 2. The safe case. Extracting the element the walk is looking at.
+//
+// Safe because the walk reads the successor before running the body. This has
+// to keep behaving identically: it is what every death, logout and object
+// destruction in the game does.
+//
+
+SCENARIO("a walk may extract the entity it was handed", "[entity_storage]")
+{
+	GIVEN("three characters on the list")
+	{
+		CHAR_DATA *oldest = MakeChar();
+		CHAR_DATA *middle = MakeChar();
+		CHAR_DATA *newest = MakeChar();
+
+		WHEN("the walk extracts the middle one as it reaches it")
+		{
+			std::vector<CHAR_DATA *> visited;
+
+			Walk<CHAR_DATA>([&](CHAR_DATA *ch)
+			{
+				visited.push_back(ch);
+
+				if (ch == middle)
+					ExtractChar(ch);
+			});
+
+			THEN("every entity was visited exactly once, in order")
+			{
+				REQUIRE(visited == std::vector<CHAR_DATA *>({newest, middle, oldest}));
+			}
+
+			THEN("the extracted one is off the list and the others are not")
+			{
+				REQUIRE(Collect<CHAR_DATA>() == std::vector<CHAR_DATA *>({newest, oldest}));
+			}
+		}
+
+		WHEN("the walk extracts every entity it is handed")
+		{
+			int visits = 0;
+
+			Walk<CHAR_DATA>([&](CHAR_DATA *ch)
+			{
+				visits++;
+				ExtractChar(ch);
+			});
+
+			THEN("the walk completed and the list is empty")
+			{
+				REQUIRE(visits == 3);
+				REQUIRE(Collect<CHAR_DATA>().empty());
+			}
+		}
+
+		DrainChars();
+	}
+
+	GIVEN("three objects on the list")
+	{
+		OBJ_DATA *oldest = MakeObj();
+		OBJ_DATA *middle = MakeObj();
+		OBJ_DATA *newest = MakeObj();
+
+		WHEN("the walk extracts the middle one as it reaches it")
+		{
+			std::vector<OBJ_DATA *> visited;
+
+			Walk<OBJ_DATA>([&](OBJ_DATA *obj)
+			{
+				visited.push_back(obj);
+
+				if (obj == middle)
+					ExtractObj(obj);
+			});
+
+			THEN("every entity was visited exactly once, in order")
+			{
+				REQUIRE(visited == std::vector<OBJ_DATA *>({newest, middle, oldest}));
+			}
+
+			THEN("the extracted one is off the list and the others are not")
+			{
+				REQUIRE(Collect<OBJ_DATA>() == std::vector<OBJ_DATA *>({newest, oldest}));
+			}
+		}
+
+		DrainObjs();
+	}
+}
+
+//
+// 3. The hazard, and this file's oracle. Extracting the successor mid-walk.
+//
+// Nothing in the game documents that a walk must not extract anything but its
+// current element, and nothing enforces it. When it happens, the cursor is left
+// holding an entity that has already been freed. The damage is not that
+// the walk reads stale bytes. It is that `free_char` *overwrites* `ch->next`
+// with the free-list head on its way out, so the walk's saved successor is a
+// pointer into the free list.
+//
+// The consequences, both pinned below:
+//
+//   - the walk leaves the live list at that point and never comes back, so
+//     every entity after the extracted one is silently skipped;
+//   - if the free list is not empty, the walk continues *through it*, handing
+//     the loop body one dead entity after another until the free list runs out.
+//
+// So a single misplaced extraction turns one pass over the living into a
+// partial pass plus a full pass over the dead. That is invisible today: the
+// memory is mapped, the fields are readable, and nothing crashes.
+//
+// ┌─ WHEN THE CONTAINERS CONVERT, THIS IS WHERE IT SHOWS ─────────────────────┐
+// │ These two scenarios assert *today's* broken behaviour on purpose, because │
+// │ that is what "no behaviour change" would mean. They are the only          │
+// │ assertions in this file expected to need editing, and editing them is the │
+// │ record of the semantic change. After conversion the same code cannot      │
+// │ silently continue. A saved iterator to an erased node is a hard failure   │
+// │ and a sanitizer report, which is the improvement being bought.            │
+// │                                                                           │
+// │ Note this is NOT fixed by keeping the entity alive past the extract: the  │
+// │ entity's lifetime is not what the walk is following, the list node is.    │
+// │ Preserving these semantics needs the *unlink* deferred, not just the      │
+// │ free, ie. the node tombstoned in place and erased later.                  │
+// └───────────────────────────────────────────────────────────────────────────┘
+//
+
+SCENARIO("a walk that extracts its successor abandons the rest of the list", "[entity_storage]")
+{
+	GIVEN("three characters on the list and an empty free list")
+	{
+		CHAR_DATA *oldest = MakeChar();
+		CHAR_DATA *middle = MakeChar();
+		CHAR_DATA *newest = MakeChar();
+
+		Handle<CHAR_DATA> middleHandle = middle->self;
+
+		REQUIRE(Deref(middleHandle) == middle);
+
+		WHEN("the first body call extracts the entity the cursor is about to reach")
+		{
+			std::vector<CHAR_DATA *> visited;
+			bool middleWasLiveWhenVisited = true;
+
+			Walk<CHAR_DATA>([&](CHAR_DATA *ch)
+			{
+				visited.push_back(ch);
+
+				if (ch == newest)
+					ExtractChar(middle);
+
+				if (ch == middle)
+					middleWasLiveWhenVisited = (Deref(middleHandle) != nullptr);
+			});
+
+			THEN("the cursor still lands on the freed entity")
+			{
+				REQUIRE(visited.size() >= 2);
+				REQUIRE(visited[0] == newest);
+				REQUIRE(visited[1] == middle);
+			}
+
+			THEN("its handle was already dead when the walk got there")
+			{
+				// Extraction expires the handle, so no supported reference can
+				// follow the raw cursor here. This is the one guarantee that
+				// does hold, and it is Phase 5's doing rather than the list's.
+				REQUIRE(middleWasLiveWhenVisited == false);
+				REQUIRE(Deref(middleHandle) == nullptr);
+			}
+
+			THEN("and the rest of the live list is never visited at all")
+			{
+				// free_char set middle->next to the free-list head, which was
+				// null, so the walk ended there. `oldest` is still linked and
+				// still alive -- it was simply skipped.
+				REQUIRE(visited.size() == 2);
+				REQUIRE(std::find(visited.begin(), visited.end(), oldest) == visited.end());
+				REQUIRE(Collect<CHAR_DATA>() == std::vector<CHAR_DATA *>({newest, oldest}));
+				REQUIRE(Deref(oldest->self) == oldest);
+			}
+		}
+
+		DrainChars();
+	}
+}
+
+SCENARIO("a walk that extracts its successor continues into the free list", "[entity_storage]")
+{
+	GIVEN("three characters on the list and two corpses on the free list")
+	{
+		CHAR_DATA *oldest = MakeChar();
+		CHAR_DATA *middle = MakeChar();
+		CHAR_DATA *newest = MakeChar();
+
+		// Seeded *after* the live list on purpose. Freeing first does not work:
+		// the MakeChar calls above would pop the corpses straight back off and
+		// reuse their addresses, which is the recycling this phase is removing.
+		CHAR_DATA *corpseA = new_char();
+		CHAR_DATA *corpseB = new_char();
+
+		free_char(corpseA);
+		free_char(corpseB);
+
+		WHEN("the first body call extracts the entity the cursor is about to reach")
+		{
+			std::vector<CHAR_DATA *> visited;
+
+			// Bounded, because the thing being characterised is a walk that has
+			// left the container it thought it was walking.
+			int guard = 0;
+
+			CHAR_DATA *next;
+
+			for (CHAR_DATA *ch = char_list; ch != nullptr && guard < 20; ch = next, guard++)
+			{
+				next = ch->next;
+				visited.push_back(ch);
+
+				if (ch == newest)
+					ExtractChar(middle);
+			}
+
+			THEN("the loop body is handed the free list's contents as if they were live")
+			{
+				// newest (live), middle (just freed), then both corpses, in
+				// free-list order. Four entities for a three-entity list.
+				REQUIRE(visited.size() == 4);
+				REQUIRE(visited[0] == newest);
+				REQUIRE(visited[1] == middle);
+				REQUIRE(visited[2] == corpseB);
+				REQUIRE(visited[3] == corpseA);
+			}
+
+			THEN("three of the four are dead, and the one live straggler was skipped")
+			{
+				REQUIRE(Deref(visited[1]->self) == nullptr);
+				REQUIRE(Deref(visited[2]->self) == nullptr);
+				REQUIRE(Deref(visited[3]->self) == nullptr);
+				REQUIRE(std::find(visited.begin(), visited.end(), oldest) == visited.end());
+				REQUIRE(Deref(oldest->self) == oldest);
+			}
+		}
+
+		DrainChars();
+	}
+}
+
+//
+// 4. Handles across list mutation.
+//
+// The slot map stores plain pointers to entities allocated elsewhere and never
+// moves them, so linking and unlinking other entities must not disturb a
+// handle. Expiry happens at exactly one point: the free.
+//
+
+SCENARIO("a handle survives list mutation and expires exactly at extract", "[entity_storage]")
+{
+	GIVEN("a character with a handle taken to it")
+	{
+		CHAR_DATA *watched = MakeChar();
+		Handle<CHAR_DATA> handle = watched->self;
+
+		REQUIRE(Deref(handle) == watched);
+
+		WHEN("other entities are linked in front of it")
+		{
+			CHAR_DATA *other = MakeChar();
+			CHAR_DATA *another = MakeChar();
+
+			THEN("the handle still resolves to the same character")
+			{
+				REQUIRE(Deref(handle) == watched);
+			}
+
+			WHEN("those others are extracted again")
+			{
+				ExtractChar(another);
+				ExtractChar(other);
+
+				THEN("the handle is untouched")
+				{
+					REQUIRE(Deref(handle) == watched);
+					REQUIRE(Collect<CHAR_DATA>() == std::vector<CHAR_DATA *>({watched}));
+				}
+			}
+		}
+
+		WHEN("the character itself is extracted")
+		{
+			ExtractChar(watched);
+
+			THEN("the handle is expired")
+			{
+				REQUIRE(Deref(handle) == nullptr);
+			}
+		}
+
+		DrainChars();
+	}
+
+	GIVEN("an object with a handle taken to it")
+	{
+		OBJ_DATA *watched = MakeObj();
+		Handle<OBJ_DATA> handle = watched->self;
+
+		REQUIRE(Deref(handle) == watched);
+
+		WHEN("another object is linked and extracted")
+		{
+			OBJ_DATA *other = MakeObj();
+
+			REQUIRE(Deref(handle) == watched);
+
+			ExtractObj(other);
+
+			THEN("the handle still resolves")
+			{
+				REQUIRE(Deref(handle) == watched);
+			}
+		}
+
+		WHEN("the object itself is extracted")
+		{
+			ExtractObj(watched);
+
+			THEN("the handle is expired")
+			{
+				REQUIRE(Deref(handle) == nullptr);
+			}
+		}
+
+		DrainObjs();
+	}
+}

--- a/tests/fight_tests.c
+++ b/tests/fight_tests.c
@@ -63,23 +63,17 @@ namespace
 		ch->hit = 100;
 		ch->position = POS_FIGHTING;
 
-		ch->next = char_list;
-		char_list = ch;
+		char_list.push_front(std::unique_ptr<CHAR_DATA>(ch));
+		ch->globalNode = char_list.begin();
 
 		return ch;
 	}
 
 	void ClearCombatants()
 	{
-		CHAR_DATA *next;
-
-		for (CHAR_DATA *ch = char_list; ch != nullptr; ch = next)
-		{
-			next = ch->next;
-			free_char(ch);
-		}
-
-		char_list = nullptr;
+		// Erasing the node is what destroys the character now, so clearing the
+		// list is the whole teardown.
+		char_list.clear();
 	}
 }
 

--- a/tests/handler_tests.c
+++ b/tests/handler_tests.c
@@ -798,7 +798,7 @@ SCENARIO("a recycled character address does not resurrect an old handle", "[hand
 
 			THEN("the old handle stays expired even though the address matches")
 			{
-				// The free list really did hand back the same memory -- if it
+				// The free list really did hand back the same memory. If it
 				// ever stops doing so this test is still correct, just less
 				// pointed, so it is asserted rather than assumed.
 				REQUIRE(second == first);
@@ -1076,9 +1076,9 @@ SCENARIO("a character is not left pointing at furniture that was destroyed", "[o
 		WHEN("the object is destroyed without going through obj_from_room")
 		{
 			// obj_from_room clears the reference for anyone in the room, so it
-			// hides this case. The paths that do not run it -- extract_obj's
-			// not-found bail-out, or an object freed while held -- are the ones
-			// that used to leave a pointer into a recycled object behind.
+			// hides this case. Two paths do not run it: extract_obj's not-found
+			// bail-out, and an object freed while held. Those are the ones that
+			// used to leave a pointer into a recycled object behind.
 			free_obj(chair);
 
 			THEN("the reference reads as nothing rather than as freed memory")
@@ -1961,13 +1961,14 @@ SCENARIO("a switched immortal's original body does not outlive it", "[descriptor
 //     else
 //         free_char(dclose->original ? dclose->original : dclose->character);
 //     ...
-//     free_descriptor(dclose);
+//     descriptor_list.erase(dclose->globalNode);
 //
 // Take the else branch with an immortal switched into a mob and it frees the
-// immortal, never touches the mob, and then frees the descriptor -- leaving the
-// mob naming a descriptor on the free list. DESCRIPTOR_DATA is recycled through
-// descriptor_free, so the next connection gets that address and the mob is
-// suddenly holding a live player's socket.
+// immortal, never touches the mob, and then destroys the descriptor, leaving
+// the mob naming one that is gone. The address is no longer handed straight back
+// out, but the slot map does recycle the freed slot, so an index-only reference
+// would still find the next connection there and the mob would be holding a live
+// player's socket.
 //
 // Narrow: it needs a shutdown or a non-CON_PLAYING close with a switch in
 // effect. It is the least severe dangle in the graph, not the worst.
@@ -2042,13 +2043,22 @@ SCENARIO("a possessed mob does not outlive the connection driving it", "[chdesc]
 				REQUIRE(Connection(mob) == nullptr);
 			}
 
-			THEN("the next connection to take the address is not adopted")
+			THEN("the next connection to take the slot is not adopted")
 			{
 				// Every reader of this field asks "is this a player with a live
 				// connection", so a recycled descriptor turns a mob into one.
+				//
+				// The address is no longer what gets recycled, because a closed
+				// descriptor is really destroyed now. But the slot map still
+				// hands the freed slot to the next Add, and the slot is what a
+				// handle names. Holding SlotCount steady across the reissue is
+				// what proves the reuse happened, and so keeps the assertion
+				// below from passing for the trivial reason.
+				std::size_t slotsBefore = descriptorHandles.SlotCount();
+
 				DESCRIPTOR_DATA *newcomer = new_descriptor();
 
-				REQUIRE(newcomer == d);
+				REQUIRE(descriptorHandles.SlotCount() == slotsBefore);
 				REQUIRE(Connection(mob) != newcomer);
 
 				free_descriptor(newcomer);
@@ -2703,15 +2713,18 @@ SCENARIO("a snoop does not outlive the connection running it", "[snoop]")
 				REQUIRE(SnoopedBy(watched) == nullptr);
 			}
 
-			THEN("it still names none once the address is reissued")
+			THEN("it still names none once the slot is reissued")
 			{
 				// This is the part the sweep could not have given: a reused
-				// descriptor address would have satisfied a raw pointer, and
-				// every reader of this field writes the snooped output
-				// straight into whatever it names.
+				// descriptor slot would have satisfied an index-only reference,
+				// and every reader of this field writes the snooped output
+				// straight into whatever it names. SlotCount holding steady is
+				// what proves the freed slot really was handed back out.
+				std::size_t slotsBefore = descriptorHandles.SlotCount();
+
 				DESCRIPTOR_DATA *newcomer = new_descriptor();
 
-				REQUIRE(newcomer == snooper);
+				REQUIRE(descriptorHandles.SlotCount() == slotsBefore);
 				REQUIRE(SnoopedBy(watched) != newcomer);
 
 				free_descriptor(newcomer);

--- a/tests/handler_tests.c
+++ b/tests/handler_tests.c
@@ -784,24 +784,30 @@ SCENARIO("new_char registers a character and free_char expires it", "[handles]")
 	}
 }
 
-SCENARIO("a recycled character address does not resurrect an old handle", "[handles]")
+SCENARIO("a recycled character slot does not resurrect an old handle", "[handles]")
 {
-	GIVEN("a character that has been freed back onto the free list")
+	GIVEN("a character that has been destroyed")
 	{
 		CHAR_DATA *first = new_char();
 		Handle<CHAR_DATA> stale = first->self;
+
 		free_char(first);
 
-		WHEN("a new character is allocated, reusing that address")
+		WHEN("a new character is allocated, reusing that slot")
 		{
+			// The address is no longer what gets recycled, because a destroyed
+			// character is really deleted now. But the slot map still hands the
+			// freed slot to the next Add, and the slot is what a handle names.
+			// Holding SlotCount steady across the allocation is what proves the
+			// reuse happened, and so keeps the assertions below from passing
+			// for the trivial reason.
+			std::size_t slotsBefore = charHandles.SlotCount();
+
 			CHAR_DATA *second = new_char();
 
-			THEN("the old handle stays expired even though the address matches")
+			THEN("the old handle stays expired even though the slot matches")
 			{
-				// The free list really did hand back the same memory. If it
-				// ever stops doing so this test is still correct, just less
-				// pointed, so it is asserted rather than assumed.
-				REQUIRE(second == first);
+				REQUIRE(charHandles.SlotCount() == slotsBefore);
 
 				REQUIRE(Deref(stale) == nullptr);
 				REQUIRE(stale != second->self);
@@ -813,33 +819,40 @@ SCENARIO("a recycled character address does not resurrect an old handle", "[hand
 	}
 }
 
-SCENARIO("freeing a character twice is a silent no-op", "[handles]")
+// Freeing the same character twice used to be spelled with a raw pointer, and
+// the free list is what made that legal to write: the struct stayed mapped, so
+// the second call could still read `ch->self`, find the slot retired and bail
+// out. Now the first free really deletes, and reading `ch->self` afterwards is
+// a use-after-free before any guard gets a chance to run.
+//
+// What survives is the property production actually relies on. Every one of the
+// nine free_char call sites reaches its character through Deref of a handle, so
+// once the first free expires the slot the second call is handed nullptr. The
+// handle is the guard, and it is a guard against the double free rather than a
+// recovery from it.
+SCENARIO("freeing a character twice through its handle is a silent no-op", "[handles]")
 {
 	GIVEN("a character that has already been freed")
 	{
 		CHAR_DATA *ch = new_char();
+		Handle<CHAR_DATA> handle = ch->self;
 
 		free_char(ch);
 
-		WHEN("it is freed again, as the old `valid` bool used to allow")
+		WHEN("the same handle is freed again, as the login paths do")
 		{
-			// This is the half of `valid` that was never about weak references:
-			// it guarded free_char against running twice over the same struct,
-			// which would free its strings twice and put it on char_free twice.
-			// The handle answers the same question -- `Deref(ch->self) != ch`
-			// once the slot is retired -- so the bool became redundant rather
-			// than merely replaceable.
-			free_char(ch);
+			REQUIRE(Deref(handle) == nullptr);
 
-			THEN("the character is on the free list exactly once")
+			free_char(Deref(handle));
+
+			THEN("nothing was destroyed twice and allocation carries on")
 			{
-				// If the guard had failed, ch would be its own ->next and
-				// new_char would return the same address twice running.
 				CHAR_DATA *first = new_char();
 				CHAR_DATA *second = new_char();
 
-				REQUIRE(first == ch);
-				REQUIRE(second != first);
+				REQUIRE(first != second);
+				REQUIRE(Deref(first->self) == first);
+				REQUIRE(Deref(second->self) == second);
 
 				free_char(first);
 				free_char(second);
@@ -858,11 +871,15 @@ SCENARIO("freeing a character the slot maps never issued does nothing", "[handle
 		{
 			// It has a null self handle, so it never resolves to itself and the
 			// guard rejects it. The old bool did the same by being false, but
-			// only because value-initialisation happened to zero it; here it is
+			// only because value-initialisation happened to zero it. Here it is
 			// the type's stated invariant rather than a coincidence.
+			//
+			// The guard matters more now than it did. Getting it wrong used to
+			// mean adopting a stack address onto the free list. It now means
+			// calling delete on one.
 			free_char(&ch);
 
-			THEN("it is not adopted onto the free list")
+			THEN("it is neither destroyed nor handed back out")
 			{
 				CHAR_DATA *fresh = new_char();
 
@@ -1129,8 +1146,8 @@ namespace
 		mob->next_in_room = room->people;
 		room->people = mob;
 
-		mob->next = char_list;
-		char_list = mob;
+		char_list.push_front(std::unique_ptr<CHAR_DATA>(mob));
+		mob->globalNode = char_list.begin();
 
 		return mob;
 	}
@@ -1145,15 +1162,9 @@ namespace
 
 	void ClearTrackers()
 	{
-		CHAR_DATA *next;
-
-		for (CHAR_DATA *ch = char_list; ch != nullptr; ch = next)
-		{
-			next = ch->next;
-			free_char(ch);
-		}
-
-		char_list = nullptr;
+		// Erasing the node is what destroys the character now, so clearing the
+		// list is the whole teardown.
+		char_list.clear();
 	}
 }
 
@@ -1593,11 +1604,17 @@ SCENARIO("a secret trailer does not outlive the master it was trailing", "[follo
 				REQUIRE(Master(trailer) == nullptr);
 			}
 
-			THEN("the address really was reissued, which is what made this silent")
+			THEN("the slot really was reissued, which is what made this silent")
 			{
+				// The slot rather than the address: a destroyed character is really
+				// deleted now, so reuse of the memory is an allocator accident. The
+				// slot map does still recycle the freed slot, and the slot is what a
+				// handle names, so this is what keeps the assertion below honest.
+				std::size_t slotsBefore = charHandles.SlotCount();
+
 				CHAR_DATA *newcomer = new_char();
 
-				REQUIRE(newcomer == master);
+				REQUIRE(charHandles.SlotCount() == slotsBefore);
 				REQUIRE(Master(trailer) == nullptr);
 			}
 		}
@@ -1695,11 +1712,17 @@ SCENARIO("defending and analyzePC do not outlive their target", "[defending]")
 				REQUIRE(Analyzing(analyzer) == nullptr);
 			}
 
-			THEN("they stay nothing even once the address is reissued")
+			THEN("they stay nothing even once the slot is reissued")
 			{
+				// The slot rather than the address: a destroyed character is really
+				// deleted now, so reuse of the memory is an allocator accident. The
+				// slot map does still recycle the freed slot, and the slot is what a
+				// handle names, so this is what keeps the assertion below honest.
+				std::size_t slotsBefore = charHandles.SlotCount();
+
 				CHAR_DATA *newcomer = new_char();
 
-				REQUIRE(newcomer == target);
+				REQUIRE(charHandles.SlotCount() == slotsBefore);
 				REQUIRE(Defending(protector) == nullptr);
 				REQUIRE(Analyzing(analyzer) == nullptr);
 			}
@@ -1789,15 +1812,21 @@ SCENARIO("a mob's quarry does not outlive it", "[hunting]")
 				REQUIRE(Hunting(anchor) == nullptr);
 			}
 
-			THEN("the next character to take the address is not mistaken for it")
+			THEN("the next character to take the slot is not mistaken for it")
 			{
 				// The whole defect, in three lines. Every reachable reader of
 				// this field walks char_list asking "is this the mob hunting
 				// me?" and answers with ==, so the newcomer used to inherit the
 				// dead character's anchor rather than crash on it.
+				// The slot rather than the address: a destroyed character is really
+				// deleted now, so reuse of the memory is an allocator accident. The
+				// slot map does still recycle the freed slot, and the slot is what a
+				// handle names, so this is what keeps the assertion below honest.
+				std::size_t slotsBefore = charHandles.SlotCount();
+
 				CHAR_DATA *newcomer = new_char();
 
-				REQUIRE(newcomer == quarry);
+				REQUIRE(charHandles.SlotCount() == slotsBefore);
 				REQUIRE(Hunting(anchor) != newcomer);
 				REQUIRE(Hunting(anchor) == nullptr);
 			}
@@ -1893,11 +1922,17 @@ SCENARIO("a descriptor's body reference does not outlive the body", "[descriptor
 				REQUIRE(Body(d) == nullptr);
 			}
 
-			THEN("the next character to take the address is not adopted")
+			THEN("the next character to take the slot is not adopted")
 			{
+				// The slot rather than the address: a destroyed character is really
+				// deleted now, so reuse of the memory is an allocator accident. The
+				// slot map does still recycle the freed slot, and the slot is what a
+				// handle names, so this is what keeps the assertion below honest.
+				std::size_t slotsBefore = charHandles.SlotCount();
+
 				CHAR_DATA *newcomer = new_char();
 
-				REQUIRE(newcomer == player);
+				REQUIRE(charHandles.SlotCount() == slotsBefore);
 				REQUIRE(Body(d) != newcomer);
 			}
 		}
@@ -1938,9 +1973,15 @@ SCENARIO("a switched immortal's original body does not outlive it", "[descriptor
 				// check_playing reads `dold->original->true_name` for every
 				// descriptor on every login, so this one is dereferenced, not
 				// just compared.
+				// The slot rather than the address: a destroyed character is really
+				// deleted now, so reuse of the memory is an allocator accident. The
+				// slot map does still recycle the freed slot, and the slot is what a
+				// handle names, so this is what keeps the assertion below honest.
+				std::size_t slotsBefore = charHandles.SlotCount();
+
 				CHAR_DATA *newcomer = new_char();
 
-				REQUIRE(newcomer == immortal);
+				REQUIRE(charHandles.SlotCount() == slotsBefore);
 				REQUIRE(OriginalBody(d) != newcomer);
 			}
 		}
@@ -2279,9 +2320,15 @@ SCENARIO("trust does not outlive the trusted player", "[trusting]")
 
 			THEN("it stays nothing once the address is reissued")
 			{
+				// The slot rather than the address: a destroyed character is really
+				// deleted now, so reuse of the memory is an allocator accident. The
+				// slot map does still recycle the freed slot, and the slot is what a
+				// handle names, so this is what keeps the assertion below honest.
+				std::size_t slotsBefore = charHandles.SlotCount();
+
 				CHAR_DATA *newcomer = new_char();
 
-				REQUIRE(newcomer == trusted);
+				REQUIRE(charHandles.SlotCount() == slotsBefore);
 				REQUIRE(Trusting(truster) != newcomer);
 			}
 		}
@@ -2494,9 +2541,15 @@ SCENARIO("an affect does not remember a caster who has left the world", "[affect
 				// The whole point. free_char pushes onto a free list, so the
 				// next new_char hands back the caster's address; a raw
 				// back-reference would silently start naming the newcomer.
+				// The slot rather than the address: a destroyed character is really
+				// deleted now, so reuse of the memory is an allocator accident. The
+				// slot map does still recycle the freed slot, and the slot is what a
+				// handle names, so this is what keeps the assertion below honest.
+				std::size_t slotsBefore = charHandles.SlotCount();
+
 				CHAR_DATA *newcomer = new_char();
 
-				REQUIRE(newcomer == caster);
+				REQUIRE(charHandles.SlotCount() == slotsBefore);
 				REQUIRE(AffectOwner(af) != newcomer);
 				REQUIRE(AffectOwner(af) == nullptr);
 			}
@@ -2533,9 +2586,15 @@ SCENARIO("an object's affect does not remember a caster who has left the world",
 
 			THEN("it still names nobody once the address is reissued")
 			{
+				// The slot rather than the address: a destroyed character is really
+				// deleted now, so reuse of the memory is an allocator accident. The
+				// slot map does still recycle the freed slot, and the slot is what a
+				// handle names, so this is what keeps the assertion below honest.
+				std::size_t slotsBefore = charHandles.SlotCount();
+
 				CHAR_DATA *newcomer = new_char();
 
-				REQUIRE(newcomer == caster);
+				REQUIRE(charHandles.SlotCount() == slotsBefore);
 				REQUIRE(AffectOwner(oaf) != newcomer);
 			}
 		}
@@ -2570,9 +2629,15 @@ SCENARIO("an area's affect does not remember a caster who has left the world", "
 
 			THEN("it still names nobody once the address is reissued")
 			{
+				// The slot rather than the address: a destroyed character is really
+				// deleted now, so reuse of the memory is an allocator accident. The
+				// slot map does still recycle the freed slot, and the slot is what a
+				// handle names, so this is what keeps the assertion below honest.
+				std::size_t slotsBefore = charHandles.SlotCount();
+
 				CHAR_DATA *newcomer = new_char();
 
-				REQUIRE(newcomer == caster);
+				REQUIRE(charHandles.SlotCount() == slotsBefore);
 				REQUIRE(AffectOwner(aaf) != newcomer);
 			}
 		}

--- a/tests/prof_tests.c
+++ b/tests/prof_tests.c
@@ -1425,7 +1425,7 @@ SCENARIO("Attempt to track a character", "[prof_tracking]")
 
 			THEN("it should display a message notifying the player")
 			{
-				char_list = player2;
+				TestHelperLinkToCharList(player2);
 				player->Profs()->InterpCommand("track", "player2");
 
 				auto result = !str_cmp(Deref(player->desc)->outbuf,"\n\rTrack who?\n\r");
@@ -1452,7 +1452,7 @@ SCENARIO("Attempt to track a character", "[prof_tracking]")
 
 			THEN("it should display a message notifying the player")
 			{
-				char_list = player2;
+				TestHelperLinkToCharList(player2);
 				player->Profs()->InterpCommand("track", "player2");
 
 				auto result = !str_cmp(Deref(player->desc)->outbuf,"\n\rYou cannot attempt to track them again yet.\n\r");
@@ -1479,7 +1479,7 @@ SCENARIO("Attempt to track a character", "[prof_tracking]")
 
 			THEN("it should display a message notifying the player")
 			{
-				char_list = player2;
+				TestHelperLinkToCharList(player2);
 				player->Profs()->InterpCommand("track", "player2");
 
 				auto result = !str_cmp(Deref(player->desc)->outbuf,"\n\rEven if they had been here, there would be no suitable tracks left for you to follow.\n\r");
@@ -1509,7 +1509,7 @@ SCENARIO("Attempt to track a character", "[prof_tracking]")
 
 			THEN("it should display a message notifying the player")
 			{
-				char_list = player2;
+				TestHelperLinkToCharList(player2);
 				player->Profs()->InterpCommand("track", "player2");
 
 				//auto result = !str_cmp(Deref(player->desc)->outbuf,"\n\rYou were unable to find any sign of player2 here.\n\r");
@@ -1539,7 +1539,7 @@ SCENARIO("Attempt to track a character", "[prof_tracking]")
 
 			THEN("it should display a message notifying the player")
 			{
-				char_list = player2;
+				TestHelperLinkToCharList(player2);
 				player->Profs()->InterpCommand("track", "player2");
 
 				// TODO: complete reset of test

--- a/tests/queue_tests.c
+++ b/tests/queue_tests.c
@@ -3,7 +3,25 @@
 #include "../code/act_comm.h"
 #include "../code/entity/char_data.h"
 #include "../code/enums.h"
+#include "../code/entity/handles.h"
  
+namespace
+{
+	/// A character the queue can index.
+	///
+	/// CQueue keys its cancellation index on Handle<CHAR_DATA> rather than on a
+	/// raw pointer, so a character that was never registered in the slot map has
+	/// no identity to key on and cannot be found or cancelled. new_char does the
+	/// registration; these mocks are built by hand, so they have to do it too.
+	char_data *MakeMockChar()
+	{
+		char_data *ch = new char_data();
+		ch->self = charHandles.Add(ch);
+
+		return ch;
+	}
+}
+
 void testQueueFunction(char_data *qChar) {
     return;
 }
@@ -17,7 +35,7 @@ SCENARIO("Testing queueing functions", "[AddToQueue]")
 		WHEN("AddToQueue is called with a positive timer")
 		{
 			CQueue sut;
-			char_data *mockPlayer = new char_data();
+			char_data *mockPlayer = MakeMockChar();
 			mockPlayer->name = "Test";
 
 			sut.AddToQueue(timer, "queue_test", "testQueueFunction", testQueueFunction, mockPlayer);
@@ -35,7 +53,7 @@ SCENARIO("Testing deleting queue entries with that involve character", "[DeleteQ
 	GIVEN("a function with no parameters")
 	{
 		CQueue sut;
-		char_data *mockPlayer = new char_data();
+		char_data *mockPlayer = MakeMockChar();
 		mockPlayer->name = "Test";
 
 		int timer = 3; // 3 tics 
@@ -95,7 +113,7 @@ SCENARIO("Testing a queued function that cancels other events for its own char",
 	{
 		CQueue sut;
 		activeSut = &sut;
-		char_data *mockVictim = new char_data();
+		char_data *mockVictim = MakeMockChar();
 		mockVictim->name = "Victim";
 
 		// All four are due this tick and all name the same char. The first is
@@ -128,7 +146,7 @@ SCENARIO("Testing a queued function that requeues itself", "[ProcessQueue]")
 	{
 		CQueue sut;
 		activeSut = &sut;
-		char_data *mockPlayer = new char_data();
+		char_data *mockPlayer = MakeMockChar();
 		mockPlayer->name = "Test";
 
 		// Four entries, so the re-entrant add below happens while three more are
@@ -166,7 +184,7 @@ SCENARIO("Testing execution order of queued events", "[ProcessQueue]")
 	GIVEN("four events queued at the same tick")
 	{
 		CQueue sut;
-		char_data *mockPlayer = new char_data();
+		char_data *mockPlayer = MakeMockChar();
 		mockPlayer->name = "Test";
 		executionOrder.clear();
 
@@ -191,7 +209,7 @@ SCENARIO("Testing execution order of queued events", "[ProcessQueue]")
 	GIVEN("events queued across several ticks, added out of order")
 	{
 		CQueue sut;
-		char_data *mockPlayer = new char_data();
+		char_data *mockPlayer = MakeMockChar();
 		mockPlayer->name = "Test";
 		executionOrder.clear();
 
@@ -216,7 +234,7 @@ SCENARIO("Testing execution order of queued events", "[ProcessQueue]")
 	GIVEN("an event queued from inside a queued event")
 	{
 		CQueue sut;
-		char_data *mockPlayer = new char_data();
+		char_data *mockPlayer = MakeMockChar();
 		mockPlayer->name = "Test";
 		executionOrder.clear();
 
@@ -254,7 +272,7 @@ SCENARIO("Testing that scalar queue arguments are copied, not referenced", "[Add
 	GIVEN("an event scheduled with scalar locals that are then overwritten")
 	{
 		CQueue sut;
-		char_data *mockPlayer = new char_data();
+		char_data *mockPlayer = MakeMockChar();
 		mockPlayer->name = "Test";
 		capturedInt = 0;
 		capturedFloat = 0.0f;
@@ -289,7 +307,7 @@ SCENARIO("Testing queue processing", "[ProcessQueue]")
 	{
 		CQueue sut;
 		int timer = 1;
-		char_data* tmpChar = new char_data();
+		char_data* tmpChar = MakeMockChar();
 		tmpChar->id = 10107;
 		long expected = 1337L;
 		sut.AddToQueue(timer, "queue_test", "updateValueFunction", updateValueFunction, tmpChar, expected);
@@ -303,7 +321,7 @@ SCENARIO("Testing queue processing", "[ProcessQueue]")
 	GIVEN("A function with a timer greater than one")
 	{
 		CQueue sut;
-		char_data* tmpChar = new char_data();
+		char_data* tmpChar = MakeMockChar();
 		tmpChar->name = "Test";
 		tmpChar->id = 10107;
 		long expected = 1337L;
@@ -312,6 +330,66 @@ SCENARIO("Testing queue processing", "[ProcessQueue]")
 		THEN("The function should update the value")
 		{
 			REQUIRE(tmpChar->id == expected);
+		}
+	}
+}
+//
+// The reason charIndex is keyed on a handle rather than on a CHAR_DATA *.
+//
+// A queued entry can outlive any character it names. Keyed by pointer, a
+// character who left the world with entries still pending leaves its key
+// behind, and the free lists hand the next character that very address -- so
+// the newcomer answers to the departed character's key and inherits its pending
+// events. A handle carries the slot's generation, so the newcomer's key differs
+// even when the address is identical.
+//
+// Expiring a handle and reissuing one for the same pointer is what that looks
+// like from the slot map's side, and it is deterministic: same address, same
+// slot, new generation. Under a pointer-keyed index the assertions below would
+// read the departed character's entry back out.
+//
+
+SCENARIO("the queue does not attribute a departed character's events to its replacement", "[DeleteQueuedEventsInvolving]")
+{
+	GIVEN("a character with a queued event, whose handle is then expired and reissued")
+	{
+		CQueue sut;
+		char_data *ch = MakeMockChar();
+
+		sut.AddToQueue(5, "queue_test", "testQueueFunction", testQueueFunction, ch);
+
+		REQUIRE(sut.HasQueuePending(ch));
+
+		Handle<CHAR_DATA> indexedUnder = ch->self;
+
+		// What free_char does to the handle, without the rest of free_char --
+		// these mocks are not built by new_char and do not own their strings.
+		charHandles.Remove(ch->self);
+
+		// And what new_char does for whoever lands on the address next.
+		ch->self = charHandles.Add(ch);
+
+		WHEN("the queue is asked about the character at that address")
+		{
+			THEN("the reissued handle is not the one the entry was indexed under")
+			{
+				REQUIRE(!(ch->self == indexedUnder));
+			}
+
+			THEN("it has nothing pending, though the address is unchanged")
+			{
+				REQUIRE(sut.HasQueuePending(ch) == false);
+			}
+
+			THEN("and cancelling for it leaves the orphaned entry alone")
+			{
+				sut.DeleteQueuedEventsInvolving(ch);
+
+				// Still indexed under the expired handle, waiting to run or be
+				// dropped when it does. It is not reachable by anyone, which is
+				// the point: nobody inherits it either.
+				REQUIRE(sut.HasQueuePending(ch) == false);
+			}
 		}
 	}
 }

--- a/tests/rune_tests.c
+++ b/tests/rune_tests.c
@@ -42,7 +42,7 @@ namespace
 		rune.owner = owner->self;
 	}
 
-	// apply_rune copies its argument into a fresh new_rune(), so the caller's
+	// apply_rune copies its argument into a rune rune_list owns, so the caller's
 	// struct is a template rather than the thing that ends up on the lists.
 	RUNE_DATA *PlaceRuneOnObj(OBJ_DATA *obj, int type, int trigger, CHAR_DATA *owner = nullptr)
 	{
@@ -62,7 +62,6 @@ namespace
 		temp.type = type;
 		temp.extra = 0;
 		temp.drawn_in = 0;
-		temp.next = nullptr;
 		temp.next_content = nullptr;
 		temp.end_fun = nullptr;
 
@@ -224,9 +223,8 @@ SCENARIO("extracting the last rune leaves the container naming nothing", "[rune]
 
 			THEN("the object names no rune at all")
 			{
-				// free_rune pushes onto the rune free list, so a container left
-				// pointing at an extracted rune is pointing at something
-				// new_rune can hand straight back out.
+				// Leaving rune_list destroys the rune, so a container left pointing
+				// at an extracted one is pointing at freed memory.
 				REQUIRE(obj->rune == nullptr);
 				REQUIRE(GlobalListLength() == 0);
 			}
@@ -324,32 +322,45 @@ SCENARIO("a recycled exit does not inherit the last one's rune", "[rune]")
 // A drawn rune waits nine ticks before draw_rune finalises it. It used to live
 // in the temp-struct pool, which is a bump allocator over a fixed buffer that
 // wraps without regard for outstanding pointers -- so the queue entry named
-// memory any other pool caller could take back. It comes from new_rune now, and
-// the queue owns it until draw_rune runs.
+// memory any other pool caller could take back. Ownership is now released into
+// the queue and adopted back by draw_rune, which takes a unique_ptr by value.
+//
+// That last part is why this scenario no longer asserts on the freeing. It used
+// to read `REQUIRE(new_rune() == drawn)` -- the free list handing the same
+// address back was the only observable proof that a bail-out path had not
+// stranded the struct. There is no free list to ask any more, and the property
+// it was testing is now enforced by the signature rather than at runtime: every
+// path out of draw_rune destroys the rune because the parameter owns it. A path
+// that failed to would not compile into a leak, it would not exist.
+//
+// What is still worth pinning is the game-visible half: a draw that bails must
+// not leave a rune applied. LeakSanitizer covers the other half.
 //
 
-SCENARIO("a drawn rune is returned to the recycler however the draw ends", "[rune]")
+SCENARIO("a draw that cannot complete applies nothing", "[rune]")
 {
 	GIVEN("a rune queued for drawing whose caster then leaves")
 	{
 		CHAR_DATA *caster = new_char();
-		RUNE_DATA *drawn = new_rune();
+		auto drawn = std::make_unique<RUNE_DATA>();
 
 		drawn->owner = caster->self;
 		drawn->drawn_in = 1;
 
 		free_char(caster);
 
+		REQUIRE(GlobalListLength() == 0);
+
 		WHEN("the draw comes due with nobody left to complete it")
 		{
-			draw_rune(drawn, nullptr);
+			draw_rune(std::move(drawn));
 
-			THEN("the rune is back on the free list rather than stranded")
+			THEN("the draw is abandoned rather than applied")
 			{
-				// The bail-out paths are the ones worth pinning: the queue held
-				// the only reference, so an early return that skips the free
-				// strands the struct for the rest of the run.
-				REQUIRE(new_rune() == drawn);
+				// The owner handle expired with the caster, so draw_rune takes
+				// its first bail-out path. Nothing reaches apply_rune, so
+				// rune_list -- which owns applied runes -- stays empty.
+				REQUIRE(GlobalListLength() == 0);
 			}
 		}
 	}

--- a/tests/rune_tests.c
+++ b/tests/rune_tests.c
@@ -262,15 +262,22 @@ SCENARIO("a rune does not remember a caster who has left the world", "[rune]")
 				REQUIRE(RuneOwner(rune) == nullptr);
 			}
 
-			THEN("it still names nobody once the address is reissued")
+			THEN("it still names nobody once the slot is reissued")
 			{
 				// The damage this does is misattribution rather than a crash:
 				// the readers pass the owner to is_safe_new and damage_new, so
-				// a recycled address makes an unrelated character the author of
-				// a stasis wall they never cast.
+				// a recycled reference makes an unrelated character the author
+				// of a stasis wall they never cast.
+				//
+				// The slot rather than the address, because a destroyed
+				// character is really deleted now. SlotCount holding steady is
+				// what proves the freed slot really was handed back out, which
+				// is what keeps the assertion below from being trivially true.
+				std::size_t slotsBefore = charHandles.SlotCount();
+
 				CHAR_DATA *newcomer = new_char();
 
-				REQUIRE(newcomer == caster);
+				REQUIRE(charHandles.SlotCount() == slotsBefore);
 				REQUIRE(RuneOwner(rune) != newcomer);
 
 				free_char(newcomer);

--- a/tests/rune_tests.c
+++ b/tests/rune_tests.c
@@ -15,15 +15,17 @@
 //
 // RUNE_DATA, and the two lists every rune is on at once.
 //
-// apply_rune puts a rune on the global `rune_list` (via `next`) AND on a
-// per-container chain hanging off obj->rune / exit->rune / room->rune (via
-// `next_content`). update.c ticks runes off the global list and calls
+// apply_rune puts a rune on the global `rune_list`, which owns it, AND on a
+// non-owning per-container chain hanging off obj->rune / exit->rune / room->rune
+// (via `next_content`). update.c ticks runes off the global list and calls
 // extract_rune when one expires; find_rune walks the per-container chain to
 // decide whether entering a room or opening a door should trigger anything.
 //
-// So the global list decides *when* a rune fires and the container chain
-// decides *whether*, and extract_rune has to unlink from both. These scenarios
-// are about the container half, because that is the half it gets wrong.
+// So the global list decides *when* a rune fires and holds it alive, and the
+// container chain decides *whether*. extract_rune has to unlink from both, and
+// the container chain strictly first, since leaving rune_list destroys the rune.
+// These scenarios are about the container half, because that is the half it
+// gets wrong.
 //
 
 namespace
@@ -67,8 +69,8 @@ namespace
 		apply_rune(&temp);
 
 		// apply_rune pushes onto both heads, so the rune it just made is the
-		// head of the global list.
-		return rune_list;
+		// front of the global list.
+		return rune_list.front().get();
 	}
 
 	// The container chain as a list of rune `type`s, read the way find_rune
@@ -85,18 +87,13 @@ namespace
 
 	int GlobalListLength()
 	{
-		int count = 0;
-
-		for (RUNE_DATA *rune = rune_list; rune != nullptr; rune = rune->next)
-			count++;
-
-		return count;
+		return (int)rune_list.size();
 	}
 
 	void ClearRunes(OBJ_DATA *obj)
 	{
-		while (rune_list != nullptr)
-			extract_rune(rune_list);
+		while (!rune_list.empty())
+			extract_rune(rune_list.front().get());
 
 		obj->rune = nullptr;
 	}

--- a/tests/test_helpers.c
+++ b/tests/test_helpers.c
@@ -28,13 +28,9 @@ void TestHelperCleanupPlayerObject(CHAR_DATA *player)
 	if (player == nullptr)
 		return;
 
-	if (Deref(player->desc) != nullptr)
-	{
-		if (Deref(player->desc)->outbuf != nullptr)
-			delete[] Deref(player->desc)->outbuf;
-		
-		delete Deref(player->desc);
-	}
+	// ~descriptor_data frees the output buffer and retires the handle, so this
+	// is one delete and not the hand-rolled teardown it used to be.
+	delete Deref(player->desc);
 
 	if(player->pIndexData != nullptr)
 	{

--- a/tests/test_helpers.c
+++ b/tests/test_helpers.c
@@ -23,6 +23,16 @@ void TestHelperSetupTrainer(CHAR_DATA *trainer, char *name = "trainer1")
 	memset(trainer->pIndexData->profs_taught, -1, sizeof(short) * MAX_PROFS_TAUGHT_BY_MOB);
 }
 
+/// Puts a fixture character on char_list so the code under test can find it
+/// through get_char_world and friends. Ownership moves to the list, exactly as
+/// it does at the real link sites, so cleanup goes through the list rather than
+/// deleting the character directly.
+void TestHelperLinkToCharList(CHAR_DATA *ch)
+{
+	char_list.push_front(std::unique_ptr<CHAR_DATA>(ch));
+	ch->globalNode = char_list.begin();
+}
+
 void TestHelperCleanupPlayerObject(CHAR_DATA *player)
 {
 	if (player == nullptr)
@@ -42,5 +52,11 @@ void TestHelperCleanupPlayerObject(CHAR_DATA *player)
 	if (player->in_room != nullptr)
 		delete player->in_room;
 
-	delete player;
+	// Same routing free_char uses. A character that was linked is owned by
+	// char_list, so erasing the node is what destroys it. One that was never
+	// linked is this helper's to delete.
+	if (player->globalNode != CharacterList::iterator{})
+		char_list.erase(player->globalNode);
+	else
+		delete player;
 }


### PR DESCRIPTION
This PR refactors the four global entity lists that held raw pointers into their own std::list<stdd:unique_ptr<T>>. 

Freeing an entity pushed it onto a per-type free list threaded through the same `next` field the lobal list used. The memory stayed mapped, so a stale pointer kept reading intact data, and a walk whose body extracted 
its own successor quietly wandered into the free list. Nothing reported either one: not the suite, not the sanitizers.

This gives `char_list`, `object_list`, `descriptor_list` and `rune_list` ownership of what they hold (`std::list<std::unique_ptr<T>>`), so extraction erases he node and the entity is actually destroyed.


