### PR TITLE
Fix logic errors and game play bugs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,20 +18,49 @@ add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Wno-write-strings>)
 # -Wall -Wextra are on everywhere as *warnings only*
 add_compile_options(-Wall -Wextra)
 
-# Four extra groups that catch expression-level logic errors -Wall -Wextra
-# miss: duplicated conditions and branches, bitwise operators used where
-# logical ones were meant, and dereferences the compiler can prove are null.
-# Warnings only for now. They are promoted to errors once the existing
-# diagnostics they report have been worked through.
-#
-# Only -Wnull-dereference is portable. The other three are GCC only, and the
-# sanitizer build compiles with clang, where an unrecognized warning option is
-# itself a warning. That turns into a hard error on the translation units built
-# with -Werror, so the three are gated on the compiler rather than added
-# everywhere.
-add_compile_options(-Wnull-dereference)
+# Catches expression-level logic errors that -Wall -Wextra miss: branches
+# duplicated within a single if/else chain. It stays a warning rather than an
+# error because its one remaining site is a pair of byte-identical branches in
+# the circle damage ladder, and this diagnostic is the only automated thing
+# still pointing at it.
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-	add_compile_options(-Wduplicated-cond -Wduplicated-branches -Wlogical-op)
+	add_compile_options(-Wduplicated-branches)
+endif()
+
+# This is mostly a severity change rather than new diagnostics. Eight of the
+# eleven groups below are already reported by the -Wall -Wextra above, and all
+# that happens here is the build stops when one of them fires. Only
+# -Wnull-dereference, -Wduplicated-cond and -Wlogical-op are groups those two
+# do not already enable.
+#
+# What makes stopping the build safe is that every group here is at zero across
+# a clean build of the whole tree, so a violation cannot appear without
+# reintroducing a defect class that has already been cleared out of this
+# codebase. Each of them has caught a real one. -Wimplicit-fallthrough is a
+# missing `break` that left a whole item class immune to shock. -Wempty-body is
+# the stray `;` after an `if`. -Wtautological-compare is `x == x` and an array
+# tested against 0. -Wsequence-point is `flag = flag++`, which never
+# increments. -Wbool-compare is `10 > level < 15`, which parses but does not
+# mean what it reads like.
+#
+# The split is by which compiler actually emits the diagnostic, not by which
+# one accepts the option, and the two are not the same question. Each group was
+# checked by compiling a planted violation with both compilers at -std=c++17.
+# clang rejects three of the gated options outright, and an unknown -Werror=
+# option is a hard error there whether or not a translation unit opted into
+# -Werror. It accepts the other three and then never fires them: it has no
+# -Wnull-dereference and no -Wint-in-bool-context, and its equivalent of
+# -Wsequence-point is -Wunsequenced, which correctly stays quiet because C++17
+# made `i = i++` well defined. Rejected and inert are grouped together so that
+# the gated list means one thing, which is that the diagnostic is GCC only in
+# practice.
+add_compile_options(-Werror=implicit-fallthrough -Werror=empty-body
+	-Werror=tautological-compare -Werror=missing-field-initializers
+	-Werror=misleading-indentation)
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+	add_compile_options(-Werror=null-dereference -Werror=sequence-point
+		-Werror=int-in-bool-context -Werror=bool-compare
+		-Werror=duplicated-cond -Werror=logical-op)
 endif()
 
 # Build option used to turn on a dedicated ASAN+UBSAN build. 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,22 @@ add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Wno-write-strings>)
 # -Wall -Wextra are on everywhere as *warnings only*
 add_compile_options(-Wall -Wextra)
 
+# Four extra groups that catch expression-level logic errors -Wall -Wextra
+# miss: duplicated conditions and branches, bitwise operators used where
+# logical ones were meant, and dereferences the compiler can prove are null.
+# Warnings only for now. They are promoted to errors once the existing
+# diagnostics they report have been worked through.
+#
+# Only -Wnull-dereference is portable. The other three are GCC only, and the
+# sanitizer build compiles with clang, where an unrecognized warning option is
+# itself a warning. That turns into a hard error on the translation units built
+# with -Werror, so the three are gated on the compiler rather than added
+# everywhere.
+add_compile_options(-Wnull-dereference)
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+	add_compile_options(-Wduplicated-cond -Wduplicated-branches -Wlogical-op)
+endif()
+
 # Build option used to turn on a dedicated ASAN+UBSAN build. 
 # Basically a built in Valgrind alternative. This is useful
 # for debugging memory issues, but it is not suitable for

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,8 +27,8 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
 	add_compile_options(-Wduplicated-branches)
 endif()
 
-# This is mostly a severity change rather than new diagnostics. Eight of the
-# eleven groups below are already reported by the -Wall -Wextra above, and all
+# This is mostly a severity change rather than new diagnostics. Nine of the
+# twelve groups below are already reported by the -Wall -Wextra above, and all
 # that happens here is the build stops when one of them fires. Only
 # -Wnull-dereference, -Wduplicated-cond and -Wlogical-op are groups those two
 # do not already enable.
@@ -41,7 +41,11 @@ endif()
 # the stray `;` after an `if`. -Wtautological-compare is `x == x` and an array
 # tested against 0. -Wsequence-point is `flag = flag++`, which never
 # increments. -Wbool-compare is `10 > level < 15`, which parses but does not
-# mean what it reads like.
+# mean what it reads like. -Wsign-compare is a bounds check written as
+# `idx > -1 || idx < table.size()`, where the `||` should have been `&&` and the
+# only thing hiding it was `-1` converting to a huge unsigned value. That last
+# one is worth reading twice. Casting the size to silence the warning would have
+# turned a function that worked into an out of bounds read.
 #
 # The split is by which compiler actually emits the diagnostic, not by which
 # one accepts the option, and the two are not the same question. Each group was
@@ -56,7 +60,7 @@ endif()
 # practice.
 add_compile_options(-Werror=implicit-fallthrough -Werror=empty-body
 	-Werror=tautological-compare -Werror=missing-field-initializers
-	-Werror=misleading-indentation)
+	-Werror=misleading-indentation -Werror=sign-compare)
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
 	add_compile_options(-Werror=null-dereference -Werror=sequence-point
 		-Werror=int-in-bool-context -Werror=bool-compare

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,11 +27,42 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
 	add_compile_options(-Wduplicated-branches)
 endif()
 
+# Reports a pointer the optimizer can prove reaches a dereference while
+# possibly null. It stays a warning for a reason specific to how it works. The
+# diagnostic is driven by value range propagation, so it emits nothing at -O0
+# and can only appear in an optimized build. A Debug tree cannot establish a
+# baseline for it, which means the zero that the gated list below rests on is
+# not something this group is able to supply. It was gated as an error in
+# 1f05371 on the strength of a clean Debug build, where it is structurally
+# silent, and the first optimized build to run afterward stopped on it.
+#
+# At -O3 across the whole tree it reports 71 distinct in repo sites in 25
+# translation units, plus two more that resolve to inlined libstdc++ headers.
+# Count these as warnings, not as errors. A translation unit that errors stops
+# before the later passes run, so the same tree gated reports only 58 sites in
+# 21 units. Fixing toward a zero measured under -Werror would have been chasing
+# a number that grows as it is approached.
+#
+# The largest concentration is the OLC editor, 28 of the 71, where descriptor
+# handles are arrowed off Deref with no null check, both directly as in
+# `switch (Deref(ch->desc)->editor)` and through the EDIT_MOB, EDIT_OBJ and
+# EDIT_AREA macros in olc.h. The remainder divide into two shapes. Some
+# re-Deref a handle already proven non null a few lines up, where the repair is
+# to use the local that already holds the proof. Others never had a guard at
+# all, and predate the gating commit rather than arriving with it.
+#
+# All of it is worth fixing. None of it is something this group can hold a line
+# against in the meantime, because the build type that would catch a new one is
+# not the build type anyone develops in.
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+	add_compile_options(-Wnull-dereference)
+endif()
+
 # This is mostly a severity change rather than new diagnostics. Nine of the
-# twelve groups below are already reported by the -Wall -Wextra above, and all
+# eleven groups below are already reported by the -Wall -Wextra above, and all
 # that happens here is the build stops when one of them fires. Only
-# -Wnull-dereference, -Wduplicated-cond and -Wlogical-op are groups those two
-# do not already enable.
+# -Wduplicated-cond and -Wlogical-op are groups those two do not already
+# enable.
 #
 # What makes stopping the build safe is that every group here is at zero across
 # a clean build of the whole tree, so a violation cannot appear without
@@ -52,17 +83,16 @@ endif()
 # checked by compiling a planted violation with both compilers at -std=c++17.
 # clang rejects three of the gated options outright, and an unknown -Werror=
 # option is a hard error there whether or not a translation unit opted into
-# -Werror. It accepts the other three and then never fires them: it has no
-# -Wnull-dereference and no -Wint-in-bool-context, and its equivalent of
-# -Wsequence-point is -Wunsequenced, which correctly stays quiet because C++17
-# made `i = i++` well defined. Rejected and inert are grouped together so that
-# the gated list means one thing, which is that the diagnostic is GCC only in
-# practice.
+# -Werror. It accepts the other two and then never fires them: it has no
+# -Wint-in-bool-context, and its equivalent of -Wsequence-point is
+# -Wunsequenced, which correctly stays quiet because C++17 made `i = i++` well
+# defined. Rejected and inert are grouped together so that the gated list means
+# one thing, which is that the diagnostic is GCC only in practice.
 add_compile_options(-Werror=implicit-fallthrough -Werror=empty-body
 	-Werror=tautological-compare -Werror=missing-field-initializers
 	-Werror=misleading-indentation -Werror=sign-compare)
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-	add_compile_options(-Werror=null-dereference -Werror=sequence-point
+	add_compile_options(-Werror=sequence-point
 		-Werror=int-in-bool-context -Werror=bool-compare
 		-Werror=duplicated-cond -Werror=logical-op)
 endif()

--- a/code/act_comm.c
+++ b/code/act_comm.c
@@ -72,7 +72,7 @@
 #include "./repositories/pklogrepository.h"
 
 /* RT code to delete yourself */
-void do_delet(CHAR_DATA *ch, char *argument)
+void do_delet(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	send_to_char("You must type the full command to delete yourself.\n\r", ch);
 }
@@ -139,7 +139,7 @@ void do_delete(CHAR_DATA *ch, char *argument)
 }
 
 /* RT code to display channel status */
-void do_channels(CHAR_DATA *ch, char *argument)
+void do_channels(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	/* lists all channels and their status */
 	send_to_char("   channel     status\n\r", ch);
@@ -196,7 +196,7 @@ void do_channels(CHAR_DATA *ch, char *argument)
 }
 
 /* RT deaf blocks out all shouts */
-void do_deaf(CHAR_DATA *ch, char *argument)
+void do_deaf(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	if (IS_SET(ch->comm, COMM_DEAF))
 	{
@@ -210,7 +210,7 @@ void do_deaf(CHAR_DATA *ch, char *argument)
 }
 
 /* RT quiet blocks out all communication */
-void do_quiet(CHAR_DATA *ch, char *argument)
+void do_quiet(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	if (IS_SET(ch->comm, COMM_QUIET))
 	{
@@ -223,7 +223,7 @@ void do_quiet(CHAR_DATA *ch, char *argument)
 	SET_BIT(ch->comm, COMM_QUIET);
 }
 
-void do_replay(CHAR_DATA *ch, char *argument)
+void do_replay(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	if (is_npc(ch))
 	{
@@ -368,7 +368,7 @@ void do_cb(CHAR_DATA *ch, char *argument)
 	}
 }
 
-void do_global(CHAR_DATA *ch, char *argument)
+void do_global(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	if (IS_SET(ch->comm, COMM_ALL_CABALS))
 	{
@@ -1305,7 +1305,7 @@ void do_tell_queue (CHAR_DATA *ch, std::string argument)
 	do_tell(ch, argument.data());
 }
 
-void do_noreply(CHAR_DATA *ch, char *argument)
+void do_noreply(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	send_to_char("You concentrate and momentarily close your ears to the replies of others.\n\r", ch);
 
@@ -1738,12 +1738,12 @@ void do_idea(CHAR_DATA *ch, char *argument)
 	send_to_char("Idea logged.  Thanks!\n\r", ch);
 }
 
-void do_rent(CHAR_DATA *ch, char *argument)
+void do_rent(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	send_to_char("There is no rent here.  Just save and quit.\n\r", ch);
 }
 
-void do_qui(CHAR_DATA *ch, char *argument)
+void do_qui(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	send_to_char("If you want to QUIT, you have to spell it out.\n\r", ch);
 }
@@ -1753,7 +1753,7 @@ void do_quit(CHAR_DATA *ch, char *argument)
 	do_quit_new(ch, argument, false);
 }
 
-void do_quit_new(CHAR_DATA *ch, char *argument, bool autoq)
+void do_quit_new(CHAR_DATA *ch, [[maybe_unused]] char *argument, bool autoq)
 {
 	if (is_npc(ch))
 		return;
@@ -1954,7 +1954,7 @@ void do_quit_new(CHAR_DATA *ch, char *argument, bool autoq)
 	}
 }
 
-void do_save(CHAR_DATA *ch, char *argument)
+void do_save(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	send_to_char("Saving. Remember that Riftshadow has automatic saving.\n\r", ch);
 

--- a/code/act_comm.c
+++ b/code/act_comm.c
@@ -2603,7 +2603,7 @@ void speech_handler(CHAR_DATA *ch, CHAR_DATA *mob, SPEECH_DATA *speech)
 	auto copy = palloc_string(line->text);
 	auto point = copy;
 
-	for (auto i = 0; *point && *point != '\0'; i++)
+	for (auto i = 0; *point != '\0'; i++)
 	{
 		if (*point == '$')
 		{

--- a/code/act_comm.c
+++ b/code/act_comm.c
@@ -1020,7 +1020,7 @@ void do_sing(CHAR_DATA *ch, char *argument)
 		buf2[i] = '\0';
 	}
 
-	auto length = !is_npc(ch)
+	const int length = !is_npc(ch)
 					  ? strlen(ch->name)
 					  : strlen(ch->short_descr);
 

--- a/code/act_info.c
+++ b/code/act_info.c
@@ -2437,7 +2437,7 @@ void do_score(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 		ch->pcdata->birth_date);
 	send_to_char(buf, ch);
 
-	auto tmp = get_hours(ch) / ch->pcdata->death_time * 100.001f;
+	auto tmp = get_hours(ch) * 100.001f / ch->pcdata->death_time;
 	auto i = (int)tmp;
 	char *state;
 

--- a/code/act_info.c
+++ b/code/act_info.c
@@ -1892,21 +1892,29 @@ void do_look(CHAR_DATA *ch, char *argument)
 		if (is_affected(ch, gsn_mark_of_wrath))
 		{
 			auto af = affect_find(ch->affected, gsn_mark_of_wrath);
+			CHAR_DATA *owner = Deref(af->owner);
 
-			for (i = 0; i < MAX_TRACKS; i++)
+			// An unused track slot holds a null prey, and an owner who can no
+			// longer be resolved is null too, so the two used to match each other
+			// and the name below was read through the null. Matching equal is not
+			// the same as being alive.
+			if (owner != nullptr)
 			{
-				if (ch->in_room->tracks[i].prey != Deref(af->owner))
-					continue;
+				for (i = 0; i < MAX_TRACKS; i++)
+				{
+					if (ch->in_room->tracks[i].prey != owner)
+						continue;
 
-				direction = (char *)flag_name_lookup(ch->in_room->tracks[i].direction, direction_table);
+					direction = (char *)flag_name_lookup(ch->in_room->tracks[i].direction, direction_table);
 
-				sprintf(buf, "%sThrough the veil of your rage, you sense %s's tracks leading %s.%s\n\r",
-					get_char_color(ch, "lightred"),
-					Deref(af->owner)->name,
-					direction,
-					END_COLOR(ch));
+					sprintf(buf, "%sThrough the veil of your rage, you sense %s's tracks leading %s.%s\n\r",
+						get_char_color(ch, "lightred"),
+						owner->name,
+						direction,
+						END_COLOR(ch));
 
-				send_to_char(buf, ch);
+					send_to_char(buf, ch);
+				}
 			}
 		}
 

--- a/code/act_info.c
+++ b/code/act_info.c
@@ -1073,7 +1073,7 @@ void do_scroll(CHAR_DATA *ch, char *argument)
 }
 
 /* RT does socials */
-void do_socials(CHAR_DATA *ch, char *argument)
+void do_socials(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	auto col = 0;
 	for (auto iSocial = 0; social_table[iSocial].name[0] != '\0'; iSocial++)
@@ -1095,33 +1095,33 @@ void do_socials(CHAR_DATA *ch, char *argument)
 
 /* RT Commands to replace news, motd, imotd, etc from ROM */
 
-void do_motd(CHAR_DATA *ch, char *argument)
+void do_motd(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	do_help(ch, "motd");
 }
 
-void do_imotd(CHAR_DATA *ch, char *argument)
+void do_imotd(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	do_help(ch, "imotd");
 }
 
-void do_rules(CHAR_DATA *ch, char *argument)
+void do_rules(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	do_help(ch, "rules");
 }
 
-void do_story(CHAR_DATA *ch, char *argument)
+void do_story(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	do_help(ch, "story");
 }
 
-void do_wizlist(CHAR_DATA *ch, char *argument)
+void do_wizlist(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	do_help(ch, "wizlist");
 }
 
 /* RT this following section holds all the auto commands from ROM, as well as replacements for config */
-void do_autolist(CHAR_DATA *ch, char *argument)
+void do_autolist(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	/* lists most player flags */
 	if (is_npc(ch))
@@ -1281,7 +1281,7 @@ void do_color(CHAR_DATA *ch, char *argument)
 	send_to_char(buf, ch);
 }
 
-void do_autoabort(CHAR_DATA *ch, char *argument)
+void do_autoabort(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	if (is_npc(ch))
 		return;
@@ -1298,7 +1298,7 @@ void do_autoabort(CHAR_DATA *ch, char *argument)
 	}
 }
 
-void do_autoassist(CHAR_DATA *ch, char *argument)
+void do_autoassist(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	if (is_npc(ch))
 		return;
@@ -1315,7 +1315,7 @@ void do_autoassist(CHAR_DATA *ch, char *argument)
 	}
 }
 
-void do_autoexit(CHAR_DATA *ch, char *argument)
+void do_autoexit(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	if (is_npc(ch))
 		return;
@@ -1332,7 +1332,7 @@ void do_autoexit(CHAR_DATA *ch, char *argument)
 	}
 }
 
-void do_autogold(CHAR_DATA *ch, char *argument)
+void do_autogold(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	if (is_npc(ch))
 		return;
@@ -1349,7 +1349,7 @@ void do_autogold(CHAR_DATA *ch, char *argument)
 	}
 }
 
-void do_autoloot(CHAR_DATA *ch, char *argument)
+void do_autoloot(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	if (is_npc(ch))
 		return;
@@ -1366,7 +1366,7 @@ void do_autoloot(CHAR_DATA *ch, char *argument)
 	}
 }
 
-void do_autosac(CHAR_DATA *ch, char *argument)
+void do_autosac(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	if (is_npc(ch))
 		return;
@@ -1383,7 +1383,7 @@ void do_autosac(CHAR_DATA *ch, char *argument)
 	}
 }
 
-void do_autosplit(CHAR_DATA *ch, char *argument)
+void do_autosplit(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	if (is_npc(ch))
 		return;
@@ -1400,7 +1400,7 @@ void do_autosplit(CHAR_DATA *ch, char *argument)
 	}
 }
 
-void do_brief(CHAR_DATA *ch, char *argument)
+void do_brief(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	if (IS_SET(ch->comm, COMM_BRIEF))
 	{
@@ -1414,7 +1414,7 @@ void do_brief(CHAR_DATA *ch, char *argument)
 	}
 }
 
-void do_compact(CHAR_DATA *ch, char *argument)
+void do_compact(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	if (IS_SET(ch->comm, COMM_COMPACT))
 	{
@@ -1428,7 +1428,7 @@ void do_compact(CHAR_DATA *ch, char *argument)
 	}
 }
 
-void do_show(CHAR_DATA *ch, char *argument)
+void do_show(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	if (IS_SET(ch->comm, COMM_SHOW_AFFECTS))
 	{
@@ -1516,7 +1516,7 @@ void do_prompt(CHAR_DATA *ch, char *argument)
 	send_to_char(buf, ch);
 }
 
-void do_combine(CHAR_DATA *ch, char *argument)
+void do_combine(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	if (IS_SET(ch->comm, COMM_COMBINE))
 	{
@@ -1530,7 +1530,7 @@ void do_combine(CHAR_DATA *ch, char *argument)
 	}
 }
 
-void do_nofollow(CHAR_DATA *ch, char *argument)
+void do_nofollow(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	if (is_npc(ch))
 		return;
@@ -1554,7 +1554,7 @@ void do_nofollow(CHAR_DATA *ch, char *argument)
 	}
 }
 
-void do_nosummon(CHAR_DATA *ch, char *argument)
+void do_nosummon(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	if (is_npc(ch))
 	{
@@ -2396,7 +2396,7 @@ void do_exits(CHAR_DATA *ch, char *argument)
 	send_to_char(buf, ch);
 }
 
-void do_worth(CHAR_DATA *ch, char *argument)
+void do_worth(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	char buf[MAX_STRING_LENGTH];
 
@@ -2415,7 +2415,7 @@ void do_worth(CHAR_DATA *ch, char *argument)
 	send_to_char(buf, ch);
 }
 
-void do_score(CHAR_DATA *ch, char *argument)
+void do_score(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	if (is_npc(ch))
 	{
@@ -2714,7 +2714,7 @@ void do_score(CHAR_DATA *ch, char *argument)
 		do_affects(ch, "");
 }
 
-void do_affects(CHAR_DATA *ch, char *argument)
+void do_affects(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	if (ch->affected.empty() || !(ch->affected.front().aftype != AFT_INVIS || ch->affected.size() > 1))
 	{
@@ -2799,7 +2799,7 @@ void do_affects(CHAR_DATA *ch, char *argument)
 	}
 }
 
-void do_time(CHAR_DATA *ch, char *argument)
+void do_time(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	char buf[MAX_STRING_LENGTH];
 	char *suf;
@@ -2848,7 +2848,7 @@ void do_time(CHAR_DATA *ch, char *argument)
 	send_to_char(buf, ch);
 }
 
-void do_weather(CHAR_DATA *ch, char *argument)
+void do_weather(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	char buf[MAX_STRING_LENGTH], buf2[MAX_STRING_LENGTH];
 
@@ -3512,7 +3512,7 @@ void do_who(CHAR_DATA *ch, char *argument)
 	page_to_char(output.str(), ch);
 }
 
-void do_count(CHAR_DATA *ch, char *argument)
+void do_count(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	auto not_seen = 0;
 	auto count = 0;
@@ -3538,13 +3538,13 @@ void do_count(CHAR_DATA *ch, char *argument)
 	send_to_char(buf, ch);
 }
 
-void do_inventory(CHAR_DATA *ch, char *argument)
+void do_inventory(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	send_to_char("You are carrying:\n\r", ch);
 	show_list_to_char(ch->carrying, ch, true, true);
 }
 
-void do_equipment(CHAR_DATA *ch, char *argument)
+void do_equipment(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	send_to_char("You are using:\n\r", ch);
 
@@ -4195,7 +4195,7 @@ void do_description(CHAR_DATA *ch, char *argument)
 	send_to_char(ch->description ? ch->description : "(None)\n\r", ch);
 }
 
-void do_report(CHAR_DATA *ch, char *argument)
+void do_report(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	char buf[MAX_STRING_LENGTH], buf2[MAX_STRING_LENGTH], buf3[MAX_STRING_LENGTH];
 
@@ -4651,7 +4651,7 @@ CHAR_DATA *get_char_from_room(CHAR_DATA *ch, ROOM_INDEX_DATA *room, char *argume
 	return nullptr;
 }
 
-void do_balance(CHAR_DATA *ch, char *argument)
+void do_balance(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	auto banker = ch->in_room->people;
 	for (; banker != nullptr; banker = banker->next_in_room)
@@ -4909,7 +4909,7 @@ void do_deposit(CHAR_DATA *ch, char *argument)
 	extract_obj(deposited);
 }
 
-void do_records(CHAR_DATA *ch, char *argument)
+void do_records(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	if (!is_immortal(ch))
 	{
@@ -5292,7 +5292,7 @@ char *get_where_name(int iWear)
 	return where_name[iWear];
 }
 
-void do_trustgroup(CHAR_DATA *ch, char *argument)
+void do_trustgroup(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	if (is_npc(ch))
 		return;
@@ -5306,7 +5306,7 @@ void do_trustgroup(CHAR_DATA *ch, char *argument)
 		send_to_char("You no longer trust your group with questionable actions.\n\r", ch);
 }
 
-void do_trustcabal(CHAR_DATA *ch, char *argument)
+void do_trustcabal(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	if (is_npc(ch))
 		return;

--- a/code/act_move.c
+++ b/code/act_move.c
@@ -414,7 +414,7 @@ void move_char(CHAR_DATA *ch, int door, bool automatic, bool fcharm)
 			if (well == nullptr)
 				return;
 
-			for (auto distance = 0; distance <= get_grav_distance(well); distance++)
+			for (distance = 0; distance <= get_grav_distance(well); distance++)
 			{
 				if (!gravroom->exit[oppdir] || !gravroom->exit[oppdir]->u1.to_room)
 					break;

--- a/code/act_move.c
+++ b/code/act_move.c
@@ -1137,7 +1137,7 @@ void move_char(CHAR_DATA *ch, int door, bool automatic, bool fcharm)
 	 */
 }
 
-void do_north(CHAR_DATA *ch, char *argument)
+void do_north(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	if (is_affected(ch, gsn_bind_feet))
 	{
@@ -1148,7 +1148,7 @@ void do_north(CHAR_DATA *ch, char *argument)
 	move_char(ch, Directions::North, false, true);
 }
 
-void do_east(CHAR_DATA *ch, char *argument)
+void do_east(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	if (is_affected(ch, gsn_bind_feet))
 	{
@@ -1159,7 +1159,7 @@ void do_east(CHAR_DATA *ch, char *argument)
 	move_char(ch, Directions::East, false, true);
 }
 
-void do_south(CHAR_DATA *ch, char *argument)
+void do_south(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	if (is_affected(ch, gsn_bind_feet))
 	{
@@ -1170,7 +1170,7 @@ void do_south(CHAR_DATA *ch, char *argument)
 	move_char(ch, Directions::South, false, true);
 }
 
-void do_west(CHAR_DATA *ch, char *argument)
+void do_west(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	if (is_affected(ch, gsn_bind_feet))
 	{
@@ -1181,7 +1181,7 @@ void do_west(CHAR_DATA *ch, char *argument)
 	move_char(ch, Directions::West, false, true);
 }
 
-void do_up(CHAR_DATA *ch, char *argument)
+void do_up(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	if (is_affected(ch, gsn_bind_feet))
 	{
@@ -1192,7 +1192,7 @@ void do_up(CHAR_DATA *ch, char *argument)
 	move_char(ch, Directions::Up, false, true);
 }
 
-void do_down(CHAR_DATA *ch, char *argument)
+void do_down(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	if (is_affected(ch, gsn_bind_feet))
 	{
@@ -2642,7 +2642,7 @@ void do_wake(CHAR_DATA *ch, char *argument)
 	do_stand(victim, "");
 }
 
-void do_sneak(CHAR_DATA *ch, char *argument)
+void do_sneak(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	auto sn_fog = skill_lookup("faerie fog");
 	auto sn_fire = skill_lookup("faerie fire");
@@ -2693,7 +2693,7 @@ void do_sneak(CHAR_DATA *ch, char *argument)
 	affect_to_char(ch, &af);
 }
 
-void do_cloak(CHAR_DATA *ch, char *argument)
+void do_cloak([[maybe_unused]] CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	/*
 	AFFECT_DATA af;
@@ -2839,7 +2839,7 @@ void do_vigilance(CHAR_DATA *ch, char *argument)
 }
 */
 
-void do_acute_vision(CHAR_DATA *ch, char *argument)
+void do_acute_vision(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	if (get_skill(ch, gsn_acute_vision) == 0 ||
 		ch->level < skill_table[gsn_acute_vision].skill_level[ch->Class()->GetIndex()])
@@ -2889,7 +2889,7 @@ void do_acute_vision(CHAR_DATA *ch, char *argument)
 	return;
 }
 
-void do_camp(CHAR_DATA *ch, char *argument)
+void do_camp(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	if (get_skill(ch, gsn_camp) == 0 || ch->level < skill_table[gsn_camp].skill_level[ch->Class()->GetIndex()])
 	{
@@ -2940,7 +2940,7 @@ void do_camp(CHAR_DATA *ch, char *argument)
 	do_sleep(ch, "");
 }
 
-void do_camouflage(CHAR_DATA *ch, char *argument)
+void do_camouflage(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	auto sn_fog = skill_lookup("faerie fog");
 	auto sn_fire = skill_lookup("faerie fire");
@@ -3050,7 +3050,7 @@ void do_creep(CHAR_DATA *ch, char *argument)
 	WAIT_STATE(ch, wait);
 }
 
-void do_hide(CHAR_DATA *ch, char *argument)
+void do_hide(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	auto sn_fog = skill_lookup("faerie fog");
 	auto sn_fire = skill_lookup("faerie fire");
@@ -3094,7 +3094,7 @@ void do_hide(CHAR_DATA *ch, char *argument)
 	check_improve(ch, gsn_hide, false, 3);
 }
 
-void un_camouflage(CHAR_DATA *ch, char *argument)
+void un_camouflage(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	if (!is_affected_by(ch, AFF_CAMOUFLAGE))
 		return;
@@ -3105,19 +3105,19 @@ void un_camouflage(CHAR_DATA *ch, char *argument)
 	send_to_char("You step out from your cover.\n\r", ch);
 }
 
-void un_blackjack(CHAR_DATA *ch, char *argument)
+void un_blackjack(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	if (is_affected(ch, gsn_blackjack))
 		affect_strip(ch, gsn_blackjack);
 }
 
-void un_strangle(CHAR_DATA *ch, char *argument)
+void un_strangle(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	if (is_affected(ch, gsn_strangle))
 		affect_strip(ch, gsn_strangle);
 }
 
-void un_hide(CHAR_DATA *ch, char *argument)
+void un_hide(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	if (!is_affected_by(ch, AFF_HIDE))
 		return;
@@ -3128,7 +3128,7 @@ void un_hide(CHAR_DATA *ch, char *argument)
 	send_to_char("You step out of the shadows.\n\r", ch);
 }
 
-void un_invis(CHAR_DATA *ch, char *argument)
+void un_invis(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	if (!is_affected_by(ch, AFF_INVISIBLE))
 		return;
@@ -3142,7 +3142,7 @@ void un_invis(CHAR_DATA *ch, char *argument)
 	send_to_char("You fade into existence.\n\r", ch);
 }
 
-void un_sneak(CHAR_DATA *ch, char *argument)
+void un_sneak(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	if (IS_SET(race_table[ch->race].aff, AFF_SNEAK))
 		return;
@@ -3164,7 +3164,7 @@ void un_sneak(CHAR_DATA *ch, char *argument)
 	send_to_char("You trample around loudly again.\n\r", ch);
 }
 
-void un_earthfade(CHAR_DATA *ch, char *argument)
+void un_earthfade(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	if (!is_affected(ch, gsn_earthfade))
 		return;
@@ -3177,7 +3177,7 @@ void un_earthfade(CHAR_DATA *ch, char *argument)
 	WAIT_STATE(ch, 3 * PULSE_VIOLENCE);
 }
 
-void un_blade_barrier(CHAR_DATA *ch, char *argument)
+void un_blade_barrier(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	if (!is_affected(ch, gsn_blade_barrier))
 		return;
@@ -3190,7 +3190,7 @@ void un_blade_barrier(CHAR_DATA *ch, char *argument)
 	WAIT_STATE(ch, PULSE_VIOLENCE);
 }
 
-void un_watermeld(CHAR_DATA *ch, char *argument)
+void un_watermeld(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	if (!is_affected(ch, gsn_watermeld))
 		return;
@@ -3200,7 +3200,7 @@ void un_watermeld(CHAR_DATA *ch, char *argument)
 	act("The water swirls around you as your concealment fails you.", ch, 0, 0, TO_CHAR);
 }
 
-void un_shroud(CHAR_DATA *ch, char *argument)
+void un_shroud(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	if (is_affected(ch, gsn_shroud_of_secrecy))
 	{
@@ -3208,7 +3208,7 @@ void un_shroud(CHAR_DATA *ch, char *argument)
 	}
 }
 
-void do_visible(CHAR_DATA *ch, char *argument)
+void do_visible(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	un_camouflage(ch, nullptr);
 	un_hide(ch, nullptr);
@@ -3220,7 +3220,7 @@ void do_visible(CHAR_DATA *ch, char *argument)
 	un_shroud(ch, nullptr);
 }
 
-void do_recall(CHAR_DATA *ch, char *argument)
+void do_recall(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	if (is_npc(ch) && !IS_SET(ch->act, ACT_PET))
 	{
@@ -4063,7 +4063,7 @@ int find_first_step(ROOM_INDEX_DATA *from, ROOM_INDEX_DATA *goal)
 	return solve->dir_from;
 }
 
-void do_aura_of_sustenance(CHAR_DATA *ch, char *argument)
+void do_aura_of_sustenance(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	if (get_skill(ch, gsn_aura_of_sustenance) == 0 || ch->level < skill_table[gsn_aura_of_sustenance].skill_level[ch->Class()->GetIndex()])
 	{
@@ -4102,7 +4102,7 @@ void do_aura_of_sustenance(CHAR_DATA *ch, char *argument)
 	ch->mana -= 40;
 }
 
-void do_vanish(CHAR_DATA *ch, char *argument)
+void do_vanish(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	auto chance = get_skill(ch, gsn_vanish);
 	if (chance == 0 || ch->level < skill_table[gsn_vanish].skill_level[ch->Class()->GetIndex()])

--- a/code/act_obj.c
+++ b/code/act_obj.c
@@ -1100,8 +1100,8 @@ void do_give(CHAR_DATA *ch, char *argument)
 
 	if (IS_SET(obj->progtypes, IPROG_GIVE))
 	{
-		if ((obj->pIndexData->iprogs->give_prog)(obj, ch, victim) == true);
-		return;
+		if ((obj->pIndexData->iprogs->give_prog)(obj, ch, victim) == true)
+			return;
 	}
 
 	obj_from_char(obj);

--- a/code/act_obj.c
+++ b/code/act_obj.c
@@ -3055,7 +3055,7 @@ void do_recite(CHAR_DATA *ch, char *argument)
 	extract_obj(scroll);
 }
 
-void do_brandish(CHAR_DATA *ch, char *argument)
+void do_brandish(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	CHAR_DATA *vch;
 	CHAR_DATA *vch_next;

--- a/code/act_obj.c
+++ b/code/act_obj.c
@@ -4567,7 +4567,7 @@ bool is_restricted(CHAR_DATA *ch, OBJ_DATA *obj)
 
 	status= false;
 
-	if (!restricted)
+	if (IS_ZERO_VECTOR(restricted))
 		return false;
 
 	for (i = 0; restrict_table[i].name != nullptr; i++)

--- a/code/act_obj.c
+++ b/code/act_obj.c
@@ -125,7 +125,7 @@ bool can_loot(CHAR_DATA *ch, OBJ_DATA *obj)
 	if (is_npc(ch))
 		return false;
 
-	if (!obj->owner || obj->owner == nullptr)
+	if (obj->owner == nullptr)
 		return true;
 
 	if (!str_cmp(ch->true_name, obj->owner))

--- a/code/act_obj.c
+++ b/code/act_obj.c
@@ -75,8 +75,6 @@
 
 bool check_arms(CHAR_DATA *ch, OBJ_DATA *obj)
 {
-	char buf[MSL];
-
 	if (is_affected_obj(obj, gsn_arms_of_light)
 		|| is_affected_obj(obj, gsn_arms_of_wrath)
 		|| is_affected_obj(obj, gsn_arms_of_purity)
@@ -4066,7 +4064,6 @@ void do_list(CHAR_DATA *ch, char *argument)
 void do_sell(CHAR_DATA *ch, char *objName)
 {
 	char buf[MAX_STRING_LENGTH];
-	char arg[MAX_INPUT_LENGTH];
 	CHAR_DATA *keeper;
 	OBJ_DATA *obj;
 	int cost,roll,haggleSkillLevel;

--- a/code/act_obj.c
+++ b/code/act_obj.c
@@ -2248,7 +2248,7 @@ void wear_obj(CHAR_DATA *ch, OBJ_DATA *obj, bool fReplace)
 		weapon = get_eq_char(ch, WEAR_WIELD);
 
 		if (weapon != nullptr
-			&& (ch->size < SIZE_LARGE && is_weapon_stat(weapon, WEAPON_TWO_HANDS)
+			&& ((ch->size < SIZE_LARGE && is_weapon_stat(weapon, WEAPON_TWO_HANDS))
 				|| weapon->value[0] == WEAPON_STAFF
 				|| weapon->value[0] == WEAPON_POLEARM
 				|| weapon->value[0] == WEAPON_SPEAR))
@@ -2555,7 +2555,7 @@ void wear_obj(CHAR_DATA *ch, OBJ_DATA *obj, bool fReplace)
 			return;
 		}
 
-		if (ch->size < SIZE_LARGE && is_weapon_stat(obj, WEAPON_TWO_HANDS)
+		if ((ch->size < SIZE_LARGE && is_weapon_stat(obj, WEAPON_TWO_HANDS))
 			|| obj->value[0] == WEAPON_SPEAR
 			|| obj->value[0] == WEAPON_STAFF
 			|| obj->value[0] == WEAPON_POLEARM)

--- a/code/act_wiz.c
+++ b/code/act_wiz.c
@@ -221,7 +221,6 @@ void do_leader(CHAR_DATA *ch, char *argument)
 	char arg1[MAX_INPUT_LENGTH];
 	char buf[MAX_STRING_LENGTH];
 	CHAR_DATA *victim;
-	int cres = 0;
 
 	if (ch->level < 54 || is_npc(ch))
 	{
@@ -6784,13 +6783,13 @@ void do_vmstat(CHAR_DATA *ch, char *argument)
 void do_vostat(CHAR_DATA *ch, char *argument)
 {
 	char buf[MAX_STRING_LENGTH];
-	char arg1[MAX_INPUT_LENGTH];
 	OBJ_INDEX_DATA *pObjIndex = nullptr;
 	OBJ_DATA *obj;
 	bool found = false;
 	int vnum, nMatch = 0;
-	char *blah;
-	blah = one_argument(argument, arg1);
+
+	char arg1[MAX_INPUT_LENGTH];
+	one_argument(argument, arg1);
 
 	if (arg1[0] == '\0')
 	{
@@ -6850,7 +6849,6 @@ void do_vostat(CHAR_DATA *ch, char *argument)
 
 void do_history(CHAR_DATA *ch, char *argument)
 {
-	char buf[MAX_STRING_LENGTH];
 	char arg1[MAX_STRING_LENGTH];
 	char arg2[MAX_STRING_LENGTH];
 	char obuf[MAX_STRING_LENGTH];
@@ -7648,7 +7646,7 @@ void buglist_end_fun(CHAR_DATA *ch, char *argument)
 
 void do_constdump(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
-	FILE *fp = fopen(CONST_DUMP_FILE, "w"), *fp2;
+	FILE *fp = fopen(CONST_DUMP_FILE, "w");
 	if (fp == nullptr)
 	{
 		RS.Logger.Warn("Unable to open const dump file: fopen {}: {}", CONST_DUMP_FILE, std::strerror(errno));

--- a/code/act_wiz.c
+++ b/code/act_wiz.c
@@ -365,7 +365,7 @@ void do_induct(CHAR_DATA *ch, char *argument)
 	
 	if ((ch->level < 54 && ch->pcdata->induct != CABAL_LEADER)
 		|| is_npc(ch)
-		|| ch->cabal == CABAL_HORDE && !is_immortal(ch))
+		|| (ch->cabal == CABAL_HORDE && !is_immortal(ch)))
 	{
 		send_to_char("Huh?\n\r", ch);
 		return;
@@ -1826,6 +1826,22 @@ void do_rstat(CHAR_DATA *ch, char *argument)
 	{
 		if (location->tracks[i].prey)
 		{
+			// TODO: this hours-ago figure is wrong whenever the hour or the day
+			// borrows. Addition binds tighter than the conditional operator, so the
+			// second and third conditions below are not the comparisons they look
+			// like. The second one parses as
+			// (24 + time_info.hour - tracks[i].time.hour) + (day >= tracks[i].day),
+			// which lands between 1 and 24 every time this branch is reached, so it
+			// is always true and the else beneath it can never run. A borrowing day
+			// prints a negative number of hours.
+			//
+			// Bracketing it is not the fix. The grouping this wants is a borrow and
+			// sum across hour, day, month and year, which is a different expression
+			// rather than this one parenthesised. Writing it changes a number
+			// immortals have been reading for years, so the intended formula needs a
+			// decision before the code moves.
+			//
+			// clang reports this under -Wparentheses. GCC does not.
 			time = (time_info.hour >= location->tracks[i].time.hour)
 					   ? (time_info.hour - location->tracks[i].time.hour)
 					   : (24 + time_info.hour - location->tracks[i].time.hour) +

--- a/code/act_wiz.c
+++ b/code/act_wiz.c
@@ -2294,7 +2294,7 @@ void do_ostat(CHAR_DATA *ch, char *argument)
 
 	for (auto &paf2 : obj->charaffs)
 	{
-		if (paf2.bitvector)
+		if (!IS_ZERO_VECTOR(paf2.bitvector))
 		{
 			sprintf(buf, "Imbues wearer with %s.\n\r", affect_bit_name(paf2.bitvector));
 			send_to_char(buf, ch);
@@ -2750,7 +2750,7 @@ void do_mstat(CHAR_DATA *ch, char *argument)
 		send_to_char(buf, ch);
 	}
 
-	if (is_npc(victim) && victim->off_flags)
+	if (is_npc(victim) && !IS_ZERO_VECTOR(victim->off_flags))
 	{
 		sprintf(buf, "Offense: %s\n\r", off_bit_name(victim->off_flags));
 		send_to_char(buf, ch);
@@ -6465,7 +6465,7 @@ void do_rinfo(CHAR_DATA *ch, char *argument)
 		}
 	}
 
-	if (location->room_flags == 0 && location->area->area_flags == 0)
+	if (IS_ZERO_VECTOR(location->room_flags) && IS_ZERO_VECTOR(location->area->area_flags))
 		strcat(buf, "(no flags)\n\r");
 
 	send_to_char(buf, ch);

--- a/code/act_wiz.c
+++ b/code/act_wiz.c
@@ -535,7 +535,7 @@ void do_induct(CHAR_DATA *ch, char *argument)
 }
 
 /* equips a character */
-void do_outfit(CHAR_DATA *ch, char *argument)
+void do_outfit(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	OBJ_DATA *obj;
 	int i, body, arms, legs, hands, feet, shield, sn, vnum;
@@ -2336,7 +2336,7 @@ void do_ostat(CHAR_DATA *ch, char *argument)
 	}
 }
 
-void do_astat(CHAR_DATA *ch, char *argument)
+void do_astat(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	char buf[MSL];
 	int count = 0;
@@ -3372,7 +3372,7 @@ void do_mwhere(CHAR_DATA *ch, char *argument)
 		page_to_char(buffer.str(), ch);
 }
 
-void do_reboo(CHAR_DATA *ch, char *argument)
+void do_reboo(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	send_to_char("If you want to REBOOT, spell it out.\n\r", ch);
 	send_to_char("Use: 'reboot nosave', if you don't want players saved at reboot.\n\r", ch);
@@ -3748,7 +3748,7 @@ void do_switch(CHAR_DATA *ch, char *argument)
 	send_to_char("Ok.\n\r", victim);
 }
 
-void do_return(CHAR_DATA *ch, char *argument)
+void do_return(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	char buf[MAX_STRING_LENGTH];
 
@@ -4644,7 +4644,7 @@ void do_notell(CHAR_DATA *ch, char *argument)
 	}
 }
 
-void do_peace(CHAR_DATA *ch, char *argument)
+void do_peace(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	for (CHAR_DATA *rch = ch->in_room->people; rch != nullptr; rch = rch->next_in_room)
 	{
@@ -4661,7 +4661,7 @@ void do_peace(CHAR_DATA *ch, char *argument)
 	send_to_char("Ok.\n\r", ch);
 }
 
-void do_wizlock(CHAR_DATA *ch, char *argument)
+void do_wizlock(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	wizlock = !wizlock;
 
@@ -4679,7 +4679,7 @@ void do_wizlock(CHAR_DATA *ch, char *argument)
 
 /* RT anti-newbie code */
 
-void do_newlock(CHAR_DATA *ch, char *argument)
+void do_newlock(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	newlock = !newlock;
 
@@ -5922,7 +5922,7 @@ int host_comp(MULTDATA *d1, MULTDATA *d2)
 	return strcmp(get_end_host(d1->des->host), get_end_host(d2->des->host));
 }
 
-void do_multicheck(CHAR_DATA *ch, char *argument)
+void do_multicheck(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	char buf[2 * MAX_STRING_LENGTH];
 	char buf2[MAX_STRING_LENGTH];
@@ -6276,7 +6276,7 @@ void do_incognito(CHAR_DATA *ch, char *argument)
 	}
 }
 
-void do_holylight(CHAR_DATA *ch, char *argument)
+void do_holylight(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	if (is_npc(ch))
 		return;
@@ -6295,7 +6295,7 @@ void do_holylight(CHAR_DATA *ch, char *argument)
 
 /* prefix command: it will put the string typed on each line typed */
 
-void do_prefi(CHAR_DATA *ch, char *argument)
+void do_prefi(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	send_to_char("You cannot abbreviate the prefix command.\r\n", ch);
 }
@@ -6399,7 +6399,7 @@ void do_limcounter(CHAR_DATA *ch, char *argument)
 	send_to_char("\n\r", ch);
 }
 
-void do_classes(CHAR_DATA *ch, char *argument)
+void do_classes(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	char buf[MAX_STRING_LENGTH];
 	int iRace;
@@ -7178,7 +7178,7 @@ void do_empower(CHAR_DATA *ch, char *argument)
 	}
 }
 
-void do_raffects(CHAR_DATA *ch, char *argument)
+void do_raffects(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	RUNE_DATA *rune;
 	char buf[MAX_STRING_LENGTH];
@@ -7286,7 +7286,7 @@ void do_rastrip(CHAR_DATA *ch, char *argument)
 	act("All affects stripped from '$t'.", ch, location->name, 0, TO_CHAR);
 }
 
-void do_aastrip(CHAR_DATA *ch, char *argument)
+void do_aastrip(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	AREA_DATA *area = ch->in_room->area;
 
@@ -7468,7 +7468,7 @@ void do_clearfavors(CHAR_DATA *ch, char *argument)
 	act("$N's favors cleared.", ch, 0, victim, TO_CHAR);
 }
 
-void do_gsnlist(CHAR_DATA *ch, char *argument)
+void do_gsnlist(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	int sn, col = 0;
 	char buf[MSL];
@@ -7494,7 +7494,7 @@ void do_ccl(CHAR_DATA *ch, char *argument)
 	clear_cabal_leaders(ch, cabal_lookup(argument), "You are gone.");
 }
 
-void do_noskills(CHAR_DATA *ch, char *argument)
+void do_noskills(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	if (!IS_SET(ch->comm, COMM_SWITCHSKILLS))
 	{
@@ -7646,7 +7646,7 @@ void buglist_end_fun(CHAR_DATA *ch, char *argument)
 	free_pstring(ch->pcdata->temp_str);
 }
 
-void do_constdump(CHAR_DATA *ch, char *argument)
+void do_constdump(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	FILE *fp = fopen(CONST_DUMP_FILE, "w"), *fp2;
 	if (fp == nullptr)
@@ -7724,7 +7724,7 @@ void do_constdump(CHAR_DATA *ch, char *argument)
 	send_to_char("Const.c dump completed and successful.\n\r", ch);
 }
 
-void do_interpdump(CHAR_DATA *ch, char *argument)
+void do_interpdump([[maybe_unused]] CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	FILE *fp = fopen(INTERP_DUMP_FILE, "w");
 	if (fp == nullptr)
@@ -7797,7 +7797,7 @@ void do_interpdump(CHAR_DATA *ch, char *argument)
 	fclose(fp);
 }
 
-void do_racedump(CHAR_DATA *ch, char *argument)
+void do_racedump(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	FILE *fp = fopen(RACE_DUMP_FILE, "w");
 	if (fp == nullptr)

--- a/code/act_wiz.c
+++ b/code/act_wiz.c
@@ -2135,7 +2135,7 @@ void do_ostat(CHAR_DATA *ch, char *argument)
 		send_to_char("'\n\r", ch);
 	}
 
-	if (obj->pIndexData->progtypes != 0)
+	if (!IS_ZERO_VECTOR(obj->pIndexData->progtypes))
 	{
 		if (IS_SET(obj->progtypes, IPROG_WEAR))
 		{
@@ -2862,7 +2862,7 @@ void do_mstat(CHAR_DATA *ch, char *argument)
 		send_to_char("\n\r", ch);
 	}
 
-	if (is_npc(victim) && victim->pIndexData->progtypes != 0)
+	if (is_npc(victim) && !IS_ZERO_VECTOR(victim->pIndexData->progtypes))
 	{
 		if (IS_SET(victim->progtypes, MPROG_ATTACK))
 		{

--- a/code/alias.c
+++ b/code/alias.c
@@ -224,7 +224,7 @@ void do_unalias(CHAR_DATA *ch, char *argument)
 
 	argument = one_argument(argument, arg);
 
-	if (arg == (char *)'\0')
+	if (arg[0] == '\0')
 	{
 		send_to_char("Unalias what?\n\r", ch);
 		return;

--- a/code/alias.c
+++ b/code/alias.c
@@ -97,7 +97,7 @@ void substitute_alias(DESCRIPTOR_DATA *d, char *argument)
 	interpret(Deref(d->character), buf);
 }
 
-void do_alia(CHAR_DATA *ch, char *argument)
+void do_alia(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	send_to_char("I'm sorry, alias must be entered in full.\n\r", ch);
 }

--- a/code/aprog.c
+++ b/code/aprog.c
@@ -457,7 +457,7 @@ void sun_prog_glasstower(AREA_DATA *area)
 	}
 }
 
-void myell_prog_lawful_city(AREA_DATA *area, CHAR_DATA *ch, CHAR_DATA *victim)
+void myell_prog_lawful_city([[maybe_unused]] AREA_DATA *area, CHAR_DATA *ch, CHAR_DATA *victim)
 {
 	AFFECT_DATA af;
 

--- a/code/cabal.c
+++ b/code/cabal.c
@@ -1658,6 +1658,12 @@ void spell_crimson_martyr(int sn, int level, CHAR_DATA *ch, SpellTarget /* vo */
 		if (is_good(vch) && vch != ch)
 		{
 			affect_to_char(vch, &af);
+
+			// TODO: ch->hit / ch->max_hit is an integer division, so it is 0 for a
+			// martyr below full health and 1 at exactly full health. The heal is
+			// all or nothing rather than scaled by the martyr's remaining health.
+			// Correcting it turns on healing that has never applied to anyone
+			// short of full, so the magnitude needs a balance decision first.
 			vch->hit = std::min((int)vch->max_hit, vch->hit + (level * 10 * (ch->hit / ch->max_hit)));
 			act("$n's sacrifice infuses you with newfound vigor!", ch, 0, vch, TO_VICT);
 		}

--- a/code/cabal.c
+++ b/code/cabal.c
@@ -184,7 +184,7 @@ void spell_fervor(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mod
 }
 */
 
-void spell_epic(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_epic(int sn, int level, CHAR_DATA *ch, [[maybe_unused]] SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	AFFECT_DATA af;
 	if (is_affected(ch, sn))
@@ -208,7 +208,7 @@ void spell_epic(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
 	act("$n concentrates intently for a moment, getting a wild look in $s eyes.", ch, 0, 0, TO_ROOM);
 }
 
-void spell_calm(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_calm(int sn, int level, CHAR_DATA *ch, [[maybe_unused]] SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	AFFECT_DATA af;
 
@@ -241,7 +241,7 @@ void spell_calm(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
 	send_to_char("You manage to snap out of your rage.\n\r", ch);
 }
 
-void spell_rage(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_rage(int sn, int level, CHAR_DATA *ch, [[maybe_unused]] SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	AFFECT_DATA af;
 	OBJ_DATA *obj;
@@ -622,7 +622,7 @@ void spell_rage(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
 	}
 }
 
-void spell_scourge(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_scourge(int sn, int level, CHAR_DATA *ch, [[maybe_unused]] SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *vch;
 	char buf[MAX_STRING_LENGTH];
@@ -651,7 +651,7 @@ void spell_scourge(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mo
 	spell_fireball(sn, level - 2, ch, SpellTarget(), CastMode::Spell);
 }
 
-void spell_hunters_vision(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_hunters_vision(int sn, int level, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
 	AFFECT_DATA af;
 
@@ -680,7 +680,7 @@ void spell_hunters_vision(int sn, int level, CHAR_DATA *ch, SpellTarget vo, Cast
 	send_to_char("You begin to see the world through the undeceiving eyes of a hunter.\n\r", ch);
 }
 
-void spell_hire_mercenary(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_hire_mercenary(int sn, int level, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
 	AFFECT_DATA af;
 	CHAR_DATA *merc;
@@ -804,7 +804,7 @@ void spell_hire_mercenary(int sn, int level, CHAR_DATA *ch, SpellTarget vo, Cast
 	affect_to_char(ch, &af);
 }
 
-void spell_hunters_strength(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_hunters_strength(int sn, int level, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
 	AFFECT_DATA af;
 	float bcr;
@@ -834,7 +834,7 @@ void spell_hunters_strength(int sn, int level, CHAR_DATA *ch, SpellTarget vo, Ca
 	act("$n seems to move with a newfound strength and agility.", ch, 0, 0, TO_ROOM);
 }
 
-void spell_hunters_awareness(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_hunters_awareness(int sn, int level, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
 	CHAR_DATA *victim;
 	AFFECT_DATA af;
@@ -918,7 +918,7 @@ void spell_hunters_awareness(int sn, int level, CHAR_DATA *ch, SpellTarget vo, C
 	affect_to_char(ch, &af);
 }
 
-void spell_web(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_web(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	AFFECT_DATA af;
@@ -955,7 +955,7 @@ void spell_web(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
 		affect_to_char(victim, &af);
 }
 
-void spell_informant(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_informant(int /* sn */, int level, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
 	CHAR_DATA *victim;
 	int amount;
@@ -997,7 +997,7 @@ void spell_informant(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode 
 	send_to_char(info, ch);
 }
 
-void do_howl(CHAR_DATA *ch, char *argument)
+void do_howl(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	CHAR_DATA *vch, *vch_next;
 	int exits = 0;
@@ -1063,7 +1063,7 @@ void do_howl(CHAR_DATA *ch, char *argument)
 	WAIT_STATE(ch, PULSE_VIOLENCE * 2);
 }
 
-void spell_mana_transfer(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_mana_transfer(int sn, int /* level */, CHAR_DATA *ch, SpellTarget vo, CastMode /* mode */)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	int mod = (ch->level * 2);
@@ -1086,7 +1086,7 @@ void spell_mana_transfer(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastM
 		victim->mana = victim->max_mana;
 }
 
-void spell_scribe(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_scribe(int /* sn */, int level, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
 	int skill, cost, ipower;
 	OBJ_DATA *obj;
@@ -1173,7 +1173,7 @@ void spell_scribe(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mod
 	act("$n makes detailed inscriptions on a scroll in $s possession.", ch, skill_table[skill].name, 0, TO_ROOM);
 }
 
-void spell_deny_magic(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_deny_magic([[maybe_unused]] int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	AFFECT_DATA af;
@@ -1209,7 +1209,7 @@ bool check_deny_magic(CHAR_DATA *ch)
 	return true;
 }
 
-void spell_bane(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_bane([[maybe_unused]] int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	int damage;
@@ -1229,7 +1229,7 @@ void spell_bane(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
 	damage_new(ch, victim, damage, gsn_bane, DAM_MENTAL, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "mental assault");
 }
 
-void spell_repose(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_repose(int /* sn */, int /* level */, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
 	AFFECT_DATA af;
 
@@ -1250,7 +1250,7 @@ void spell_repose(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mod
 	}
 }
 
-void spell_medicine(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_medicine(int /* sn */, int level, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
 	CHAR_DATA *vch;
 	AFFECT_DATA af;
@@ -1289,7 +1289,7 @@ void spell_medicine(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode m
 	}
 }
 
-void spell_horde_communion(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_horde_communion(int /* sn */, int level, CHAR_DATA *ch, SpellTarget vo, CastMode /* mode */)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	AFFECT_DATA af;
@@ -1445,7 +1445,7 @@ void do_exile(CHAR_DATA *ch, char *argument)
 	victim->pcdata->extitle = palloc_string(", Exiled from the Horde");
 }
 
-void spell_piety(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_piety(int /* sn */, int level, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
 	AFFECT_DATA af;
 	char buf[MSL];
@@ -1473,7 +1473,7 @@ void spell_piety(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode
 	act("$n stands taller as $s righteous wrath infuses $m.", ch, 0, 0, TO_ROOM);
 }
 
-void spell_fervor(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_fervor(int /* sn */, int level, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
 	AFFECT_DATA af;
 
@@ -1513,7 +1513,7 @@ void spell_fervor(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mod
 	act("You feel your spirit rejoice as holy fervor enters you.", ch, 0, 0, TO_CHAR);
 }
 
-void spell_spiritual_healing(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_spiritual_healing(int /* sn */, int level, CHAR_DATA *ch, SpellTarget vo, CastMode /* mode */)
 {
 	AFFECT_DATA af;
 	CHAR_DATA *victim = vo.AsChar();
@@ -1570,7 +1570,7 @@ void spell_spiritual_healing(int sn, int level, CHAR_DATA *ch, SpellTarget vo, C
 	new_affect_to_char(ch, &af);
 }
 
-void spell_shroud_of_light(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_shroud_of_light(int sn, int level, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
 	AFFECT_DATA af;
 
@@ -1601,7 +1601,7 @@ void spell_shroud_of_light(int sn, int level, CHAR_DATA *ch, SpellTarget vo, Cas
 	affect_to_char(ch, &af);
 }
 
-void spell_crimson_martyr(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_crimson_martyr(int sn, int level, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
 	CHAR_DATA *victim = Deref(ch->fighting), *vch, *vch_next;
 	AFFECT_DATA af;
@@ -1683,7 +1683,7 @@ void retribution_tick(CHAR_DATA *ch, AFFECT_DATA *af)
 	af->modifier -= (int)dam;
 }
 
-void spell_retribution(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_retribution(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	AFFECT_DATA af;
@@ -1780,7 +1780,7 @@ void do_phalanx(CHAR_DATA *ch, char *argument)
 	}
 }
 
-void spell_safehaven(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_safehaven(int /* sn */, int /* level */, CHAR_DATA *ch, SpellTarget vo, CastMode /* mode */)
 {
 	CHAR_DATA *victim = vo.AsChar();
 

--- a/code/cabal.c
+++ b/code/cabal.c
@@ -1448,7 +1448,6 @@ void do_exile(CHAR_DATA *ch, char *argument)
 void spell_piety(int /* sn */, int level, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
 	AFFECT_DATA af;
-	char buf[MSL];
 
 	if (is_npc(ch))
 		return;

--- a/code/characterClasses/ap.c
+++ b/code/characterClasses/ap.c
@@ -2164,7 +2164,7 @@ void mephisto_two(CHAR_DATA *ch, CHAR_DATA *victim, char *argument)
 	act("$n opens $s mouth and a plume of deathly cold issues forth!", ch, 0, 0, TO_ROOM);
 	act("You open your mouth and unleash your icy fury!", ch, 0, 0, TO_CHAR);
 
-	damage_new(ch, victim, ch->level * 3, TYPE_UNDEFINED, true, DAM_COLD, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "icy breath");
+	damage_new(ch, victim, ch->level * 3, TYPE_UNDEFINED, DAM_COLD, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "icy breath");
 
 	act("$n freezes in $s tracks under the icy onslaught.", victim, 0, ch, TO_ROOM);
 	act("The intense cold shocks you into temporary immobility!", ch, 0, victim, TO_VICT);

--- a/code/characterClasses/ap.c
+++ b/code/characterClasses/ap.c
@@ -2321,6 +2321,16 @@ void check_orobas_gamygyn(CHAR_DATA *ch, CHAR_DATA *victim)
 
 void burning_pulse(CHAR_DATA *ch, AFFECT_DATA *af)
 {
+	// TODO: owner is null once the character who lit the burn is gone, and
+	// owner->level below is read without a guard, so the pulse dereferences
+	// null. The fix is not mechanical because the owner's level is the only
+	// thing scaling the damage. Ending the burn early is one answer, and it
+	// matches what the mark of wrath and the track listing now do with a
+	// vanished owner. Letting it burn on is the other, and that needs a source
+	// to attribute the damage to, because damage_new reads ch->level itself and
+	// is_npc returns false for null rather than guarding it. The affect already
+	// carries a finite duration, so this decides the ticks in between rather
+	// than whether the burn ever stops. Needs a game design decision.
 	CHAR_DATA *owner = Deref(af->owner);
 	if (number_percent() > 50)
 		return;

--- a/code/characterClasses/ap.c
+++ b/code/characterClasses/ap.c
@@ -1728,7 +1728,6 @@ void greater_demon_tick(CHAR_DATA *mob, AFFECT_DATA *af)
 
 void furcas_vanish(CHAR_DATA *ch, CHAR_DATA *mob)
 {
-	char buf[MSL];
 	ROOM_INDEX_DATA *pRoomIndex;
 	long nocrash;
 

--- a/code/characterClasses/ap.c
+++ b/code/characterClasses/ap.c
@@ -98,7 +98,7 @@ void check_leech(CHAR_DATA *ch, CHAR_DATA *victim)
 	check_improve(ch, gsn_leech, true, 6);
 }
 
-void spell_indomitability(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_indomitability(int /* sn */, int level, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
 	AFFECT_DATA af;
 
@@ -165,7 +165,7 @@ void do_taunt(CHAR_DATA *ch, char *argument)
 	WAIT_STATE(ch, PULSE_VIOLENCE * 2);
 }
 
-void spell_wrack(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_wrack(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	AFFECT_DATA af;
@@ -203,7 +203,7 @@ void spell_wrack(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode
 	affect_to_char(victim, &af);
 }
 
-void spell_radiance(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_radiance(int sn, int level, CHAR_DATA *ch, [[maybe_unused]] SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	AFFECT_DATA af;
 
@@ -238,7 +238,7 @@ void wrack_tick(CHAR_DATA *ch, AFFECT_DATA *af)
 	}
 }
 
-void spell_inspire_lust(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_inspire_lust(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 
 	CHAR_DATA *victim = vo.AsChar();
@@ -304,7 +304,7 @@ void spell_inspire_lust(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMo
 	}
 }
 
-void lust_pulse(CHAR_DATA *ch, AFFECT_DATA *af)
+void lust_pulse(CHAR_DATA *ch, [[maybe_unused]] AFFECT_DATA *af)
 {
 	OBJ_DATA *steal;
 	CHAR_DATA *victim;
@@ -351,7 +351,7 @@ void lust_pulse(CHAR_DATA *ch, AFFECT_DATA *af)
 	}
 }
 
-void spell_dispaters(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_dispaters(int /* sn */, int /* level */, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
 	CHAR_DATA *victim;
 	OBJ_DATA *obj;
@@ -440,7 +440,7 @@ void do_consume(CHAR_DATA *ch, char *argument)
 	}
 }
 
-void spell_baals_mastery(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_baals_mastery(int /* sn */, int /* level */, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
 	AFFECT_DATA af;
 	int weapon;
@@ -589,7 +589,7 @@ void check_baals_mastery(CHAR_DATA *ch, CHAR_DATA *victim)
 	return;
 }
 
-void spell_word_of_command(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_word_of_command(int /* sn */, int level, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
 	char arg1[MSL], arg2[MSL], buf[MSL];
 	AFFECT_DATA af;
@@ -729,7 +729,7 @@ void command_execute_delay(CHAR_DATA *ch, char *command)
 	free_pstring(ch->pcdata->command[1]);
 }
 
-void spell_mark_of_wrath(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_mark_of_wrath(int /* sn */, int level, CHAR_DATA *ch, SpellTarget vo, CastMode /* mode */)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	AFFECT_DATA af;
@@ -777,7 +777,7 @@ void spell_mark_of_wrath(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastM
 	return;
 }
 
-void spell_living_blade(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_living_blade(int /* sn */, int level, CHAR_DATA *ch, SpellTarget vo, CastMode /* mode */)
 {
 	OBJ_DATA *weapon = vo.AsObj();
 	OBJ_AFFECT_DATA oaf;
@@ -981,7 +981,7 @@ void traitor_pulse(CHAR_DATA *ch, AFFECT_DATA *af)
 	}
 }
 
-void spell_dark_familiar(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_dark_familiar(int /* sn */, int /* level */, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
 	CHAR_DATA *fam;
 	AFFECT_DATA af;
@@ -1096,7 +1096,7 @@ void spell_dark_familiar(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastM
 }
 
 /* The spell used to begin the demon-summoning rituals for AP favors. */
-void spell_unholy_communion(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_unholy_communion(int /* sn */, int level, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
 	AFFECT_DATA af;
 
@@ -1756,7 +1756,7 @@ void furcas_vanish(CHAR_DATA *ch, CHAR_DATA *mob)
 	char_to_room(mob, pRoomIndex);
 }
 
-void spell_insanity(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_insanity(int sn, int level, CHAR_DATA *ch, [[maybe_unused]] SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	AFFECT_DATA af;
 
@@ -1781,7 +1781,7 @@ void spell_insanity(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode m
 	affect_to_char(ch, &af);
 }
 
-void insanity_pulse(CHAR_DATA *ch, AFFECT_DATA *af)
+void insanity_pulse(CHAR_DATA *ch, [[maybe_unused]] AFFECT_DATA *af)
 {
 	CHAR_DATA *victim;
 	int room;
@@ -1931,7 +1931,7 @@ void insanity_two(CHAR_DATA *ch, int room)
 	}
 }
 
-void insanity_end(CHAR_DATA *ch, AFFECT_DATA *af)
+void insanity_end(CHAR_DATA *ch, [[maybe_unused]] AFFECT_DATA *af)
 {
 	send_to_char("Your sanity returns as the dark magic relinquishes control over your body.\n\r", ch);
 	return;
@@ -2330,7 +2330,7 @@ void burning_pulse(CHAR_DATA *ch, AFFECT_DATA *af)
 	damage_new(owner, ch, owner->level / 2, skill_lookup("burning touch"), DAM_FIRE, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "the consuming fire*");
 }
 
-void do_darksight(CHAR_DATA *ch, char *argument)
+void do_darksight(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	AFFECT_DATA af;
 	int number;
@@ -2390,7 +2390,7 @@ void do_darksight(CHAR_DATA *ch, char *argument)
 	check_improve(ch, gsn_darksight, true, 1);
 }
 
-void darksight_end(CHAR_DATA *ch, AFFECT_DATA *af)
+void darksight_end(CHAR_DATA *ch, [[maybe_unused]] AFFECT_DATA *af)
 {
 	AFFECT_DATA af2;
 
@@ -2447,7 +2447,7 @@ char *get_insight_line(long where[])
 	return beep;
 }
 
-void spell_dark_insight(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_dark_insight(int /* sn */, int /* level */, CHAR_DATA *ch, SpellTarget vo, CastMode /* mode */)
 {
 	int found = 0;
 	float dammod;

--- a/code/characterClasses/chrono.c
+++ b/code/characterClasses/chrono.c
@@ -103,7 +103,7 @@ void spell_stasis_wall(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMod
 	RS.Queue.AddToQueue(9, "spell_stasis_wall", "draw_rune_queue", draw_rune_queue, rune.release(), ch);
 }
 
-bool trigger_stasis_wall(void *vo, void *vo2, void *vo3, void *vo4)
+bool trigger_stasis_wall(void *vo, void *vo2, void *vo3, [[maybe_unused]] void *vo4)
 {
 	RUNE_DATA *rune = (RUNE_DATA *)vo;
 	CHAR_DATA *victim = (CHAR_DATA *)vo2, *ch = Deref(rune->owner);
@@ -121,7 +121,7 @@ bool trigger_stasis_wall(void *vo, void *vo2, void *vo3, void *vo4)
 	return true;
 }
 
-bool activate_stasis_wall(void *vo, void *vo2, void *vo3, void *vo4)
+bool activate_stasis_wall(void *vo, void *vo2, void *vo3, [[maybe_unused]] void *vo4)
 {
 	// Zero-initialized, like the sibling template in spell_stasis_wall: this sets
 	// nine of the twelve fields and apply_rune copies the whole struct, so
@@ -198,7 +198,7 @@ void draw_rune(std::unique_ptr<RUNE_DATA> rune)
 // CQueue::GetCharacterData scrapes the argument list for CHAR_DATA pointers to
 // build the cancellation index, so dropping it would make this entry
 // uncancellable by DeleteQueuedEventsInvolving.
-void draw_rune_queue(RUNE_DATA *rune, CHAR_DATA *ch)
+void draw_rune_queue(RUNE_DATA *rune, [[maybe_unused]] CHAR_DATA *ch)
 {
 	draw_rune(std::unique_ptr<RUNE_DATA>(rune));
 }

--- a/code/characterClasses/druid.c
+++ b/code/characterClasses/druid.c
@@ -92,7 +92,7 @@ void spell_imbue_stone(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMod
 }
 */
 
-void spell_tangleroot(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_tangleroot([[maybe_unused]] int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	int dam = (int)((float)((float)ch->level * 0.60f) + (dice(10, level / 4)));

--- a/code/characterClasses/healer.c
+++ b/code/characterClasses/healer.c
@@ -18,7 +18,7 @@
 #include "../const.h"
 #include "../utility.h"
 
-void spell_healing_sleep(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_healing_sleep(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	AFFECT_DATA af;
@@ -64,7 +64,7 @@ void spell_healing_sleep(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastM
 	new_affect_to_char(victim, &af);
 }
 
-void healing_sleep_end(CHAR_DATA *ch, AFFECT_DATA *af)
+void healing_sleep_end(CHAR_DATA *ch, [[maybe_unused]] AFFECT_DATA *af)
 {
 	if (is_awake(ch))
 		return;

--- a/code/characterClasses/necro.c
+++ b/code/characterClasses/necro.c
@@ -783,7 +783,7 @@ void visceral_four(CHAR_DATA *ch)
 
 void spell_ritual_soul(int /* sn */, int /* level */, CHAR_DATA *ch, SpellTarget vo, CastMode /* mode */)
 {
-	CHAR_DATA *search, *victim = vo.AsChar();
+	CHAR_DATA *victim = vo.AsChar();
 
 	for (OwningListWalk<CHAR_DATA> walk(char_list); !walk.Done(); walk.Step())
 	{

--- a/code/characterClasses/necro.c
+++ b/code/characterClasses/necro.c
@@ -24,7 +24,7 @@
 #include "../devextra.h"
 #include "../pstring.h"
 
-void spell_dark_vessel(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_dark_vessel(int /* sn */, int /* level */, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
 	OBJ_DATA *urn, *corpse;
 
@@ -192,7 +192,7 @@ void power_urn(CHAR_DATA *ch, int charges)
 	send_to_char(buf, ch);
 }
 
-void spell_siphon(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_siphon([[maybe_unused]] int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	int dam, blood;
@@ -229,7 +229,7 @@ void spell_siphon(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mod
 	}
 }
 
-void spell_hex(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_hex(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	AFFECT_DATA hex;
@@ -329,7 +329,7 @@ void spell_hex(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
 	ch->hit -= drain;
 }
 
-void spell_animate_dead(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_animate_dead(int sn, int level, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
 	OBJ_DATA *corpse;
 	char *obj_name;
@@ -574,7 +574,7 @@ void animate_four(CHAR_DATA *ch, OBJ_DATA *corpse)
 	check_bond(ch, zombie);
 }
 
-void spell_vampiric_touch(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_vampiric_touch(int /* sn */, int level, CHAR_DATA *ch, SpellTarget vo, CastMode /* mode */)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	int dam;
@@ -595,7 +595,7 @@ void spell_vampiric_touch(int sn, int level, CHAR_DATA *ch, SpellTarget vo, Cast
 	ch->hit += dam;
 }
 
-void spell_black_circle(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_black_circle(int sn, int /* level */, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
 	AFFECT_DATA af;
 	bool found= false;
@@ -644,7 +644,7 @@ void spell_black_circle(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMo
 	new_affect_to_char(ch, &af);
 }
 
-void spell_visceral(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_visceral(int sn, int /* level */, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
 	OBJ_DATA *corpse, *ccorpses[5];
 	int corpses = 0, i;
@@ -781,7 +781,7 @@ void visceral_four(CHAR_DATA *ch)
 	}
 }
 
-void spell_ritual_soul(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_ritual_soul(int /* sn */, int /* level */, CHAR_DATA *ch, SpellTarget vo, CastMode /* mode */)
 {
 	CHAR_DATA *search, *victim = vo.AsChar();
 
@@ -913,7 +913,7 @@ void ritual_four(CHAR_DATA *ch, CHAR_DATA *victim)
 	//TODO: no affect_to_char or similar
 }
 
-void spell_ritual_flesh(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_ritual_flesh(int /* sn */, int /* level */, CHAR_DATA *ch, SpellTarget vo, CastMode /* mode */)
 {
 	CHAR_DATA *search, *victim = vo.AsChar();
 
@@ -1041,7 +1041,7 @@ void flesh_four(CHAR_DATA *ch, CHAR_DATA *victim)
 	}
 }
 
-void spell_decrepify(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_decrepify(int sn, [[maybe_unused]] int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	AFFECT_DATA af;
@@ -1073,7 +1073,7 @@ void spell_decrepify(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode 
 	affect_to_char(victim, &af);
 }
 
-void spell_corrupt_flesh(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_corrupt_flesh(int sn, int /* level */, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
 	char arg1[MSL], arg2[MSL];
 	OBJ_DATA *obj;
@@ -1257,7 +1257,7 @@ void spell_corrupt_flesh(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastM
 	}
 }
 
-void spell_corpse_trap(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_corpse_trap(int sn, int /* level */, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
 	OBJ_DATA *corpse;
 	OBJ_DATA *trap;
@@ -1338,7 +1338,7 @@ void spell_corpse_trap(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMod
 	affect_to_char(ch, &af);
 }
 
-void spell_lesser_golem(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_lesser_golem(int sn, int /* level */, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
 	CHAR_DATA *mob;
 	int vnum = 0;
@@ -1452,7 +1452,7 @@ void spell_lesser_golem(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMo
 	act("You pour some blood on the floor.  It begins shifting and changing, finally forming $N!", ch, 0, mob, TO_CHAR);
 }
 
-void spell_greater_golem(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_greater_golem(int sn, int /* level */, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
 	CHAR_DATA *mob;
 	AFFECT_DATA af;

--- a/code/characterClasses/paladin.c
+++ b/code/characterClasses/paladin.c
@@ -25,7 +25,7 @@
 #include "../act_info.h"
 #include "../pstring.h"
 
-void spell_rites_of_preparation(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_rites_of_preparation(int sn, int /* level */, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
 	CHAR_DATA *to;
 	AFFECT_DATA af;
@@ -97,7 +97,7 @@ void spell_rites_of_preparation(int sn, int level, CHAR_DATA *ch, SpellTarget vo
 	}
 }
 
-void spell_spiritual_hammer(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_spiritual_hammer(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	float dam = dice(level, 4);
@@ -133,7 +133,7 @@ void spell_spiritual_hammer(int sn, int level, CHAR_DATA *ch, SpellTarget vo, Ca
 	damage_new(ch, victim, (int)dam, sn, DAM_HOLY, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "spiritual hammer");
 }
 
-void do_turn_undead(CHAR_DATA *ch, char *argument)
+void do_turn_undead(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	int dam;
 	int difference = 0;
@@ -322,7 +322,7 @@ bool check_intercept(CHAR_DATA *ch, CHAR_DATA *victim, CHAR_DATA *paladin, int d
 	return true;
 }
 
-void spell_blinding_orb(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_blinding_orb(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar(), *vch_next;
 	AFFECT_DATA af;
@@ -396,7 +396,7 @@ void spell_blinding_orb(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMo
 	}
 }
 
-void spell_voice_of_damnation(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_voice_of_damnation(int sn, int /* level */, CHAR_DATA *ch, SpellTarget vo, CastMode /* mode */)
 {
 	CHAR_DATA *victim = vo.AsChar(), *vch_next;
 
@@ -429,7 +429,7 @@ void spell_voice_of_damnation(int sn, int level, CHAR_DATA *ch, SpellTarget vo, 
 	}
 }
 
-void spell_seraphic_mantle(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_seraphic_mantle(int sn, int /* level */, CHAR_DATA *ch, SpellTarget vo, CastMode /* mode */)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	AFFECT_DATA af;
@@ -467,7 +467,7 @@ void spell_seraphic_mantle(int sn, int level, CHAR_DATA *ch, SpellTarget vo, Cas
 	affect_to_char(ch, &af);
 }
 
-void spell_arms_of_light(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_arms_of_light(int sn, int level, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
 	char arg[MSL];
 	OBJ_DATA *weapon;
@@ -530,7 +530,7 @@ void spell_arms_of_light(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastM
 	WAIT_STATE(ch, PULSE_VIOLENCE * 2);
 }
 
-void spell_arms_of_purity(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_arms_of_purity(int sn, int level, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
 	char arg[MSL];
 	OBJ_DATA *weapon;
@@ -591,7 +591,7 @@ void spell_arms_of_purity(int sn, int level, CHAR_DATA *ch, SpellTarget vo, Cast
 	WAIT_STATE(ch, PULSE_VIOLENCE * 2);
 }
 
-void spell_arms_of_wrath(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_arms_of_wrath(int sn, int level, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
 	char arg[MSL];
 	OBJ_DATA *weapon;
@@ -654,7 +654,7 @@ void spell_arms_of_wrath(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastM
 	WAIT_STATE(ch, PULSE_VIOLENCE * 2);
 }
 
-void spell_arms_of_judgement(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_arms_of_judgement(int sn, int level, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
 	char arg[MSL];
 	OBJ_DATA *weapon;
@@ -716,7 +716,7 @@ void spell_arms_of_judgement(int sn, int level, CHAR_DATA *ch, SpellTarget vo, C
 	WAIT_STATE(ch, PULSE_VIOLENCE * 2);
 }
 
-void do_strike_of_virtue(CHAR_DATA *ch, char *argument)
+void do_strike_of_virtue(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	OBJ_DATA *weapon;
 	CHAR_DATA *victim = Deref(ch->fighting);
@@ -753,7 +753,7 @@ void do_strike_of_virtue(CHAR_DATA *ch, char *argument)
 	WAIT_STATE(ch, PULSE_VIOLENCE * 2);
 }
 
-void spell_divine_frenzy(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_divine_frenzy(int sn, int /* level */, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
 	AFFECT_DATA af;
 
@@ -973,7 +973,7 @@ void do_valiant_charge(CHAR_DATA *ch, char *argument)
 	WAIT_STATE(ch, PULSE_VIOLENCE * 3);
 }
 
-void spell_awe(int level, int sn, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_awe(int /* level */, int /* sn */, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
 	AFFECT_DATA af;
 
@@ -998,7 +998,7 @@ void spell_awe(int level, int sn, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
 	affect_to_char(ch, &af);
 }
 
-void spell_shield_of_faith(int level, int sn, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_shield_of_faith(int /* level */, int /* sn */, CHAR_DATA *ch, SpellTarget vo, CastMode /* mode */)
 {
 	AFFECT_DATA af;
 	CHAR_DATA *to = vo.AsChar();
@@ -1033,7 +1033,7 @@ void spell_shield_of_faith(int level, int sn, CHAR_DATA *ch, SpellTarget vo, Cas
 	affect_to_char(to, &af);
 }
 
-void spell_holy_shroud(int level, int sn, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_holy_shroud(int /* level */, int /* sn */, CHAR_DATA *ch, SpellTarget vo, CastMode /* mode */)
 {
 	AFFECT_DATA af;
 	CHAR_DATA *to = vo.AsChar();
@@ -1149,7 +1149,7 @@ int check_arms(CHAR_DATA *ch, OBJ_DATA *wield, bool bOncePerRound)
 	return 0;
 }
 
-void spell_empathy(int level, int sn, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_empathy(int /* level */, int /* sn */, CHAR_DATA *ch, SpellTarget vo, CastMode /* mode */)
 {
 	AFFECT_DATA af;
 	CHAR_DATA *vict = vo.AsChar();
@@ -1190,7 +1190,7 @@ void empathy_end(CHAR_DATA *ch, AFFECT_DATA *af)
 		act("You feel pained as your spiritual link with $n is severed!", Deref(af->owner), 0, ch, TO_VICT);
 }
 
-void spell_tower_of_fortitude(int level, int sn, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_tower_of_fortitude(int /* level */, int /* sn */, CHAR_DATA *ch, SpellTarget vo, CastMode /* mode */)
 {
 	AFFECT_DATA af;
 	CHAR_DATA *vict = vo.AsChar();
@@ -1217,7 +1217,7 @@ void spell_tower_of_fortitude(int level, int sn, CHAR_DATA *ch, SpellTarget vo, 
 	affect_to_char(ch, &af);
 }
 
-void spell_indomitable_spirit(int level, int sn, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_indomitable_spirit(int /* level */, int /* sn */, CHAR_DATA *ch, SpellTarget vo, CastMode /* mode */)
 {
 	AFFECT_DATA af;
 	CHAR_DATA *vict = vo.AsChar();
@@ -1271,7 +1271,7 @@ void ispirit_beat(CHAR_DATA *ch, AFFECT_DATA *af)
 	}
 }
 
-void ispirit_end(CHAR_DATA *ch, AFFECT_DATA *af)
+void ispirit_end(CHAR_DATA *ch, [[maybe_unused]] AFFECT_DATA *af)
 {
 	if (ch->hit < 0)
 	{
@@ -1282,7 +1282,7 @@ void ispirit_end(CHAR_DATA *ch, AFFECT_DATA *af)
 	}
 }
 
-void spell_altruism(int level, int sn, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_altruism(int /* level */, int /* sn */, CHAR_DATA *ch, SpellTarget vo, CastMode /* mode */)
 {
 	CHAR_DATA *vict = vo.AsChar();
 

--- a/code/characterClasses/paladin.c
+++ b/code/characterClasses/paladin.c
@@ -790,7 +790,6 @@ void do_group_retreat(CHAR_DATA *ch, char *argument)
 	CHAR_DATA *vch, *vch_next;
 	CHAR_DATA *victim = Deref(ch->fighting);
 	ROOM_INDEX_DATA *to_room = nullptr;
-	char buf[MAX_INPUT_LENGTH];
 	EXIT_DATA *pexit;
 	int dir;
 	int skill;
@@ -911,7 +910,6 @@ void do_valiant_charge(CHAR_DATA *ch, char *argument)
 	char arg[MAX_INPUT_LENGTH];
 	CHAR_DATA *victim;
 	CHAR_DATA *to;
-	char buf[MAX_INPUT_LENGTH];
 	int count = 0;
 
 	one_argument(argument, arg);

--- a/code/characterClasses/sorcerer.c
+++ b/code/characterClasses/sorcerer.c
@@ -587,7 +587,8 @@ void conflagration_pulse(ROOM_INDEX_DATA *room, ROOM_AFFECT_DATA *af)
 {
 	CHAR_DATA *vch, *vch_next;
 	ROOM_INDEX_DATA *room_next;
-	int dam, exit;
+	int dam, exit, door, count;
+	int candidates[MAX_DIR];
 
 	if (room->sector_type != SECT_CONFLAGRATION)
 		return;
@@ -616,7 +617,21 @@ void conflagration_pulse(ROOM_INDEX_DATA *room, ROOM_AFFECT_DATA *af)
 		}
 	}
 
-	while (!room->exit[(exit = number_range(0, 5))]);
+	// Pick a random exit that exists. Collecting the candidates first keeps this
+	// bounded. Drawing directions at random until one hits never returns when the
+	// room has no exits at all, which is a reachable state.
+	count = 0;
+
+	for (door = 0; door < MAX_DIR; door++)
+	{
+		if (room->exit[door])
+			candidates[count++] = door;
+	}
+
+	if (count == 0)
+		return;
+
+	exit = candidates[number_range(0, count - 1)];
 
 	if (room->exit[exit]
 		&& (room_next = room->exit[exit]->u1.to_room)

--- a/code/characterClasses/sorcerer.c
+++ b/code/characterClasses/sorcerer.c
@@ -1581,7 +1581,10 @@ void spell_earthquake(int sn, int level, CHAR_DATA *ch, [[maybe_unused]] SpellTa
 			break;
 		case SECT_HILLS:
 			act("Loose rocks and earth tumbles down from the hills around you!", ch, 0, 0, TO_ALL);
-			// meant to fall through
+
+			// The cave case below re-guards on the sector, so hills gets the
+			// shared damage loop without the cave message.
+			[[fallthrough]];
 		case SECT_CAVE:
 			if (ch->in_room->sector_type != SECT_HILLS)
 				act("Loose rocks and earth tumbles down from the cave around you!", ch, 0, 0, TO_ALL);
@@ -2148,6 +2151,7 @@ void spell_hydration(int /* sn */, int /* level */, CHAR_DATA *ch, SpellTarget v
 			break;
 		case SECT_SWAMP:
 			heal = dice(12, 10);
+			break;
 		case SECT_WATER:
 			heal = dice(16, 10);
 			break;
@@ -3857,7 +3861,7 @@ int scramble_sn(CHAR_DATA *ch, int sn)
 			continue;
 		}
 
-		if (skill_table[gsn].target == skill_table[sn].target && skill_table[gsn].ctype == skill_table[gsn].ctype)
+		if (skill_table[gsn].target == skill_table[sn].target && skill_table[gsn].ctype == skill_table[sn].ctype)
 		{
 			snarray[found] = gsn;
 			found++;
@@ -6809,8 +6813,10 @@ void spell_rust([[maybe_unused]] int sn, int level, CHAR_DATA *ch, SpellTarget v
 			case WEAR_LEGS:
 			case WEAR_ABOUT:
 				oaf.modifier = -3;
+				break;
 			case WEAR_BODY:
 				oaf.modifier = -4;
+				break;
 			default:
 				continue;
 		}
@@ -8027,7 +8033,7 @@ void spell_mana_infusion(int /* sn */, int level, CHAR_DATA *ch, SpellTarget vo,
 
 	if (ch->level < 10)
 		dammod = 300;
-	else if (10 > ch->level < 15)
+	else if (ch->level < 15)
 		dammod = 200;
 	else
 		dammod = 120;

--- a/code/characterClasses/sorcerer.c
+++ b/code/characterClasses/sorcerer.c
@@ -1070,7 +1070,7 @@ void spell_vacuum(int sn, int level, CHAR_DATA *ch, [[maybe_unused]] SpellTarget
 
 		if (!is_npc(vch) && !is_same_group(vch, ch))
 		{
-			std:snprintf(buf, static_cast<int>(MSL), "Die, %s you sorcerous dog!", pers(ch, vch));
+			std::snprintf(buf, static_cast<int>(MSL), "Die, %s you sorcerous dog!", pers(ch, vch));
 			do_myell(vch, buf, ch);
 		}
 
@@ -2814,7 +2814,7 @@ void spell_disruption(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_
 
 void spell_anchor(int /* sn */, int level, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
-	CHAR_DATA *anchor, *wch, *wch_next, *oldanchor = nullptr;
+	CHAR_DATA *anchor, *oldanchor = nullptr;
 
 	if (ch->in_room->sector_type == SECT_INSIDE
 		|| ch->in_room->sector_type == SECT_UNDERWATER
@@ -3445,7 +3445,7 @@ void spell_frigidaura(int sn, int level, CHAR_DATA *ch, [[maybe_unused]] SpellTa
 /// @note Used to take the spell functions' tag parameter as well, and never read it. It is
 ///       not a SPELL_FUN itself, so it does not have to mirror that signature.
 ///
-void spell_enervate_agitate_helper(int sn, int level, CHAR_DATA *ch, SpellTarget vo, int iDir)
+void spell_enervate_agitate_helper(int sn, int level, CHAR_DATA *ch, [[maybe_unused]] SpellTarget vo, int iDir)
 {
 	CHAR_DATA *victim = get_char_room(ch, target_name);
 	AFFECT_DATA af;

--- a/code/characterClasses/sorcerer.c
+++ b/code/characterClasses/sorcerer.c
@@ -118,7 +118,7 @@ int para_compute(int ele1, int ele2)
 	return -1;
 }
 
-void spell_scorch(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_scorch(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 
@@ -132,7 +132,7 @@ void spell_scorch(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mod
 	damage_new(ch, victim, dam, sn, DAM_FIRE, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, nullptr);
 }
 
-void spell_gravity_well(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_gravity_well(int sn, int level, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
 	OBJ_DATA *well = get_obj_list(ch, target_name, ch->in_room->contents), *gwell;
 	AFFECT_DATA af;
@@ -274,7 +274,7 @@ void gravity_well_explode(ROOM_INDEX_DATA *room, ROOM_AFFECT_DATA *af)
 	}
 }
 
-void spell_cyclone(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_cyclone(int /* sn */, int level, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
 	AREA_AFFECT_DATA aaf;
 	AFFECT_DATA af;
@@ -351,17 +351,17 @@ void cyclone_begin(AREA_DATA *area, AREA_AFFECT_DATA *af)
 	affect_to_area(area, &aaf);
 }
 
-void cyclone_begin_tick(AREA_DATA *area, AREA_AFFECT_DATA *af)
+void cyclone_begin_tick(AREA_DATA *area, [[maybe_unused]] AREA_AFFECT_DATA *af)
 {
 	zone_echo(area, "{cThe surrounding winds seem to pick up noticeably as the horizon darkens.{x");
 }
 
-void cyclone_end_fun(AREA_DATA *area, AREA_AFFECT_DATA *af)
+void cyclone_end_fun(AREA_DATA *area, [[maybe_unused]] AREA_AFFECT_DATA *af)
 {
 	zone_echo(area, "{cThe cyclone gradually dissipates as the skies lighten and debris settles.{x");
 }
 
-void spell_chill(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_chill(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	AFFECT_DATA af;
@@ -398,7 +398,7 @@ void spell_chill(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode
 	}
 }
 
-void spell_chillmetal(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_chillmetal(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = nullptr;
 	OBJ_DATA *obj = nullptr;
@@ -459,7 +459,7 @@ void spell_chillmetal(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode
 	}
 }
 
-void spell_conflagration(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_conflagration(int sn, int level, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
 	AFFECT_DATA af;
 	ROOM_AFFECT_DATA raf;
@@ -651,7 +651,7 @@ void conflag_burnout(ROOM_INDEX_DATA *room, ROOM_AFFECT_DATA *af)
 	}
 }
 
-void spell_ultradiffusion(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_ultradiffusion(int sn, int level, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
 	AFFECT_DATA af;
 
@@ -712,7 +712,7 @@ void ultradiffusion_tick(CHAR_DATA *ch, AFFECT_DATA *af)
 	}
 }
 
-void un_ultradiffusion(CHAR_DATA *ch, char *argument)
+void un_ultradiffusion(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	AFFECT_DATA *paf;
 
@@ -842,7 +842,7 @@ void ultradiffusion_end(CHAR_DATA *ch, AFFECT_DATA *af)
 	WAIT_STATE(ch, 3 * PULSE_VIOLENCE);
 }
 
-void spell_heat_metal(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_heat_metal([[maybe_unused]] int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	OBJ_DATA *obj, *obj2;
@@ -923,7 +923,7 @@ void spell_heat_metal(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode
 	}
 }
 
-void spell_knock(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_knock(int /* sn */, int /* level */, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
 	ROOM_INDEX_DATA *to_room;
 	EXIT_DATA *pexit;
@@ -1000,7 +1000,7 @@ void spell_knock(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode
 	send_to_char("There is no door there.\n\r", ch);
 }
 
-void spell_vacuum(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_vacuum(int sn, int level, CHAR_DATA *ch, [[maybe_unused]] SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	ROOM_AFFECT_DATA raf;
 	CHAR_DATA *vch, *vch_next;
@@ -1230,7 +1230,7 @@ void vacuum_end_fun(ROOM_INDEX_DATA *room, ROOM_AFFECT_DATA *af)
 	}
 }
 
-void spell_incandescense(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_incandescense(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	AFFECT_DATA af;
@@ -1253,7 +1253,7 @@ void spell_incandescense(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastM
 	act("$n begins to glow with a soft white light.", victim, nullptr, nullptr, TO_ROOM);
 }
 
-void spell_infravision(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_infravision(int sn, int level, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
 	AFFECT_DATA af;
 
@@ -1277,7 +1277,7 @@ void spell_infravision(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMod
 	send_to_char("Your sensitivity to heat sources increases.\n\r", ch);
 }
 
-void spell_diuretic(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_diuretic(int /* sn */, int level, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
 	AFFECT_DATA *af;
 	CHAR_DATA *victim = get_char_room(ch, target_name);
@@ -1340,7 +1340,7 @@ void spell_diuretic(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode m
 		multi_hit(victim, ch, TYPE_HIT);
 }
 
-void spell_corona(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_corona(int sn, int level, CHAR_DATA *ch, [[maybe_unused]] SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	AFFECT_DATA af;
 
@@ -1376,7 +1376,7 @@ void spell_corona(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mod
 	affect_to_char(ch, &af);
 }
 
-void spell_heatshield(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_heatshield(int /* sn */, int level, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
 	AFFECT_DATA af;
 
@@ -1401,7 +1401,7 @@ void spell_heatshield(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode
 	act("The air around $n ripples with heat.", ch, 0, 0, TO_ROOM);
 }
 
-void spell_immolate(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_immolate([[maybe_unused]] int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	OBJ_AFFECT_DATA oaf;
@@ -1449,7 +1449,7 @@ void spell_immolate(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode m
 		act("You failed to ignite any of $N's armor.", ch, 0, victim, TO_CHAR);
 }
 
-void immolate_end(OBJ_DATA *obj, OBJ_AFFECT_DATA *af)
+void immolate_end(OBJ_DATA *obj, [[maybe_unused]] OBJ_AFFECT_DATA *af)
 {
 	if (CHAR_DATA *carrier = Deref(obj->carried_by))
 		act("$p stops burning.", carrier, obj, 0, TO_CHAR);
@@ -1458,7 +1458,7 @@ void immolate_end(OBJ_DATA *obj, OBJ_AFFECT_DATA *af)
 		act("$p stops burning.", obj->in_room->people, obj, 0, TO_ALL);
 }
 
-void spell_scathing(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_scathing(int sn, int level, CHAR_DATA *ch, [[maybe_unused]] SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *vch, *vch_next;
 	AFFECT_DATA af;
@@ -1511,7 +1511,7 @@ void spell_scathing(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode m
 	}
 }
 
-void spell_earthquake(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_earthquake(int sn, int level, CHAR_DATA *ch, [[maybe_unused]] SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	ROOM_AFFECT_DATA raf;
 	CHAR_DATA *vch, *vch_next;
@@ -1646,7 +1646,7 @@ void spell_earthquake(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode
 	}
 }
 
-void spell_electrocute(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_electrocute(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	OBJ_DATA *obj;
@@ -1698,7 +1698,7 @@ void spell_electrocute(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMod
 	LAG_CHAR(victim, (tconduct / 15) * PULSE_VIOLENCE);
 }
 
-void spell_induce_pain(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_induce_pain(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	int dam = dice(level, 7) + 10;
@@ -1719,7 +1719,7 @@ void spell_induce_pain(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMod
 	damage_new(ch, victim, dam, sn, DAM_OTHER, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, nullptr);
 }
 
-void spell_disrupt_vision(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_disrupt_vision(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	AFFECT_DATA af;
@@ -1752,7 +1752,7 @@ void spell_disrupt_vision(int sn, int level, CHAR_DATA *ch, SpellTarget vo, Cast
 	act("$n appears to be blinded.", victim, nullptr, nullptr, TO_ROOM);
 }
 
-void spell_mana_conduit(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_mana_conduit(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	AFFECT_DATA af;
@@ -1780,7 +1780,7 @@ void spell_mana_conduit(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMo
 	act("You feel energized, mana flowing more easily through your body.", victim, 0, 0, TO_CHAR);
 }
 
-void spell_synaptic_enhancement(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_synaptic_enhancement(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	AFFECT_DATA af;
@@ -1814,7 +1814,7 @@ void spell_synaptic_enhancement(int sn, int level, CHAR_DATA *ch, SpellTarget vo
 	act("Your mind suddenly feels much clearer and your reflexes sharpen.", victim, 0, 0, TO_CHAR);
 }
 
-void spell_synaptic_impairment(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_synaptic_impairment(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	AFFECT_DATA af;
@@ -1855,7 +1855,7 @@ void spell_synaptic_impairment(int sn, int level, CHAR_DATA *ch, SpellTarget vo,
 	act("Your mind clouds and you find concentration somewhat more difficult.", ch, 0, victim, TO_VICT);
 }
 
-void spell_elecshield(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_elecshield(int sn, int level, CHAR_DATA *ch, [[maybe_unused]] SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	AFFECT_DATA af;
 
@@ -1880,7 +1880,7 @@ void spell_elecshield(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode
 	act("A crackling sphere of electricity briefly surrounds $n.", ch, 0, 0, TO_ROOM);
 }
 
-void spell_scramble_neurons(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_scramble_neurons(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	AFFECT_DATA af;
@@ -1913,7 +1913,7 @@ void spell_scramble_neurons(int sn, int level, CHAR_DATA *ch, SpellTarget vo, Ca
 	act("$n disrupts $N's neurons!", ch, nullptr, victim, TO_NOTVICT);
 }
 
-void spell_mana_leech(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_mana_leech(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	int drain;
@@ -1949,7 +1949,7 @@ void spell_mana_leech(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode
 	}
 }
 
-void spell_interference(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_interference(int sn, int level, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
 	AREA_AFFECT_DATA aaf;
 	AREA_DATA *area;
@@ -2000,12 +2000,12 @@ void spell_interference(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMo
 	rarea_echo(ch->in_room, buf);
 }
 
-void interference_end(AREA_DATA *area, AREA_AFFECT_DATA *af)
+void interference_end(AREA_DATA *area, [[maybe_unused]] AREA_AFFECT_DATA *af)
 {
 	zone_echo(area, "{yThe electrical interference in the area subsides.{x");
 }
 
-void spell_hydroperception(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_hydroperception(int sn, int level, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
 	AFFECT_DATA af;
 
@@ -2029,7 +2029,7 @@ void spell_hydroperception(int sn, int level, CHAR_DATA *ch, SpellTarget vo, Cas
 	send_to_char("You focus your senses on changes in the water around you.\n\r", ch);
 }
 
-void spell_dehydrate(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_dehydrate(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 
@@ -2056,7 +2056,7 @@ void spell_dehydrate(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode 
 	}
 }
 
-void spell_drown(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_drown(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	int dam = dice(level + 10, 4);
@@ -2073,7 +2073,7 @@ void spell_drown(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode
 	damage_new(ch, victim, dam, sn, DAM_DROWNING, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, nullptr);
 }
 
-void spell_hydration(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_hydration(int /* sn */, int /* level */, CHAR_DATA *ch, SpellTarget vo, CastMode /* mode */)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	int heal = 0;
@@ -2175,7 +2175,7 @@ void spell_hydration(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode 
 	victim->hit = std::min(victim->hit + heal, (int)victim->max_hit);
 }
 
-void spell_regeneration(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_regeneration(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	AFFECT_DATA af;
@@ -2209,7 +2209,7 @@ void spell_regeneration(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMo
 	send_to_char("A soothing coolness washes over you as you feel a surge of vitality.\n\r", victim);
 }
 
-void spell_watershield(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_watershield(int /* sn */, int level, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
 	AFFECT_DATA af;
 
@@ -2234,7 +2234,7 @@ void spell_watershield(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMod
 	act("A magical sphere of swirling water briefly surrounds $n.", ch, 0, 0, TO_ROOM);
 }
 
-void spell_flood(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_flood(int sn, int level, CHAR_DATA *ch, [[maybe_unused]] SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	ROOM_INDEX_DATA *to_room;
 	int door, duration;
@@ -2342,7 +2342,7 @@ void spell_flood(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode
 	}
 }
 
-void flood_recede(ROOM_INDEX_DATA *room, ROOM_AFFECT_DATA *af)
+void flood_recede(ROOM_INDEX_DATA *room, [[maybe_unused]] ROOM_AFFECT_DATA *af)
 {
 	if (room->people)
 		act("The flood begins to recede, and before long no trace of the water remains.", room->people, nullptr, nullptr, TO_ALL);
@@ -2351,7 +2351,7 @@ void flood_recede(ROOM_INDEX_DATA *room, ROOM_AFFECT_DATA *af)
 		affect_strip_room(room, gsn_riptide);
 }
 
-void spell_tidalwave(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_tidalwave(int sn, int level, CHAR_DATA *ch, [[maybe_unused]] SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	int door, i;
 	ROOM_INDEX_DATA *to_room;
@@ -2511,7 +2511,7 @@ void spell_tidalwave(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode 
 	affect_to_char(ch, &af);
 }
 
-void spell_riptide(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_riptide(int sn, int level, CHAR_DATA *ch, [[maybe_unused]] SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	ROOM_INDEX_DATA *room, *first_room = nullptr, *second_room = nullptr;
 	AFFECT_DATA af;
@@ -2633,7 +2633,7 @@ void riptide_one_end(ROOM_INDEX_DATA *room, ROOM_AFFECT_DATA *af)
 		act("The ripples in the water cease.", room->people, nullptr, nullptr, TO_ALL);
 }
 
-void riptide_two_end(ROOM_INDEX_DATA *room, ROOM_AFFECT_DATA *af)
+void riptide_two_end(ROOM_INDEX_DATA *room, [[maybe_unused]] ROOM_AFFECT_DATA *af)
 {
 	if (room->people)
 		act("The ripples in the water cease.", room->people, nullptr, nullptr, TO_ALL);
@@ -2651,7 +2651,7 @@ int average_ac(CHAR_DATA *ch)
 	return avg / 3;
 }
 
-void spell_watermeld(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_watermeld(int sn, int level, CHAR_DATA *ch, [[maybe_unused]] SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	AFFECT_DATA af;
 
@@ -2685,7 +2685,7 @@ void spell_watermeld(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode 
 	}
 }
 
-void spell_sense_disturbance(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_sense_disturbance(int sn, int level, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
 	AFFECT_DATA af;
 
@@ -2709,7 +2709,7 @@ void spell_sense_disturbance(int sn, int level, CHAR_DATA *ch, SpellTarget vo, C
 	send_to_char("You attune yourself to notice disturbances in the air around you.\n\r", ch);
 }
 
-void spell_travelease(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_travelease(int sn, int level, CHAR_DATA *ch, [[maybe_unused]] SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	AFFECT_DATA af;
 	CHAR_DATA *gch;
@@ -2739,7 +2739,7 @@ void spell_travelease(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode
 	send_to_char("Ok.\n\r", ch);
 }
 
-void spell_diffusion(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_diffusion(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	AFFECT_DATA af;
@@ -2778,7 +2778,7 @@ void spell_diffusion(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode 
 	}
 }
 
-void spell_disruption(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_disruption(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	int dam = dice(level, 5) + 20;
@@ -2793,7 +2793,7 @@ void spell_disruption(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode
 	damage_new(ch, victim, dam, sn, DAM_INTERNAL, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, nullptr);
 }
 
-void spell_anchor(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_anchor(int /* sn */, int level, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
 	CHAR_DATA *anchor, *wch, *wch_next, *oldanchor = nullptr;
 
@@ -2831,7 +2831,7 @@ void spell_anchor(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mod
 	act("$n concentrates intently, and a small funnel cloud begins to spin in place beside $m.", ch, 0, 0, TO_ROOM);
 }
 
-void spell_aerial_transferrence(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_aerial_transferrence(int sn, int /* level */, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
 	CHAR_DATA *anchor = nullptr, *wch, *wch_next;
 	ROOM_INDEX_DATA *pRoomIndex;
@@ -2908,7 +2908,7 @@ void spell_aerial_transferrence(int sn, int level, CHAR_DATA *ch, SpellTarget vo
 	}
 }
 
-void spell_airshield(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_airshield(int /* sn */, int level, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
 	AFFECT_DATA af;
 
@@ -2941,7 +2941,7 @@ void spell_airshield(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode 
 
 /* Earth spells */
 
-void spell_hardenfist(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_hardenfist(int sn, int level, CHAR_DATA *ch, [[maybe_unused]] SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	AFFECT_DATA af;
 
@@ -2968,7 +2968,7 @@ void spell_hardenfist(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode
 	}
 }
 
-void spell_stability(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_stability(int sn, int level, CHAR_DATA *ch, [[maybe_unused]] SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	AFFECT_DATA af;
 
@@ -2993,7 +2993,7 @@ void spell_stability(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode 
 	send_to_char("You focus on manipulating your own mass, steadying your balance.\n\r", ch);
 }
 
-void spell_crush(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_crush(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	int dam;
@@ -3010,7 +3010,7 @@ void spell_crush(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode
 	damage_new(ch, victim, dam, sn, DAM_INTERNAL, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "crushing force");
 }
 
-void spell_sensevibrations(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_sensevibrations(int sn, int level, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
 	AFFECT_DATA af;
 
@@ -3037,7 +3037,7 @@ void spell_sensevibrations(int sn, int level, CHAR_DATA *ch, SpellTarget vo, Cas
 	}
 }
 
-void spell_diamondskin(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_diamondskin(int sn, int level, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
 	AFFECT_DATA af;
 	if (!(ch->hit < ch->max_hit * .75))
@@ -3077,7 +3077,7 @@ void spell_diamondskin(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMod
 	}
 }
 
-void spell_overbear(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_overbear(int sn, [[maybe_unused]] int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	int str = 0;
@@ -3151,7 +3151,7 @@ void spell_overbear(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode m
 	}
 }
 
-void spell_reduce(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_reduce([[maybe_unused]] int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	AFFECT_DATA af;
@@ -3209,7 +3209,7 @@ void spell_reduce(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mod
 	}
 }
 
-void spell_earthshield(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_earthshield(int /* sn */, int level, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
 	AFFECT_DATA af;
 
@@ -3234,7 +3234,7 @@ void spell_earthshield(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMod
 	act("$n's form is suddenly masked by an opaque gray shield that vanishes as quickly as it appeared.", ch, 0, 0, TO_ROOM);
 }
 
-void spell_coldshield(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_coldshield(int sn, int level, CHAR_DATA *ch, [[maybe_unused]] SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	AFFECT_DATA af;
 
@@ -3259,7 +3259,7 @@ void spell_coldshield(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode
 	act("The air around $n suddenly turns frigid.", ch, 0, 0, TO_ROOM);
 }
 
-void spell_coagulate(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_coagulate(int /* sn */, int level, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
 	CHAR_DATA *victim = get_char_room(ch, target_name);
 
@@ -3301,7 +3301,7 @@ void spell_coagulate(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode 
 	}
 }
 
-void spell_hypothermia(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_hypothermia(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	AFFECT_DATA af;
@@ -3343,7 +3343,7 @@ void spell_hypothermia(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMod
 	}
 }
 
-void spell_imprisonvoice(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_imprisonvoice(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	AFFECT_DATA af;
@@ -3381,7 +3381,7 @@ void spell_imprisonvoice(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastM
 	act_new("Your throat constricts painfully as your vocal cords are frozen solid.", ch, nullptr, victim, TO_VICT, POS_SLEEPING);
 }
 
-void spell_frigidaura(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_frigidaura(int sn, int level, CHAR_DATA *ch, [[maybe_unused]] SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	AFFECT_DATA af;
 
@@ -3612,12 +3612,12 @@ void spell_enervate_agitate_helper(int sn, int level, CHAR_DATA *ch, SpellTarget
 	}
 }
 
-void spell_enervate(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_enervate(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	spell_enervate_agitate_helper(sn, level, ch, vo, -1);
 }
 
-void spell_agitate(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_agitate(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	spell_enervate_agitate_helper(sn, level, ch, vo, 1);
 }
@@ -3656,7 +3656,7 @@ void agitate_tick(CHAR_DATA *ch, AFFECT_DATA *af)
 	}
 }
 
-void spell_freezemetal(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_freezemetal(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	OBJ_DATA *obj;
@@ -3716,7 +3716,7 @@ void spell_freezemetal(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMod
 		damage_new(ch, victim, piercedam, sn, DAM_PIERCE, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "the metal shards*$");
 }
 
-void spell_frostbite(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_frostbite(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	AFFECT_DATA af;
@@ -3852,7 +3852,7 @@ int scramble_sn(CHAR_DATA *ch, int sn)
 	return snarray[number_range(0, found - 1)];
 }
 
-void spell_acid_stream(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_acid_stream(int /* sn */, int level, CHAR_DATA *ch, SpellTarget vo, CastMode /* mode */)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	OBJ_DATA *armor;
@@ -4033,7 +4033,7 @@ void spell_acid_stream(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMod
 		damage_new(victim, victim, dam, gsn_acid_stream, DAM_ACID, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "The stream of acid*");
 }
 
-void spell_acid_vein(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_acid_vein(int sn, int level, CHAR_DATA *ch, [[maybe_unused]] SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	char arg[MSL];
 	OBJ_DATA *weapon;
@@ -4077,7 +4077,7 @@ void spell_acid_vein(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode 
 	WAIT_STATE(ch, PULSE_VIOLENCE * 2);
 }
 
-void acid_end(OBJ_DATA *obj, OBJ_AFFECT_DATA *af)
+void acid_end(OBJ_DATA *obj, [[maybe_unused]] OBJ_AFFECT_DATA *af)
 {
 	if (CHAR_DATA *carrier = Deref(obj->carried_by))
 		act("$p is dissolved by the acid coating it.", carrier, obj, 0, TO_CHAR);
@@ -4094,7 +4094,7 @@ void acid_end(OBJ_DATA *obj, OBJ_AFFECT_DATA *af)
 	extract_obj(obj);
 }
 
-void spell_corrode_lock(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_corrode_lock(int /* sn */, int /* level */, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
 	char arg[MAX_INPUT_LENGTH];
 	OBJ_DATA *obj;
@@ -4238,7 +4238,7 @@ void spell_corrode_lock(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMo
 	}
 }
 
-void spell_attract(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_attract(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	AFFECT_DATA af;
@@ -4291,7 +4291,7 @@ void attract_tick(CHAR_DATA *ch, AFFECT_DATA *af)
 		ch->position = POS_STANDING;
 }
 
-void spell_absorb(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_absorb([[maybe_unused]] int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	AFFECT_DATA af;
@@ -4316,7 +4316,7 @@ void spell_absorb(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mod
 	act("Flashes of light illuminate $N's eyes for a moment as $E completes the spell.", ch, nullptr, victim, TO_ROOM);
 }
 
-void spell_call_lightning(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_call_lightning(int sn, int level, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
 	CHAR_DATA *victim;
 	AFFECT_DATA af;
@@ -4380,7 +4380,7 @@ void spell_call_lightning(int sn, int level, CHAR_DATA *ch, SpellTarget vo, Cast
 	damage_new(ch, victim, dice(level, 8), sn, DAM_LIGHTNING, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "The lightning strike*");
 }
 
-void spell_grounding(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_grounding(int sn, int level, CHAR_DATA *ch, [[maybe_unused]] SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = get_char_room(ch, target_name);
 	AFFECT_DATA af;
@@ -4470,7 +4470,7 @@ void spell_grounding(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode 
 	}
 }
 
-void grounding_end(CHAR_DATA *ch, AFFECT_DATA *af)
+void grounding_end(CHAR_DATA *ch, [[maybe_unused]] AFFECT_DATA *af)
 {
 	if (!str_cmp(race_table[ch->race].name, "imp") || !str_cmp(race_table[ch->race].name, "sidhe"))
 	{
@@ -4485,7 +4485,7 @@ void grounding_end(CHAR_DATA *ch, AFFECT_DATA *af)
 	}
 }
 
-void spell_thunderclap(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_thunderclap(int sn, int level, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
 	CHAR_DATA *vch, *vch_next;
 	AFFECT_DATA af;
@@ -4527,7 +4527,7 @@ void spell_thunderclap(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMod
 	}
 }
 
-void spell_neutralize(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_neutralize([[maybe_unused]] int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	AFFECT_DATA af;
@@ -4571,7 +4571,7 @@ void spell_neutralize(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode
 	affect_to_char(victim, &af);
 }
 
-void spell_caustic_vapor(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_caustic_vapor(int sn, int level, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
 	AFFECT_DATA af;
 	ROOM_AFFECT_DATA raf;
@@ -4624,7 +4624,7 @@ void spell_caustic_vapor(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastM
 	zone_echo(ch->in_room->area, "You hear a massive hissing sound.");
 }
 
-void caustic_vapor_burnout(ROOM_INDEX_DATA *room, ROOM_AFFECT_DATA *af)
+void caustic_vapor_burnout(ROOM_INDEX_DATA *room, [[maybe_unused]] ROOM_AFFECT_DATA *af)
 {
 	for (CHAR_DATA *rch = room->people; rch != nullptr; rch = rch->next_in_room)
 	{
@@ -4632,7 +4632,7 @@ void caustic_vapor_burnout(ROOM_INDEX_DATA *room, ROOM_AFFECT_DATA *af)
 	}
 }
 
-void spell_smokescreen(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_smokescreen(int sn, int level, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
 	ROOM_AFFECT_DATA raf;
 	AFFECT_DATA af;
@@ -4673,13 +4673,13 @@ void spell_smokescreen(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMod
 	act("Dense smoke fills the room, concealing any way out!", ch, 0, 0, TO_ALL);
 }
 
-void smokescreen_end(ROOM_INDEX_DATA *room, ROOM_AFFECT_DATA *af)
+void smokescreen_end(ROOM_INDEX_DATA *room, [[maybe_unused]] ROOM_AFFECT_DATA *af)
 {
 	if (room->people)
 		act("The thick smoke in the room clears.", room->people, nullptr, nullptr, TO_ALL);
 }
 
-void spell_smother(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_smother(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	AFFECT_DATA af;
@@ -4709,7 +4709,7 @@ void spell_smother(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mo
 	LAG_CHAR(victim, PULSE_VIOLENCE);
 }
 
-void spell_putrid_air(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_putrid_air(int /* sn */, int /* level */, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
 	CHAR_DATA *vch, *vch_next;
 
@@ -4743,7 +4743,7 @@ void spell_putrid_air(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode
 	}
 }
 
-void spell_asphyxiate(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_asphyxiate(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	int dam = dice(level, 5);
@@ -4764,7 +4764,7 @@ void spell_asphyxiate(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode
 	damage_new(ch, victim, dam, sn, DAM_INTERNAL, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, nullptr);
 }
 
-void spell_shroud_of_secrecy(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_shroud_of_secrecy(int sn, int level, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
 	AFFECT_DATA af;
 
@@ -4799,7 +4799,7 @@ void spell_shroud_of_secrecy(int sn, int level, CHAR_DATA *ch, SpellTarget vo, C
 	affect_to_char(ch, &af);
 }
 
-void shroud_end(CHAR_DATA *ch, AFFECT_DATA *af)
+void shroud_end(CHAR_DATA *ch, [[maybe_unused]] AFFECT_DATA *af)
 {
 	free_pstring(ch->name);
 	ch->name = palloc_string(ch->true_name);
@@ -4808,7 +4808,7 @@ void shroud_end(CHAR_DATA *ch, AFFECT_DATA *af)
 	act("The shroud of smoke concealing $n dissipates.", ch, 0, 0, TO_ROOM);
 }
 
-void spell_noxious_ward(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_noxious_ward(int sn, int level, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
 	AFFECT_DATA af;
 
@@ -4832,7 +4832,7 @@ void spell_noxious_ward(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMo
 	act("You feel protected by a noxious ward.", ch, 0, 0, TO_CHAR);
 }
 
-void spell_molten_stones(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_molten_stones(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	int blunt = 0, fire = 0;
@@ -4865,7 +4865,7 @@ void spell_molten_stones(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastM
 	damage_new(ch, victim, fire, sn, DAM_FIRE, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "the searing heat*");
 }
 
-void spell_heat_earth(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_heat_earth(int /* sn */, int level, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
 	char buf[MSL];
 	CHAR_DATA *vch, *vch_next;
@@ -4905,7 +4905,7 @@ void spell_heat_earth(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode
 	}
 }
 
-void spell_blanket(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_blanket(int sn, int level, CHAR_DATA *ch, [[maybe_unused]] SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	AFFECT_DATA af;
 	ROOM_AFFECT_DATA raf;
@@ -4974,7 +4974,7 @@ void spell_blanket(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mo
 	act("A sudden gust sweeps through, bearing heavy snowflakes that rapidly blanket the ground.", ch, 0, 0, TO_ALL);
 }
 
-void blanket_melt(ROOM_INDEX_DATA *room, ROOM_AFFECT_DATA *af)
+void blanket_melt(ROOM_INDEX_DATA *room, [[maybe_unused]] ROOM_AFFECT_DATA *af)
 {
 	for (CHAR_DATA *rch = room->people; rch != nullptr; rch = rch->next_in_room)
 	{
@@ -4984,7 +4984,7 @@ void blanket_melt(ROOM_INDEX_DATA *room, ROOM_AFFECT_DATA *af)
 	clear_tracks(room);
 }
 
-void spell_boreal_wind(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_boreal_wind(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	int dam;
@@ -5025,7 +5025,7 @@ void spell_boreal_wind(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMod
 	damage_new(ch, victim, dam, sn, DAM_COLD, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, nullptr);
 }
 
-void spell_concave_shell(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_concave_shell(int /* sn */, int /* level */, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
 	EXIT_DATA *pexit;
 	int dir;
@@ -5179,7 +5179,7 @@ void concave_shell_move(CHAR_DATA *ch, int dir, ROOM_INDEX_DATA *oldroom)
 		REMOVE_BIT(ch->comm, COMM_BRIEF);
 }
 
-void spell_frost_glaze(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_frost_glaze(int sn, int level, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
 	AFFECT_DATA af;
 	int acmod;
@@ -5231,7 +5231,7 @@ void spell_frost_glaze(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMod
 	affect_to_char(ch, &af);
 }
 
-void spell_unbreakable(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_unbreakable(int /* sn */, int level, CHAR_DATA *ch, SpellTarget vo, CastMode /* mode */)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	OBJ_DATA *obj;
@@ -5295,7 +5295,7 @@ void spell_unbreakable(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMod
 	affect_to_char(victim, &af);
 }
 
-void spell_earthsembrace(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_earthsembrace(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	AFFECT_DATA af;
@@ -5330,7 +5330,7 @@ void spell_earthsembrace(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastM
 	}
 }
 
-void spell_whiteout(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_whiteout(int /* sn */, int level, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
 	AREA_DATA *area;
 	AREA_AFFECT_DATA aaf;
@@ -5400,12 +5400,12 @@ void spell_whiteout(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode m
 	affect_to_char(ch, &af);
 }
 
-void whiteout_end(AREA_DATA *area, AREA_AFFECT_DATA *af)
+void whiteout_end(AREA_DATA *area, [[maybe_unused]] AREA_AFFECT_DATA *af)
 {
 	outdoors_echo(area, "{WThe whipping winds and thick snow suddenly subside as visibility returns.{x");
 }
 
-void spell_frigid_breeze(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_frigid_breeze(int /* sn */, int /* level */, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
 	CHAR_DATA *vch, *vch_next;
 	int chance;
@@ -5459,7 +5459,7 @@ void spell_frigid_breeze(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastM
 	}
 }
 
-void spell_pure_air(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_pure_air(int /* sn */, int /* level */, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
 	CHAR_DATA *vch;
 	bool cleansed;
@@ -5515,7 +5515,7 @@ void spell_pure_air(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode m
 	}
 }
 
-void spell_icelance(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_icelance(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	AFFECT_DATA af;
@@ -5556,7 +5556,7 @@ void spell_icelance(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode m
 	}
 }
 
-void spell_freeze_door(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_freeze_door(int /* sn */, int level, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
 	int door;
 	ROOM_INDEX_DATA *to_room;
@@ -5629,7 +5629,7 @@ void door_unfreeze(ROOM_INDEX_DATA *room, ROOM_AFFECT_DATA *af)
 	REMOVE_BIT(pexit->exit_info, EX_JAMMED);
 }
 
-void spell_frost_growth(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_frost_growth(int /* sn */, int level, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
 	ROOM_AFFECT_DATA raf;
 
@@ -5653,13 +5653,13 @@ void spell_frost_growth(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMo
 	new_affect_to_room(ch->in_room, &raf);
 }
 
-void ground_thaw(ROOM_INDEX_DATA *room, ROOM_AFFECT_DATA *af)
+void ground_thaw(ROOM_INDEX_DATA *room, [[maybe_unused]] ROOM_AFFECT_DATA *af)
 {
 	if (room->people)
 		act("The fine layer of frost coating the ground melts away.", room->people, 0, 0, TO_ALL);
 }
 
-void spell_bind_feet(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_bind_feet([[maybe_unused]] int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	AFFECT_DATA af;
@@ -5697,7 +5697,7 @@ void spell_bind_feet(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode 
 	affect_to_char(victim, &af);
 }
 
-void spell_glaciate(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_glaciate(int /* sn */, int level, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
 	ROOM_INDEX_DATA *room = ch->in_room;
 	ROOM_AFFECT_DATA raf;
@@ -5730,13 +5730,13 @@ void spell_glaciate(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode m
 	act("The water beneath you suddenly congeals into glacial ice.", ch, 0, 0, TO_CHAR);
 }
 
-void glaciate_melt(ROOM_INDEX_DATA *room, ROOM_AFFECT_DATA *raf)
+void glaciate_melt(ROOM_INDEX_DATA *room, [[maybe_unused]] ROOM_AFFECT_DATA *raf)
 {
 	if (room->people)
 		act("The ice beneath you melts into water as the magic dissipates.", room->people, 0, 0, TO_ALL);
 }
 
-void spell_hailstorm(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_hailstorm(int /* sn */, int level, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
 	char buf[MSL];
 	CHAR_DATA *vch, *vch_next;
@@ -5770,7 +5770,7 @@ void spell_hailstorm(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode 
 	}
 }
 
-void spell_stalactites(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_stalactites(int /* sn */, int level, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
 	ROOM_AFFECT_DATA raf;
 
@@ -5803,7 +5803,7 @@ void spell_stalactites(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMod
 	new_affect_to_room(ch->in_room, &raf);
 }
 
-void spell_ice_blast(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_ice_blast([[maybe_unused]] int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	OBJ_DATA *obj, *obj_next;
@@ -5862,13 +5862,13 @@ void spell_ice_blast(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode 
 	}
 }
 
-void container_defrost(OBJ_DATA *obj, OBJ_AFFECT_DATA *af)
+void container_defrost(OBJ_DATA *obj, [[maybe_unused]] OBJ_AFFECT_DATA *af)
 {
 	if (CHAR_DATA *carrier = Deref(obj->carried_by))
 		act("The ice sealing $p melts.", carrier, obj, 0, TO_CHAR);
 }
 
-void spell_icy_carapace(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_icy_carapace(int /* sn */, int level, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
 	OBJ_DATA *obj = nullptr;
 	AFFECT_DATA af;
@@ -5940,7 +5940,7 @@ void spell_icy_carapace(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMo
 	affect_to_char(ch, &af);
 }
 
-void spell_sheath_of_ice(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_sheath_of_ice(int /* sn */, int level, CHAR_DATA *ch, SpellTarget vo, CastMode /* mode */)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	AFFECT_DATA af;
@@ -5995,13 +5995,13 @@ void spell_sheath_of_ice(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastM
 	affect_strip(ch, gsn_bash);
 }
 
-void ice_sheath_melt(OBJ_DATA *obj, OBJ_AFFECT_DATA *af)
+void ice_sheath_melt(OBJ_DATA *obj, [[maybe_unused]] OBJ_AFFECT_DATA *af)
 {
 	if (CHAR_DATA *carrier = Deref(obj->carried_by))
 		act("The ice surrounding $p melts.", carrier, obj, 0, TO_CHAR);
 }
 
-void spell_ironskin(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_ironskin(int /* sn */, int level, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
 	AFFECT_DATA af;
 
@@ -6034,7 +6034,7 @@ void spell_ironskin(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode m
 	new_affect_to_char(ch, &af);
 }
 
-void spell_metal_shards(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_metal_shards(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	OBJ_DATA *weapon;
@@ -6083,7 +6083,7 @@ void spell_metal_shards(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMo
 	}
 }
 
-void spell_burden(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_burden([[maybe_unused]] int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	AFFECT_DATA af;
@@ -6120,7 +6120,7 @@ void spell_burden(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mod
 	new_affect_to_char(victim, &af);
 }
 
-void spell_fortify_weapon(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_fortify_weapon(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	OBJ_DATA *weapon = vo.AsObj();
 	OBJ_APPLY_DATA *hitapp = nullptr, *damapp = nullptr;
@@ -6299,7 +6299,7 @@ void spell_fortify_weapon(int sn, int level, CHAR_DATA *ch, SpellTarget vo, Cast
 	}
 }
 
-void spell_fortify_armor(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_fortify_armor(int /* sn */, int level, CHAR_DATA *ch, SpellTarget vo, CastMode /* mode */)
 {
 	OBJ_DATA *armor = vo.AsObj();
 	int chance = 50, i, avg_ac = 0;
@@ -6388,7 +6388,7 @@ void spell_fortify_armor(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastM
 	}
 }
 
-void spell_alter_metal(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_alter_metal(int /* sn */, int /* level */, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
 	char arg1[MSL], arg2[MSL];
 	OBJ_DATA *obj;
@@ -6474,7 +6474,7 @@ void spell_alter_metal(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMod
 	}
 }
 
-void spell_cloak_of_mist(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_cloak_of_mist(int /* sn */, int level, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
 	AFFECT_DATA af;
 
@@ -6501,7 +6501,7 @@ void spell_cloak_of_mist(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastM
 	affect_to_char(ch, &af);
 }
 
-void spell_vigorize(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_vigorize(int /* sn */, int level, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
 	CHAR_DATA *vch;
 	int refresh = 0;
@@ -6530,7 +6530,7 @@ void spell_vigorize(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode m
 	}
 }
 
-void spell_creeping_tomb(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_creeping_tomb(int /* sn */, int level, CHAR_DATA *ch, SpellTarget vo, CastMode /* mode */)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	AFFECT_DATA af;
@@ -6596,7 +6596,7 @@ void creeping_tomb_tick(CHAR_DATA *ch, AFFECT_DATA *af)
 	}
 }
 
-void spell_pass_without_trace(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_pass_without_trace(int /* sn */, int level, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
 	AFFECT_DATA af;
 
@@ -6621,7 +6621,7 @@ void spell_pass_without_trace(int sn, int level, CHAR_DATA *ch, SpellTarget vo, 
 	affect_to_char(ch, &af);
 }
 
-void spell_quicksand(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_quicksand(int /* sn */, int level, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
 	ROOM_AFFECT_DATA raf;
 	AFFECT_DATA af;
@@ -6664,7 +6664,7 @@ void spell_quicksand(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode 
 	affect_to_char(ch, &af);
 }
 
-void quicksand_end(ROOM_INDEX_DATA *room, ROOM_AFFECT_DATA *af)
+void quicksand_end(ROOM_INDEX_DATA *room, [[maybe_unused]] ROOM_AFFECT_DATA *af)
 {
 	if (room->people)
 		act("The ground beneath you solidifies.", room->people, 0, 0, TO_ALL);
@@ -6693,7 +6693,7 @@ void quicksand_pulse_sink(CHAR_DATA *ch, AFFECT_DATA *af)
 	af->modifier++;
 }
 
-void spell_sap_endurance(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_sap_endurance(int /* sn */, int level, CHAR_DATA *ch, SpellTarget vo, CastMode /* mode */)
 {
 	CHAR_DATA *victim = vo.AsChar();
 
@@ -6710,7 +6710,7 @@ void spell_sap_endurance(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastM
 	victim->move = std::max(0, victim->move - number_range((int)((float)level * .9), (int)((float)level * 1.1)));
 }
 
-void spell_emulsify(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_emulsify(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	int dam;
@@ -6726,7 +6726,7 @@ void spell_emulsify(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode m
 	damage_new(ch, victim, dam, sn, DAM_INTERNAL, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "emulsification");
 }
 
-void spell_rust(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_rust([[maybe_unused]] int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	OBJ_DATA *eq;
@@ -6807,7 +6807,7 @@ void spell_rust(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
 	}
 }
 
-void spell_airy_water(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_airy_water(int /* sn */, int level, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
 	ROOM_INDEX_DATA *room = ch->in_room;
 	ROOM_AFFECT_DATA raf;
@@ -6841,7 +6841,7 @@ void spell_airy_water(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode
 	affect_to_room(room, &raf);
 }
 
-void spell_cooling_mist(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_cooling_mist(int /* sn */, int level, CHAR_DATA *ch, SpellTarget vo, CastMode /* mode */)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	AFFECT_DATA af;
@@ -6876,7 +6876,7 @@ void spell_cooling_mist(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMo
 	affect_to_char(victim, &af);
 }
 
-void spell_prismatic_spray(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_prismatic_spray(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	AFFECT_DATA af;
@@ -7032,7 +7032,7 @@ void spell_prismatic_spray(int sn, int level, CHAR_DATA *ch, SpellTarget vo, Cas
 	}
 }
 
-void spell_earthfade(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_earthfade(int /* sn */, int level, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
 	AFFECT_DATA af;
 
@@ -7081,17 +7081,17 @@ void spell_earthfade(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode 
 	affect_to_char(ch, &af);
 }
 
-void earthfade_end(CHAR_DATA *ch, AFFECT_DATA *af)
+void earthfade_end([[maybe_unused]] CHAR_DATA *ch, [[maybe_unused]] AFFECT_DATA *af)
 {
 	return;
 }
 
-void earthfade_tick(CHAR_DATA *ch, AFFECT_DATA *af)
+void earthfade_tick([[maybe_unused]] CHAR_DATA *ch, [[maybe_unused]] AFFECT_DATA *af)
 {
 	return;
 }
 
-void spell_plasma_arc(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_plasma_arc(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	AFFECT_DATA af;
@@ -7122,7 +7122,7 @@ void spell_plasma_arc(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode
 	act("$n's vision is disrupted!", victim, nullptr, nullptr, TO_ROOM);
 }
 
-void spell_plasma_bolt(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_plasma_bolt(int sn, int level, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
 	CHAR_DATA *vch, *vch_next;
 	ROOM_INDEX_DATA *pRoomIndex = nullptr;
@@ -7235,7 +7235,7 @@ void sphere_of_plasma_pulse(CHAR_DATA *ch, AFFECT_DATA *af)
 		affect_remove(ch, af);
 }
 
-void spell_sphere_of_plasma(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_sphere_of_plasma(int sn, int level, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
 	AFFECT_DATA af;
 
@@ -7265,7 +7265,7 @@ void spell_sphere_of_plasma(int sn, int level, CHAR_DATA *ch, SpellTarget vo, Ca
 	die_follower(ch);
 }
 
-void spell_plasma_cube(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_plasma_cube(int sn, int level, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
 	ROOM_AFFECT_DATA raf;
 
@@ -7290,7 +7290,7 @@ void spell_plasma_cube(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMod
 	affect_to_room(ch->in_room, &raf);
 }
 
-void spell_essence_of_plasma(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_essence_of_plasma(int /* sn */, int level, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
 	ROOM_INDEX_DATA *room;
 	ROOM_AFFECT_DATA raf;
@@ -7394,7 +7394,7 @@ void essence_of_plasma_pulse(ROOM_INDEX_DATA *room, ROOM_AFFECT_DATA *af)
 		affect_remove_room(room, af);
 }
 
-void essence_of_plasma_end(ROOM_INDEX_DATA *room, ROOM_AFFECT_DATA *af)
+void essence_of_plasma_end(ROOM_INDEX_DATA *room, [[maybe_unused]] ROOM_AFFECT_DATA *af)
 {
 	if (!room->people)
 		return;
@@ -7408,7 +7408,7 @@ void plasma_thread_end(CHAR_DATA *ch, AFFECT_DATA *paf)
 		act("The thread of plasma no longer connects you to $N.", ch, nullptr, Deref(paf->owner), TO_CHAR);
 }
 
-void spell_plasma_thread(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_plasma_thread(int sn, int level, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
 	AFFECT_DATA af;
 	CHAR_DATA *victim;
@@ -7546,7 +7546,7 @@ void check_plasma_thread(CHAR_DATA *ch, int direction)
 	}
 }
 
-void spell_accumulate_heat(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_accumulate_heat(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	AFFECT_DATA af;
@@ -7581,7 +7581,7 @@ void spell_accumulate_heat(int sn, int level, CHAR_DATA *ch, SpellTarget vo, Cas
 	}
 }
 
-void spell_melt_rock(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_melt_rock(int sn, [[maybe_unused]] int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	OBJ_DATA *obj;
@@ -7630,7 +7630,7 @@ void spell_melt_rock(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode 
 	}
 }
 
-void spell_magma_tunnel(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_magma_tunnel(int /* sn */, int /* level */, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
 	ROOM_INDEX_DATA *to_room = nullptr, *old_room = nullptr;
 	EXIT_DATA *pexit;
@@ -7699,7 +7699,7 @@ void spell_magma_tunnel(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMo
 	act("$n emerges from the ground.", ch, 0, 0, TO_ROOM);
 }
 
-void spell_fashion_crystal(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_fashion_crystal(int /* sn */, int level, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
 	OBJ_DATA *obj;
 	OBJ_AFFECT_DATA oaf;
@@ -7764,7 +7764,7 @@ void crystal_tick(OBJ_DATA *obj, OBJ_AFFECT_DATA *af)
 	}
 }
 
-void spell_farsee(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_farsee(int /* sn */, int level, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
 	AFFECT_DATA af;
 
@@ -7789,7 +7789,7 @@ void spell_farsee(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mod
 	affect_to_char(ch, &af);
 }
 
-void spell_mana_beam(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_mana_beam(int sn, [[maybe_unused]] int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	OBJ_AFFECT_DATA *af;
@@ -7830,7 +7830,7 @@ void spell_mana_beam(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode 
 	}
 }
 
-void spell_detonation(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_detonation(int sn, int /* level */, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
 	CHAR_DATA *vch, *vch_next;
 	OBJ_AFFECT_DATA *af;
@@ -7880,7 +7880,7 @@ void spell_detonation(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode
 	extract_obj(obj);
 }
 
-void spell_rotating_ward(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_rotating_ward(int /* sn */, int level, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
 	OBJ_AFFECT_DATA *oaf;
 	AFFECT_DATA af;
@@ -7959,7 +7959,7 @@ void rotating_tick(CHAR_DATA *ch, AFFECT_DATA *af)
 	}
 }
 
-void spell_fortify_crystal(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_fortify_crystal(int /* sn */, int /* level */, CHAR_DATA *ch, SpellTarget vo, CastMode /* mode */)
 {
 	OBJ_DATA *crystal = vo.AsObj();
 	OBJ_AFFECT_DATA *af;
@@ -7998,7 +7998,7 @@ void mana_infusion_helper(CHAR_DATA *ch, CHAR_DATA *victim)
 	affect_to_char(victim, &af);
 }
 
-void spell_mana_infusion(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_mana_infusion(int /* sn */, int level, CHAR_DATA *ch, SpellTarget vo, CastMode /* mode */)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	int dammod;

--- a/code/characterClasses/sorcerer.c
+++ b/code/characterClasses/sorcerer.c
@@ -8068,5 +8068,5 @@ void infusion_tick(CHAR_DATA *ch, AFFECT_DATA *af)
 	// between them.
 	CHAR_DATA *owner = Deref(af->owner);
 
-	damage_new(owner ? owner : ch, ch, owner ? owner->level / 2 : ch->level / 2, gsn_mana_sickness, true, DAM_OTHER, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "the escaping mana*");
+	damage_new(owner ? owner : ch, ch, owner ? owner->level / 2 : ch->level / 2, gsn_mana_sickness, DAM_OTHER, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "the escaping mana*");
 }

--- a/code/characterClasses/thief.c
+++ b/code/characterClasses/thief.c
@@ -283,6 +283,14 @@ void do_circle_stab(CHAR_DATA *ch, char *argument)
 		dam = dice(obj->value[1], obj->value[2]);
 		dam += 40;
 
+		// TODO: Each fraction below is an integer division that evaluates on its
+		// own before it is applied, so 3 / 2 is 1 and 7 / 3 is 2. The bands
+		// actually run 1, 1, 2, 2, 2, 3, 3, 3 rather than the values written.
+		// Restoring the written numbers literally is not right either, because
+		// they are not monotonic. 7 / 2 at level 49 is larger than 10 / 3 at
+		// level 50, so a thief would lose damage on reaching 50. Truncation has
+		// hidden that because both fractions come out as 3. This needs a damage
+		// curve decision rather than a mechanical fix.
 		if (ch->level <= 15)
 			dam *= 1;
 		else if (ch->level <= 20)

--- a/code/characterClasses/thief.c
+++ b/code/characterClasses/thief.c
@@ -569,7 +569,7 @@ void do_ghetto_bind(CHAR_DATA *ch, char *argument)
 	}
 }
 
-void do_ghetto_unbind(CHAR_DATA *ch, char *argument)
+void do_ghetto_unbind(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	if (!is_affected(ch, gsn_bind))
 	{
@@ -1515,7 +1515,7 @@ void do_disguise(CHAR_DATA *ch, char *argument)
 	WAIT_STATE(ch, PULSE_VIOLENCE * 2);
 }
 
-void disguise_end(CHAR_DATA *ch, AFFECT_DATA *af)
+void disguise_end(CHAR_DATA *ch, [[maybe_unused]] AFFECT_DATA *af)
 {
 	disguise_remove(ch);
 }
@@ -1554,7 +1554,7 @@ void disguise_remove(CHAR_DATA *ch)
 	ch->pcdata->old.reset();
 }
 
-void do_undisguise(CHAR_DATA *ch, char *argument)
+void do_undisguise(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	if (!is_affected(ch, gsn_disguise) || !ch->pcdata->old)
 	{
@@ -1578,7 +1578,7 @@ void do_undisguise(CHAR_DATA *ch, char *argument)
 	WAIT_STATE(ch, PULSE_VIOLENCE * 2);
 }
 
-void do_search(CHAR_DATA *ch, char *argument)
+void do_search(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	OBJ_DATA *obj = nullptr;
 	int chance;
@@ -1712,7 +1712,7 @@ void do_counterfeit(CHAR_DATA *ch, char *argument)
 	WAIT_STATE(ch, PULSE_VIOLENCE * 2);
 }
 
-void counterfeit_end(OBJ_DATA *obj, OBJ_AFFECT_DATA *af)
+void counterfeit_end(OBJ_DATA *obj, [[maybe_unused]] OBJ_AFFECT_DATA *af)
 {
 
 	if (CHAR_DATA *carrier = Deref(obj->carried_by))
@@ -1743,7 +1743,7 @@ void counterfeit_end(OBJ_DATA *obj, OBJ_AFFECT_DATA *af)
 	obj->description = palloc_string(obj->pIndexData->description);
 }
 
-void do_shadow_cloak(CHAR_DATA *ch, char *argument)
+void do_shadow_cloak(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	AFFECT_DATA af;
 	int skill, cost;
@@ -2231,7 +2231,7 @@ void do_bind(CHAR_DATA *ch, char *argument)
 	}
 }
 
-void do_unbind(CHAR_DATA *ch, char *argument)
+void do_unbind(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	AFFECT_DATA *af = check_bind(ch, "arms");
 

--- a/code/characterClasses/thief.c
+++ b/code/characterClasses/thief.c
@@ -1204,7 +1204,6 @@ void do_sign(CHAR_DATA *ch, char *argument)
 
 void do_slash(CHAR_DATA *ch, char *argument)
 {
-	char buf[MAX_STRING_LENGTH];
 	char arg1[MAX_INPUT_LENGTH];
 	char arg2[MAX_INPUT_LENGTH];
 	CHAR_DATA *victim;
@@ -2151,8 +2150,6 @@ void do_bind(CHAR_DATA *ch, char *argument)
 
 	if (number_percent() < skill)
 	{
-		char buf[50];
-
 		init_affect(&af);
 		af.aftype = AFT_SKILL;
 		af.where = TO_AFFECTS;

--- a/code/characterClasses/warrior.c
+++ b/code/characterClasses/warrior.c
@@ -183,7 +183,7 @@ void do_style(CHAR_DATA *ch, char *argument)
 	ch->pcdata->style = style;
 }
 
-void do_entrap(CHAR_DATA *ch, char *argument)
+void do_entrap(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	float skill;
 	CHAR_DATA *victim;
@@ -409,7 +409,7 @@ void do_entrap(CHAR_DATA *ch, char *argument)
 	WAIT_STATE(ch, PULSE_VIOLENCE * 2);
 }
 
-void do_hobble(CHAR_DATA *ch, char *argument)
+void do_hobble(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	int skill;
 	CHAR_DATA *victim;
@@ -690,7 +690,7 @@ void do_hobble(CHAR_DATA *ch, char *argument)
 	}
 }
 
-void do_crippling_blow(CHAR_DATA *ch, char *argument)
+void do_crippling_blow(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	int skill;
 	CHAR_DATA *victim;
@@ -952,7 +952,7 @@ void do_crippling_blow(CHAR_DATA *ch, char *argument)
 	WAIT_STATE(ch, PULSE_VIOLENCE * 2);
 }
 
-void do_gouge(CHAR_DATA *ch, char *argument)
+void do_gouge(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	char hit1[MSL], hit2[MSL], hit3[MSL], miss1[MSL], miss2[MSL], miss3[MSL];
 	int dammod, affect;
@@ -1120,7 +1120,7 @@ void do_gouge(CHAR_DATA *ch, char *argument)
 	WAIT_STATE(ch, PULSE_VIOLENCE * 2);
 }
 
-void do_bleed(CHAR_DATA *ch, char *argument)
+void do_bleed(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	char hit1[MSL], hit2[MSL], hit3[MSL], miss1[MSL], miss2[MSL], miss3[MSL];
 	int skill, dammod, affect;
@@ -1356,7 +1356,7 @@ void posture_pulse(CHAR_DATA *ch, AFFECT_DATA *af)
 		affect_remove(ch, af);
 }
 
-void do_unbalance(CHAR_DATA *ch, char *argument)
+void do_unbalance(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	int skill;
 	CHAR_DATA *victim;
@@ -1426,7 +1426,7 @@ void do_unbalance(CHAR_DATA *ch, char *argument)
 	WAIT_STATE(ch, PULSE_VIOLENCE * 2);
 }
 
-void do_uppercut(CHAR_DATA *ch, char *argument)
+void do_uppercut(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	int success = 0, skill, special = 100, duration = ch->level;
 	CHAR_DATA *victim = Deref(ch->fighting);
@@ -1578,7 +1578,7 @@ int skirmisher_max_weapweight(CHAR_DATA *ch)
 	return 10;
 }
 
-void do_dart(CHAR_DATA *ch, char *argument)
+void do_dart(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	OBJ_DATA *weapon;
 	AFFECT_DATA af;
@@ -2323,7 +2323,7 @@ void do_overhead(CHAR_DATA *ch, char *argument)
 	WAIT_STATE(ch, PULSE_VIOLENCE * 2);
 }
 
-void do_extract(CHAR_DATA *ch, char *argument)
+void do_extract(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	CHAR_DATA *owner;
 	int dam;
@@ -2350,7 +2350,7 @@ void do_extract(CHAR_DATA *ch, char *argument)
 	affect_strip(ch, gsn_impale);
 }
 
-void do_exchange(CHAR_DATA *ch, char *argument)
+void do_exchange(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	CHAR_DATA *victim;
 	int AC;
@@ -2573,7 +2573,7 @@ bool check_ease(CHAR_DATA *ch)
 	}
 }
 
-void do_shieldbash(CHAR_DATA *ch, char *argument)
+void do_shieldbash(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	CHAR_DATA *victim;
 	int skill, chance, weight;
@@ -2656,7 +2656,7 @@ void do_shieldbash(CHAR_DATA *ch, char *argument)
 	}
 }
 
-void do_brace(CHAR_DATA *ch, char *arg)
+void do_brace(CHAR_DATA *ch, [[maybe_unused]] char *arg)
 {
 	int skill, ac;
 	float bracemod;
@@ -4179,7 +4179,7 @@ void do_exploit(CHAR_DATA *ch, char *argument)
 	WAIT_STATE(ch, PULSE_VIOLENCE * 2);
 }
 
-void do_offhand(CHAR_DATA *ch, char *arg)
+void do_offhand(CHAR_DATA *ch, [[maybe_unused]] char *arg)
 {
 	int chance;
 	OBJ_DATA *wield, *offhand;
@@ -4874,7 +4874,7 @@ void do_disrupt_formation(CHAR_DATA *ch, char *arg)
 	one_hit(victim, ch, TYPE_UNDEFINED);
 }
 
-void do_leadership(CHAR_DATA *ch, char *argument)
+void do_leadership(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	AFFECT_DATA af;
 	CHAR_DATA *to;

--- a/code/characterClasses/zealot.c
+++ b/code/characterClasses/zealot.c
@@ -17,7 +17,7 @@
 #include "../db.h"
 #include "../lookup.h"
 
-void spell_infidels_weight(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_infidels_weight(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	AFFECT_DATA af;
@@ -70,7 +70,7 @@ int get_bv_stage(CHAR_DATA *ch)
 	return ((20 - af->duration) / af->modifier);
 }
 
-void spell_burning_vision(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_burning_vision(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	AFFECT_DATA af, *maf;
@@ -126,7 +126,7 @@ void spell_burning_vision(int sn, int level, CHAR_DATA *ch, SpellTarget vo, Cast
 	}
 }
 
-void burning_vision_tick(CHAR_DATA *ch, AFFECT_DATA *af)
+void burning_vision_tick(CHAR_DATA *ch, [[maybe_unused]] AFFECT_DATA *af)
 {
 	AFFECT_DATA *caf;
 
@@ -150,7 +150,7 @@ void burning_vision_tick(CHAR_DATA *ch, AFFECT_DATA *af)
 	}
 }
 
-void spell_divine_malison(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_divine_malison(int /* sn */, int level, CHAR_DATA *ch, SpellTarget vo, CastMode /* mode */)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	AFFECT_DATA af, *paf;

--- a/code/chardef.c
+++ b/code/chardef.c
@@ -11,10 +11,13 @@
 const	struct	pc_race_type	pc_race_table	[]	=
 {
      {
+	// The reserved slot. It stopped short of racePulse, racialDam and status,
+	// which the compiler was zero-filling. They are written out here so that
+	// giving any of them a non-zero default cannot silently change this row.
 	"null race", 	"", 	"",	"", 0, 0, 0, 0,
 	{ "" },
 	{0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,},
-	{ 18, 18, 18, 18, 18 }, 0
+	{ 18, 18, 18, 18, 18 }, 0, 0, 0, 0
      },
 
 /*

--- a/code/comm.c
+++ b/code/comm.c
@@ -2412,6 +2412,8 @@ void nanny(DESCRIPTOR_DATA *d, char *argument)
 
 			write_to_buffer(d, "\n\r", 2);
 			d->connected = CON_NEW_CHAR;
+
+			[[fallthrough]];
 		case CON_NEW_CHAR:
 			// motd
 			do_help(ch, "motd");

--- a/code/comm.c
+++ b/code/comm.c
@@ -716,10 +716,7 @@ void bust_a_prompt(CHAR_DATA *ch)
 				i = buf2;
 				break;
 			case 'h':
-				if (!IS_SET(ch->comm, COMM_ANSI))
-					sprintf(buf2, "%d", ch->hit);
-				else
-					sprintf(buf2, "%d", ch->hit);
+				sprintf(buf2, "%d", ch->hit);
 
 				i = buf2;
 				break;

--- a/code/comm.c
+++ b/code/comm.c
@@ -3331,7 +3331,7 @@ void announce_logout(CHAR_DATA *ch)
 
 void do_rename(CHAR_DATA *ch, char *argument)
 {
-	char old_name[MAX_INPUT_LENGTH], new_name[MAX_INPUT_LENGTH], strsave[MAX_INPUT_LENGTH], pbuf[MSL], *cname;
+	char old_name[MAX_INPUT_LENGTH], new_name[MAX_INPUT_LENGTH], strsave[MAX_INPUT_LENGTH], *cname;
 	CHAR_DATA *victim;
 
 	argument = one_argument(argument, old_name);

--- a/code/comm.c
+++ b/code/comm.c
@@ -3421,7 +3421,7 @@ void do_rename(CHAR_DATA *ch, char *argument)
 	act("$n has renamed you to $N!", ch, nullptr, victim, TO_VICT);
 }
 
-void do_renam(CHAR_DATA *ch, char *argument)
+void do_renam(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	send_to_char("If you want to RENAME an existing player your must type rename in full.\n\r", ch);
 	send_to_char("rename <current name> <new name>\n\r", ch);

--- a/code/comm.c
+++ b/code/comm.c
@@ -2928,17 +2928,22 @@ void show_string(struct descriptor_data *d, char *input)
 		{
 			*scan = '\0';
 			write_to_buffer(d, buffer, strlen(buffer));
-			for (chk = d->showstr_point; isspace(*chk); chk++);
+			// Scanning for the first non-space is the whole of this loop. The
+			// empty body is deliberate, and the block below runs once after it
+			// rather than being the body.
+			for (chk = d->showstr_point; isspace(*chk); chk++)
 			{
-				if (!*chk)
+			}
+
+			if (!*chk)
+			{
+				if (d->showstr_head)
 				{
-					if (d->showstr_head)
-					{
-						delete[] d->showstr_head;
-						d->showstr_head = 0;
-					}
-					d->showstr_point = 0;
+					delete[] d->showstr_head;
+					d->showstr_head = 0;
 				}
+
+				d->showstr_point = 0;
 			}
 
 			return;

--- a/code/db.c
+++ b/code/db.c
@@ -287,7 +287,7 @@ char *munch(char *str)
 
 	copy = str;
 
-	for (i = 0; *copy && *copy != '\0'; i++)
+	for (i = 0; *copy != '\0'; i++)
 	{
 		if (*copy == '\r')
 		{

--- a/code/db.c
+++ b/code/db.c
@@ -852,7 +852,7 @@ void fix_exits(void)
 		{
 			bool fexit = false;
 
-			auto pRoomIndex_exit_size = std::size(pRoomIndex->exit);
+			const int pRoomIndex_exit_size = std::size(pRoomIndex->exit);
 			for (door = 0; door < pRoomIndex_exit_size; door++)
 			{
 				pexit = pRoomIndex->exit[door];
@@ -3052,7 +3052,8 @@ long number_mm(void)
 	if(rgiState[0] == 0) // check if they're all zero, if so call init_mm()
 	{
 		bool isAnyrgiStateNumberNotZero = false;
-		for(auto i = 0; i < std::size(rgiState); i++)
+		const int rgiState_size = std::size(rgiState);
+		for(auto i = 0; i < rgiState_size; i++)
 		{
 			if(rgiState[i] != 0)
 			{
@@ -3593,7 +3594,7 @@ void load_rooms(FILE *fp)
 			SET_BIT(pRoomIndex->room_flags, ROOM_NO_GATE);
 		}
 
-		auto pRoomIndex_exit_size = std::size(pRoomIndex->exit);
+		const int pRoomIndex_exit_size = std::size(pRoomIndex->exit);
 		for (door = 0; door < pRoomIndex_exit_size; door++)
 		{
 			pRoomIndex->exit[door] = nullptr;

--- a/code/db.c
+++ b/code/db.c
@@ -2729,7 +2729,7 @@ void do_areas(CHAR_DATA *ch, char *argument)
 	}
 }
 
-void do_memory(CHAR_DATA *ch, char *argument)
+void do_memory(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	char buf[MAX_STRING_LENGTH];
 
@@ -2776,7 +2776,7 @@ void do_memory(CHAR_DATA *ch, char *argument)
 	send_to_char(buf, ch);
 }
 
-void do_dump(CHAR_DATA *ch, char *argument)
+void do_dump([[maybe_unused]] CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	int count, count2, num_pcs, aff_count;
 	MOB_INDEX_DATA *pMobIndex;
@@ -3300,7 +3300,7 @@ void tail_chain(void)
 	return;
 }
 
-void do_force_reset(CHAR_DATA *ch, char *argument)
+void do_force_reset(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	AREA_DATA *pArea;
 	char buf[MAX_STRING_LENGTH];
@@ -3403,7 +3403,7 @@ void do_alist(CHAR_DATA *ch,char *argument)
 }
 */
 
-void do_llimit(CHAR_DATA *ch, char *argument)
+void do_llimit(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	FILE *fpChar;
 	char strPlr[MAX_INPUT_LENGTH];

--- a/code/db.c
+++ b/code/db.c
@@ -1025,7 +1025,6 @@ void reset_room(ROOM_INDEX_DATA *pRoom)
 	EXIT_DATA *pexit = nullptr;
 	bool last;
 	int level = 0;
-	char buf[MSL];
 	CHAR_DATA *rch;
 	bool found;
 
@@ -1807,7 +1806,6 @@ void clone_mobile(CHAR_DATA *parent, CHAR_DATA *clone)
 OBJ_DATA *create_object(OBJ_INDEX_DATA *pObjIndex, int level)
 {
 	OBJ_DATA *obj;
-	int i;
 
 	if (pObjIndex == nullptr)
 	{

--- a/code/db2.c
+++ b/code/db2.c
@@ -1037,6 +1037,18 @@ void load_objs(FILE *fp)
 		newobjs++;
 		pObjIndex->limcount = 0;
 		pObjIndex->limtotal = 0;
+
+		// The allocation above is default-init, so every scalar member starts
+		// indeterminate and this one is read before anything else assigns it.
+		// The reset walker in db.c compares it against a 'P' reset's limit, and
+		// a prototype whose count lands above that limit is skipped totally and
+		// permanently rather than intermittently. Measured over five boots, 29
+		// of 2,677 prototypes came up non-zero, running from 2,608 to 30,066
+		// against a limit that is at most 999, and the values decode as
+		// recycled string bytes. No reset is currently gated off by it, so
+		// zeroing here changes no behaviour today. load_mobiles above does the
+		// same thing for the matching field on a mob prototype.
+		pObjIndex->count = 0;
 		pObjIndex->extra_descr.clear();
 
 		pObjIndex->name = fread_string(fp);

--- a/code/db2.c
+++ b/code/db2.c
@@ -944,21 +944,29 @@ void load_mobs(FILE *fp)
 	}
 }
 
-void bugout(char *reason)
+[[noreturn]] void bugout(char *reason)
 {
 	//TODO: Tie this into the logging system
 
 	RS.Logger.Warn(reason);
 
 	auto fp = fopen(BUGOUT_FILE, "a");
+
+	// Every caller of this treats it as a halt, so the exit has to happen whether
+	// or not the log file can be opened. Returning early instead left the callers
+	// running on into code written on the assumption that they would not, and two
+	// of them in the area loader go straight into a SET_BIT with NO_FLAG, which
+	// indexes before the start of the field.
 	if (fp == nullptr)
 	{
 		RS.Logger.Warn("Unable to open bug file: fopen {}: {}", BUGOUT_FILE, std::strerror(errno));
-		return;
+	}
+	else
+	{
+		fprintf(fp, "%s\n", reason);
+		fclose(fp);
 	}
 
-	fprintf(fp, "%s\n", reason);
-	fclose(fp);
 	exit(3);
 }
 

--- a/code/db2.c
+++ b/code/db2.c
@@ -676,14 +676,14 @@ void load_mobs(FILE *fp)
 			}
 		}
 
-		auto pMobIndex_affect_sn_size = std::size(pMobIndex->affect_sn);
+		const int pMobIndex_affect_sn_size = std::size(pMobIndex->affect_sn);
 		for (i = 0; i < pMobIndex_affect_sn_size; i++)
 		{
 			pMobIndex->affect_sn[i] = -1;
 		}
 
 		/* Morg - Valgrind fix */
-		auto pMobIndex_cast_spell_size = std::size(pMobIndex->cast_spell);
+		const int pMobIndex_cast_spell_size = std::size(pMobIndex->cast_spell);
 		for (i = 0; i < pMobIndex_cast_spell_size; i++)
 		{
 			pMobIndex->cast_spell[i] = nullptr;

--- a/code/db2.h
+++ b/code/db2.h
@@ -43,7 +43,7 @@ void load_socials (FILE *fp);
 void load_improgs (FILE *fp);
 void load_specs (FILE *fp);
 void load_mobs (FILE *fp);
-void bugout (char *reason);
+[[noreturn]] void bugout (char *reason);
 void bug_exit (char *file, int nLine);
 
 

--- a/code/devextra.c
+++ b/code/devextra.c
@@ -950,8 +950,8 @@ void plug_graveyard(CHAR_DATA *ch, int type)
 	//  this insert must go through the repositories, not the deleted raw
 	//  one_fquery/open_fconn helpers.
 	// auto buf = fmt::sprintf(
-	// 		"insert into gabe20010201051916(zposter,zposter_email,zsubject,zmessage,zdatetime,zaddress,zunique,"\
-	// 		"zthreadid,zdelete,zmod) values('Death_Wizard','immortals@riftshadow.com','%s','%s',"\
+	// 		"insert into gabe20010201051916(zposter,zposter_email,zsubject,zmessage,zdatetime,zaddress,zunique,"
+	// 		"zthreadid,zdelete,zmod) values('Death_Wizard','immortals@riftshadow.com','%s','%s',"
 	// 		"'%s','localhost',%s,'%s',0,'Death_Wizard')",
 	// 		name, message, cur_date, unique, stid);
 }
@@ -3111,15 +3111,18 @@ void do_createcosmetic(CHAR_DATA *ch, char *argument)
 
 OBJ_DATA *make_cosmetic(char *name, char *wearloc, char *underloc, char *cosmeticloc)
 {
-	CHAR_DATA *ch;
+	CHAR_DATA *ch = nullptr;
 	OBJ_DATA *obj;
 
 	for (OwningListWalk<CHAR_DATA> walk(char_list); !walk.Done(); walk.Step())
 	{
-		CHAR_DATA *ch = walk.Current();
+		CHAR_DATA *wch = walk.Current();
 
-		if (is_npc(ch))
+		if (is_npc(wch))
+		{
+			ch = wch;
 			break;
+		}
 	}
 
 	char buf[MSL];

--- a/code/devextra.c
+++ b/code/devextra.c
@@ -1803,7 +1803,7 @@ char *flags_to_string(CHAR_DATA *ch, const struct flag_type *showflags, int flag
 	char temp_value[MAX_INPUT_LENGTH];
 	temp_value[0] = '\0';
 
-	for (flag = 0; showflags[flag].name != nullptr; flag = flag++)
+	for (flag = 0; showflags[flag].name != nullptr; flag++)
 	{
 		strcat(temp_value, showflags[flag].name);
 

--- a/code/devextra.c
+++ b/code/devextra.c
@@ -1954,10 +1954,11 @@ void do_assess_old(CHAR_DATA *ch, char *argument)
 	{
 		buf[0] = '\0';
 
-		if (skill < 91);
+		if (skill < 91)
+		{
 			sprintf(buf, "%s seems to be affected by %s.\n\r", is_npc(victim) ? victim->short_descr : victim->name, skill_table[paf.type].name);
-
-		if (skill >= 91);
+		}
+		else
 		{
 			fuzzy = number_range(0, 2);
 			// Let's fuz up the duration a bit if it's not permanent.

--- a/code/devextra.c
+++ b/code/devextra.c
@@ -1362,7 +1362,7 @@ void do_credits(CHAR_DATA *ch, char *argument)
 			return;
 		}
 
-		if (buf && buf2[0] == '\0')
+		if (buf2[0] == '\0')
 		{
 			sprintf(buf3, "%s has %i bounty credits.\n\r", victim->name, victim->pcdata->bounty_credits);
 			send_to_char(buf3, ch);
@@ -1479,7 +1479,7 @@ void do_bounty(CHAR_DATA *ch, char *argument)
 		return;
 	}
 
-	if (!arg1 || !arg2 || (!is_number(arg2) && !is_immortal(ch)))
+	if (arg1[0] == '\0' || arg2[0] == '\0' || (!is_number(arg2) && !is_immortal(ch)))
 	{
 		send_to_char("Syntax:   bounty <character> <amount>\n\r", ch);
 		send_to_char("Places a bounty of the specified amount on the life of the specified character.\n\r", ch);

--- a/code/devextra.c
+++ b/code/devextra.c
@@ -152,7 +152,7 @@ void do_gold(CHAR_DATA *ch, char *argument)
 	send_to_char(buf, ch);
 }
 
-void do_clean(CHAR_DATA *ch, char *argument)
+void do_clean(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	send_to_char("Cleaning logins...\n\r", ch);
 	send_to_char("Cleaning notes...\n\r", ch);
@@ -656,7 +656,7 @@ void show_database_info(CHAR_DATA *ch, char *argument)
 	}
 }
 
-void do_demo(CHAR_DATA *ch, char *name)
+void do_demo(CHAR_DATA *ch, [[maybe_unused]] char *name)
 {
 	FILE *fp;
 	char tempbuf[MSL], buf[MSL];
@@ -1431,7 +1431,7 @@ void bounty_cb(char *string)
 		do_cb(guardian, string);
 }
 
-void do_topbounties(CHAR_DATA *ch, char *argument)
+void do_topbounties(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	int i, pnum = 0, plus = 0;
 	char buf[MAX_STRING_LENGTH];
@@ -1621,7 +1621,7 @@ void pay_bounty(CHAR_DATA *ch, CHAR_DATA *victim)
 	victim->pcdata->bounty = 0;
 }
 
-void do_rchanges(CHAR_DATA *ch, char *argument)
+void do_rchanges([[maybe_unused]] CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	/*
 	char arg1[MAX_STRING_LENGTH], buf[MAX_STRING_LENGTH], list[2000][110], nlist[110];
@@ -2886,7 +2886,7 @@ void do_call(CHAR_DATA *ch, char *argument)
 	}
 }
 
-void do_snare(CHAR_DATA *ch, char *argument)
+void do_snare(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	ROOM_AFFECT_DATA af;
 	AFFECT_DATA snaretimer;
@@ -3148,7 +3148,7 @@ OBJ_DATA *make_cosmetic(char *name, char *wearloc, char *underloc, char *cosmeti
 	return obj;
 }
 
-void pulse_prog_repop_container(OBJ_DATA *obj, bool isTick)
+void pulse_prog_repop_container(OBJ_DATA *obj, [[maybe_unused]] bool isTick)
 {
 	if (obj->contains)
 		return;

--- a/code/dioextra.c
+++ b/code/dioextra.c
@@ -1575,23 +1575,23 @@ bool can_live_in(CHAR_DATA *ch, int hometown)
 		return false;
 
 	if (hometown_table[hometown].align == ALIGN_NONE
-		|| hometown_table[hometown].align == ALIGN_GN && is_evil(ch)
-		|| hometown_table[hometown].align == ALIGN_NE && is_good(ch)
-		|| hometown_table[hometown].align == ALIGN_G && !is_good(ch)
-		|| hometown_table[hometown].align == ALIGN_N && !is_neutral(ch)
-		|| hometown_table[hometown].align == ALIGN_E && !is_evil(ch)
-		|| hometown_table[hometown].align == ALIGN_GE && is_neutral(ch))
+		|| (hometown_table[hometown].align == ALIGN_GN && is_evil(ch))
+		|| (hometown_table[hometown].align == ALIGN_NE && is_good(ch))
+		|| (hometown_table[hometown].align == ALIGN_G && !is_good(ch))
+		|| (hometown_table[hometown].align == ALIGN_N && !is_neutral(ch))
+		|| (hometown_table[hometown].align == ALIGN_E && !is_evil(ch))
+		|| (hometown_table[hometown].align == ALIGN_GE && is_neutral(ch)))
 	{
 		return false;
 	}
 
 	if (hometown_table[hometown].ethos == ETHOS_NONE
-		|| hometown_table[hometown].ethos == ETHOS_LN && is_chaotic(ch)
-		|| hometown_table[hometown].ethos == ETHOS_NC && is_lawful(ch)
-		|| hometown_table[hometown].ethos == ETHOS_L && !is_lawful(ch)
-		|| hometown_table[hometown].ethos == ETHOS_N && !is_eneutral(ch)
-		|| hometown_table[hometown].ethos == ETHOS_C && !is_chaotic(ch)
-		|| hometown_table[hometown].ethos == ETHOS_LC && is_eneutral(ch))
+		|| (hometown_table[hometown].ethos == ETHOS_LN && is_chaotic(ch))
+		|| (hometown_table[hometown].ethos == ETHOS_NC && is_lawful(ch))
+		|| (hometown_table[hometown].ethos == ETHOS_L && !is_lawful(ch))
+		|| (hometown_table[hometown].ethos == ETHOS_N && !is_eneutral(ch))
+		|| (hometown_table[hometown].ethos == ETHOS_C && !is_chaotic(ch))
+		|| (hometown_table[hometown].ethos == ETHOS_LC && is_eneutral(ch)))
 	{
 		return false;
 	}

--- a/code/dioextra.c
+++ b/code/dioextra.c
@@ -916,7 +916,7 @@ void report_cabal_items(CHAR_DATA *ch, char *argument)
 			}
 		}
 
-		if (guardian != nullptr && pbuf != nullptr && obj != nullptr)
+		if (guardian != nullptr && pbuf[0] != '\0' && obj != nullptr)
 			do_say(guardian, pbuf);
 	}
 }

--- a/code/effects.c
+++ b/code/effects.c
@@ -638,6 +638,7 @@ void shock_effect(SpellTarget target, int level, int dam)
 			case ITEM_JEWELRY:
 				chance -= 10;
 				msg = "$p is fused into a worthless lump.";
+				break;
 			default:
 				return;
 		}

--- a/code/fight.c
+++ b/code/fight.c
@@ -5025,7 +5025,7 @@ void disarm(CHAR_DATA *ch, CHAR_DATA *victim)
 	}
 }
 
-void do_berserk(CHAR_DATA *ch, char *argument)
+void do_berserk(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	float chance;
 	int hp_percent;
@@ -5848,7 +5848,7 @@ void do_kill(CHAR_DATA *ch, char *argument)
 	multi_hit(ch, victim, TYPE_UNDEFINED);
 }
 
-void do_murde(CHAR_DATA *ch, char *argument)
+void do_murde(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	send_to_char("If you want to MURDER, spell it out.\n\r", ch);
 }
@@ -6128,7 +6128,7 @@ void do_rescue(CHAR_DATA *ch, char *argument)
 	set_fighting(fch, ch);
 }
 
-void do_kick(CHAR_DATA *ch, char *argument)
+void do_kick(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	CHAR_DATA *victim;
 	int dam, skill;
@@ -6187,7 +6187,7 @@ void do_kick(CHAR_DATA *ch, char *argument)
 	}
 }
 
-void do_disarm(CHAR_DATA *ch, char *argument)
+void do_disarm(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	CHAR_DATA *victim;
 	OBJ_DATA *obj;
@@ -6286,7 +6286,7 @@ void do_disarm(CHAR_DATA *ch, char *argument)
 	}
 }
 
-void do_surrender(CHAR_DATA *ch, char *argument)
+void do_surrender(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	CHAR_DATA *mob = Deref(ch->fighting);
 
@@ -6302,7 +6302,7 @@ void do_surrender(CHAR_DATA *ch, char *argument)
 	stop_fighting(ch, true);
 }
 
-void do_sla(CHAR_DATA *ch, char *argument)
+void do_sla(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	send_to_char("If you want to SLAY, spell it out.\n\r", ch);
 }
@@ -6346,7 +6346,7 @@ void do_slay(CHAR_DATA *ch, char *argument)
 	raw_kill(ch, victim);
 }
 
-void spell_power_word_kill(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_power_word_kill(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	int dam, saves, modify;
@@ -7017,7 +7017,7 @@ void do_nerve(CHAR_DATA *ch, char *argument)
 	}
 }
 
-void do_endure(CHAR_DATA *ch, char *argument)
+void do_endure(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	AFFECT_DATA af;
 
@@ -7063,7 +7063,7 @@ void do_endure(CHAR_DATA *ch, char *argument)
 	ch->mana -= 30;
 }
 
-void do_blindness_dust(CHAR_DATA *ch, char *argument)
+void do_blindness_dust(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	CHAR_DATA *vch;
 	CHAR_DATA *vch_next;
@@ -7149,7 +7149,7 @@ void do_blindness_dust(CHAR_DATA *ch, char *argument)
 	}
 }
 
-void do_poison_dust(CHAR_DATA *ch, char *argument)
+void do_poison_dust(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	CHAR_DATA *vch;
 	CHAR_DATA *vch_next;
@@ -7238,7 +7238,7 @@ void do_poison_dust(CHAR_DATA *ch, char *argument)
 	}
 }
 
-void do_warcry(CHAR_DATA *ch, char *argument)
+void do_warcry(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	AFFECT_DATA af;
 
@@ -7587,7 +7587,7 @@ void do_tame(CHAR_DATA *ch, char *argument)
 	REMOVE_BIT(victim->off_flags, SPAM_MURDER);
 }
 
-void do_find_water(CHAR_DATA *ch, char *argument)
+void do_find_water(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	OBJ_DATA *spring;
 
@@ -7637,7 +7637,7 @@ void do_find_water(CHAR_DATA *ch, char *argument)
 	obj_to_room(spring, ch->in_room);
 }
 
-void do_track(CHAR_DATA *ch, char *argument)
+void do_track([[maybe_unused]] CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	return;
 }
@@ -7820,7 +7820,7 @@ void age_death(CHAR_DATA *ch)
 	send_to_char("You have died and become a permanent ghost, awaiting your final departure.\n\r", ch);
 }
 
-void do_forage(CHAR_DATA *ch, char *argument)
+void do_forage(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	OBJ_DATA *berry_1;
 	OBJ_DATA *berry_2;
@@ -8552,7 +8552,7 @@ void do_pugil(CHAR_DATA *ch, char *argument)
 	WAIT_STATE(ch, 20);
 }
 
-void do_protection_heat_cold(CHAR_DATA *ch, char *argument)
+void do_protection_heat_cold(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	AFFECT_DATA af;
 	int chance;
@@ -8596,7 +8596,7 @@ void do_protection_heat_cold(CHAR_DATA *ch, char *argument)
 	check_improve(ch, gsn_protection_heat_cold, true, 1);
 }
 
-void do_call_to_arms(CHAR_DATA *ch, char *arguement)
+void do_call_to_arms(CHAR_DATA *ch, [[maybe_unused]] char *arguement)
 {
 	CHAR_DATA *target;
 	CHAR_DATA *target_next;
@@ -8685,7 +8685,7 @@ void do_call_to_arms(CHAR_DATA *ch, char *arguement)
 	WAIT_STATE(ch, 12);
 }
 
-void do_iron_resolve(CHAR_DATA *ch, char *argument)
+void do_iron_resolve(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	AFFECT_DATA af;
 
@@ -8725,7 +8725,7 @@ void do_iron_resolve(CHAR_DATA *ch, char *argument)
 	WAIT_STATE(ch, 12);
 }
 
-void do_quiet_movement(CHAR_DATA *ch, char *argument)
+void do_quiet_movement(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	AFFECT_DATA af;
 	int chance;
@@ -9340,7 +9340,7 @@ void do_gore(CHAR_DATA *ch, char *argument)
 	}
 }
 
-void do_headbutt(CHAR_DATA *ch, char *argument)
+void do_headbutt(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	CHAR_DATA *victim;
 	AFFECT_DATA af;
@@ -9443,7 +9443,7 @@ void do_headbutt(CHAR_DATA *ch, char *argument)
 	WAIT_STATE(ch, 2 * PULSE_VIOLENCE);
 }
 
-void do_disengage(CHAR_DATA *ch, char *argument)
+void do_disengage(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	CHAR_DATA *opponent;
 

--- a/code/fight.c
+++ b/code/fight.c
@@ -1383,10 +1383,7 @@ int damage_new(CHAR_DATA *ch, CHAR_DATA *victim, int idam, int dt, int dam_type,
 			dam = 0;
 			break;
 		case IS_RESISTANT:
-			if (is_npc(victim))
-				dam -= dam / 3;
-			else
-				dam -= dam / 3;
+			dam -= dam / 3;
 
 			break;
 		case IS_VULNERABLE:

--- a/code/fight.c
+++ b/code/fight.c
@@ -683,6 +683,13 @@ void mob_hit(CHAR_DATA *ch, CHAR_DATA *victim, int dt)
 	if (Deref(ch->fighting) != victim || dt == gsn_backstab)
 		return;
 
+	// TODO: The dual_chance multipliers further down are integer divisions that
+	// evaluate on their own before they are applied. 6 / 4 and 3 / 2 are both 1,
+	// so haste does nothing to either off-hand attack, and 2 / 3 is 0, so the
+	// second off-hand attack can never fire. This is the NPC path only. The
+	// player path in multi_hit keeps dual_chance as a float and is correct.
+	// Correcting the arithmetic raises mob damage, so it needs a balance
+	// decision on the intended curve rather than a mechanical fix.
 	chance = std::max(70, get_skill(ch, gsn_second_attack));
 	dual_chance = ch->level * 2 / 3;
 

--- a/code/fight.c
+++ b/code/fight.c
@@ -3196,6 +3196,10 @@ void death_cry(CHAR_DATA *ch, bool infidels)
 					msg = "$n splatters blood on your armor.";
 					break;
 				}
+
+				// A corpse that is not flesh has no blood to splatter, so it
+				// takes the guts message below instead.
+				[[fallthrough]];
 			case 2:
 				if (IS_SET(ch->parts, PART_GUTS))
 				{
@@ -9384,7 +9388,7 @@ void do_headbutt(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 
 		damage_new(ch, victim, dam, gsn_headbutt, DAM_BASH, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "headbutt");
 
-		if (number_percent() < 3 && !IS_SET(victim->imm_flags, IMM_BASH && !IS_SET(victim->imm_flags, IMM_SLEEP)))
+		if (number_percent() < 3 && !IS_SET(victim->imm_flags, IMM_BASH) && !IS_SET(victim->imm_flags, IMM_SLEEP))
 		{
 			act("With the impact, everything suddenly goes black....", victim, 0, 0, TO_CHAR);
 			act("$n staggers back from the collision and then collapses in a heap!", victim, 0, 0, TO_ROOM);

--- a/code/fight.h
+++ b/code/fight.h
@@ -44,6 +44,14 @@ int one_hit_new (CHAR_DATA *ch, CHAR_DATA *victim, int dt, bool specials, bool b
  * Inflict damage from a hit.
  */
 int damage_new (CHAR_DATA *ch, CHAR_DATA *victim, int idam, int dt, int dam_type, bool show, bool blockable, int addition, int multiplier, char *dnoun);
+//
+// The dam_type and show arguments sit next to each other and one is a bool, so
+// swapping them compiles silently and deals DAM_BASH (which is 1, the same as
+// true). Two of the 179 call sites had drifted that way. This overload makes the
+// mistake a compile error instead: a bool is an exact match here and only a
+// promotion for the declaration above, so passing one picks this and fails.
+//
+int damage_new (CHAR_DATA *ch, CHAR_DATA *victim, int idam, int dt, bool dam_type, bool show, bool blockable, int addition, int multiplier, char *dnoun) = delete;
 int damage (CHAR_DATA *ch,CHAR_DATA *victim, int dam,int dt,int dam_type, bool show);
 /*
  * Inflict damage from a hit.

--- a/code/handler.c
+++ b/code/handler.c
@@ -884,36 +884,35 @@ int get_curr_stat(CHAR_DATA *ch, int stat)
 
 		if (!str_cmp(race_table[ch->race].name, "human"))
 		{
-			int iClass;
-			iClass = ch->Class()->GetIndex();
+			int iClass = ch->Class()->GetIndex();
 			switch (ch->Class()->attr_prime)
 			{
 				case STAT_STR:
 					if (stat == STAT_STR &&
-						(ch->Class()->GetIndex() == CLASS_WARRIOR || ch->Class()->GetIndex() == CLASS_ANTI_PALADIN ||
-						ch->Class()->GetIndex() == CLASS_RANGER || ch->Class()->GetIndex() == CLASS_PALADIN))
+						(iClass == CLASS_WARRIOR || iClass == CLASS_ANTI_PALADIN ||
+						iClass == CLASS_RANGER || iClass == CLASS_PALADIN))
 						max = 23;
 					else
 						max = 20;
 					break;
 				case STAT_INT:
 					if (stat == STAT_INT &&
-						(ch->Class()->GetIndex() == CLASS_SORCERER || ch->Class()->GetIndex() == CLASS_NECROMANCER ||
-						ch->Class()->GetIndex() == CLASS_SHAPESHIFTER))
+						(iClass == CLASS_SORCERER || iClass == CLASS_NECROMANCER ||
+						iClass == CLASS_SHAPESHIFTER))
 						max = 23;
 					else
 						max = 20;
 					break;
 				case STAT_WIS:
 					if (stat == STAT_WIS &&
-						(ch->Class()->GetIndex() == CLASS_HEALER || ch->Class()->GetIndex() == CLASS_ZEALOT))
+						(iClass == CLASS_HEALER || iClass == CLASS_ZEALOT))
 						max = 23;
 					else
 						max = 20;
 					break;
 				case STAT_DEX:
 					if (stat == STAT_DEX &&
-						(ch->Class()->GetIndex() == CLASS_ASSASSIN || ch->Class()->GetIndex() == CLASS_THIEF))
+						(iClass == CLASS_ASSASSIN || iClass == CLASS_THIEF))
 						max = 23;
 					else
 						max = 20;

--- a/code/handler.c
+++ b/code/handler.c
@@ -1888,13 +1888,13 @@ void equip_char(CHAR_DATA *ch, OBJ_DATA *obj, int iWear, bool show)
 	}
 
 	if (!is_npc(ch)
-		&& (is_obj_stat(obj, ITEM_ANTI_EVIL) && palign < 0)
-		|| (is_obj_stat(obj, ITEM_ANTI_GOOD) && palign > 0)
-		|| (is_obj_stat(obj, ITEM_ANTI_NEUTRAL) && palign == 0)
-		|| (is_obj_stat(obj, ITEM_ANTI_LAWFUL) && pethos > 0)
-		|| (is_obj_stat(obj, ITEM_ANTI_NEUT) && pethos == 0)
-		|| (is_obj_stat(obj, ITEM_ANTI_CHAOTIC) && pethos < 0)
-		|| is_restricted(ch, obj))
+		&& ((is_obj_stat(obj, ITEM_ANTI_EVIL) && palign < 0)
+			|| (is_obj_stat(obj, ITEM_ANTI_GOOD) && palign > 0)
+			|| (is_obj_stat(obj, ITEM_ANTI_NEUTRAL) && palign == 0)
+			|| (is_obj_stat(obj, ITEM_ANTI_LAWFUL) && pethos > 0)
+			|| (is_obj_stat(obj, ITEM_ANTI_NEUT) && pethos == 0)
+			|| (is_obj_stat(obj, ITEM_ANTI_CHAOTIC) && pethos < 0)
+			|| is_restricted(ch, obj)))
 	{
 		/*
 		 * Thanks to Morgenes for the bug fix here!

--- a/code/handler.c
+++ b/code/handler.c
@@ -187,8 +187,10 @@ int weapon_lookup(const char *name)
 /// @returns The type of the given weapon. (Default: WEAPON_EXOTIC)
 int weapon_type_lookup(const char *name)
 {
-	auto idx = weapon_lookup(name);
-	return idx > -1 || idx < weapon_table.size()
+	const int idx = weapon_lookup(name);
+	const int weapon_table_size = weapon_table.size();
+
+	return idx > -1 && idx < weapon_table_size
 		? weapon_table[idx].type
 		: WEAPON_EXOTIC;
 }

--- a/code/help.c
+++ b/code/help.c
@@ -173,7 +173,7 @@ void do_delhelp(CHAR_DATA *ch, char *argument)
 	send_to_char(buf, ch);
 }
 
-void addhelp_end_fun(CHAR_DATA *ch, char *argument)
+void addhelp_end_fun(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	send_to_char("Help text modified.\n\r", ch);
 	send_to_char("Use addhelp to specify the rest of your helpfiles settings and add it.\n\r", ch);

--- a/code/interp.c
+++ b/code/interp.c
@@ -1426,8 +1426,8 @@ void do_wizhelp(CHAR_DATA *ch, char *argument)
 
 	for (cmd = 0; cmd_table[cmd].name[0] != '\0'; cmd++)
 	{
-		if ((!showlevel && cmd_table[cmd].level >= LEVEL_HERO && cmd_table[cmd].level <= get_trust(ch))
-			|| (showlevel && cmd_table[cmd].level == showval)
+		if (((!showlevel && cmd_table[cmd].level >= LEVEL_HERO && cmd_table[cmd].level <= get_trust(ch))
+				|| (showlevel && cmd_table[cmd].level == showval))
 			&& cmd_table[cmd].level == arrangeListLooper)
 		{
 			if (!showlevel && argument[0] != '\0' && str_prefix(argument, cmd_table[cmd].name))

--- a/code/interp.c
+++ b/code/interp.c
@@ -1383,7 +1383,7 @@ char *one_argument(char *argument, char *arg_first)
 /*
  * Contributed by Alander.
  */
-void do_commands(CHAR_DATA *ch, char *argument)
+void do_commands(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	char buf[MAX_STRING_LENGTH];
 	int cmd;

--- a/code/interp.c
+++ b/code/interp.c
@@ -782,8 +782,8 @@ void interpret(CHAR_DATA *ch, char *argument)
 	if (!is_npc(ch)
 		&& (is_affected(ch, gsn_hold_person) || ch->pcdata->energy_state < -4)
 		&& get_trust(ch) < MAX_LEVEL
-		&& cmd_table[cmd].name != "immtalk"
-		&& cmd_table[cmd].name != "astrip")
+		&& str_cmp(cmd_table[cmd].name, "immtalk")
+		&& str_cmp(cmd_table[cmd].name, "astrip"))
 	{
 		send_to_char("You are totally frozen!\n\r", ch);
 		return;
@@ -793,7 +793,7 @@ void interpret(CHAR_DATA *ch, char *argument)
 	{
 		paf = affect_find(ch->affected, gsn_creeping_tomb);
 		
-		if (paf->duration <= 2 && (cmd_table[cmd].name != "astrip") && (cmd_table[cmd].name != "immtalk"))
+		if (paf->duration <= 2 && (str_cmp(cmd_table[cmd].name, "astrip")) && (str_cmp(cmd_table[cmd].name, "immtalk")))
 		{
 			send_to_char("You are entombed in ooze and cannot move.\n\r", ch);
 			return;
@@ -809,29 +809,29 @@ void interpret(CHAR_DATA *ch, char *argument)
 	}
 
 	if (is_affected(ch, gsn_ultradiffusion)
-		&& cmd_table[cmd].name != "visible"
-		&& cmd_table[cmd].name != "score"
-		&& cmd_table[cmd].name != "look"
-		&& cmd_table[cmd].name != "who"
-		&& cmd_table[cmd].name != "where"
-		&& cmd_table[cmd].name != "affects"
-		&& cmd_table[cmd].name != "group"
-		&& cmd_table[cmd].name != "gt"
-		&& cmd_table[cmd].name != "gtell"
-		&& cmd_table[cmd].name != "tell"
-		&& cmd_table[cmd].name != "reply"
-		&& cmd_table[cmd].name != "north"
-		&& cmd_table[cmd].name != "east"
-		&& cmd_table[cmd].name != "south"
-		&& cmd_table[cmd].name != "west"
-		&& cmd_table[cmd].name != "up"
-		&& cmd_table[cmd].name != "down"
-		&& cmd_table[cmd].name != "equipment"
-		&& cmd_table[cmd].name != "skills"
-		&& cmd_table[cmd].name != "save"
-		&& cmd_table[cmd].name != "skills"
-		&& cmd_table[cmd].name != "spells"
-		&& cmd_table[cmd].name != "pray"
+		&& str_cmp(cmd_table[cmd].name, "visible")
+		&& str_cmp(cmd_table[cmd].name, "score")
+		&& str_cmp(cmd_table[cmd].name, "look")
+		&& str_cmp(cmd_table[cmd].name, "who")
+		&& str_cmp(cmd_table[cmd].name, "where")
+		&& str_cmp(cmd_table[cmd].name, "affects")
+		&& str_cmp(cmd_table[cmd].name, "group")
+		&& str_cmp(cmd_table[cmd].name, "gt")
+		&& str_cmp(cmd_table[cmd].name, "gtell")
+		&& str_cmp(cmd_table[cmd].name, "tell")
+		&& str_cmp(cmd_table[cmd].name, "reply")
+		&& str_cmp(cmd_table[cmd].name, "north")
+		&& str_cmp(cmd_table[cmd].name, "east")
+		&& str_cmp(cmd_table[cmd].name, "south")
+		&& str_cmp(cmd_table[cmd].name, "west")
+		&& str_cmp(cmd_table[cmd].name, "up")
+		&& str_cmp(cmd_table[cmd].name, "down")
+		&& str_cmp(cmd_table[cmd].name, "equipment")
+		&& str_cmp(cmd_table[cmd].name, "skills")
+		&& str_cmp(cmd_table[cmd].name, "save")
+		&& str_cmp(cmd_table[cmd].name, "skills")
+		&& str_cmp(cmd_table[cmd].name, "spells")
+		&& str_cmp(cmd_table[cmd].name, "pray")
 		&& !(cmd_table[cmd].level > LEVEL_HERO))
 	{
 		send_to_char("You cannot do that while your molecules are diffused from your body.\n\r", ch);
@@ -848,53 +848,53 @@ void interpret(CHAR_DATA *ch, char *argument)
 	}
 
 	if (is_affected(ch, gsn_bind_feet)
-		&& cmd_table[cmd].name != "score"
-		&& cmd_table[cmd].name != "look"
-		&& cmd_table[cmd].name != "glance"
-		&& cmd_table[cmd].name != "examine"
-		&& cmd_table[cmd].name != "get"
-		&& cmd_table[cmd].name != "wear"
-		&& cmd_table[cmd].name != "remove"
-		&& cmd_table[cmd].name != "wield"
-		&& cmd_table[cmd].name != "zap"
-		&& cmd_table[cmd].name != "recite"
-		&& cmd_table[cmd].name != "brandish"
-		&& cmd_table[cmd].name != "invoke"
-		&& cmd_table[cmd].name != "quaff"
-		&& cmd_table[cmd].name != "eat"
-		&& cmd_table[cmd].name != "drink"
-		&& cmd_table[cmd].name != "say"
-		&& cmd_table[cmd].name != "'"
-		&& cmd_table[cmd].name != "tell"
-		&& cmd_table[cmd].name != "whisper"
-		&& cmd_table[cmd].name != "["
-		&& cmd_table[cmd].name != ";"
-		&& cmd_table[cmd].name != ","
-		&& cmd_table[cmd].name != "yell"
-		&& cmd_table[cmd].name != "who"
-		&& cmd_table[cmd].name != "where"
-		&& cmd_table[cmd].name != "chess"
-		&& cmd_table[cmd].name != "affects"
-		&& cmd_table[cmd].name != "group"
-		&& cmd_table[cmd].name != "gt"
-		&& cmd_table[cmd].name != "gtell"
-		&& cmd_table[cmd].name != "reply"
-		&& cmd_table[cmd].name != "immtalk"
-		&& cmd_table[cmd].name != "equipment"
-		&& cmd_table[cmd].name != "save"
-		&& cmd_table[cmd].name != "trustgroup"
-		&& cmd_table[cmd].name != "trustall"
-		&& cmd_table[cmd].name != "trustcabal"
-		&& cmd_table[cmd].name != "skills"
-		&& cmd_table[cmd].name != "spells"
-		&& cmd_table[cmd].name != "supplications"
-		&& cmd_table[cmd].name != "powers"
-		&& cmd_table[cmd].name != "pray"
-		&& cmd_table[cmd].name != "cast"
-		&& cmd_table[cmd].name != "commune"
-		&& cmd_table[cmd].name != "cast"
-		&& cmd_table[cmd].name != "astrip"
-		&& cmd_table[cmd].name != "force"
+		&& str_cmp(cmd_table[cmd].name, "score")
+		&& str_cmp(cmd_table[cmd].name, "look")
+		&& str_cmp(cmd_table[cmd].name, "glance")
+		&& str_cmp(cmd_table[cmd].name, "examine")
+		&& str_cmp(cmd_table[cmd].name, "get")
+		&& str_cmp(cmd_table[cmd].name, "wear")
+		&& str_cmp(cmd_table[cmd].name, "remove")
+		&& str_cmp(cmd_table[cmd].name, "wield")
+		&& str_cmp(cmd_table[cmd].name, "zap")
+		&& str_cmp(cmd_table[cmd].name, "recite")
+		&& str_cmp(cmd_table[cmd].name, "brandish")
+		&& str_cmp(cmd_table[cmd].name, "invoke")
+		&& str_cmp(cmd_table[cmd].name, "quaff")
+		&& str_cmp(cmd_table[cmd].name, "eat")
+		&& str_cmp(cmd_table[cmd].name, "drink")
+		&& str_cmp(cmd_table[cmd].name, "say")
+		&& str_cmp(cmd_table[cmd].name, "'")
+		&& str_cmp(cmd_table[cmd].name, "tell")
+		&& str_cmp(cmd_table[cmd].name, "whisper")
+		&& str_cmp(cmd_table[cmd].name, "[")
+		&& str_cmp(cmd_table[cmd].name, ";")
+		&& str_cmp(cmd_table[cmd].name, ",")
+		&& str_cmp(cmd_table[cmd].name, "yell")
+		&& str_cmp(cmd_table[cmd].name, "who")
+		&& str_cmp(cmd_table[cmd].name, "where")
+		&& str_cmp(cmd_table[cmd].name, "chess")
+		&& str_cmp(cmd_table[cmd].name, "affects")
+		&& str_cmp(cmd_table[cmd].name, "group")
+		&& str_cmp(cmd_table[cmd].name, "gt")
+		&& str_cmp(cmd_table[cmd].name, "gtell")
+		&& str_cmp(cmd_table[cmd].name, "reply")
+		&& str_cmp(cmd_table[cmd].name, "immtalk")
+		&& str_cmp(cmd_table[cmd].name, "equipment")
+		&& str_cmp(cmd_table[cmd].name, "save")
+		&& str_cmp(cmd_table[cmd].name, "trustgroup")
+		&& str_cmp(cmd_table[cmd].name, "trustall")
+		&& str_cmp(cmd_table[cmd].name, "trustcabal")
+		&& str_cmp(cmd_table[cmd].name, "skills")
+		&& str_cmp(cmd_table[cmd].name, "spells")
+		&& str_cmp(cmd_table[cmd].name, "supplications")
+		&& str_cmp(cmd_table[cmd].name, "powers")
+		&& str_cmp(cmd_table[cmd].name, "pray")
+		&& str_cmp(cmd_table[cmd].name, "cast")
+		&& str_cmp(cmd_table[cmd].name, "commune")
+		&& str_cmp(cmd_table[cmd].name, "cast")
+		&& str_cmp(cmd_table[cmd].name, "astrip")
+		&& str_cmp(cmd_table[cmd].name, "force")
 		&& !is_social)
 	{
 		send_to_char("Your feet are rooted to the ground and you cannot move!\n\r", ch);

--- a/code/iprog.c
+++ b/code/iprog.c
@@ -1236,14 +1236,17 @@ void get_prog_bad_idea(OBJ_DATA *obj, CHAR_DATA *ch)
 
 void greet_prog_corpse_explode(OBJ_DATA *obj, CHAR_DATA *ch)
 {
-	CHAR_DATA *owner;
+	CHAR_DATA *owner = nullptr;
 
 	for (OwningListWalk<CHAR_DATA> walk(char_list); !walk.Done(); walk.Step())
 	{
-		CHAR_DATA *owner = walk.Current();
+		CHAR_DATA *wch = walk.Current();
 
-		if (!is_npc(owner) && (!str_cmp(owner->true_name, obj->owner)))
+		if (!is_npc(wch) && !str_cmp(wch->true_name, obj->owner))
+		{
+			owner = wch;
 			break;
+		}
 	}
 
 	if (owner == nullptr)
@@ -3287,12 +3290,12 @@ void trapdoor_end(ROOM_INDEX_DATA *room, [[maybe_unused]] ROOM_AFFECT_DATA *af)
 
 bool open_prog_beef_balls([[maybe_unused]] OBJ_DATA *obj, CHAR_DATA *ch)
 {
-	CHAR_DATA *mob;
+	CHAR_DATA *mob = nullptr;
 	bool found= false;
 
 	for (OwningListWalk<CHAR_DATA> walk(char_list); !walk.Done(); walk.Step())
 	{
-		CHAR_DATA *mob = walk.Current();
+		mob = walk.Current();
 
 		if (is_npc(mob))
 		{

--- a/code/iprog.c
+++ b/code/iprog.c
@@ -1732,9 +1732,8 @@ void verb_prog_sidhe_climb_vine([[maybe_unused]] OBJ_DATA *obj, CHAR_DATA *ch, c
 
 void verb_prog_listen_conversation([[maybe_unused]] OBJ_DATA *obj, CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
-	int i = 0, rand, inc = 2, tc = 0, ccount[MAX_CABAL];
+	int rand, inc = 2;
 	CHAR_DATA *fat, *minotaur, *violet;
-	char buf[MSL];
 	std::string temp;
 
 	rand = dice(1, 4);
@@ -3967,7 +3966,6 @@ void verb_prog_turn_wyntran([[maybe_unused]] OBJ_DATA *obj, CHAR_DATA *ch, [[may
 {
 	MOB_INDEX_DATA *pMobIndex;
 	CHAR_DATA *victim;
-	char buf[MAX_STRING_LENGTH];
 
 	if ((pMobIndex = get_mob_index(4627)) == nullptr)
 	{

--- a/code/iprog.c
+++ b/code/iprog.c
@@ -732,7 +732,7 @@ void fight_prog_cure_critical(OBJ_DATA *obj, CHAR_DATA *ch)
 	}
 }
 
-void pulse_prog_steal(OBJ_DATA *obj, bool isTick)
+void pulse_prog_steal(OBJ_DATA *obj, [[maybe_unused]] bool isTick)
 {
 	CHAR_DATA *vch, *ch = Deref(obj->carried_by);
 	OBJ_DATA *stolen = nullptr;
@@ -780,7 +780,7 @@ void pulse_prog_steal(OBJ_DATA *obj, bool isTick)
 	obj_to_char(stolen, ch);
 }
 
-void invoke_prog_tattoo_dioxide(OBJ_DATA *obj, CHAR_DATA *ch, char *argument)
+void invoke_prog_tattoo_dioxide(OBJ_DATA *obj, CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	AFFECT_DATA af;
 
@@ -838,7 +838,7 @@ void invoke_prog_tattoo_dioxide(OBJ_DATA *obj, CHAR_DATA *ch, char *argument)
 	affect_to_char(ch, &af);
 }
 
-void invoke_prog_tattoo_jackass(OBJ_DATA *obj, CHAR_DATA *ch, char *argument)
+void invoke_prog_tattoo_jackass(OBJ_DATA *obj, CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	obj = get_eq_char(ch, WEAR_BRAND);
 	act("$n's $p doesn't glow much due to $s stupidity.", ch, obj, 0, TO_ROOM);
@@ -850,12 +850,12 @@ void invoke_prog_tattoo_jackass(OBJ_DATA *obj, CHAR_DATA *ch, char *argument)
 	ch->hit /= 2;
 }
 
-void invoke_prog_tattoo_morglum(OBJ_DATA *obj, CHAR_DATA *ch, char *argument)
+void invoke_prog_tattoo_morglum(OBJ_DATA * /* obj */, CHAR_DATA * /* ch */, char * /* argument */)
 {
 	return;
 }
 
-void invoke_prog_tattoo_calenduil(OBJ_DATA *obj, CHAR_DATA *ch, char *argument)
+void invoke_prog_tattoo_calenduil([[maybe_unused]] OBJ_DATA *obj, CHAR_DATA *ch, char *argument)
 {
 	if (strstr(argument, "jackal"))
 	{
@@ -941,7 +941,7 @@ void invoke_prog_tattoo_sceptre(OBJ_DATA *obj, CHAR_DATA *ch, char *argument)
 	WAIT_STATE(ch, PULSE_VIOLENCE);
 }
 
-void invoke_prog_tattoo_zethus(OBJ_DATA *obj, CHAR_DATA *ch, char *argument)
+void invoke_prog_tattoo_zethus(OBJ_DATA *obj, CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	AFFECT_DATA af;
 	obj = get_eq_char(ch, WEAR_BRAND);
@@ -1262,7 +1262,7 @@ void greet_prog_corpse_explode(OBJ_DATA *obj, CHAR_DATA *ch)
 	extract_obj(obj);
 }
 
-void fight_prog_horde_bull(OBJ_DATA *obj, CHAR_DATA *ch)
+void fight_prog_horde_bull([[maybe_unused]] OBJ_DATA *obj, CHAR_DATA *ch)
 {
 	if (!is_affected(ch, gsn_rage) || !Deref(ch->fighting) || number_percent() > (.1 * get_skill(ch, gsn_rage)))
 		return;
@@ -1276,7 +1276,7 @@ void fight_prog_horde_bull(OBJ_DATA *obj, CHAR_DATA *ch)
 	ch->hit = std::min((int)ch->max_hit, ch->hit + number_range(ch->level * (short)1.2, ch->level * (short)2.2));
 }
 
-void fight_prog_horde_bear(OBJ_DATA *obj, CHAR_DATA *ch)
+void fight_prog_horde_bear([[maybe_unused]] OBJ_DATA *obj, CHAR_DATA *ch)
 {
 	if (!is_affected(ch, gsn_rage) || !Deref(ch->fighting) || number_percent() > (.15 * get_skill(ch, gsn_rage)))
 		return;
@@ -1290,7 +1290,7 @@ void fight_prog_horde_bear(OBJ_DATA *obj, CHAR_DATA *ch)
 	damage_new(ch, Deref(ch->fighting), dice(8, 8), TYPE_UNDEFINED, DAM_BASH, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "charge");
 }
 
-void fight_prog_horde_lion(OBJ_DATA *obj, CHAR_DATA *ch)
+void fight_prog_horde_lion([[maybe_unused]] OBJ_DATA *obj, CHAR_DATA *ch)
 {
 	AFFECT_DATA af;
 
@@ -1323,7 +1323,7 @@ void fight_prog_horde_lion(OBJ_DATA *obj, CHAR_DATA *ch)
 	act("Bright red blood begins to gush from $n's wounds.", Deref(ch->fighting), 0, 0, TO_ROOM);
 }
 
-void fight_prog_horde_wolf(OBJ_DATA *obj, CHAR_DATA *ch)
+void fight_prog_horde_wolf([[maybe_unused]] OBJ_DATA *obj, CHAR_DATA *ch)
 {
 	AFFECT_DATA af;
 
@@ -1373,7 +1373,7 @@ void fight_prog_horde_wolf(OBJ_DATA *obj, CHAR_DATA *ch)
 	}
 }
 
-void fight_prog_horde_hawk(OBJ_DATA *obj, CHAR_DATA *ch)
+void fight_prog_horde_hawk([[maybe_unused]] OBJ_DATA *obj, CHAR_DATA *ch)
 {
 	if (!is_affected(ch, gsn_rage) || !Deref(ch->fighting) || number_percent() > (.2 * get_skill(ch, gsn_rage)))
 		return;
@@ -1385,7 +1385,7 @@ void fight_prog_horde_hawk(OBJ_DATA *obj, CHAR_DATA *ch)
 	one_hit_new(ch, Deref(ch->fighting), TYPE_TRUESTRIKE, HIT_NOSPECIALS, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, nullptr);
 }
 
-void pulse_prog_horde_jackal(OBJ_DATA *obj, bool isTick)
+void pulse_prog_horde_jackal(OBJ_DATA *obj, [[maybe_unused]] bool isTick)
 {
 	CHAR_DATA *victim, *ch = Deref(obj->carried_by);
 	AFFECT_DATA af;
@@ -1449,7 +1449,7 @@ void fight_prog_ruins_sword(OBJ_DATA *obj, CHAR_DATA *ch)
 	obj_cast_spell(skill_lookup("drown"), ch->level / 2, ch, Deref(ch->fighting), obj);
 }
 
-void verb_prog_check_bounties(OBJ_DATA *obj, CHAR_DATA *ch, char *argument)
+void verb_prog_check_bounties([[maybe_unused]] OBJ_DATA *obj, CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	char buf[MSL];
 	bool found= false;
@@ -1585,7 +1585,7 @@ void verb_prog_tilt_scales(OBJ_DATA *obj, CHAR_DATA *ch, char *argument)
 	}
 }
 
-void verb_prog_ilopheth_bush(OBJ_DATA *obj, CHAR_DATA *ch, char *argument)
+void verb_prog_ilopheth_bush([[maybe_unused]] OBJ_DATA *obj, CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	ROOM_INDEX_DATA *room;
 
@@ -1607,7 +1607,7 @@ void verb_prog_ilopheth_bush(OBJ_DATA *obj, CHAR_DATA *ch, char *argument)
 	WAIT_STATE(ch, PULSE_VIOLENCE * 2);
 }
 
-void verb_prog_ilopheth_climb_tree(OBJ_DATA *obj, CHAR_DATA *ch, char *argument)
+void verb_prog_ilopheth_climb_tree([[maybe_unused]] OBJ_DATA *obj, CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	ROOM_INDEX_DATA *to_room = get_room_index(4100);
 
@@ -1631,7 +1631,7 @@ void verb_prog_ilopheth_climb_tree(OBJ_DATA *obj, CHAR_DATA *ch, char *argument)
 	do_look(ch, "auto");
 }
 
-void verb_prog_antava_touch_hand(OBJ_DATA *obj, CHAR_DATA *ch, char *argument)
+void verb_prog_antava_touch_hand([[maybe_unused]] OBJ_DATA *obj, CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	ROOM_INDEX_DATA *tomb = get_room_index(102);
 
@@ -1667,7 +1667,7 @@ void verb_prog_antava_touch_hand(OBJ_DATA *obj, CHAR_DATA *ch, char *argument)
 	RS.Queue.AddToQueue(2, "verb_prog_antava_touch_hand", "WAIT_STATE", WAIT_STATE, ch, PULSE_VIOLENCE * 5);
 }
 
-void verb_prog_sidhe_climb_vine(OBJ_DATA *obj, CHAR_DATA *ch, char *argument)
+void verb_prog_sidhe_climb_vine([[maybe_unused]] OBJ_DATA *obj, CHAR_DATA *ch, char *argument)
 {
 	ROOM_INDEX_DATA *up_room = nullptr, *down_room = nullptr;
 
@@ -1730,7 +1730,7 @@ void verb_prog_sidhe_climb_vine(OBJ_DATA *obj, CHAR_DATA *ch, char *argument)
 	}
 }
 
-void verb_prog_listen_conversation(OBJ_DATA *obj, CHAR_DATA *ch, char *argument)
+void verb_prog_listen_conversation([[maybe_unused]] OBJ_DATA *obj, CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	int i = 0, rand, inc = 2, tc = 0, ccount[MAX_CABAL];
 	CHAR_DATA *fat, *minotaur, *violet;
@@ -1866,7 +1866,7 @@ void verb_prog_listen_conversation(OBJ_DATA *obj, CHAR_DATA *ch, char *argument)
 	WAIT_STATE(ch, PULSE_VIOLENCE * 3);
 }
 
-void verb_prog_rub_ball(OBJ_DATA *obj, CHAR_DATA *ch, char *argument)
+void verb_prog_rub_ball(OBJ_DATA *obj, CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	act("You rub the BALL OF DEATH.", ch, obj, 0, TO_CHAR);
 	act("$n rubs the BALL OF DEATH.", ch, obj, 0, TO_ROOM);
@@ -1874,7 +1874,7 @@ void verb_prog_rub_ball(OBJ_DATA *obj, CHAR_DATA *ch, char *argument)
 	raw_kill(ch, ch);
 }
 
-void verb_prog_twist_ring(OBJ_DATA *obj, CHAR_DATA *ch, char *argument)
+void verb_prog_twist_ring(OBJ_DATA *obj, CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	if (!is_worn(obj))
 	{
@@ -1889,7 +1889,7 @@ void verb_prog_twist_ring(OBJ_DATA *obj, CHAR_DATA *ch, char *argument)
 	WAIT_STATE(ch, PULSE_VIOLENCE);
 }
 
-void verb_prog_twist_two_faced(OBJ_DATA *obj, CHAR_DATA *ch, char *argument)
+void verb_prog_twist_two_faced([[maybe_unused]] OBJ_DATA *obj, CHAR_DATA *ch, char *argument)
 {
 	int nChance = 0;
 	EXIT_DATA *pexit;
@@ -1937,7 +1937,7 @@ void verb_prog_twist_two_faced(OBJ_DATA *obj, CHAR_DATA *ch, char *argument)
 	}
 }
 
-void verb_prog_energize_tattoo(OBJ_DATA *obj, CHAR_DATA *ch, char *argument)
+void verb_prog_energize_tattoo(OBJ_DATA *obj, CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	OBJ_AFFECT_DATA oaf;
 	obj = get_eq_char(ch, WEAR_BRAND);
@@ -2028,7 +2028,7 @@ void verb_prog_evoke_stone(OBJ_DATA *obj, CHAR_DATA *ch, char *argument)
 	*/
 }
 
-void verb_prog_harness_crystal(OBJ_DATA *obj, CHAR_DATA *ch, char *argument)
+void verb_prog_harness_crystal(OBJ_DATA *obj, CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	OBJ_AFFECT_DATA *oaf;
 	int mana, efficiency;
@@ -2198,7 +2198,7 @@ void verb_prog_fire_pistol(OBJ_DATA *obj, CHAR_DATA *ch, char *argument)
 	WAIT_STATE(ch, PULSE_VIOLENCE);
 }
 
-void verb_prog_kneel_guillotine(OBJ_DATA *obj, CHAR_DATA *ch, char *argument)
+void verb_prog_kneel_guillotine([[maybe_unused]] OBJ_DATA *obj, CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	ROOM_INDEX_DATA *old_room = ch->in_room;
 
@@ -2217,7 +2217,7 @@ void verb_prog_kneel_guillotine(OBJ_DATA *obj, CHAR_DATA *ch, char *argument)
 	}
 }
 
-void hit_prog_blade_truth(OBJ_DATA *obj, CHAR_DATA *ch, CHAR_DATA *victim, int damage)
+void hit_prog_blade_truth(OBJ_DATA *obj, CHAR_DATA *ch, CHAR_DATA *victim, [[maybe_unused]] int damage)
 {
 	bool dual= false;
 
@@ -2384,7 +2384,7 @@ void fight_prog_essence_darkness(OBJ_DATA *obj, CHAR_DATA *ch)
 	}
 }
 
-void verb_prog_rub_talisman(OBJ_DATA *obj, CHAR_DATA *ch, char *argument)
+void verb_prog_rub_talisman(OBJ_DATA *obj, CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	int sn = skill_lookup("word of recall");
 	SpellTarget vo = ch;
@@ -2410,7 +2410,7 @@ void verb_prog_rub_talisman(OBJ_DATA *obj, CHAR_DATA *ch, char *argument)
 	extract_obj(obj);
 }
 
-void verb_prog_gate_talisman(OBJ_DATA *obj, CHAR_DATA *ch, char *argument)
+void verb_prog_gate_talisman([[maybe_unused]] OBJ_DATA *obj, CHAR_DATA *ch, char *argument)
 {
 	int vnum;
 	ROOM_INDEX_DATA *to_room;
@@ -2439,7 +2439,7 @@ void verb_prog_gate_talisman(OBJ_DATA *obj, CHAR_DATA *ch, char *argument)
 	do_look(ch, "auto");
 }
 
-void speech_prog_vnum_talisman(OBJ_DATA *obj, CHAR_DATA *ch, char *speech)
+void speech_prog_vnum_talisman([[maybe_unused]] OBJ_DATA *obj, CHAR_DATA *ch, char *speech)
 {
 	char buf[MSL];
 
@@ -2450,7 +2450,7 @@ void speech_prog_vnum_talisman(OBJ_DATA *obj, CHAR_DATA *ch, char *speech)
 	}
 }
 
-void pulse_prog_pillar_zap(OBJ_DATA *obj, bool isTick)
+void pulse_prog_pillar_zap(OBJ_DATA *obj, [[maybe_unused]] bool isTick)
 {
 	char buf[MSL];
 	CHAR_DATA *mob, *mob_next;
@@ -2491,7 +2491,7 @@ void pulse_prog_pillar_zap(OBJ_DATA *obj, bool isTick)
 	}
 }
 
-bool loot_prog_shelf(OBJ_DATA *shelf, OBJ_DATA *obj, CHAR_DATA *ch)
+bool loot_prog_shelf(OBJ_DATA *shelf, [[maybe_unused]] OBJ_DATA *obj, CHAR_DATA *ch)
 {
 	ROOM_INDEX_DATA *room;
 	CHAR_DATA *mob;
@@ -2567,7 +2567,7 @@ bool open_prog_sewer_casket(OBJ_DATA *obj, CHAR_DATA *ch)
 	return false;
 }
 
-void verb_prog_pull_hook(OBJ_DATA *obj, CHAR_DATA *ch, char *argument)
+void verb_prog_pull_hook([[maybe_unused]] OBJ_DATA *obj, CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	ROOM_INDEX_DATA *to_room;
 	EXIT_DATA *pexit;
@@ -2598,7 +2598,7 @@ void verb_prog_pull_hook(OBJ_DATA *obj, CHAR_DATA *ch, char *argument)
 	}
 }
 
-void verb_prog_turn_spindle(OBJ_DATA *obj, CHAR_DATA *ch, char *argument)
+void verb_prog_turn_spindle(OBJ_DATA *obj, CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	ROOM_INDEX_DATA *room = obj->in_room;
 	EXIT_DATA *pexit;
@@ -2666,7 +2666,7 @@ void verb_prog_turn_spindle(OBJ_DATA *obj, CHAR_DATA *ch, char *argument)
 	}
 }
 
-void verb_prog_touch_obelisk(OBJ_DATA *obj, CHAR_DATA *ch, char *argument)
+void verb_prog_touch_obelisk([[maybe_unused]] OBJ_DATA *obj, CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	char buf[MSL];
 	AFFECT_DATA *af;
@@ -3149,7 +3149,7 @@ void communion_handler(CHAR_DATA *ch)
 	}
 }
 
-void pulse_prog_cimar_babies(OBJ_DATA *obj, bool isTick)
+void pulse_prog_cimar_babies(OBJ_DATA *obj, [[maybe_unused]] bool isTick)
 {
 	CHAR_DATA *ch = Deref(obj->carried_by);
 
@@ -3163,7 +3163,7 @@ void pulse_prog_cimar_babies(OBJ_DATA *obj, bool isTick)
 	act("$n's baby begins wailing...", ch, obj, 0, TO_ROOM);
 }
 
-void verb_prog_feed_baby(OBJ_DATA *obj, CHAR_DATA *ch, char *argument)
+void verb_prog_feed_baby(OBJ_DATA *obj, CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	OBJ_DATA *milk;
 	OBJ_AFFECT_DATA af, af2;
@@ -3215,7 +3215,7 @@ void verb_prog_feed_baby(OBJ_DATA *obj, CHAR_DATA *ch, char *argument)
 	affect_to_obj(obj, &af2);
 }
 
-void baby_end(OBJ_DATA *obj, OBJ_AFFECT_DATA *af)
+void baby_end(OBJ_DATA *obj, [[maybe_unused]] OBJ_AFFECT_DATA *af)
 {
 	CHAR_DATA *ch = Deref(obj->carried_by);
 
@@ -3226,7 +3226,7 @@ void baby_end(OBJ_DATA *obj, OBJ_AFFECT_DATA *af)
 	act("$n's baby wakes up.", ch, 0, 0, TO_ROOM);
 }
 
-void baby_burp(OBJ_DATA *obj, OBJ_AFFECT_DATA *af)
+void baby_burp(OBJ_DATA *obj, [[maybe_unused]] OBJ_AFFECT_DATA *af)
 {
 	CHAR_DATA *ch = Deref(obj->carried_by);
 
@@ -3237,7 +3237,7 @@ void baby_burp(OBJ_DATA *obj, OBJ_AFFECT_DATA *af)
 	act("$n's baby burps loudly.", ch, 0, 0, TO_ROOM);
 }
 
-void verb_prog_pull_book(OBJ_DATA *obj, CHAR_DATA *ch, char *argument)
+void verb_prog_pull_book([[maybe_unused]] OBJ_DATA *obj, CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	EXIT_DATA *pexit = ch->in_room->exit[Directions::Down];
 	ROOM_AFFECT_DATA raf;
@@ -3269,7 +3269,7 @@ void verb_prog_pull_book(OBJ_DATA *obj, CHAR_DATA *ch, char *argument)
 }
 
 /* Fix0red by Morglum */
-void trapdoor_end(ROOM_INDEX_DATA *room, ROOM_AFFECT_DATA *af)
+void trapdoor_end(ROOM_INDEX_DATA *room, [[maybe_unused]] ROOM_AFFECT_DATA *af)
 {
 	EXIT_DATA *pexit = room->exit[Directions::Down];
 
@@ -3286,7 +3286,7 @@ void trapdoor_end(ROOM_INDEX_DATA *room, ROOM_AFFECT_DATA *af)
 	}
 }
 
-bool open_prog_beef_balls(OBJ_DATA *obj, CHAR_DATA *ch)
+bool open_prog_beef_balls([[maybe_unused]] OBJ_DATA *obj, CHAR_DATA *ch)
 {
 	CHAR_DATA *mob;
 	bool found= false;
@@ -3317,12 +3317,12 @@ bool open_prog_beef_balls(OBJ_DATA *obj, CHAR_DATA *ch)
 	return true;
 }
 
-void verb_prog_look_topbounties(OBJ_DATA *obj, CHAR_DATA *ch, char *argument)
+void verb_prog_look_topbounties([[maybe_unused]] OBJ_DATA *obj, CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	do_topbounties(ch, "");
 }
 
-void verb_prog_pour_wine(OBJ_DATA *obj, CHAR_DATA *ch, char *argument)
+void verb_prog_pour_wine(OBJ_DATA *obj, CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	OBJ_DATA *obj2;
 	bool found= false;
@@ -3373,7 +3373,7 @@ void verb_prog_pour_wine(OBJ_DATA *obj, CHAR_DATA *ch, char *argument)
 	affect_to_obj(obj2, &af);
 }
 
-void wine_pulse(OBJ_DATA *obj, OBJ_AFFECT_DATA *af)
+void wine_pulse(OBJ_DATA *obj, [[maybe_unused]] OBJ_AFFECT_DATA *af)
 {
 	CHAR_DATA *ch = Deref(obj->carried_by);
 
@@ -3386,7 +3386,7 @@ void wine_pulse(OBJ_DATA *obj, OBJ_AFFECT_DATA *af)
 	}
 }
 
-void verb_prog_attach_weapon(OBJ_DATA *obj, CHAR_DATA *ch, char *argument)
+void verb_prog_attach_weapon(OBJ_DATA *obj, CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	OBJ_DATA *pole, *finished;
 	bool found= false;
@@ -3457,7 +3457,7 @@ void verb_prog_attach_weapon(OBJ_DATA *obj, CHAR_DATA *ch, char *argument)
 	}
 }
 
-void verb_prog_join_guild(OBJ_DATA *obj, CHAR_DATA *ch, char *argument)
+void verb_prog_join_guild([[maybe_unused]] OBJ_DATA *obj, CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	if (ch->cabal)
 	{
@@ -3472,7 +3472,7 @@ void verb_prog_join_guild(OBJ_DATA *obj, CHAR_DATA *ch, char *argument)
 	send_to_char("You have been inducted into the Common Guild of Shalar.\n\r", ch);
 }
 
-void verb_prog_pull_lever(OBJ_DATA *obj, CHAR_DATA *ch, char *argument)
+void verb_prog_pull_lever(OBJ_DATA *obj, CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	CHAR_DATA *mob;
 	int vnum = 0;
@@ -3525,7 +3525,7 @@ void verb_prog_pull_lever(OBJ_DATA *obj, CHAR_DATA *ch, char *argument)
 	WAIT_STATE(ch, PULSE_VIOLENCE);
 }
 
-void verb_prog_tie_rope(OBJ_DATA *obj, CHAR_DATA *ch, char *argument)
+void verb_prog_tie_rope(OBJ_DATA *obj, CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	OBJ_DATA *obj2;
 	OBJ_AFFECT_DATA oaf;
@@ -3562,7 +3562,7 @@ void verb_prog_tie_rope(OBJ_DATA *obj, CHAR_DATA *ch, char *argument)
 	extract_obj(obj);
 }
 
-void verb_prog_turn_wheel(OBJ_DATA *obj, CHAR_DATA *ch, char *argument)
+void verb_prog_turn_wheel(OBJ_DATA *obj, CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	EXIT_DATA *exit = obj->in_room->exit[Directions::Down];
 
@@ -3581,7 +3581,7 @@ void verb_prog_turn_wheel(OBJ_DATA *obj, CHAR_DATA *ch, char *argument)
 	act("$n spins the wheel and a metal plate in the floor opens!", ch, 0, 0, TO_ROOM);
 }
 
-void rope_end(OBJ_DATA *obj, OBJ_AFFECT_DATA *af)
+void rope_end(OBJ_DATA *obj, [[maybe_unused]] OBJ_AFFECT_DATA *af)
 {
 	EXIT_DATA *exit = obj->in_room->exit[Directions::Down];
 	ROOM_INDEX_DATA *room = obj->in_room;
@@ -3597,7 +3597,7 @@ void rope_end(OBJ_DATA *obj, OBJ_AFFECT_DATA *af)
 	act("As the rope breaks, the metal plate slams back into the floor.", room->people, 0, 0, TO_ALL);
 }
 
-void verb_prog_tilt_bust(OBJ_DATA *obj, CHAR_DATA *ch, char *argument)
+void verb_prog_tilt_bust([[maybe_unused]] OBJ_DATA *obj, CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	EXIT_DATA *exit = ch->in_room->exit[Directions::South];
 
@@ -3617,7 +3617,7 @@ void verb_prog_tilt_bust(OBJ_DATA *obj, CHAR_DATA *ch, char *argument)
 	REMOVE_BIT(exit->exit_info, EX_NONOBVIOUS);
 }
 
-void verb_prog_roll_tablet(OBJ_DATA *obj, CHAR_DATA *ch, char *argument)
+void verb_prog_roll_tablet([[maybe_unused]] OBJ_DATA *obj, CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	EXIT_DATA *exit = ch->in_room->exit[Directions::East];
 
@@ -3708,7 +3708,7 @@ void act_to_room_queue(std::string format, ROOM_INDEX_DATA *room)
 	act(format.c_str(), room->people, nullptr, nullptr, TO_ALL);
 }
 
-void verb_prog_iseldheim_lever_pull(OBJ_DATA *obj, CHAR_DATA *ch, char *argument)
+void verb_prog_iseldheim_lever_pull(OBJ_DATA *obj, CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 
 	ROOM_INDEX_DATA *lRoom = ch->in_room, *eleRoom, *tRoom = nullptr;
@@ -3963,7 +3963,7 @@ void speech_prog_elven_mirror(OBJ_DATA *obj, CHAR_DATA *ch, char *speech)
 		act("$p fails to form into a coherent image.", ch, obj, 0, TO_CHAR);
 }
 
-void verb_prog_turn_wyntran(OBJ_DATA *obj, CHAR_DATA *ch, char *argument)
+void verb_prog_turn_wyntran([[maybe_unused]] OBJ_DATA *obj, CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	MOB_INDEX_DATA *pMobIndex;
 	CHAR_DATA *victim;
@@ -3987,7 +3987,7 @@ void verb_prog_turn_wyntran(OBJ_DATA *obj, CHAR_DATA *ch, char *argument)
 	WAIT_STATE(ch, PULSE_VIOLENCE * 2);
 }
 
-void verb_prog_place_star(OBJ_DATA *obj, CHAR_DATA *ch, char *argument)
+void verb_prog_place_star(OBJ_DATA *obj, CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	OBJ_DATA *pContainer, *aStar, *aS_next;
 	ROOM_INDEX_DATA *room = ch->in_room, *nroom;
@@ -4064,7 +4064,7 @@ void verb_prog_place_star(OBJ_DATA *obj, CHAR_DATA *ch, char *argument)
 }
 
 // Fallen Desert Progs
-void verb_prog_fallendesert_climb_ladder(OBJ_DATA *obj, CHAR_DATA *ch, char *argument)
+void verb_prog_fallendesert_climb_ladder([[maybe_unused]] OBJ_DATA *obj, CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	ROOM_INDEX_DATA *to_room = nullptr;
 	int vnum = 0;

--- a/code/lookup.c
+++ b/code/lookup.c
@@ -125,7 +125,6 @@ std::string get_demon_names(CHAR_DATA *ch)
 {
 	int favor, i;
 	char buf[MSL], buf2[MSL], buf3[MSL];
-	bool dFound= false;
 
 	sprintf(buf, "Lesser: ");
 	buf2[0] = '\0';

--- a/code/magic.c
+++ b/code/magic.c
@@ -621,7 +621,6 @@ void cast_myell(CHAR_DATA *ch, CHAR_DATA *victim)
  */
 void do_cast(CHAR_DATA *ch, char *argument)
 {
-	char buf[MAX_STRING_LENGTH];
 	char arg1[MAX_INPUT_LENGTH];
 	char arg2[MAX_INPUT_LENGTH];
 	CHAR_DATA *victim;
@@ -3265,7 +3264,6 @@ void spell_identify(int /* sn */, int /* level */, CHAR_DATA *ch, SpellTarget vo
 {
 	OBJ_DATA *obj = vo.AsObj();
 	char buf[MAX_STRING_LENGTH];
-	OBJ_APPLY_DATA *app;
 	int lorebonus = 0;
 
 	if (!is_npc(ch) && (lorebonus = ch->Profs()->GetProf("forgotten lore") > -1))

--- a/code/magic.c
+++ b/code/magic.c
@@ -5812,6 +5812,11 @@ void spell_heavenly_sceptre_frenzy(int sn, int level, CHAR_DATA *ch, SpellTarget
 	af.location = APPLY_HITROLL;
 	affect_to_char(ch, &af);
 
+	// TODO: this third affect is built and never applied. No affect_to_char
+	// follows it, so the saving throw location and the modifier are both dead,
+	// and the modifier is assigned outside the level test as well. Either the
+	// call is missing or these lines are. Deciding which needs a view on what
+	// the spell is meant to grant, so it is recorded rather than guessed at.
 	if (ch->level > 40)
 		af.location = APPLY_SAVING_SPELL;
 
@@ -5864,6 +5869,13 @@ void spell_heavenly_sceptre_fire(int sn, int /* level */, CHAR_DATA *ch, SpellTa
 	{
 		act("Your sceptre of heavenly orders crumbles to dust.", ch, 0, 0, TO_ROOM);
 		send_to_char("Your sceptre of heavenly orders crumbles to dust.\n\r", ch);
+
+		// TODO: sceptre is still the nullptr it was declared as, because nothing
+		// between there and here ever finds the object. extract_obj dereferences
+		// it without a null check, so this crashes. The branch is taken about
+		// 100 - 2 * level percent of the time, which is roughly 40 percent at the
+		// level 30 minimum. Nothing reaches this function today because its only
+		// dispatcher is commented out, so re-enabling that turns this live.
 		extract_obj(sceptre);
 		return;
 	}

--- a/code/magic.c
+++ b/code/magic.c
@@ -450,7 +450,7 @@ int mana_cost(CHAR_DATA *ch, int min_mana, int level)
 	return std::max(min_mana, (100 / (2 + ch->level - level)));
 }
 
-void do_barkskin(CHAR_DATA *ch, char *argument)
+void do_barkskin(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	AFFECT_DATA af;
 
@@ -1304,7 +1304,7 @@ void obj_cast_spell(int sn, int level, CHAR_DATA *ch, CHAR_DATA *victim, OBJ_DAT
  * Spell functions.
  */
 
-void spell_acid_blast(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_acid_blast(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	int dam;
@@ -1317,7 +1317,7 @@ void spell_acid_blast(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode
 	damage_old(ch, victim, dam, sn, DAM_ACID, true);
 }
 
-void spell_armor(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_armor(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	AFFECT_DATA af;
@@ -1348,7 +1348,7 @@ void spell_armor(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode
 		act("$N is protected by your magic.", ch, nullptr, victim, TO_CHAR);
 }
 
-void spell_bless(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_bless(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim;
 	AFFECT_DATA af;
@@ -1402,7 +1402,7 @@ void spell_bless(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode
 		act("You grant $N the favor of your god.", ch, nullptr, victim, TO_CHAR);
 }
 
-void spell_blindness(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_blindness(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	AFFECT_DATA af;
@@ -1452,7 +1452,7 @@ void spell_blindness(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode 
 	act("$n appears to be blinded.", victim, nullptr, nullptr, TO_ROOM);
 }
 
-void spell_burning_hands(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_burning_hands(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	static const short dam_each[] =
@@ -1477,7 +1477,7 @@ void spell_burning_hands(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastM
 
 /* RT calm spell stops all fighting in the room */
 
-void spell_cancellation(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_cancellation(int /* sn */, int level, CHAR_DATA *ch, SpellTarget vo, CastMode /* mode */)
 {
 	char arg1[MSL], arg2[MSL];
 	CHAR_DATA *victim = vo.AsChar();
@@ -1561,22 +1561,22 @@ void spell_cancellation(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMo
 		send_to_char("They aren't affected by anything that can be cancelled.\n\r", ch);
 }
 
-void spell_cause_light(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_cause_light(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	damage_old(ch, vo.AsChar(), dice(1, 8) + level / 3, sn, DAM_INTERNAL, true);
 }
 
-void spell_cause_critical(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_cause_critical(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	damage_old(ch, vo.AsChar(), dice(3, 8) + level - 6, sn, DAM_INTERNAL, true);
 }
 
-void spell_cause_serious(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_cause_serious(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	damage_old(ch, vo.AsChar(), dice(2, 8) + level / 2, sn, DAM_INTERNAL, true);
 }
 
-void spell_chain_lightning(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_chain_lightning(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	CHAR_DATA *tmp_vict, *last_vict, *next_vict;
@@ -1671,7 +1671,7 @@ void spell_chain_lightning(int sn, int level, CHAR_DATA *ch, SpellTarget vo, Cas
 	}
 }
 
-void spell_change_sex(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_change_sex(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	AFFECT_DATA af;
@@ -1706,7 +1706,7 @@ void spell_change_sex(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode
 	act("$n doesn't look like $mself anymore...", victim, nullptr, nullptr, TO_ROOM);
 }
 
-void spell_charm_person(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_charm_person(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	AFFECT_DATA af;
@@ -1774,7 +1774,7 @@ void spell_charm_person(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMo
 		act("$N looks at you with adoring eyes.", ch, nullptr, victim, TO_CHAR);
 }
 
-void spell_chill_touch(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_chill_touch(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	static const short dam_each[] =
@@ -1815,7 +1815,7 @@ void spell_chill_touch(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMod
 	damage_old(ch, victim, dam, sn, DAM_COLD, true);
 }
 
-void spell_color_spray(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_color_spray(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	static const short dam_each[] =
@@ -1840,7 +1840,7 @@ void spell_color_spray(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMod
 	damage_old(ch, victim, dam, sn, DAM_LIGHT, true);
 }
 
-void spell_wrath(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_wrath(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	int dam = 0;
@@ -1881,7 +1881,7 @@ void spell_wrath(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode
 	spell_curse(gsn_curse, level, ch, victim, CastMode::Spell);
 }
 
-void spell_continual_light(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_continual_light(int /* sn */, int /* level */, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
 	OBJ_DATA *light;
 
@@ -1914,12 +1914,12 @@ void spell_continual_light(int sn, int level, CHAR_DATA *ch, SpellTarget vo, Cas
 	act("You twiddle your thumbs and $p appears.", ch, light, nullptr, TO_CHAR);
 }
 
-void spell_control_weather(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_control_weather(int /* sn */, int /* level */, CHAR_DATA * /* ch */, SpellTarget /* vo */, CastMode /* mode */)
 {
 	return;
 }
 
-void spell_create_food(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_create_food(int /* sn */, int level, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
 	OBJ_DATA *mushroom;
 
@@ -1933,7 +1933,7 @@ void spell_create_food(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMod
 	act("$p suddenly appears.", ch, mushroom, nullptr, TO_CHAR);
 }
 
-void spell_create_rose(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_create_rose(int /* sn */, int /* level */, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
 	OBJ_DATA *rose = create_object(get_obj_index(OBJ_VNUM_ROSE), 0);
 
@@ -1942,7 +1942,7 @@ void spell_create_rose(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMod
 	obj_to_char(rose, ch);
 }
 
-void spell_create_spring(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_create_spring(int /* sn */, int level, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
 	OBJ_DATA *spring;
 
@@ -1966,7 +1966,7 @@ void spell_create_spring(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastM
 	act("$p flows from the ground.", ch, spring, nullptr, TO_CHAR);
 }
 
-void spell_create_water(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_create_water(int /* sn */, int level, CHAR_DATA *ch, SpellTarget vo, CastMode /* mode */)
 {
 	OBJ_DATA *obj = vo.AsObj();
 	int water;
@@ -2004,7 +2004,7 @@ void spell_create_water(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMo
 	}
 }
 
-void spell_cure_blindness(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_cure_blindness(int /* sn */, int level, CHAR_DATA *ch, SpellTarget vo, CastMode /* mode */)
 {
 	CHAR_DATA *victim = vo.AsChar();
 
@@ -2059,7 +2059,7 @@ void spell_cure_blindness(int sn, int level, CHAR_DATA *ch, SpellTarget vo, Cast
 	}
 }
 
-void spell_cure_critical(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_cure_critical(int /* sn */, int level, CHAR_DATA *ch, SpellTarget vo, CastMode /* mode */)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	int heal;
@@ -2076,7 +2076,7 @@ void spell_cure_critical(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastM
 }
 
 /* RT added to cure plague */
-void spell_cure_disease(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_cure_disease(int /* sn */, int level, CHAR_DATA *ch, SpellTarget vo, CastMode /* mode */)
 {
 	CHAR_DATA *victim = vo.AsChar();
 
@@ -2107,7 +2107,7 @@ void spell_cure_disease(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMo
 	}
 }
 
-void spell_cure_light(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_cure_light([[maybe_unused]] int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	int heal;
@@ -2122,7 +2122,7 @@ void spell_cure_light(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode
 		send_to_char("Ok.\n\r", ch);
 }
 
-void spell_cure_poison(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_cure_poison(int /* sn */, int level, CHAR_DATA *ch, SpellTarget vo, CastMode /* mode */)
 {
 	CHAR_DATA *victim = vo.AsChar();
 
@@ -2164,7 +2164,7 @@ void spell_cure_poison(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMod
 	}
 }
 
-void spell_cure_serious(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_cure_serious(int /* sn */, int level, CHAR_DATA *ch, SpellTarget vo, CastMode /* mode */)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	int heal;
@@ -2179,7 +2179,7 @@ void spell_cure_serious(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMo
 		send_to_char("Ok.\n\r", ch);
 }
 
-void spell_curse(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_curse(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim;
 	OBJ_DATA *obj;
@@ -2274,7 +2274,7 @@ void spell_curse(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode
 		act("$N looks very uncomfortable.", ch, nullptr, victim, TO_CHAR);
 }
 
-void spell_dark_wrath(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_dark_wrath(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	int dam;
@@ -2302,7 +2302,7 @@ void spell_dark_wrath(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode
 
 /* RT replacement demonfire spell */
 
-void spell_demonfire(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_demonfire(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	int dam, dam_mod, oldhp;
@@ -2335,7 +2335,7 @@ void spell_demonfire(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode 
 		spell_curse(gsn_curse, 3 * level / 4, ch, victim, CastMode::Spell);
 }
 
-void spell_detect_evil(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_detect_evil(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	AFFECT_DATA af;
@@ -2370,7 +2370,7 @@ void spell_detect_evil(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMod
 		send_to_char("Ok.\n\r", ch);
 }
 
-void spell_detect_good(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_detect_good(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	AFFECT_DATA af;
@@ -2404,7 +2404,7 @@ void spell_detect_good(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMod
 		send_to_char("Ok.\n\r", ch);
 }
 
-void do_detect_hidden(CHAR_DATA *ch, char *argument)
+void do_detect_hidden(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	AFFECT_DATA af;
 	int number;
@@ -2451,7 +2451,7 @@ void do_detect_hidden(CHAR_DATA *ch, char *argument)
 	check_improve(ch, gsn_detect_hidden, true, 2);
 }
 
-void do_detect_movement(CHAR_DATA *ch, char *argument)
+void do_detect_movement(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	AFFECT_DATA af;
 	int number;
@@ -2495,7 +2495,7 @@ void do_detect_movement(CHAR_DATA *ch, char *argument)
 	send_to_char("You listen intently to your surroundings.\n\r", ch);
 }
 
-void spell_detect_invis(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_detect_invis(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	AFFECT_DATA af;
@@ -2530,7 +2530,7 @@ void spell_detect_invis(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMo
 		send_to_char("Ok.\n\r", ch);
 }
 
-void spell_detect_magic(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_detect_magic(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	AFFECT_DATA af;
@@ -2564,7 +2564,7 @@ void spell_detect_magic(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMo
 		send_to_char("Ok.\n\r", ch);
 }
 
-void spell_detect_poison(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_detect_poison(int /* sn */, int /* level */, CHAR_DATA *ch, SpellTarget vo, CastMode /* mode */)
 {
 	OBJ_DATA *obj = vo.AsObj();
 
@@ -2581,7 +2581,7 @@ void spell_detect_poison(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastM
 	}
 }
 
-void spell_dispel_evil(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_dispel_evil(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	int dam;
@@ -2609,7 +2609,7 @@ void spell_dispel_evil(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMod
 	damage_old(ch, victim, dam, sn, DAM_HOLY, true);
 }
 
-void spell_dispel_good(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_dispel_good(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	int dam;
@@ -2639,7 +2639,7 @@ void spell_dispel_good(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMod
 
 /* modified for enhanced use */
 
-void spell_dispel_magic(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_dispel_magic(int /* sn */, int level, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
 	char arg1[MSL], arg2[MSL];
 	char buf[MSL];
@@ -2725,7 +2725,7 @@ void spell_dispel_magic(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMo
 	return;
 }
 
-void spell_fireball(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_fireball(int sn, int level, CHAR_DATA *ch, [[maybe_unused]] SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *vch;
 	CHAR_DATA *vch_next;
@@ -2778,7 +2778,7 @@ void spell_fireball(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode m
 	}
 }
 
-void spell_fireproof(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_fireproof(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	OBJ_DATA *obj = vo.AsObj();
 	OBJ_AFFECT_DATA oaf;
@@ -2804,7 +2804,7 @@ void spell_fireproof(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode 
 	act("$p is surrounded by a protective aura.", ch, obj, nullptr, TO_ROOM);
 }
 
-void spell_flamestrike(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_flamestrike(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	int dam;
@@ -2817,7 +2817,7 @@ void spell_flamestrike(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMod
 	damage_old(ch, victim, dam, sn, DAM_FIRE, true);
 }
 
-void spell_faerie_fire(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_faerie_fire(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	AFFECT_DATA af;
@@ -2850,7 +2850,7 @@ void spell_faerie_fire(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMod
 	act("$n is surrounded by a pink outline.", victim, nullptr, nullptr, TO_ROOM);
 }
 
-void spell_faerie_fog(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_faerie_fog(int sn, int level, CHAR_DATA *ch, [[maybe_unused]] SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *ich;
 	AFFECT_DATA af;
@@ -2898,7 +2898,7 @@ void spell_faerie_fog(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode
 	}
 }
 
-void spell_fly(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_fly(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	AFFECT_DATA af;
@@ -2939,7 +2939,7 @@ void spell_fly(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
 
 /* RT clerical berserking spell */
 
-void spell_frenzy(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_frenzy(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	AFFECT_DATA af;
@@ -2992,7 +2992,7 @@ void spell_frenzy(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mod
 
 /* RT ROM-style gate */
 
-void spell_gate(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_gate(int /* sn */, int level, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
 	CHAR_DATA *victim;
 	bool gate_pet;
@@ -3083,7 +3083,7 @@ void spell_gate(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
 	}
 }
 
-void spell_giant_strength(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_giant_strength(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	AFFECT_DATA af;
@@ -3111,7 +3111,7 @@ void spell_giant_strength(int sn, int level, CHAR_DATA *ch, SpellTarget vo, Cast
 	act("$n's muscles surge with heightened power.", victim, nullptr, nullptr, TO_ROOM);
 }
 
-void spell_harm(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_harm(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	int dam;
@@ -3125,7 +3125,7 @@ void spell_harm(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
 
 /* RT haste spell */
 
-void spell_haste(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_haste(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	AFFECT_DATA af;
@@ -3176,7 +3176,7 @@ void spell_haste(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode
 		send_to_char("Ok.\n\r", ch);
 }
 
-void spell_heal(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_heal(int /* sn */, int /* level */, CHAR_DATA *ch, SpellTarget vo, CastMode /* mode */)
 {
 	CHAR_DATA *victim = vo.AsChar();
 
@@ -3190,7 +3190,7 @@ void spell_heal(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
 }
 
 /* RT really nasty high-level attack spell */
-void spell_holy_word(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_holy_word(int sn, int level, CHAR_DATA *ch, [[maybe_unused]] SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *vch;
 	CHAR_DATA *vch_next;
@@ -3261,7 +3261,7 @@ void spell_holy_word(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode 
 	ch->hit -= 100;
 }
 
-void spell_identify(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_identify(int /* sn */, int /* level */, CHAR_DATA *ch, SpellTarget vo, CastMode /* mode */)
 {
 	OBJ_DATA *obj = vo.AsObj();
 	char buf[MAX_STRING_LENGTH];
@@ -3407,7 +3407,7 @@ void spell_identify(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode m
 	}
 }
 
-void spell_invis(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_invis(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim;
 	AFFECT_DATA af;
@@ -3452,7 +3452,7 @@ void spell_invis(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode
 	send_to_char("You fade out of existence.\n\r", victim);
 }
 
-void spell_know_alignment(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_know_alignment(int /* sn */, int /* level */, CHAR_DATA *ch, SpellTarget vo, CastMode /* mode */)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	char *msg;
@@ -3483,7 +3483,7 @@ void spell_know_alignment(int sn, int level, CHAR_DATA *ch, SpellTarget vo, Cast
 	return;
 }
 
-void spell_lightning_bolt(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_lightning_bolt(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	static const short dam_each[] =
@@ -3513,7 +3513,7 @@ void spell_lightning_bolt(int sn, int level, CHAR_DATA *ch, SpellTarget vo, Cast
 	damage_old(ch, victim, (int)dam, sn, DAM_LIGHTNING, true);
 }
 
-void spell_locate_object(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_locate_object(int /* sn */, int level, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
 	char buf[MAX_INPUT_LENGTH];
 	BUFFER buffer;
@@ -3593,7 +3593,7 @@ void spell_locate_object(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastM
 
 }
 
-void spell_magic_missile(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_magic_missile(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	int dam;
@@ -3611,7 +3611,7 @@ void spell_magic_missile(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastM
 	damage_new(ch, victim, dam, sn, DAM_ENERGY, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "magic missiles$");
 }
 
-void spell_mass_healing(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_mass_healing(int /* sn */, int level, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
 	CHAR_DATA *gch;
 	int heal_num, refresh_num;
@@ -3629,7 +3629,7 @@ void spell_mass_healing(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMo
 	}
 }
 
-void spell_mass_invis(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_mass_invis(int sn, int level, CHAR_DATA *ch, [[maybe_unused]] SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	AFFECT_DATA af;
 	CHAR_DATA *gch;
@@ -3670,12 +3670,12 @@ void spell_mass_invis(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode
 	send_to_char("Ok.\n\r", ch);
 }
 
-void spell_null(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_null(int /* sn */, int /* level */, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
 	send_to_char("That's not a spell!\n\r", ch);
 }
 
-void spell_pass_door(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_pass_door(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	AFFECT_DATA af;
@@ -3710,7 +3710,7 @@ void spell_pass_door(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode 
 
 /* RT plague spell, very nasty */
 
-void spell_plague(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_plague([[maybe_unused]] int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	AFFECT_DATA af;
@@ -3809,7 +3809,7 @@ void plague_tick(CHAR_DATA *ch, AFFECT_DATA *af)
 	ch->move -= number_range(af->level / 2, (int)(af->level * 1.5));
 }
 
-void spell_poison(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_poison(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim;
 	OBJ_DATA *obj;
@@ -3892,7 +3892,7 @@ void poison_tick(CHAR_DATA *ch, AFFECT_DATA *af)
 	damage_new(Deref(af->owner), ch, af->level, gsn_poison, DAM_POISON, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "poison");
 }
 
-void spell_protection(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_protection(int sn, int level, CHAR_DATA *ch, [[maybe_unused]] SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	AFFECT_DATA af;
 
@@ -3918,7 +3918,7 @@ void spell_protection(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode
 	send_to_char("You feel protected.\n\r", ch);
 }
 
-void spell_ray_of_truth(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_ray_of_truth(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	int dam;
@@ -3955,7 +3955,7 @@ void spell_ray_of_truth(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMo
 	spell_blindness(gsn_blindness, 3 * level / 4, ch, victim, CastMode::Spell);
 }
 
-void spell_recharge(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_recharge([[maybe_unused]] int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	OBJ_DATA *obj = vo.AsObj();
 	int chance, percent;
@@ -4026,7 +4026,7 @@ void spell_recharge(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode m
 	}
 }
 
-void spell_refresh(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_refresh([[maybe_unused]] int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 
@@ -4041,7 +4041,7 @@ void spell_refresh(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mo
 		send_to_char("Ok.\n\r", ch);
 }
 
-void spell_remove_curse(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_remove_curse(int /* sn */, int level, CHAR_DATA *ch, SpellTarget vo, CastMode /* mode */)
 {
 	CHAR_DATA *victim;
 	OBJ_DATA *obj;
@@ -4102,7 +4102,7 @@ void spell_remove_curse(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMo
 	}
 }
 
-void spell_sanctuary(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_sanctuary(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	AFFECT_DATA af;
@@ -4156,7 +4156,7 @@ void spell_sanctuary(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode 
 	affect_to_char(victim, &af);
 }
 
-void spell_shield(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_shield(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	AFFECT_DATA af;
@@ -4185,7 +4185,7 @@ void spell_shield(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mod
 	send_to_char("You are surrounded by a force shield.\n\r", victim);
 }
 
-void spell_shocking_grasp(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_shocking_grasp(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	static const int dam_each[] =
@@ -4208,7 +4208,7 @@ void spell_shocking_grasp(int sn, int level, CHAR_DATA *ch, SpellTarget vo, Cast
 	damage_old(ch, victim, dam, sn, DAM_LIGHTNING, true);
 }
 
-void spell_sleep(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_sleep(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	AFFECT_DATA af;
@@ -4245,7 +4245,7 @@ void spell_sleep(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode
 	}
 }
 
-void spell_slow(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_slow(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	AFFECT_DATA af;
@@ -4302,7 +4302,7 @@ void spell_slow(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
 		multi_hit(victim, ch, TYPE_UNDEFINED);
 }
 
-void spell_stone_skin(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_stone_skin(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	AFFECT_DATA af;
@@ -4331,7 +4331,7 @@ void spell_stone_skin(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode
 	send_to_char("Your skin turns to stone.\n\r", victim);
 }
 
-void spell_summon(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_summon(int /* sn */, int level, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
 	CHAR_DATA *victim;
 
@@ -4424,7 +4424,7 @@ void summon_char(CHAR_DATA *ch, CHAR_DATA *victim)
 
 /* Modified teleport -- only within radius of one area now. */
 
-void spell_teleport(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_teleport(int /* sn */, int /* level */, CHAR_DATA *ch, SpellTarget vo, CastMode /* mode */)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	ROOM_INDEX_DATA *pRoomIndex;
@@ -4497,7 +4497,7 @@ void spell_teleport(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode m
 undead, with good aligns getting a bonus. Evil try to either subdue aggro
 undead or control them, depending on the difference in their level.
 */
-void spell_turn_undead(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_turn_undead(int sn, int level, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
 	CHAR_DATA *victim;
 	CHAR_DATA *v_next;
@@ -4614,7 +4614,7 @@ void spell_turn_undead(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMod
 	}
 }
 
-void spell_ventriloquate(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_ventriloquate(int /* sn */, int level, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
 	char speaker[MAX_INPUT_LENGTH];
 	CHAR_DATA *vch;
@@ -4632,7 +4632,7 @@ void spell_ventriloquate(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastM
 	}
 }
 
-void spell_weaken(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_weaken(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	AFFECT_DATA af;
@@ -4665,7 +4665,7 @@ void spell_weaken(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mod
 
 /* RT recall spell is back */
 
-void spell_word_of_recall(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_word_of_recall(int /* sn */, int /* level */, CHAR_DATA *ch, SpellTarget vo, CastMode /* mode */)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	ROOM_INDEX_DATA *location;
@@ -4753,7 +4753,7 @@ void recall_execute(CHAR_DATA *ch, ROOM_INDEX_DATA *location)
 /*
  * NPC spells.
  */
-void spell_acid_breath(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_acid_breath(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	int dam, hp_dam, dice_dam, hpch;
@@ -4791,7 +4791,7 @@ void spell_acid_breath(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMod
 	}
 }
 
-void spell_fire_breath(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_fire_breath(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	CHAR_DATA *vch, *vch_next;
@@ -4868,7 +4868,7 @@ void spell_fire_breath(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMod
 	}
 }
 
-void spell_frost_breath(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_frost_breath(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	CHAR_DATA *vch, *vch_next;
@@ -4940,7 +4940,7 @@ void spell_frost_breath(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMo
 	}
 }
 
-void spell_gas_breath(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_gas_breath(int sn, int level, CHAR_DATA *ch, [[maybe_unused]] SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *vch;
 	CHAR_DATA *vch_next;
@@ -4976,7 +4976,7 @@ void spell_gas_breath(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode
 	}
 }
 
-void spell_nether_breath(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_nether_breath(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	AFFECT_DATA af;
@@ -5016,7 +5016,7 @@ void spell_nether_breath(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastM
 	}
 }
 
-void spell_lightning_breath(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_lightning_breath(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	int dam, hp_dam, dice_dam, hpch;
@@ -5054,7 +5054,7 @@ void spell_lightning_breath(int sn, int level, CHAR_DATA *ch, SpellTarget vo, Ca
 	}
 }
 
-void spell_iceball(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_iceball(int sn, int level, CHAR_DATA *ch, [[maybe_unused]] SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *vch;
 	CHAR_DATA *vch_next;
@@ -5095,7 +5095,7 @@ void spell_iceball(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mo
 	}
 }
 
-void spell_protective_shield(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_protective_shield(int sn, int level, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
 	AFFECT_DATA af;
 
@@ -5165,7 +5165,7 @@ void sanguine_blind(CHAR_DATA *ch, CHAR_DATA *victim)
 	affect_to_char(victim, &af);
 }
 
-void spell_sanguine_ward(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_sanguine_ward(int sn, int level, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
 	AFFECT_DATA af;
 
@@ -5217,7 +5217,7 @@ void spell_sanguine_ward(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastM
 	send_to_char("\n\r", ch);
 }
 
-void spell_consecrate(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_consecrate(int sn, int level, CHAR_DATA *ch, [[maybe_unused]] SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	ROOM_INDEX_DATA *in_room;
 	ROOM_INDEX_DATA *room_check;
@@ -5309,7 +5309,7 @@ void spell_consecrate(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode
 	affect_to_char(ch, &af);
 }
 
-void spell_safety(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_safety(int /* sn */, int /* level */, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
 	CHAR_DATA *gch;
 	CHAR_DATA *gch_next;
@@ -5364,7 +5364,7 @@ void spell_safety(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mod
 	ch->move /= 2;
 }
 
-void spell_blade_barrier(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_blade_barrier(int /* sn */, int /* level */, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
 	AFFECT_DATA af;
 
@@ -5391,7 +5391,7 @@ void spell_blade_barrier(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastM
 	WAIT_STATE(ch, PULSE_VIOLENCE * 2);
 }
 
-void spell_old_blade_barrier(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_old_blade_barrier(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	int dam, spins;
@@ -5460,7 +5460,7 @@ void spell_old_blade_barrier(int sn, int level, CHAR_DATA *ch, SpellTarget vo, C
 	act("Your blade barrier fades away.", ch, 0, 0, TO_CHAR);
 }
 
-void spell_holy_fire(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_holy_fire(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	int dam;
@@ -5515,7 +5515,7 @@ void spell_holy_fire(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode 
 	damage_old(ch, victim, dam, sn, DAM_HOLY, true);
 }
 
-void spell_talk_to_dead(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_talk_to_dead(int /* sn */, int /* level */, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
 	OBJ_DATA *corpse;
 	char *obj_name;
@@ -5560,7 +5560,7 @@ void spell_talk_to_dead(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMo
 useless the old one was.
 -Ceran
 */
-void spell_energy_drain(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_energy_drain(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	int amount;
@@ -5592,7 +5592,7 @@ void spell_energy_drain(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMo
 	victim->move /= 2;
 }
 
-void spell_dark_shield(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_dark_shield(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	AFFECT_DATA af;
@@ -5652,7 +5652,7 @@ int check_spellcraft(CHAR_DATA *ch, int sn)
 	return (int)bonus;
 }
 
-void spell_deathspell(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_deathspell(int sn, int level, CHAR_DATA *ch, [[maybe_unused]] SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *vch;
 	CHAR_DATA *vch_next;
@@ -5719,7 +5719,7 @@ void spell_deathspell(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode
 	}
 }
 
-void spell_lifebane(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_lifebane(int sn, int level, CHAR_DATA *ch, [[maybe_unused]] SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *vch;
 	CHAR_DATA *vch_next;
@@ -5785,7 +5785,7 @@ void spell_lifebane(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode m
 /* Green tower obj progs */
 
 /* sceptre of heavens...say 'i am the wrath of god' */
-void spell_heavenly_sceptre_frenzy(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_heavenly_sceptre_frenzy(int sn, int level, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
 	AFFECT_DATA af;
 	if (is_affected(ch, sn) || (!is_good(ch) && !is_evil(ch)))
@@ -5830,7 +5830,7 @@ void spell_heavenly_sceptre_frenzy(int sn, int level, CHAR_DATA *ch, SpellTarget
 }
 
 /* sceptre of heavens, say 'Feel the force of god' */
-void spell_heavenly_sceptre_fire(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_heavenly_sceptre_fire(int sn, int /* level */, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
 	AFFECT_DATA af;
 	OBJ_DATA *sceptre = nullptr;
@@ -5879,7 +5879,7 @@ void spell_heavenly_sceptre_fire(int sn, int level, CHAR_DATA *ch, SpellTarget v
 	affect_to_char(ch, &af);
 }
 
-void spell_lightshield(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_lightshield(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	AFFECT_DATA af;
@@ -5927,7 +5927,7 @@ void spell_lightshield(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMod
 		act("$N is surrounded by a glowing afflatus of purity.", ch, nullptr, victim, TO_CHAR);
 }
 
-void spell_forget(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_forget(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	AFFECT_DATA af;
 	CHAR_DATA *victim = vo.AsChar();
@@ -5964,7 +5964,7 @@ void spell_forget(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mod
 	act("$n suddenly looks disoriented.", victim, 0, 0, TO_ROOM);
 }
 
-void spell_earthbind(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_earthbind(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	AFFECT_DATA af;
 	CHAR_DATA *victim = vo.AsChar();
@@ -5996,7 +5996,7 @@ void spell_earthbind(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode 
 	act("$n suddenly drops to the ground.", victim, 0, 0, TO_ROOM);
 }
 
-void spell_cremate(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_cremate(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	int dam;
@@ -6012,7 +6012,7 @@ void spell_cremate(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mo
 	damage_old(ch, victim, dam, sn, DAM_FIRE, true);
 }
 
-void spell_divine_touch(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_divine_touch(int sn, int level, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
 	AFFECT_DATA af;
 
@@ -6033,7 +6033,7 @@ void spell_divine_touch(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMo
 	act("$n's hands seem to glow with an inner energy.", ch, 0, 0, TO_ROOM);
 }
 
-void spell_transfer_object(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_transfer_object(int /* sn */, int /* level */, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
 	CHAR_DATA *victim;
 	OBJ_DATA *obj;
@@ -6113,7 +6113,7 @@ void spell_transfer_object(int sn, int level, CHAR_DATA *ch, SpellTarget vo, Cas
 }
 
 /* Necros use this to keep body parts longer...for lesser golems */
-void spell_preserve(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_preserve(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	OBJ_DATA *obj = vo.AsObj();
 	int vnum, chance;
@@ -6156,7 +6156,7 @@ void spell_preserve(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode m
 /* Make a victim flee...if they really fail their saves big time it can
 kill them outright..(Ceran)
 */
-void spell_power_word_fear(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_power_word_fear(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	AFFECT_DATA af;
@@ -6259,7 +6259,7 @@ void spell_power_word_fear(int sn, int level, CHAR_DATA *ch, SpellTarget vo, Cas
 
 /* Causes a target's hp to regenerate at a constant rate, plus removes the
    effects of a wither prevent healing spell */
-void spell_imbue_regeneration(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_imbue_regeneration(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	AFFECT_DATA af;
@@ -6333,7 +6333,7 @@ void spell_imbue_regeneration(int sn, int level, CHAR_DATA *ch, SpellTarget vo, 
 	Restores forget, wither, prevent healing, atrophy.
 	Also restores lost levels due to energy drain by powerful undead
 */
-void spell_restoration(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_restoration(int /* sn */, int level, CHAR_DATA *ch, SpellTarget vo, CastMode /* mode */)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	int sn_forget, sn_wither, sn_drain, sn_prevent_healing;
@@ -6386,7 +6386,7 @@ void spell_restoration(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMod
 		send_to_char("Spell had no effect.\n\r", ch);
 }
 
-void spell_prevent_healing(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_prevent_healing(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	AFFECT_DATA af;
@@ -6418,7 +6418,7 @@ void spell_prevent_healing(int sn, int level, CHAR_DATA *ch, SpellTarget vo, Cas
 	affect_to_char(victim, &af);
 }
 
-void spell_atrophy(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_atrophy(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	AFFECT_DATA af;
@@ -6459,7 +6459,7 @@ void spell_atrophy(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mo
 	Can stop wasting, but no heal benefit is gained if used this way. Won't
 	restore undead_drains or wither etc.
 */
-void spell_utter_heal(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_utter_heal(int /* sn */, int /* level */, CHAR_DATA *ch, SpellTarget vo, CastMode /* mode */)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	int sn_atrophy, sn_poison;
@@ -6504,7 +6504,7 @@ void spell_utter_heal(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode
 		send_to_char("Ok.\n\r", ch);
 }
 
-void spell_hold_person(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_hold_person(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	AFFECT_DATA af;
@@ -6564,7 +6564,7 @@ void spell_hold_person(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMod
 	WAIT_STATE(ch, PULSE_VIOLENCE * 2);
 }
 
-void spell_crushing_hand(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_crushing_hand(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	int dam;
@@ -6590,7 +6590,7 @@ void spell_crushing_hand(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastM
 	damage_old(ch, victim, dam, sn, DAM_BASH, true);
 }
 
-void spell_deafen(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_deafen(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	AFFECT_DATA af;
@@ -6628,7 +6628,7 @@ void spell_deafen(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mod
 	send_to_char("The world around you fades to silence.\n\r", victim);
 }
 
-void spell_talismanic_aura(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_talismanic_aura(int /* sn */, int level, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
 	AFFECT_DATA af;
 	float reduction;
@@ -6700,7 +6700,7 @@ void talismanic_end(CHAR_DATA *ch, AFFECT_DATA *af)
 		send_to_char("The multihued aura flickers and fades.\n\r", ch);
 }
 
-void puddle_evaporate(OBJ_DATA *obj, OBJ_AFFECT_DATA *af)
+void puddle_evaporate(OBJ_DATA *obj, [[maybe_unused]] OBJ_AFFECT_DATA *af)
 {
 	if (obj->in_room && obj->in_room->people)
 		act("The last traces of the puddle fade, as it seeps into the ground and evaporates.", obj->in_room->people, 0, 0, TO_ALL);
@@ -6734,17 +6734,17 @@ bool check_somatic(CHAR_DATA *ch)
 	return true;
 }
 
-void mana_drain_pulse(CHAR_DATA *ch, AFFECT_DATA *af)
+void mana_drain_pulse(CHAR_DATA *ch, [[maybe_unused]] AFFECT_DATA *af)
 {
 	ch->mana = 0;
 }
 
-void colorful_end(CHAR_DATA *ch, AFFECT_DATA *af)
+void colorful_end(CHAR_DATA *ch, [[maybe_unused]] AFFECT_DATA *af)
 {
 	REMOVE_BIT(ch->comm, COMM_LOTS_O_COLOR);
 }
 
-void spell_colorful(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_colorful(int sn, int /* level */, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
 	AFFECT_DATA af;
 	char *parg, arg1[500], arg[500];

--- a/code/misc.c
+++ b/code/misc.c
@@ -265,7 +265,7 @@ char *act_msg(const char *point, CHAR_DATA *ch)
 	return buf;
 }
 
-void do_rngtest(CHAR_DATA *ch, char *argument)
+void do_rngtest(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	long total = 0;
 	int count;
@@ -481,7 +481,7 @@ char *int_to_string(int number)
 	}
 }
 
-void spell_summon_nephilim(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_summon_nephilim(int /* sn */, int level, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
 	CHAR_DATA *nephilim;
 	int vnum = 2948;
@@ -1191,7 +1191,7 @@ char num_to_letter(int coord)
 	}
 }
 
-void do_diku(CHAR_DATA *ch, char *argument)
+void do_diku(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	send_to_char("                    Original game idea, concept, and design:\n\r\n\r", ch);
 	send_to_char("          Katja Nyboe               [Superwoman] (katz@freja.diku.dk)\n\r", ch);
@@ -1210,7 +1210,7 @@ void do_diku(CHAR_DATA *ch, char *argument)
 	send_to_char("                      at the University of Copenhagen.\n\r", ch);
 }
 
-void do_antiidle(CHAR_DATA *ch, char *arg)
+void do_antiidle(CHAR_DATA *ch, [[maybe_unused]] char *arg)
 {
 	AFFECT_DATA af;
 
@@ -1236,7 +1236,7 @@ void do_antiidle(CHAR_DATA *ch, char *arg)
 	send_to_char("Anti-idle enabled.\n\r", ch);
 }
 
-void idle_pulse(CHAR_DATA *ch, AFFECT_DATA *af)
+void idle_pulse(CHAR_DATA *ch, [[maybe_unused]] AFFECT_DATA *af)
 {
 	if (number_percent() < 99)
 		return;

--- a/code/misc.c
+++ b/code/misc.c
@@ -185,7 +185,7 @@ char *act_msg(const char *point, CHAR_DATA *ch)
 	for (i = 0; i < MSL; i++)
 		buf[i] = '\0';
 
-	for (i = 0; *point && *point != '\0'; i++)
+	for (i = 0; *point != '\0'; i++)
 	{
 		if (*point == '$')
 		{

--- a/code/misc.c
+++ b/code/misc.c
@@ -550,7 +550,7 @@ void do_devilfavor(CHAR_DATA *ch, char *argument)
 
 	argument = one_argument(argument, devil);
 
-	if (devil == nullptr)
+	if (devil[0] == '\0')
 	{
 		send_to_char("Which devil?\n\r", ch);
 		return;

--- a/code/moremagic.c
+++ b/code/moremagic.c
@@ -57,7 +57,7 @@
 #include "skills.h"
 #include "db.h"
 
-void spell_enlarge(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_enlarge([[maybe_unused]] int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	AFFECT_DATA af;
@@ -111,7 +111,7 @@ void spell_enlarge(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mo
 	}
 }
 
-void spell_sunray(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_sunray(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	int dam = 0;
@@ -175,7 +175,7 @@ void spell_sunray(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mod
 	damage_old(ch, victim, dam, sn, DAM_LIGHT, true);
 }
 
-void spell_cleanse(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_cleanse(int sn, [[maybe_unused]] int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 
@@ -319,7 +319,7 @@ int get_affect_level(CHAR_DATA *ch, int sn)
 	return -1;
 }
 
-void spell_cure_deafness(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_cure_deafness(int /* sn */, int level, CHAR_DATA *ch, SpellTarget vo, CastMode /* mode */)
 {
 	CHAR_DATA *victim = vo.AsChar();
 
@@ -344,7 +344,7 @@ void spell_cure_deafness(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastM
 	}
 }
 
-void spell_remove_paralysis(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_remove_paralysis(int /* sn */, int level, CHAR_DATA *ch, SpellTarget vo, CastMode /* mode */)
 {
 	CHAR_DATA *victim = vo.AsChar();
 
@@ -369,7 +369,7 @@ void spell_remove_paralysis(int sn, int level, CHAR_DATA *ch, SpellTarget vo, Ca
 	}
 }
 
-void spell_awaken(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_awaken([[maybe_unused]] int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	AFFECT_DATA *laf;
@@ -408,7 +408,7 @@ void spell_awaken(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mod
 	}
 }
 
-void spell_resist_heat(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_resist_heat(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	AFFECT_DATA af;
@@ -441,7 +441,7 @@ void spell_resist_heat(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMod
 	affect_to_char(victim, &af);
 }
 
-void spell_resist_cold(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_resist_cold(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	AFFECT_DATA af;
@@ -474,7 +474,7 @@ void spell_resist_cold(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMod
 	affect_to_char(victim, &af);
 }
 
-void spell_resist_lightning(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_resist_lightning(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	AFFECT_DATA af;
@@ -507,7 +507,7 @@ void spell_resist_lightning(int sn, int level, CHAR_DATA *ch, SpellTarget vo, Ca
 	affect_to_char(victim, &af);
 }
 
-void spell_resist_mental(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_resist_mental(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	AFFECT_DATA af;
@@ -540,7 +540,7 @@ void spell_resist_mental(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastM
 	affect_to_char(victim, &af);
 }
 
-void spell_resist_acid(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_resist_acid(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	AFFECT_DATA af;
@@ -573,7 +573,7 @@ void spell_resist_acid(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMod
 	affect_to_char(victim, &af);
 }
 
-void spell_resist_negative(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_resist_negative(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	AFFECT_DATA af;
@@ -606,7 +606,7 @@ void spell_resist_negative(int sn, int level, CHAR_DATA *ch, SpellTarget vo, Cas
 	affect_to_char(victim, &af);
 }
 
-void spell_group_teleport(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_group_teleport(int /* sn */, int level, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
 	ROOM_INDEX_DATA *old_room;
 	CHAR_DATA *group;
@@ -643,7 +643,7 @@ void spell_group_teleport(int sn, int level, CHAR_DATA *ch, SpellTarget vo, Cast
 	}
 }
 
-void spell_soften(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_soften(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	AFFECT_DATA af;
@@ -673,7 +673,7 @@ void spell_soften(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mod
 	send_to_char("You feel more frail.\n\r", victim);
 }
 
-void spell_rejuvenate(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_rejuvenate(int /* sn */, int /* level */, CHAR_DATA *ch, SpellTarget vo, CastMode /* mode */)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	victim->hit = std::min(victim->hit + 200, (int)victim->max_hit);
@@ -686,7 +686,7 @@ void spell_rejuvenate(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode
 		send_to_char("Ok.\n\r", ch);
 }
 
-void spell_fatigue(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_fatigue(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	int dam = dice(level, 4);
@@ -705,7 +705,7 @@ void spell_fatigue(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mo
 	damage_new(ch, victim, dam, sn, DAM_MENTAL, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, nullptr);
 }
 
-void spell_strength(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_strength(int sn, int level, CHAR_DATA *ch, [[maybe_unused]] SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	AFFECT_DATA af;
 
@@ -733,7 +733,7 @@ void spell_strength(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode m
 	act("$n meditates for a period of time, building up $s faith in $s Deity.", ch, 0, 0, TO_ROOM);
 }
 
-void spell_remove_taint(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_remove_taint(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	OBJ_DATA *obj = vo.AsObj();
 	int chance;
@@ -761,7 +761,7 @@ void spell_remove_taint(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMo
 	}
 }
 
-void spell_worldbind(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_worldbind(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim = vo.AsChar();
 	AFFECT_DATA af;
@@ -793,12 +793,12 @@ void spell_worldbind(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode 
 	affect_to_char(victim, &af);
 }
 
-void waterbreath_end(CHAR_DATA *ch, AFFECT_DATA *af)
+void waterbreath_end(CHAR_DATA *ch, [[maybe_unused]] AFFECT_DATA *af)
 {
 	check_waterbreath(ch, ch->in_room);
 }
 
-void spell_waterbreath(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMode mode)
+void spell_waterbreath(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	AFFECT_DATA af;
 	CHAR_DATA *victim = vo.AsChar();

--- a/code/mprog.c
+++ b/code/mprog.c
@@ -3562,14 +3562,17 @@ void pulse_prog_night_creeps(CHAR_DATA *mob)
 
 void sucker_pulse(CHAR_DATA *ch, [[maybe_unused]] AFFECT_DATA *af)
 {
-	CHAR_DATA *owner;
+	CHAR_DATA *owner = nullptr;
 
 	for (OwningListWalk<CHAR_DATA> walk(char_list); !walk.Done(); walk.Step())
 	{
-		CHAR_DATA *owner = walk.Current();
+		CHAR_DATA *wch = walk.Current();
 
-		if (is_npc(owner) && owner->pIndexData->vnum == 3002 && Deref(owner->hunting) == ch)
+		if (is_npc(wch) && wch->pIndexData->vnum == 3002 && Deref(wch->hunting) == ch)
+		{
+			owner = wch;
 			break;
+		}
 	}
 
 	if (!owner)

--- a/code/mprog.c
+++ b/code/mprog.c
@@ -176,8 +176,6 @@ void mprog_emote(int inc, char *arg, CHAR_DATA *mob, CHAR_DATA *ch)
 
 int mprog_drop(int inc, char *arg, OBJ_DATA *obj, CHAR_DATA *mob, CHAR_DATA *ch)
 {
-	char buf[MSL];
-
 	if (arg)
 	{
 		auto buffer = fmt::format("{} says '{}{}{}'", mob->short_descr, get_char_color(ch, "speech"), arg, END_COLOR(ch));
@@ -194,8 +192,6 @@ int mprog_drop(int inc, char *arg, OBJ_DATA *obj, CHAR_DATA *mob, CHAR_DATA *ch)
 
 int mprog_give(int inc, char *arg, OBJ_DATA *obj, CHAR_DATA *mob, CHAR_DATA *ch)
 {
-	char buf[MSL];
-
 	if (arg)
 	{
 		auto buffer = fmt::format("{} says '{}{}{}'", mob->short_descr, get_char_color(ch, "speech"), arg, END_COLOR(ch));
@@ -1989,7 +1985,6 @@ void speech_prog_oze(CHAR_DATA *mob, CHAR_DATA *ch, char *speech)
 void speech_prog_gamygyn(CHAR_DATA *mob, CHAR_DATA *ch, char *speech)
 {
 	AFFECT_DATA *paf = affect_find(mob->affected, gsn_greater_demon), af;
-	char buf[MSL];
 	std::string buffer;
 
 	if (!paf || !Deref(paf->owner))
@@ -2043,7 +2038,6 @@ void speech_prog_gamygyn(CHAR_DATA *mob, CHAR_DATA *ch, char *speech)
 void speech_prog_orobas(CHAR_DATA *mob, CHAR_DATA *ch, char *speech)
 {
 	AFFECT_DATA *paf = affect_find(mob->affected, gsn_greater_demon), af;
-	char buf[MSL];
 	std::string buffer;
 
 	if (!paf || !Deref(paf->owner))

--- a/code/mprog.c
+++ b/code/mprog.c
@@ -651,7 +651,7 @@ void greet_prog_ruins_spirit(CHAR_DATA *mob, CHAR_DATA *ch)
 	}
 }
 
-void greet_prog_ruins_mouth(CHAR_DATA *mob, CHAR_DATA *ch)
+void greet_prog_ruins_mouth(CHAR_DATA *mob, [[maybe_unused]] CHAR_DATA *ch)
 {
 	do_say(mob, "Welcome to the Ministry of Magic.  Shall I direct you to the Room of Testing, the Office of the "\
 				"Master of the Art, or the Room of Inventory?");
@@ -663,7 +663,7 @@ void speech_prog_testmob(CHAR_DATA *mob, CHAR_DATA *ch, char *speech)
 		execute_speech(ch, mob, mob->pIndexData->speech.empty() ? nullptr : &mob->pIndexData->speech.front());
 }
 
-void speech_prog_ruins_mouth(CHAR_DATA *mob, CHAR_DATA *ch, char *speech)
+void speech_prog_ruins_mouth([[maybe_unused]] CHAR_DATA *mob, CHAR_DATA *ch, char *speech)
 {
 	ROOM_INDEX_DATA *to_room = nullptr;
 
@@ -789,7 +789,7 @@ void greet_prog_knight(CHAR_DATA *mob, CHAR_DATA *ch)
 	do_murder(mob, ch->name);
 }
 
-void fight_prog_priest(CHAR_DATA *mob, CHAR_DATA *ch)
+void fight_prog_priest(CHAR_DATA *mob, [[maybe_unused]] CHAR_DATA *ch)
 {
 	switch (number_bits(6))
 	{
@@ -882,7 +882,7 @@ void pulse_prog_formian_queen(CHAR_DATA *mob)
 
 /* Not really an mprog, but hey, it MAKES a mob, so.... */
 
-void formian_egg_hatch(OBJ_DATA *obj, OBJ_AFFECT_DATA *af)
+void formian_egg_hatch(OBJ_DATA *obj, [[maybe_unused]] OBJ_AFFECT_DATA *af)
 {
 	int egg_vnum = obj->pIndexData->vnum;
 
@@ -1328,7 +1328,7 @@ void pulse_prog_tahlu_mist_ward(CHAR_DATA *mob)
 	}
 }
 
-bool move_prog_horde_shrine_ward(CHAR_DATA *ch, CHAR_DATA *mob, ROOM_INDEX_DATA *from, int direction)
+bool move_prog_horde_shrine_ward(CHAR_DATA *ch, CHAR_DATA * /* mob */, ROOM_INDEX_DATA * /* from */, int direction)
 {
 	if (direction != Directions::South)
 		return true;
@@ -1357,7 +1357,7 @@ bool aggress_prog_anchor(CHAR_DATA *mob, CHAR_DATA *attacker)
 	return true;
 }
 
-bool death_prog_glass(CHAR_DATA *mob, CHAR_DATA *killer)
+bool death_prog_glass(CHAR_DATA *mob, [[maybe_unused]] CHAR_DATA *killer)
 {
 
 	CHAR_DATA *ch, *vch, *vch_next;
@@ -1494,7 +1494,7 @@ void pulse_prog_shopkeeper(CHAR_DATA *mob)
 	mob->exp = 10;
 }
 
-bool move_prog_theatre_guard(CHAR_DATA *ch, CHAR_DATA *mob, ROOM_INDEX_DATA *from, int direction)
+bool move_prog_theatre_guard(CHAR_DATA *ch, CHAR_DATA *mob, [[maybe_unused]] ROOM_INDEX_DATA *from, int direction)
 {
 	if (direction != Directions::South || is_immortal(ch))
 		return true;
@@ -1532,7 +1532,7 @@ void greet_prog_necro_skull(CHAR_DATA *mob, CHAR_DATA *ch)
 	act(buf, master, 0, 0, TO_CHAR);
 }
 
-bool death_prog_necro_skull(CHAR_DATA *mob, CHAR_DATA *killer)
+bool death_prog_necro_skull(CHAR_DATA *mob, [[maybe_unused]] CHAR_DATA *killer)
 {
 	act("$n crumbles into dust.", mob, 0, 0, TO_ROOM);
 	extract_char(mob, true);
@@ -2438,7 +2438,7 @@ void pulse_prog_diurnal_mob(CHAR_DATA *mob)
 	}
 }
 
-bool death_prog_cim(CHAR_DATA *mob, CHAR_DATA *killer)
+bool death_prog_cim(CHAR_DATA *mob, [[maybe_unused]] CHAR_DATA *killer)
 {
 	CHAR_DATA *extract;
 
@@ -3566,7 +3566,7 @@ void pulse_prog_night_creeps(CHAR_DATA *mob)
 	}
 }
 
-void sucker_pulse(CHAR_DATA *ch, AFFECT_DATA *af)
+void sucker_pulse(CHAR_DATA *ch, [[maybe_unused]] AFFECT_DATA *af)
 {
 	CHAR_DATA *owner;
 

--- a/code/mspec.c
+++ b/code/mspec.c
@@ -111,7 +111,7 @@ static int horde_tanner_give(CHAR_DATA *ch, CHAR_DATA *mob, OBJ_DATA *obj)
 		{
 			OBJ_DATA *venison = nullptr;
 			int i, num;
-			char give[MSL], buf2[MSL];
+			char give[MSL];
 
 			num = dice(3, 4);
 			sprintf(give, "venison %s", ch->true_name);
@@ -284,8 +284,6 @@ void create_academy_pet(CHAR_DATA *ch)
 
 void apet_force(CHAR_DATA *ch, const char *cmd, int delay)
 {
-	char *tcmd;
-
 	auto buffer = fmt::format("You feel the irresistible urge to '{}}'.\n\r", cmd);
 
 	RS.Queue.AddToQueue(delay, "apet_force", "interpret_queue", interpret_queue, ch, std::string(cmd));

--- a/code/mspec.h
+++ b/code/mspec.h
@@ -4,8 +4,6 @@
 #include "entity/fwd.h"
 #include "spec.h"
 
-DO_FUN(do_give);
-
 // Handlers defined in quest.c. The program table in mspec.c refers to them.
 int academy_smith_greet(CHAR_DATA *ch, CHAR_DATA *mob);
 int academy_smith_speech(CHAR_DATA *ch, CHAR_DATA *mob, char *argument);

--- a/code/mud.c
+++ b/code/mud.c
@@ -209,7 +209,6 @@ void CMud::LoadObjLimits()
 	char strPlr[MAX_INPUT_LENGTH];
 	char chkbuf[MAX_STRING_LENGTH];
 	char temp_player_name[MSL];
-	char pbuf[100];
 	int i;
 	long temp_bounty;
 	long min_bounty = 0;

--- a/code/mud.c
+++ b/code/mud.c
@@ -197,7 +197,7 @@ char * CMud::GetError()
 
 /* the following functions are so incredibly slick, they're illegal in connecticut */
 
-void bug(const char *bugstr, ...)
+void bug([[maybe_unused]] const char *bugstr, ...)
 {
 	//TODO: The linker errors out if this is deleted. Need to find what references this.
 }

--- a/code/note.c
+++ b/code/note.c
@@ -77,7 +77,7 @@ int count_spool(CHAR_DATA *ch, int type)
 /// Sends the number of unread notes a character has to the player.
 /// @param ch: The character being sent the message.
 /// @param arg: unused
-void do_unread(CHAR_DATA *ch, char *arg)
+void do_unread(CHAR_DATA *ch, [[maybe_unused]] char *arg)
 {
 	char buf[MAX_STRING_LENGTH];
 

--- a/code/olc.c
+++ b/code/olc.c
@@ -350,7 +350,7 @@ void show_olc_cmds(CHAR_DATA *ch, const struct olc_cmd_type *olc_table)
  Purpose:	Display all olc commands.
  Called by:	olc interpreters.
  ****************************************************************************/
-bool show_commands(CHAR_DATA *ch, char *argument)
+bool show_commands(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	switch (Deref(ch->desc)->editor)
 	{

--- a/code/olc_act.c
+++ b/code/olc_act.c
@@ -1199,7 +1199,7 @@ bool redit_trap(CHAR_DATA *ch, char *argument)
 		{
 			num = atoi(argument);
 
-			if (num > 0 || num < 101)
+			if (num > 0 && num < 101)
 			{
 				pRoom->trap->complexity = num;
 				send_to_char("Trap complexity updated.\n\r", ch);

--- a/code/olc_act.c
+++ b/code/olc_act.c
@@ -123,7 +123,7 @@ const struct wear_type wear_table[] =
 	{NO_FLAG, NO_FLAG}
 };
 
-bool show_version(CHAR_DATA *ch, char *argument)
+bool show_version(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	send_to_char(SHOW_VERSION, ch);
 	send_to_char("\n\r", ch);
@@ -1667,7 +1667,7 @@ bool aedit_security(CHAR_DATA *ch, char *argument)
 	return true;
 }
 
-bool aedit_show(CHAR_DATA *ch, char *argument)
+bool aedit_show(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	AREA_DATA *pArea;
 	char buf[MAX_STRING_LENGTH];
@@ -1752,7 +1752,7 @@ bool aedit_show(CHAR_DATA *ch, char *argument)
 	return false;
 }
 
-bool aedit_reset(CHAR_DATA *ch, char *argument)
+bool aedit_reset(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	AREA_DATA *pArea;
 
@@ -1764,7 +1764,7 @@ bool aedit_reset(CHAR_DATA *ch, char *argument)
 	return false;
 }
 
-bool aedit_create(CHAR_DATA *ch, char *argument)
+bool aedit_create(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	AREA_DATA *pArea;
 
@@ -2225,7 +2225,7 @@ bool redit_owner(CHAR_DATA *ch, char *argument)
 	return true;
 }
 
-bool redit_show(CHAR_DATA *ch, char *argument)
+bool redit_show(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	ROOM_INDEX_DATA *pRoom;
 	char buf[MAX_STRING_LENGTH];
@@ -3080,7 +3080,7 @@ bool redit_mana(CHAR_DATA *ch, char *argument)
 	return false;
 }
 
-bool redit_clan(CHAR_DATA *ch, char *argument)
+bool redit_clan(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	ROOM_INDEX_DATA *pRoom;
 
@@ -3090,7 +3090,7 @@ bool redit_clan(CHAR_DATA *ch, char *argument)
 	return true;
 }
 
-bool redit_format(CHAR_DATA *ch, char *argument)
+bool redit_format(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	ROOM_INDEX_DATA *pRoom;
 
@@ -3923,7 +3923,7 @@ bool set_obj_values(CHAR_DATA *ch, OBJ_INDEX_DATA *pObj, int value_num, char *ar
 	return true;
 }
 
-bool oedit_show(CHAR_DATA *ch, char *argument)
+bool oedit_show(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	OBJ_INDEX_DATA *pObj;
 	char buf[MAX_STRING_LENGTH];
@@ -4577,7 +4577,7 @@ bool oedit_restrict(CHAR_DATA *ch, char *argument)
 	return true;
 }
 
-bool oedit_notes(CHAR_DATA *ch, char *argument)
+bool oedit_notes(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	OBJ_INDEX_DATA *pObj;
 
@@ -5486,7 +5486,7 @@ bool medit_yell(CHAR_DATA *ch, char *argument)
 	return true;
 }
 
-bool medit_notes(CHAR_DATA *ch, char *argument)
+bool medit_notes(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	MOB_INDEX_DATA *pMob;
 
@@ -5602,7 +5602,7 @@ bool medit_class(CHAR_DATA *ch, char *argument)
 	}
 }
 
-bool medit_show(CHAR_DATA *ch, char *argument)
+bool medit_show(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	MOB_INDEX_DATA *pMob;
 	char buf[MAX_STRING_LENGTH], msg_type[MSL], comparison[MSL];
@@ -6522,7 +6522,7 @@ bool medit_vuln(CHAR_DATA *ch, char *argument)
 	return false;
 }
 
-bool medit_material(CHAR_DATA *ch, char *argument)
+bool medit_material([[maybe_unused]] CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	return false;
 }
@@ -6909,7 +6909,7 @@ bool medit_hitroll(CHAR_DATA *ch, char *argument)
 	return true;
 }
 
-bool oedit_liqlist(CHAR_DATA *ch, char *argument)
+bool oedit_liqlist(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	BUFFER buffer;
 	char buf[MAX_STRING_LENGTH];

--- a/code/olc_save.c
+++ b/code/olc_save.c
@@ -368,7 +368,6 @@ void save_object(FILE *fp, OBJ_INDEX_DATA *pObjIndex)
 {
 	long i;
 	long dummy[MAX_BITVECTOR];
-	OBJ_APPLY_DATA *app;
 
 	zero_vector(dummy);
 
@@ -806,7 +805,7 @@ void save_progs(FILE *fp, AREA_DATA *pArea)
 
 void save_specs(FILE *fp, AREA_DATA *pArea)
 {
-	int iHash, i;
+	int iHash;
 	OBJ_INDEX_DATA *pObjIndex;
 	MOB_INDEX_DATA *pMob;
 
@@ -941,11 +940,8 @@ void do_asave(CHAR_DATA *ch, char *argument)
 {
 	char arg1[MAX_INPUT_LENGTH], buf[MSL];
 	AREA_DATA *pArea;
-	FILE *fp;
 	int value;
 	bool found = false;
-
-	fp = nullptr;
 
 	if (!check_security(ch))
 		return;

--- a/code/olc_save.c
+++ b/code/olc_save.c
@@ -667,7 +667,7 @@ void save_progs(FILE *fp, AREA_DATA *pArea)
 			if (pRoomIndex->area != pArea)
 				continue;
 
-			if (pRoomIndex->progtypes)
+			if (!IS_ZERO_VECTOR(pRoomIndex->progtypes))
 			{
 				if (IS_SET(pRoomIndex->progtypes, RPROG_PULSE))
 					fprintf(fp, "R %d pulse_prog %s\n", pRoomIndex->vnum, pRoomIndex->rprogs->pulse_name);
@@ -739,7 +739,7 @@ void save_progs(FILE *fp, AREA_DATA *pArea)
 	{
 		for (pObjIndex = obj_index_hash[iHash]; pObjIndex; pObjIndex = pObjIndex->next)
 		{
-			if (pObjIndex->area != pArea || !pObjIndex->progtypes)
+			if (pObjIndex->area != pArea || IS_ZERO_VECTOR(pObjIndex->progtypes))
 				continue;
 
 			if (IS_SET(pObjIndex->progtypes, IPROG_WEAR))

--- a/code/olc_save.c
+++ b/code/olc_save.c
@@ -694,9 +694,7 @@ void save_progs(FILE *fp, AREA_DATA *pArea)
 			if (mIndex->area != pArea)
 				continue;
 
-			if (!mIndex->progtypes)
-				continue;
-			if (mIndex->progtypes)
+			if (!IS_ZERO_VECTOR(mIndex->progtypes))
 			{
 				if (IS_SET(mIndex->progtypes, MPROG_BRIBE))
 					fprintf(fp, "M %d bribe_prog %s\n", mIndex->vnum, mIndex->mprogs->bribe_name);

--- a/code/olc_save.c
+++ b/code/olc_save.c
@@ -893,7 +893,7 @@ void save_resets(FILE *fp, AREA_DATA *pArea)
 	fprintf(fp, "S\n\n");
 }
 
-void save_shops(FILE *fp, AREA_DATA *pArea)
+void save_shops([[maybe_unused]] FILE *fp, [[maybe_unused]] AREA_DATA *pArea)
 {
 	return;
 }

--- a/code/prof.c
+++ b/code/prof.c
@@ -817,7 +817,7 @@ void add_prof_affect(CHAR_DATA *ch, char *name, int duration, bool fInvis = true
 	af.type = gsn_timer;
 	af.name = palloc_string(name);
 	af.duration = duration;
-	af.aftype == fInvis ? AFT_INVIS : AFT_SKILL;
+	af.aftype = fInvis ? AFT_INVIS : AFT_SKILL;
 	affect_to_char(ch, &af);
 }
 

--- a/code/prof.c
+++ b/code/prof.c
@@ -987,7 +987,7 @@ void build_fire(CHAR_DATA *ch, int dur)
 /// Perform the firestarting proficiency.
 /// @param ch: The character who is attempting to start a fire.
 /// @param argument: (Not used).
-void prof_firestart(CHAR_DATA *ch, char *argument)
+void prof_firestart(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	if (is_affected_prof(ch, "firestarting"))
 	{

--- a/code/prof.c
+++ b/code/prof.c
@@ -208,7 +208,7 @@ CProficiencies::~CProficiencies()
 /// Assigns each proficiency in the proficiency table with their associated psn.
 void CProficiencies::AssignPsns()
 {
-	auto prof_table_size = std::size(prof_table);
+	const int prof_table_size = std::size(prof_table);
 	for (auto i = 0; i < prof_table_size; i++)
 	{
 		*(prof_table[i].ppsn) = i;
@@ -223,7 +223,7 @@ short CProficiencies::ProfIndexLookup(const char *profname)
 	if (profname == nullptr)
 		return -1;
 
-	auto prof_table_size = std::size(prof_table);
+	const int prof_table_size = std::size(prof_table);
 	for (int i = 0; i < prof_table_size; i++)
 	{
 		if (!str_cmp(profname, prof_table[i].name))
@@ -238,8 +238,8 @@ short CProficiencies::ProfIndexLookup(const char *profname)
 /// @returns true if the given psn has a correlated proficiency; otherwise false.
 bool CProficiencies::HasProf(int psn)
 {
-	auto profs_size = std::size(profs);
-	if (psn < 0 || psn > profs_size - 1)
+	const int profs_size = std::size(profs);
+	if (psn < 0 || psn >= profs_size)
 		return false;
 
 	return profs[psn] > -1;
@@ -263,8 +263,8 @@ bool CProficiencies::HasProf(char *profname)
 /// @returns The level of the retrieved proficiency. (Default: -1)
 int CProficiencies::GetProf(int psn)
 {
-	auto profs_size = std::size(profs);
-	if (psn < 0 || psn > profs_size - 1)
+	const int profs_size = std::size(profs);
+	if (psn < 0 || psn >= profs_size)
 		return -1;
 
 	auto prof = profs[psn];
@@ -303,8 +303,8 @@ void CProficiencies::GetProfsTaughtByTrainer(char_data* ch, char_data* trainer)
 
 	act("You may learn the following proficiencies from $N:", ch, 0, trainer, TO_CHAR);
 
-	auto prof_table_size = std::size(prof_table);
-	auto profs_taught_size = std::size(trainer->pIndexData->profs_taught);
+	const int prof_table_size = std::size(prof_table);
+	const int profs_taught_size = std::size(trainer->pIndexData->profs_taught);
 	for (auto i = 0; i < prof_table_size; i++)
 	{
 		for (auto j = 0; j < profs_taught_size; j++)
@@ -349,7 +349,7 @@ void CProficiencies::TrainProficiency(char_data* ch, char_data* trainer, char* a
 
 	int i;
 	auto found = false;
-	auto profs_taught_size = std::size(trainer->pIndexData->profs_taught);
+	const int profs_taught_size = std::size(trainer->pIndexData->profs_taught);
 	for (i = 0; i < profs_taught_size; i++)
 	{
 		if (trainer->pIndexData->profs_taught[i] == prof)
@@ -423,8 +423,8 @@ proficiency_type CProficiencies::GetProficiency(int psn)
 {
 	proficiency_type result = { &psn_none, "", 0, 0, nullptr, PFLAGS_NONE };
 
-	auto prof_table_size = std::size(prof_table);
-	if (psn < 0 || psn > prof_table_size - 1)
+	const int prof_table_size = std::size(prof_table);
+	if (psn < 0 || psn >= prof_table_size)
 		return result;
 
 	return prof_table[psn];
@@ -489,8 +489,8 @@ float CProficiencies::ProfEffect(char *profname, float nArg)
 /// @returns TBD
 float CProficiencies::ProfEffect(int psn)
 {
-	auto prof_table_size = std::size(prof_table);
-	if (psn < 0 || psn > prof_table_size - 1)
+	const int prof_table_size = std::size(prof_table);
+	if (psn < 0 || psn >= prof_table_size)
 		return 0;
 
 	return ProfEffect(prof_table[psn].name);
@@ -508,7 +508,7 @@ void CProficiencies::ListKnownProficiencies(char_data* player)
 
 	std::vector<std::string> responseList;
 
-	auto limit = std::size(profs);
+	const int limit = std::size(profs);
 	for (int i = 0; i < limit ; i++)
 	{
 		if(profs[i] < 0)
@@ -547,7 +547,7 @@ void CProficiencies::ListBasicProficiencies(char_data* player)
 
 	send_to_char("The basic proficiencies available to adventurers are:\n\r", player);
 
-	auto prof_table_size = std::size(prof_table);
+	const int prof_table_size = std::size(prof_table);
 	for (auto i = 0; i < prof_table_size; i++)
 	{
 		if (prof_table[i].flags & PFLAGS_BASIC)
@@ -583,8 +583,8 @@ void CProficiencies::SetChar(char_data *nch)
 /// @param proflevel: The level of the proficiency to assign.
 void CProficiencies::SetProf(int profindex, int proflevel)
 {
-	auto profs_size = std::size(profs);
-	if (profindex < 0 || profindex > profs_size - 1)
+	const int profs_size = std::size(profs);
+	if (profindex < 0 || profindex >= profs_size)
 	{
 		RS.Logger.Warn("CProficiencies::SetProf : profindex out of bounds [{}]", profindex);
 		return;
@@ -603,7 +603,7 @@ void CProficiencies::WriteProfs(void *vfp)
 	FILE *fp = static_cast<FILE *>(vfp);
 	fprintf(fp,"ProfPoints %d %ld\n", points, pawardedtime);
 
-	auto prof_table_size = std::size(prof_table);
+	const int prof_table_size = std::size(prof_table);
 	for (int i = 0; i < prof_table_size; i++)
 	{
 		if (profs[i] > -1)
@@ -636,7 +636,7 @@ void CProficiencies::DisplayProfsForStat(CHAR_DATA *imm)
 	char buf[MSL], buf2[MSL];
 	int i;
 	sprintf(buf, "Proficiencies (%d pts left): ", GetPoints());
-	auto prof_table_size = std::size(prof_table);
+	const int prof_table_size = std::size(prof_table);
 	for(i = 0; i < prof_table_size; i++)
 	{
 		if(profs[i] == -1)
@@ -655,15 +655,15 @@ void CProficiencies::DisplayProfsForStat(CHAR_DATA *imm)
 /// @returns The name of the skill mastery that correlates with the specific level.
 const char* CProficiencies::GetSkillLevelName(int ind)
 {
-	auto profs_size = std::size(profs);
-	if(ind < 0 || ind > profs_size - 1)
+	const int profs_size = std::size(profs);
+	if(ind < 0 || ind >= profs_size)
 	{
 		RS.Logger.Warn("CProficiencies::GetSkillLevelName : index out of bounds [{}]", ind);
 		return "";
 	}
 
 	auto slevel = profs[ind];
-	auto prof_level_table_size = std::size(prof_level_table);
+	const int prof_level_table_size = std::size(prof_level_table);
 	for (int i = prof_level_table_size - 1; i >= 0; i--)
 	{
 		if (prof_level_table[i].level <= slevel)
@@ -676,7 +676,7 @@ const char* CProficiencies::GetSkillLevelName(int ind)
 /// Sends a list of proficiencies and at what skill mastery the character has learned.
 void CProficiencies::ShowProfsToChar()
 {
-	auto prof_table_size = std::size(prof_table);
+	const int prof_table_size = std::size(prof_table);
 	for (auto i = 0; i < prof_table_size; i++)
 	{
 		if (profs[i] > -1)
@@ -786,7 +786,7 @@ bool CProficiencies::InterpCommand(char *command, char *argument)
 	if (strlen(command) == 0)
 		return false;
 
-	auto prof_cmd_table_size = std::size(prof_cmd_table);
+	const int prof_cmd_table_size = std::size(prof_cmd_table);
 	for (auto i = 0; i < prof_cmd_table_size; i++)
 	{
 		auto cmd = prof_cmd_table[i];

--- a/code/quest.c
+++ b/code/quest.c
@@ -732,7 +732,7 @@ void talismanic_reward(CHAR_DATA *ch)
 	}
 }
 
-void pulse_prog_talismanic_page(OBJ_DATA *obj, bool isTick)
+void pulse_prog_talismanic_page(OBJ_DATA *obj, [[maybe_unused]] bool isTick)
 {
 	OBJ_DATA *scrap;
 	CHAR_DATA *ch;
@@ -756,7 +756,7 @@ void pulse_prog_talismanic_page(OBJ_DATA *obj, bool isTick)
 	obj_to_char(scrap, ch);
 }
 
-void pulse_prog_talismanic_scrap(OBJ_DATA *obj, bool isTick)
+void pulse_prog_talismanic_scrap(OBJ_DATA *obj, [[maybe_unused]] bool isTick)
 {
 	OBJ_DATA *page;
 	CHAR_DATA *ch;

--- a/code/race.c
+++ b/code/race.c
@@ -44,7 +44,7 @@ bool check_silent_movement(CHAR_DATA *ch, ROOM_INDEX_DATA *room)
 		return false;
 }
 
-void do_silent_movement(CHAR_DATA *ch, char *argument)
+void do_silent_movement(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	AFFECT_DATA af;
 	int skill;

--- a/code/rprog.c
+++ b/code/rprog.c
@@ -135,10 +135,7 @@ void rprog_set(ROOM_INDEX_DATA *room, const char *progtype, const char *name)
 	if (!str_cmp(progtype, "move_prog"))
 	{
 		room->rprogs->move_prog = (RPROG_FUN_MOVE *)rprog_table[i].function;
-
-		if (room->progtypes)
-			free_pstring(room->rprogs->move_name);
-
+		free_pstring(room->rprogs->move_name);
 		room->rprogs->move_name = palloc_string(name);
 		SET_BIT(room->progtypes, RPROG_MOVE);
 		return;
@@ -533,7 +530,7 @@ void speech_prog_elven_down([[maybe_unused]] ROOM_INDEX_DATA *room, CHAR_DATA *c
 			SET_BIT(af.bitvector, AFF_BLIND);
 
 			af.end_fun = rprog_elven_down_end;
-			new_affect_to_char(ch, &af);
+			new_affect_to_char(ich, &af);
 		}
 	}
 }

--- a/code/rprog.c
+++ b/code/rprog.c
@@ -488,7 +488,11 @@ void entry_prog_iseldheim_lift([[maybe_unused]] ROOM_INDEX_DATA *room, CHAR_DATA
 
 void drop_prog_elven_star([[maybe_unused]] ROOM_INDEX_DATA *room, CHAR_DATA *ch, OBJ_DATA *obj)
 {
-	if (obj->pIndexData->vnum != (4637 || 4638 || 4639 || 4640 || 4641))
+	// The chained ors here used to collapse to 1, so this compared the vnum
+	// against 1 and returned for every object in the game.
+	auto vnum = obj->pIndexData->vnum;
+
+	if (vnum != 4637 && vnum != 4638 && vnum != 4639 && vnum != 4640 && vnum != 4641)
 		return;
 
 	act("As $p falls to the ground, it is immediately drawn to it's place in the star of the Chilliad.", ch, obj, 0, TO_ROOM);

--- a/code/rprog.c
+++ b/code/rprog.c
@@ -236,7 +236,7 @@ void entry_prog_ilopheth_flute(ROOM_INDEX_DATA *room, CHAR_DATA *ch)
 	}
 }
 
-void entry_prog_sidhe_ankle(ROOM_INDEX_DATA *room, CHAR_DATA *ch)
+void entry_prog_sidhe_ankle([[maybe_unused]] ROOM_INDEX_DATA *room, CHAR_DATA *ch)
 {
 	AFFECT_DATA af;
 
@@ -275,7 +275,7 @@ void entry_prog_sidhe_ankle(ROOM_INDEX_DATA *room, CHAR_DATA *ch)
 	}
 }
 
-bool open_prog_mudschool_key(ROOM_INDEX_DATA *room, CHAR_DATA *ch, EXIT_DATA *exit)
+bool open_prog_mudschool_key([[maybe_unused]] ROOM_INDEX_DATA *room, CHAR_DATA *ch, EXIT_DATA *exit)
 {
 	OBJ_DATA *obj, *obj2;
 	bool found= false;
@@ -402,7 +402,7 @@ void pulse_prog_mudschool_snake(ROOM_INDEX_DATA *room)
 	affect_to_char(ch, &paf);
 }
 
-bool open_prog_bust_room(ROOM_INDEX_DATA *room, CHAR_DATA *ch, EXIT_DATA *exit)
+bool open_prog_bust_room([[maybe_unused]] ROOM_INDEX_DATA *room, CHAR_DATA *ch, [[maybe_unused]] EXIT_DATA *exit)
 {
 	send_to_char("You see no door south here.\n\r", ch);
 	return false;
@@ -424,7 +424,7 @@ bool open_prog_nodoor(ROOM_INDEX_DATA *room, CHAR_DATA *ch, EXIT_DATA *exit)
 	return false;
 }
 
-bool move_prog_stone_roll(ROOM_INDEX_DATA *room, CHAR_DATA *ch, int dir)
+bool move_prog_stone_roll(ROOM_INDEX_DATA *room, CHAR_DATA *ch, [[maybe_unused]] int dir)
 {
 	ROOM_INDEX_DATA *room2 = get_room_index(24559);
 	EXIT_DATA *exit = room2->exit[Directions::East];
@@ -463,7 +463,7 @@ bool move_prog_stone_roll(ROOM_INDEX_DATA *room, CHAR_DATA *ch, int dir)
 	return true;
 }
 
-bool move_prog_horde_shrine(ROOM_INDEX_DATA *room, CHAR_DATA *ch, int dir)
+bool move_prog_horde_shrine([[maybe_unused]] ROOM_INDEX_DATA *room, CHAR_DATA *ch, int dir)
 {
 	if (dir == Directions::South && !is_affected(ch, gsn_horde_communion))
 	{
@@ -480,13 +480,13 @@ bool move_prog_horde_shrine(ROOM_INDEX_DATA *room, CHAR_DATA *ch, int dir)
 	return true;
 }
 
-void entry_prog_iseldheim_lift(ROOM_INDEX_DATA *room, CHAR_DATA *ch)
+void entry_prog_iseldheim_lift([[maybe_unused]] ROOM_INDEX_DATA *room, CHAR_DATA *ch)
 {
 	send_to_char("You step onto the swaying lift.\n\r", ch);
 	act("$n steps onto the lift, causing it to sway momentarily.", ch, 0, 0, TO_ROOM);
 }
 
-void drop_prog_elven_star(ROOM_INDEX_DATA *room, CHAR_DATA *ch, OBJ_DATA *obj)
+void drop_prog_elven_star([[maybe_unused]] ROOM_INDEX_DATA *room, CHAR_DATA *ch, OBJ_DATA *obj)
 {
 	if (obj->pIndexData->vnum != (4637 || 4638 || 4639 || 4640 || 4641))
 		return;
@@ -494,7 +494,7 @@ void drop_prog_elven_star(ROOM_INDEX_DATA *room, CHAR_DATA *ch, OBJ_DATA *obj)
 	act("As $p falls to the ground, it is immediately drawn to it's place in the star of the Chilliad.", ch, obj, 0, TO_ROOM);
 }
 
-void speech_prog_elven_down(ROOM_INDEX_DATA *room, CHAR_DATA *ch, char *speech)
+void speech_prog_elven_down([[maybe_unused]] ROOM_INDEX_DATA *room, CHAR_DATA *ch, char *speech)
 {
 	AFFECT_DATA af;
 	ROOM_AFFECT_DATA raf;
@@ -534,7 +534,7 @@ void speech_prog_elven_down(ROOM_INDEX_DATA *room, CHAR_DATA *ch, char *speech)
 	}
 }
 
-void rprog_elven_down_end(CHAR_DATA *ch, AFFECT_DATA *af)
+void rprog_elven_down_end(CHAR_DATA *ch, [[maybe_unused]] AFFECT_DATA *af)
 {
 	ROOM_INDEX_DATA *to_room = nullptr;
 
@@ -547,7 +547,7 @@ void rprog_elven_down_end(CHAR_DATA *ch, AFFECT_DATA *af)
 	act("$n appears out of thin air, crumpling in to the ground with a thud.", ch, 0, 0, TO_ROOM);
 }
 
-void pulse_prog_elven_star(ROOM_INDEX_DATA *room)
+void pulse_prog_elven_star([[maybe_unused]] ROOM_INDEX_DATA *room)
 {
 	/*
 	OBJ_DATA *obj;

--- a/code/save.c
+++ b/code/save.c
@@ -704,7 +704,7 @@ void fwrite_pet(CHAR_DATA *pet, FILE *fp)
 	if (!IS_ZERO_VECTOR(pet->comm))
 		fprintf(fp, "Comm %s\n", print_flags(pet->comm));
 
-	fprintf(fp, "Pos  %d\n", pet->position = POS_FIGHTING ? POS_STANDING : pet->position);
+	fprintf(fp, "Pos  %d\n", pet->position == POS_FIGHTING ? POS_STANDING : pet->position);
 
 	if (pet->saving_throw != 0)
 		fprintf(fp, "Save %d\n", pet->saving_throw);

--- a/code/save.c
+++ b/code/save.c
@@ -92,7 +92,7 @@ int isAftSpell(int aftype)
  */
 void save_char_obj(CHAR_DATA *ch)
 {
-	char strsave[MAX_INPUT_LENGTH], filenm[MSL], query[MSL * 2];
+	char strsave[MAX_INPUT_LENGTH];
 	FILE *fp;
 
 	if (is_npc(ch) || mPort == 4000) // do not save, sir!!!

--- a/code/skills.c
+++ b/code/skills.c
@@ -618,7 +618,7 @@ bool parse_gen_groups(CHAR_DATA *ch,char *argument)
 */
 
 /* shows all groups, or the sub-members of a group */
-void do_groups(CHAR_DATA *ch, char *argument)
+void do_groups(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	if (is_npc(ch))
 		return;
@@ -867,7 +867,7 @@ void gn_remove(CHAR_DATA *ch, int gn)
 }
 
 /* use for processing a skill or group for addition  */
-void group_add(CHAR_DATA *ch, const char *name, bool deduct)
+void group_add(CHAR_DATA *ch, const char *name, [[maybe_unused]] bool deduct)
 {
 	if (is_npc(ch)) /* NPCs do not have skills */
 		return;

--- a/code/update.c
+++ b/code/update.c
@@ -2117,7 +2117,7 @@ int get_hours(CHAR_DATA *ch)
  * @param racenumber The race index of the player race (used as an age adjustment)
  * @return char* The "age name", i.e. "young", "old", etc.
  */
-char *get_age_name_new(int age, int racenumber)
+char *get_age_name_new(int age, [[maybe_unused]] int racenumber)
 {
 	char *name;
 	if(age < 0)
@@ -2335,7 +2335,7 @@ void update_handler(void)
 	tail_chain();
 }
 
-void do_forcetick(CHAR_DATA *ch, char *argument)
+void do_forcetick([[maybe_unused]] CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	wiznet("TICK!", nullptr, nullptr, WIZ_TICKS, 0, 0);
 

--- a/code/update.c
+++ b/code/update.c
@@ -1999,7 +1999,12 @@ void aggr_update(void)
 			{
 				vch_next = vch->next_in_room;
 
-				if (Deref(paf->owner)->ghost > 0)
+				CHAR_DATA *owner = Deref(paf->owner);
+
+				// An owner who can no longer be resolved has been destroyed, which
+				// ends the mark for the same reason a dead owner does. Deref hands
+				// back a null in that case and reading through it crashes the tick.
+				if (owner == nullptr || owner->ghost > 0)
 				{
 					affect_remove(wch, paf);
 					break;		// paf is gone; nothing further reads the mark

--- a/code/update.c
+++ b/code/update.c
@@ -1420,8 +1420,8 @@ void char_update(void)
 					CHAR_DATA *owner = Deref(paf->owner);
 
 					if (((owner && owner->Class()->GetIndex() == CLASS_PALADIN)
-							|| (!owner && ch->Class()->GetIndex() == CLASS_PALADIN)
-							&& trusts(ch, owner ? owner : ch))
+							|| (!owner && ch->Class()->GetIndex() == CLASS_PALADIN))
+						&& trusts(ch, owner ? owner : ch)
 						&& paf->aftype == AFT_COMMUNE)
 					{
 						if (number_percent() < (get_skill(owner ? owner : ch, gsn_channeling) * .85)

--- a/code/update.c
+++ b/code/update.c
@@ -1793,8 +1793,6 @@ void track_attack(CHAR_DATA *mob, CHAR_DATA *victim)
 
 void track_update(void)
 {
-	char buf[MAX_STRING_LENGTH];
-
 	for (OwningListWalk<CHAR_DATA> walk(char_list); !walk.Done(); walk.Step())
 	{
 		CHAR_DATA *tch = walk.Current();
@@ -2496,7 +2494,7 @@ void room_affect_update(void)
 {
 	ROOM_INDEX_DATA *room, *to_room;
 	CHAR_DATA *victim, *v_next, *vch;
-	int i, dam, chance, roomcount = 0;
+	int dam, chance, roomcount = 0;
 	AREA_AFFECT_DATA *aaf;
 	ROOM_AFFECT_DATA *af, *af2;
 	AFFECT_DATA *paf, cvaf, cvaf2;

--- a/code/update.c
+++ b/code/update.c
@@ -1180,6 +1180,7 @@ void char_update(void)
 		bool charm_gone;
 
 		master = nullptr;
+		charm_gone = false;
 
 		if (is_npc(ch)
 			&& (sun == SolarPosition::Sunrise || sun == SolarPosition::Daylight)
@@ -1372,7 +1373,6 @@ void char_update(void)
 				auto next = std::next(it);
 				AFFECT_DATA *paf = &*it;
 				AFFECT_DATA *paf_next = (next != ch->affected.end()) ? &*next : nullptr;
-				charm_gone= false;
 
 				if (!ghost && ch->ghost > 0)
 					break;
@@ -1456,11 +1456,32 @@ void char_update(void)
 						if (paf->type && str_cmp(skill_table[paf->type].room_msg_off, "") && is_awake(ch))
 							act(skill_table[paf->type].room_msg_off, ch, 0, 0, TO_ROOM);
 					}
+
+					// A charm running out has to release the following as well
+					// as the affect. affect_remove only clears the bit, and
+					// stop_follower is the only thing that ends the follow and
+					// tells both sides. It cannot be called from here, because
+					// it strips the character's charm affects and would
+					// invalidate the iterator this loop is holding, so the
+					// break is recorded and carried out once the walk is done.
+					if (IS_SET(paf->bitvector, AFF_CHARM))
+					{
+						master = Deref(ch->master);
+						charm_gone = true;
+					}
+
 					affect_remove(ch, paf);
 				}
 
 				it = next;
 			}
+
+			// Deferred from the loop above. Only if the tick did not free the
+			// character, and only if it is still following the same master it
+			// was charmed by, so that a follow changed in the meantime is left
+			// alone.
+			if (charm_gone && master != nullptr && Deref(ticking) == ch && Deref(ch->master) == master)
+				stop_follower(ch);
 		}
 
 		if (!ch)

--- a/code/utility.c
+++ b/code/utility.c
@@ -261,8 +261,13 @@ bool is_awake(CHAR_DATA *ch)
 /// @returns The armor class of the piece of armor the character is wearing.
 short get_ac (CHAR_DATA *ch, short type)
 {
-	if (ch == nullptr || type > std::size(ch->armor))
-		return false;
+	if (ch == nullptr)
+		return 0;
+
+	const int armor_size = std::size(ch->armor);
+
+	if (type < 0 || type >= armor_size)
+		return 0;
 
 	return ch->armor[type];
 }

--- a/code/vote.c
+++ b/code/vote.c
@@ -126,7 +126,7 @@ void do_listvotes(CHAR_DATA *ch, char *argument)
 	{
 		// TODO: make hold and holdi into a std::map<char*, int>
 		// NOTE: hold and holdi are the same size.
-		auto hold_size = std::size(hold);
+		const int hold_size = std::size(hold);
 		for (j = 0; j < hold_size; j++)
 		{
 			hold[j].clear();

--- a/tests/act_obj_tests.c
+++ b/tests/act_obj_tests.c
@@ -65,7 +65,6 @@ void TestHelperLoadCClass()
 	cclass->name = "ANTI_PALADIN";
 	cclass->index = 5;
 	CClass::first = cclass;
-	CClass::first->name;
 }
 
 char_data* TestHelperCreatePlayer(char *name, obj_data *item = nullptr)

--- a/tests/fight_tests.c
+++ b/tests/fight_tests.c
@@ -6,6 +6,7 @@
 #include "../code/handler.h"
 #include "../code/db.h"
 #include "../code/recycle.h"
+#include "../code/interp.h"
 
 SCENARIO("testing updating victim position", "[update_pos]")
 {
@@ -286,5 +287,53 @@ SCENARIO("a reference to a freed opponent reads as nothing", "[stop_fighting]")
 		}
 
 		ClearCombatants();
+	}
+}
+static bool CommandExists(const char *name)
+{
+	for (auto cmd = 0; cmd_table[cmd].name[0] != '\0'; cmd++)
+	{
+		if (!str_cmp(cmd_table[cmd].name, name))
+			return true;
+	}
+
+	return false;
+}
+
+SCENARIO("the command names exempted by movement and silence affects", "[interp][whitelist]")
+{
+	// interpret matches what the player typed against cmd_table by prefix, then
+	// compares cmd_table[cmd].name against these literals. A literal naming no
+	// command exempts nothing, and until the comparisons here were string
+	// comparisons rather than pointer comparisons there was no way to notice.
+	GIVEN("the command names the whitelists exempt")
+	{
+		WHEN("each is looked up in the command table")
+		{
+			THEN("the exemptions players rely on name real commands")
+			{
+				REQUIRE(CommandExists("astrip"));
+				REQUIRE(CommandExists("immtalk"));
+				REQUIRE(CommandExists("look"));
+				REQUIRE(CommandExists("who"));
+				REQUIRE(CommandExists("tell"));
+				REQUIRE(CommandExists("reply"));
+				REQUIRE(CommandExists("say"));
+				REQUIRE(CommandExists("cast"));
+				REQUIRE(CommandExists("gtell"));
+				REQUIRE(CommandExists("score"));
+			}
+
+			THEN("the three that name nothing are still inert")
+			{
+				// Not commands. "gt" is harmless because typing it prefix-matches
+				// "gtell", which is exempted in its own right. "examine" is
+				// commented out of the table and "trustall" was never in it. If
+				// any of these becomes a command, revisit the lists that name it.
+				REQUIRE_FALSE(CommandExists("gt"));
+				REQUIRE_FALSE(CommandExists("examine"));
+				REQUIRE_FALSE(CommandExists("trustall"));
+			}
+		}
 	}
 }

--- a/tests/handle_tests.c
+++ b/tests/handle_tests.c
@@ -54,7 +54,19 @@ TEST_CASE("an all-zero handle is null, so zeroing a struct clears it", "[handle]
 	auto handle = map.Add(&widget);
 	REQUIRE(!handle.IsNull());
 
-	std::memset(&handle, 0, sizeof(handle));
+	// Handle's default member initializers make it a non-trivial type, so a
+	// plain memset here draws -Wclass-memaccess. Casting the destination to
+	// void * is the documented way to say the byte write is deliberate.
+	//
+	// That cast silences the diagnostic unconditionally though, including for a
+	// Handle that had gained a vtable or a member owning heap memory. In either
+	// of those cases this test would be memsetting something it must not, and
+	// nothing would say so. The assertion states the property the test actually
+	// depends on, so it fails loudly instead.
+	static_assert(std::is_trivially_copyable_v<Handle<Widget>>,
+		"These tests pin Handle's byte representation, so it must stay trivially copyable.");
+
+	std::memset(static_cast<void *>(&handle), 0, sizeof(handle));
 
 	REQUIRE(handle.IsNull());
 	REQUIRE(map.Deref(handle) == nullptr);
@@ -213,7 +225,12 @@ TEST_CASE("a handle with an out-of-range slot derefs to nothing", "[handle]")
 	auto handle = map.Add(&widget);
 	auto garbage = handle;
 
-	std::memset(&garbage, 0xFF, sizeof(garbage));
+	// Same reasoning as the all-zero test above: the cast is what silences
+	// -Wclass-memaccess, and the assertion is what keeps the cast honest.
+	static_assert(std::is_trivially_copyable_v<Handle<Widget>>,
+		"These tests pin Handle's byte representation, so it must stay trivially copyable.");
+
+	std::memset(static_cast<void *>(&garbage), 0xFF, sizeof(garbage));
 
 	REQUIRE(map.Deref(garbage) == nullptr);
 	REQUIRE(!map.IsLive(garbage));

--- a/tests/magic_tests.c
+++ b/tests/magic_tests.c
@@ -22,7 +22,7 @@ char* AllUpper(char* arr)
 {
 	auto len = strlen(arr);
 	char* res = new char[len + 1];
-	for(auto i = 0; i < len; i++)
+	for(size_t i = 0; i < len; i++)
 	{
 		if(arr[i] == '\0')
 			break;
@@ -33,7 +33,8 @@ char* AllUpper(char* arr)
 }
 char* AllLower(char* arr)
 {
-	for(auto i = 0; i < strlen(arr); i++)
+	const size_t len = strlen(arr);
+	for(size_t i = 0; i < len; i++)
 	{
 		if(arr[i] == '\0')
 			break;

--- a/tests/magic_tests.c
+++ b/tests/magic_tests.c
@@ -52,7 +52,7 @@ SCENARIO("testing skill lookup","[skill_lookup]")
 			auto actual = skill_lookup(nullptr);
 			THEN("it should return negative 1")
 			{
-				REQUIRE(expected == -1);
+				REQUIRE(actual == expected);
 			}
 		}
 	}
@@ -64,7 +64,7 @@ SCENARIO("testing skill lookup","[skill_lookup]")
 			auto actual = skill_lookup("");
 			THEN("it should return negative 1")
 			{
-				REQUIRE(expected == -1);
+				REQUIRE(actual == expected);
 			}
 		}
 	}
@@ -76,7 +76,7 @@ SCENARIO("testing skill lookup","[skill_lookup]")
 			auto actual = skill_lookup("Jimmy dean sausage");
 			THEN("it should return negative 1")
 			{
-				REQUIRE(expected == -1);
+				REQUIRE(actual == expected);
 			}
 		}
 	}

--- a/tests/magic_tests.c
+++ b/tests/magic_tests.c
@@ -2,7 +2,12 @@
 
 #include "catch.hpp"
 #include "../code/magic.h"
+#include "../code/merc.h"
+#include "../code/enums.h"
 #include "../code/const.h"
+#include "../code/handler.h"
+#include "../code/characterClasses/sorcerer.h"
+#include "../code/entity/room_index_data.h"
 
 char* substr(char* arr, int begin, int len = 0)
 {	
@@ -105,5 +110,36 @@ SCENARIO("testing skill lookup","[skill_lookup]")
 				REQUIRE(actual == expected);
 			}
 		}
+	}
+}
+SCENARIO("a conflagration pulses in a room with no exits", "[conflagration_pulse]")
+{
+	GIVEN("a burning, empty room whose six exits are all null")
+	{
+		auto room = new room_index_data();
+		room->sector_type = SECT_CONFLAGRATION;
+		room->people = nullptr;
+
+		for (auto door = 0; door < MAX_DIR; door++)
+			room->exit[door] = nullptr;
+
+		ROOM_AFFECT_DATA af;
+		init_affect_room(&af);
+
+		WHEN("the pulse runs enough times to clear its one-in-three gate")
+		{
+			// The spread step picks a random exit. Choosing by rejection sampling
+			// never terminates when there is nothing to choose from, so the point
+			// of this case is that the calls return at all.
+			for (auto i = 0; i < 200; i++)
+				conflagration_pulse(room, &af);
+
+			THEN("every call returns and the room does not spread")
+			{
+				REQUIRE(room->sector_type == SECT_CONFLAGRATION);
+			}
+		}
+
+		delete room;
 	}
 }

--- a/tests/prof_tests.c
+++ b/tests/prof_tests.c
@@ -1237,7 +1237,7 @@ SCENARIO("check to see if player leveled a proficiency (char* int)", "[CheckImpr
 			THEN("it should display a message notifying the player")
 			{
 				// TODO: figure out how to game the chance generator to test correct output
-				auto result = Deref(player->desc)->outbuf;
+				//auto result = Deref(player->desc)->outbuf;
 
 				REQUIRE(1 == 1);
 			}
@@ -1377,7 +1377,6 @@ SCENARIO("Attempt to track a character", "[prof_tracking]")
 
 			THEN("it should return false")
 			{
-				auto track = 1;
 				auto result = player->Profs()->InterpCommand("track", nullptr);
 
 				REQUIRE(result == false);
@@ -1398,7 +1397,6 @@ SCENARIO("Attempt to track a character", "[prof_tracking]")
 
 			THEN("it should return false")
 			{
-				auto t = 1;
 				auto result = player->Profs()->InterpCommand("track", "player2");
 
 				REQUIRE(result == false);
@@ -1602,7 +1600,6 @@ SCENARIO("Attempt to bandage a character", "[prof_bandage]")
 
 			THEN("it should return false")
 			{
-				auto t = 1;
 				auto result = player->Profs()->InterpCommand("bandage", "self");
 
 				REQUIRE(result == false);
@@ -1623,7 +1620,6 @@ SCENARIO("Attempt to bandage a character", "[prof_bandage]")
 
 			THEN("it should return false")
 			{
-				auto t = 1;
 				auto result = player->Profs()->InterpCommand("bandage", "player2");
 
 				REQUIRE(result == false);
@@ -1645,7 +1641,6 @@ SCENARIO("Attempt to bandage a character", "[prof_bandage]")
 
 			THEN("it should return false")
 			{
-				auto t = 1;
 				auto result = player->Profs()->InterpCommand("bandage", "player2");
 
 				REQUIRE(result == false);

--- a/tests/prof_tests.c
+++ b/tests/prof_tests.c
@@ -1730,3 +1730,36 @@ SCENARIO("Attempt to bandage a character", "[prof_bandage]")
 		}
 	}
 }
+
+SCENARIO("typing a proficiency affect as visible or invisible", "[add_prof_affect]")
+{
+	GIVEN("a player character")
+	{
+		auto player = new char_data();
+		player->Profs()->SetChar(player);
+
+		WHEN("a proficiency affect is added as invisible")
+		{
+			add_prof_affect(player, (char *)"testprof", 5, true);
+
+			THEN("the affect carries AFT_INVIS rather than whatever init_affect left")
+			{
+				REQUIRE(player->affected.size() == 1);
+				REQUIRE(player->affected.back().aftype == AFT_INVIS);
+			}
+		}
+
+		WHEN("a proficiency affect is added as visible")
+		{
+			add_prof_affect(player, (char *)"testprof", 5, false);
+
+			THEN("the affect carries AFT_SKILL")
+			{
+				REQUIRE(player->affected.size() == 1);
+				REQUIRE(player->affected.back().aftype == AFT_SKILL);
+			}
+		}
+
+		TestHelperCleanupPlayerObject(player);
+	}
+}

--- a/tests/queue_tests.c
+++ b/tests/queue_tests.c
@@ -22,7 +22,7 @@ namespace
 	}
 }
 
-void testQueueFunction(char_data *qChar) {
+void testQueueFunction([[maybe_unused]] char_data *qChar) {
     return;
 }
 
@@ -89,14 +89,14 @@ void reentrantRequeueFunction(char_data *qChar)
 
 static int inertCallCount = 0;
 
-void inertQueueFunction(char_data *qChar)
+void inertQueueFunction([[maybe_unused]] char_data *qChar)
 {
 	inertCallCount++;
 	return;
 }
 
 // Reproduces a re-entrant erase bug found in the code.
-void wideArgQueueFunction(char_data *qChar, long a, long b, long c)
+void wideArgQueueFunction(char_data * /* qChar */, long /* a */, long /* b */, long /* c */)
 {
 	inertCallCount++;
 	return;
@@ -174,7 +174,7 @@ SCENARIO("Testing a queued function that requeues itself", "[ProcessQueue]")
 // Same-tick execution order that must run in the order they were added.
 static std::vector<int> executionOrder;
 
-void recordOrderFunction(char_data *qChar, long tag)
+void recordOrderFunction([[maybe_unused]] char_data *qChar, long tag)
 {
 	executionOrder.push_back(static_cast<int>(tag));
 }
@@ -261,7 +261,7 @@ SCENARIO("Testing execution order of queued events", "[ProcessQueue]")
 static int capturedInt = 0;
 static float capturedFloat = 0.0f;
 
-void recordScalarsFunction(char_data *qChar, int i, float f)
+void recordScalarsFunction([[maybe_unused]] char_data *qChar, int i, float f)
 {
 	capturedInt = i;
 	capturedFloat = f;

--- a/tests/utility_tests.c
+++ b/tests/utility_tests.c
@@ -4,6 +4,8 @@
 #include "../code/merc.h"
 #include "../code/utility.h"
 #include "../code/db.h"
+#include "../code/devextra.h"
+#include "../code/tables.h"
 
 // TEST_CASE("Test capitalization", "[string]" )
 // {
@@ -1298,3 +1300,33 @@ SCENARIO("retrieve a player character's armor type", "[get_ac]")
 
 // TODO: write tests
 // bool is_switched (CHAR_DATA *ch)
+
+SCENARIO("building a printable string from a flag table", "[flags_to_string]")
+{
+	GIVEN("a flag table with three named entries")
+	{
+		const struct flag_type table[] =
+		{
+			{(char *)"alpha", 1, true},
+			{(char *)"beta", 2, true},
+			{(char *)"gamma", 4, true},
+			{nullptr, 0, false}
+		};
+
+		WHEN("flags_to_string walks the table")
+		{
+			// This returns only if the loop advances. The character argument is
+			// unread by the function, so a null one is safe here.
+			auto result = flags_to_string(nullptr, table, 15);
+
+			THEN("it terminates and names every entry exactly once")
+			{
+				REQUIRE(result != nullptr);
+				REQUIRE(strstr(result, "alpha") != nullptr);
+				REQUIRE(strstr(result, "beta") != nullptr);
+				REQUIRE(strstr(result, "gamma") != nullptr);
+				REQUIRE(strlen(result) < MAX_INPUT_LENGTH);
+			}
+		}
+	}
+}


### PR DESCRIPTION
Closes #30

This PR fixes logic errors, boolean grouping issues, fallthrough switch errors, and removes a ton of compiler warnings around unused parameters/variables.

The main bonus in this one is it removes two infinite loops that would hard lock the server. See the first two bullets under Stability.

> Note: Most of the churn is from updating function signatures to use [[maybe_unused]] or commented the parameter name out. It's mainly localized in the first commit if you want to skip that. Did that to silence all those unused parameter warnings that flood the compiler output.


## Gameplay changes

### Combat and spells
- **Rust now affects arms, hands, feet, legs, about and body.** Missing `break`s let those
  cases fall through to `default: continue`, which skipped applying the affect entirely. It
  previously only worked on fingers, neck, wrists, waist and head.
- **Icy breath deals cold, and the mana sickness tick deals its proper type.** Two `damage_new`
  calls had the damage type and the `show` flag transposed, so both passed `true` (1) as the
  damage type. `DAM_BASH` is 1, so both were landing as bash and resistances did not apply.
- **Shock now destroys jewelry** and prints "$p is fused into a worthless lump." A missing
  `break` fell through to `default: return`, so it never has.
- **Headbutt's knockout respects immunity to bash and sleep.** A misplaced closing paren meant
  the code tested `IS_SET(imm_flags, IMM_BASH && !IS_SET(imm_flags, IMM_SLEEP))`, checking a
  flag value of 0 or 1 rather than the two immunities.
- **A charmed creature now stops following when the charm expires**, and both parties are told.
  Nothing called `stop_follower` on expiry, so it followed forever.

### Balance-affecting
- **Mana infusion deals less damage for casters level 15 and up.** The tier test was
  `else if (10 > ch->level < 15)`, which parses as `(10 > ch->level) < 15` and is always true,
  so every caster level 10+ received the 200% multiplier. Level 15+ now correctly receive 120%.
- **Hydration heals less in a swamp.** A missing `break` fell through to `SECT_WATER`, so swamp
  used the water value. It is now `dice(12, 10)` rather than `dice(16, 10)`.
- **The command whitelists for movement and silence affects now actually restrict.** They
  compared string literals by pointer, so they matched nothing and exempted nothing. Affects
  such as hold person, ultradiffusion, bind feet and entangling roots are now meaningfully
  harder than players are used to.

### Skills and commands
- **Assess reports by skill tier again.** A stray `;` after `if (skill < 91)` made the body
  unconditional, so it always showed the master-tier line.
- **Giving an item that carries a give prog now transfers the item.** A stray `;` made the
  `return` unconditional, so `do_give` always returned before `obj_from_char`/`obj_to_char`.

### World
- **Elven down now blinds everyone in the room**, not only whoever spoke. The affect was applied
  to `ch` instead of the room loop variable `ich`.

### Stability
- **`affto` no longer hangs the server.** `flag = flag++` in `flags_to_string` never increments.
- **Conflagration no longer freezes the game.** Its pulse drew random directions until it found
  an exit, which never returns in a room with no exits. It now collects candidates first.
- **Three object and mob progs no longer read an uninitialized pointer** (corpse explode, the
  flatworm drain, and cosmetic creation). An inner declaration shadowed the outer one, so the
  post-loop null check read uninitialized memory. The not-found case is now handled correctly
  rather than falling back to whichever character happened to be last in the list.
- Unguarded `owner` dereferences, an uninitialized `obj_index` count in the area loader, and
  `bugout` is now unconditionally fatal instead of returning into a corrupted state.