### PR TITLE
More game crash and game command fixes.

### DIFF
--- a/code/act_comm.c
+++ b/code/act_comm.c
@@ -422,11 +422,11 @@ void do_newbie(CHAR_DATA *ch, char *argument)
 	if (IS_SET(ch->comm, COMM_ANSI))
 	{
 		sprintf(buf2, "%s[NEWBIE] $n$t%s", get_char_color(ch, "newbie"), END_COLOR(ch));
-		act_new(buf2, ch, buf, 0, TO_CHAR, POS_DEAD);
+		act_new(buf2, ch, buf, nullptr, TO_CHAR, POS_DEAD);
 	}
 	else
 	{
-		act_new("[NEWBIE] $n$t", ch, buf, 0, TO_CHAR, POS_DEAD);
+		act_new("[NEWBIE] $n$t", ch, buf, nullptr, TO_CHAR, POS_DEAD);
 	}
 
 	for (OwningListWalk<CHAR_DATA> walk(char_list); !walk.Done(); walk.Step())
@@ -494,11 +494,11 @@ void do_builder(CHAR_DATA *ch, char *argument)
 	if (IS_SET(ch->comm, COMM_ANSI))
 	{
 		sprintf(buf2, "%s[BUILDER] $n$t%s", get_char_color(ch, "builder"), END_COLOR(ch));
-		act_new(buf2, ch, buf, 0, TO_CHAR, POS_DEAD);
+		act_new(buf2, ch, buf, nullptr, TO_CHAR, POS_DEAD);
 	}
 	else
 	{
-		act_new("[BUILDER] $n$t", ch, buf, 0, TO_CHAR, POS_DEAD);
+		act_new("[BUILDER] $n$t", ch, buf, nullptr, TO_CHAR, POS_DEAD);
 	}
 
 	for (OwningListWalk<CHAR_DATA> walk(char_list); !walk.Done(); walk.Step())
@@ -587,11 +587,11 @@ void do_immtalk(CHAR_DATA *ch, char *argument)
 	if (IS_SET(ch->comm, COMM_ANSI))
 	{
 		sprintf(buf2, "%s[IMM] $n$t%s", get_char_color(ch, "immtalk"), END_COLOR(ch));
-		act_new(buf2, ch, buffer.data(), 0, TO_CHAR, POS_DEAD);
+		act_new(buf2, ch, buffer.data(), nullptr, TO_CHAR, POS_DEAD);
 	}
 	else
 	{
-		act_new("[IMM] $n$t", ch, buffer.data(), 0, TO_CHAR, POS_DEAD);
+		act_new("[IMM] $n$t", ch, buffer.data(), nullptr, TO_CHAR, POS_DEAD);
 	}
 
 	for (OwningListWalk<CHAR_DATA> walk(char_list); !walk.Done(); walk.Step())
@@ -753,7 +753,7 @@ void do_say(CHAR_DATA *ch, char *argument)
 		{
 			if (!(is_immortal(ch)) && is_affected(victim, gsn_deafen))
 			{
-				act("$n says something you can't quite hear.", ch, 0, victim, TO_VICT);
+				act("$n says something you can't quite hear.", ch, nullptr, victim, TO_VICT);
 			}
 			else
 			{
@@ -867,7 +867,7 @@ void say_to(CHAR_DATA *ch, CHAR_DATA *victim, char *argument, char *extra)
 	{
 		if (!(is_immortal(ch)) && is_affected(victim, gsn_deafen))
 		{
-			act("$n says something you can't quite hear.", ch, 0, victim, TO_VICT);
+			act("$n says something you can't quite hear.", ch, nullptr, victim, TO_VICT);
 		}
 		else
 		{
@@ -939,12 +939,12 @@ void do_whisper(CHAR_DATA *ch, char *argument) /* whisper -- dioxide */
 		{
 			if (!is_immortal(ch) && is_affected(victim, gsn_deafen))
 			{
-				act("$n says something you can't quite hear.", ch, 0, victim, TO_VICT);
+				act("$n says something you can't quite hear.", ch, nullptr, victim, TO_VICT);
 			}
 			else
 			{
 				sprintf(buf, "$n whispers '%s%s%s'", get_char_color(victim, "red"), argument, END_COLOR(victim));
-				act(buf, ch, 0, victim, TO_VICT);
+				act(buf, ch, nullptr, victim, TO_VICT);
 
 				if (IS_SET(victim->progtypes, MPROG_SPEECH) && victim != ch)
 					victim->pIndexData->mprogs->speech_prog(victim, ch, argument);
@@ -1086,12 +1086,12 @@ void do_sing(CHAR_DATA *ch, char *argument)
 		{
 			if (!is_immortal(ch) && is_affected(victim, gsn_deafen))
 			{
-				act("$n sings something you can't quite hear.", ch, 0, victim, TO_VICT);
+				act("$n sings something you can't quite hear.", ch, nullptr, victim, TO_VICT);
 			}
 			else
 			{
 				buffer3 = fmt::format("$n sings '{}{}{}'", get_char_color(victim, "song"), buf, END_COLOR(victim));
-				act(buffer3.c_str(), ch, 0, victim, TO_VICT);
+				act(buffer3.c_str(), ch, nullptr, victim, TO_VICT);
 
 				if (is_affected(victim, gsn_word_of_command) && strstr(argument, victim->pcdata->command[0]))
 					command_execute(victim);
@@ -1100,7 +1100,7 @@ void do_sing(CHAR_DATA *ch, char *argument)
 	}
 
 	buffer3 = fmt::format("You sing '{}{}{}'", get_char_color(ch, "song"), buf2, END_COLOR(ch));
-	act(buffer3.c_str(), ch, 0, 0, TO_CHAR);
+	act(buffer3.c_str(), ch, nullptr, nullptr, TO_CHAR);
 }
 
 void do_pray(CHAR_DATA *ch, char *argument)
@@ -1257,13 +1257,13 @@ void do_tell(CHAR_DATA *ch, char *argument)
 
 	if (!(is_immortal(ch) && ch->level > LEVEL_IMMORTAL) && (!is_awake(victim) || is_affected(victim, gsn_deafen)))
 	{
-		act("$E can't hear you.", ch, 0, victim, TO_CHAR);
+		act("$E can't hear you.", ch, nullptr, victim, TO_CHAR);
 		return;
 	}
 
 	if ((IS_SET(victim->comm, COMM_QUIET) || IS_SET(victim->comm, COMM_DEAF)) && !is_immortal(ch)) /* Let Imms send tells to deaf players */
 	{
-		act("$E is not receiving tells.", ch, 0, victim, TO_CHAR);
+		act("$E is not receiving tells.", ch, nullptr, victim, TO_CHAR);
 		return;
 	}
 
@@ -1345,13 +1345,13 @@ void do_reply(CHAR_DATA *ch, char *argument)
 
 	if (!is_immortal(ch) && (!is_awake(victim) || is_affected(victim, gsn_deafen)))
 	{
-		act("$E can't hear you.", ch, 0, victim, TO_CHAR);
+		act("$E can't hear you.", ch, nullptr, victim, TO_CHAR);
 		return;
 	}
 
 	if ((IS_SET(victim->comm, COMM_QUIET) || IS_SET(victim->comm, COMM_DEAF)) && !is_immortal(ch) && !is_immortal(victim))
 	{
-		act_new("$E is not receiving tells.", ch, 0, victim, TO_CHAR, POS_DEAD);
+		act_new("$E is not receiving tells.", ch, nullptr, victim, TO_CHAR, POS_DEAD);
 		return;
 	}
 
@@ -1831,7 +1831,7 @@ void do_quit_new(CHAR_DATA *ch, [[maybe_unused]] char *argument, bool autoq)
 			{
 				if (obj->carried_by == ch->self)
 				{
-					act("You cannot quit with cabal items in your inventory!", ch, 0, 0, TO_CHAR);
+					act("You cannot quit with cabal items in your inventory!", ch, nullptr, nullptr, TO_CHAR);
 					return;
 				}
 			}
@@ -1926,7 +1926,7 @@ void do_quit_new(CHAR_DATA *ch, [[maybe_unused]] char *argument, bool autoq)
 
 		if (wch->pIndexData->vnum == MOB_VNUM_DECOY && is_name(ch->name, wch->name))
 		{
-			act("$n crumbles to dust.", wch, 0, 0, TO_ROOM);
+			act("$n crumbles to dust.", wch, nullptr, nullptr, TO_ROOM);
 			extract_char(wch, true);
 		}
 	}
@@ -2726,7 +2726,7 @@ void do_release(CHAR_DATA *ch, char *argument)
 
 	if (is_npc(victim))
 	{
-		act("$n slowly fades away.", victim, 0, 0, TO_ROOM);
+		act("$n slowly fades away.", victim, nullptr, nullptr, TO_ROOM);
 		extract_char(victim, true);
 	}
 	else

--- a/code/act_comm.c
+++ b/code/act_comm.c
@@ -1909,21 +1909,10 @@ void do_quit_new(CHAR_DATA *ch, [[maybe_unused]] char *argument, bool autoq)
 	{
 		CHAR_DATA *wch = walk.Current();
 
-		if (is_affected(wch, gsn_empathy))
-		{
-			AFFECT_DATA *laf = nullptr;
-			for (auto &laf_elem : wch->affected)
-			{
-				if (laf_elem.type == gsn_empathy)
-				{
-					laf = &laf_elem;
-					break;
-				}
-			}
+		AFFECT_DATA *laf = affect_find(wch->affected, gsn_empathy);
 
-			if (Deref(laf->owner) == ch)
-				affect_strip(wch, gsn_empathy);
-		}
+		if (laf != nullptr && Deref(laf->owner) == ch)
+			affect_strip(wch, gsn_empathy);
 
 		if (!is_npc(wch))
 			continue;
@@ -2835,7 +2824,12 @@ void mob_death_log(CHAR_DATA *killer, CHAR_DATA *dead)
 /* type 0 = create, 1 = login, 2 = logout */
 void login_log(CHAR_DATA *ch, int type)
 {
-	if (!ch->pcdata->host && !Deref(ch->desc))
+	// Read once. The guard below proves the descriptor is there when the stored
+	// host is not, but only if both reads see the same descriptor, and resolving
+	// the handle twice is two separate lookups.
+	DESCRIPTOR_DATA *connection = Deref(ch->desc);
+
+	if (!ch->pcdata->host && !connection)
 		return;
 
 	if (IS_SET(ch->comm, COMM_NOSOCKET))
@@ -2843,7 +2837,7 @@ void login_log(CHAR_DATA *ch, int type)
 
 	Login login;
 	login.name = ch->true_name;
-	login.site = ch->pcdata->host ? ch->pcdata->host : Deref(ch->desc)->host;
+	login.site = ch->pcdata->host ? ch->pcdata->host : connection->host;
 	login.time = log_time();
 	login.ctime = current_time;
 	login.played = type == 2 ? (int)((current_time - ch->logon) / 60) : -1;

--- a/code/act_comm.c
+++ b/code/act_comm.c
@@ -1141,6 +1141,9 @@ void do_pray(CHAR_DATA *ch, char *argument)
 
 		auto victim = Deref(d->original) ? Deref(d->original) : Deref(d->character);
 
+		if (victim == nullptr)
+			continue;
+
 		if (d->connected == CON_PLAYING && Deref(d->character) != ch && !IS_SET(victim->comm, COMM_SHOUTSOFF) && !IS_SET(victim->comm, COMM_QUIET) && victim->level >= 52)
 		{
 			sprintf(buf, "%s%s [%d] is PRAYing for: %s%s\n\r",
@@ -1485,6 +1488,9 @@ void do_yell(CHAR_DATA *ch, char *argument)
 		// Read once: command_execute below can extract the listener, but it is
 		// the last thing this iteration does with it.
 		CHAR_DATA *listener = Deref(d->character);
+
+		if (listener == nullptr)
+			continue;
 
 		if (d->connected == CON_PLAYING && listener != ch && listener->in_room != nullptr && listener->in_room->area == ch->in_room->area && !IS_SET(listener->comm, COMM_QUIET))
 		{

--- a/code/act_comm.c
+++ b/code/act_comm.c
@@ -112,8 +112,12 @@ void do_delete(CHAR_DATA *ch, char *argument)
 			do_quit_new(ch, "", true);
 
 			auto cname = palloc_string(ch->true_name);
+
+			// Archiving the pfile into dead_char is what makes a name refuse to
+			// be reused, so only a character with real time behind it retires
+			// its name. Anything shorter frees the name for someone else.
 			auto save_pfile = ((ch->played + (current_time - ch->logon)) / 3600) >= 15;
-			delete_char(cname, true); // >= 15 hours. Make name unusable.
+			delete_char(cname, save_pfile);
 
 			free_pstring(cname);
 			return;

--- a/code/act_ente.c
+++ b/code/act_ente.c
@@ -119,7 +119,7 @@ void do_enter(CHAR_DATA *ch, char *argument)
 		|| (IS_SET_OLD(portal->value[2], GATE_BUGGY) && number_percent() < 5))
 	{
 		send_to_char("You enter the portal and find yourself elsewhere.\n\r", ch);
-		act("$n steps into $p.", ch, portal, 0, TO_ROOM);
+		act("$n steps into $p.", ch, portal, nullptr, TO_ROOM);
 		spell_teleport(skill_lookup("teleport"), ch->level, ch, ch, CastMode::Spell);
 		return;
 	}

--- a/code/act_info.c
+++ b/code/act_info.c
@@ -676,7 +676,7 @@ void show_char_to_char_1(CHAR_DATA *victim, CHAR_DATA *ch)
 			get_char_color(ch, "white"),
 			END_COLOR(ch));
 
-		act(buf, ch, 0, victim, TO_CHAR);
+		act(buf, ch, nullptr, victim, TO_CHAR);
 	}
 
 	if (is_affected(victim, gsn_corona))
@@ -685,7 +685,7 @@ void show_char_to_char_1(CHAR_DATA *victim, CHAR_DATA *ch)
 			get_char_color(ch, "lightred"),
 			END_COLOR(ch));
 
-		act(buf, ch, 0, victim, TO_CHAR);
+		act(buf, ch, nullptr, victim, TO_CHAR);
 	}
 
 	if (is_affected(victim, gsn_frigidaura))
@@ -694,7 +694,7 @@ void show_char_to_char_1(CHAR_DATA *victim, CHAR_DATA *ch)
 			get_char_color(ch, "lightblue"),
 			END_COLOR(ch));
 
-		act(buf, ch, 0, victim, TO_CHAR);
+		act(buf, ch, nullptr, victim, TO_CHAR);
 	}
 
 	if (is_affected(victim, gsn_rotating_ward))
@@ -714,7 +714,7 @@ void show_char_to_char_1(CHAR_DATA *victim, CHAR_DATA *ch)
 				: "Multifaceted crystals are",
 			END_COLOR(ch));
 
-		act(buf, ch, 0, victim, TO_CHAR);
+		act(buf, ch, nullptr, victim, TO_CHAR);
 	}
 
 	if (is_affected(victim, gsn_cloak_form) && !is_immortal(ch))
@@ -789,7 +789,7 @@ void show_char_to_char_1(CHAR_DATA *victim, CHAR_DATA *ch)
 		&& belt->pIndexData->vnum == OBJ_VNUM_TROPHY_BELT
 		&& !victim->pcdata->trophy.empty() && belt->value[4] >= 1)
 	{
-		act("\n\r$p catches your eye, meriting closer examination.", ch, belt, 0, TO_CHAR);
+		act("\n\r$p catches your eye, meriting closer examination.", ch, belt, nullptr, TO_CHAR);
 
 		if (!belt->extra_descr.empty())
 			send_to_char(belt->extra_descr.front().description, ch);
@@ -846,35 +846,35 @@ void show_char_to_char_1(CHAR_DATA *victim, CHAR_DATA *ch)
 
 		if (!is_npc(victim))
 		{
-			act("\n\rYou check for gold coins on $N's person:", ch, 0, victim, TO_CHAR);
+			act("\n\rYou check for gold coins on $N's person:", ch, nullptr, victim, TO_CHAR);
 
 			if (victim->gold <= 0)
 			{
-				act("$N does not seem to be carrying any gold.", ch, 0, victim, TO_CHAR);
+				act("$N does not seem to be carrying any gold.", ch, nullptr, victim, TO_CHAR);
 			}
 			else if (victim->gold < 10)
 			{
-				act("Scant few gold pieces jingle softly in $N's purse.", ch, 0, victim, TO_CHAR);
+				act("Scant few gold pieces jingle softly in $N's purse.", ch, nullptr, victim, TO_CHAR);
 			}
 			else if (victim->gold < 100)
 			{
-				act("$N's coinpurse appears fairly empty.", ch, 0, victim, TO_CHAR);
+				act("$N's coinpurse appears fairly empty.", ch, nullptr, victim, TO_CHAR);
 			}
 			else if (victim->gold < 1000)
 			{
-				act("$N's coinpurse has a healthy bulge to it.", ch, 0, victim, TO_CHAR);
+				act("$N's coinpurse has a healthy bulge to it.", ch, nullptr, victim, TO_CHAR);
 			}
 			else if (victim->gold < 10000)
 			{
-				act("$N's coinpurse hangs heavily at $S waist, laden with gold.", ch, 0, victim, TO_CHAR);
+				act("$N's coinpurse hangs heavily at $S waist, laden with gold.", ch, nullptr, victim, TO_CHAR);
 			}
 			else if (victim->gold < 100000)
 			{
-				act("$N's coinpurse bulges at the seams, overflowing with gold!", ch, 0, victim, TO_CHAR);
+				act("$N's coinpurse bulges at the seams, overflowing with gold!", ch, nullptr, victim, TO_CHAR);
 			}
 			else
 			{
-				act("Not only does $N have the largest coinpurse you've ever laid eyes upon, but it can scarcely contain the veritable motherlode $E is toting around.  Thieves the world over are having wet dreams about $N at this very moment.", ch, 0, victim, TO_CHAR);
+				act("Not only does $N have the largest coinpurse you've ever laid eyes upon, but it can scarcely contain the veritable motherlode $E is toting around.  Thieves the world over are having wet dreams about $N at this very moment.", ch, nullptr, victim, TO_CHAR);
 			}
 		}
 	}
@@ -2009,7 +2009,7 @@ void do_look(CHAR_DATA *ch, char *argument)
 
 				if (is_affected_obj(obj, gsn_ice_blast))
 				{
-					act("$p is frozen shut!", ch, obj, 0, TO_CHAR);
+					act("$p is frozen shut!", ch, obj, nullptr, TO_CHAR);
 					break;
 				}
 
@@ -2073,7 +2073,7 @@ void do_look(CHAR_DATA *ch, char *argument)
 		}
 
 		if (is_immortal(victim))
-			act("$n looks at you.", ch, 0, victim, TO_VICT);
+			act("$n looks at you.", ch, nullptr, victim, TO_VICT);
 
 		show_char_to_char_1(victim, ch);
 		return;
@@ -2701,9 +2701,9 @@ void do_score(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 		for (i = 0; demon_table[i].name; i++)
 		{
 			if (demon_table[i].type == LESSER_DEMON && ch->pcdata->lesserdata[i] >= FAVOR_GRANTED)
-				act("You have been granted the favor of the lesser demon $t.", ch, capitalize(demon_table[i].name), 0, TO_CHAR);
+				act("You have been granted the favor of the lesser demon $t.", ch, capitalize(demon_table[i].name), nullptr, TO_CHAR);
 			if (demon_table[i].type == GREATER_DEMON && i >= MAX_LESSER && ch->pcdata->greaterdata[i - MAX_LESSER] >= FAVOR_GRANTED)
-				act("You have been granted the favor of the greater demon $t.", ch, capitalize(demon_table[i].name), 0, TO_CHAR);
+				act("You have been granted the favor of the greater demon $t.", ch, capitalize(demon_table[i].name), nullptr, TO_CHAR);
 		}
 	}
 
@@ -3848,34 +3848,34 @@ void do_consider(CHAR_DATA *ch, char *argument)
 
 	auto diff = victim->level - ch->level;
 	if (diff <= -10)
-		act("Your sneeze would kill $N.", ch, 0, victim, TO_CHAR);
+		act("Your sneeze would kill $N.", ch, nullptr, victim, TO_CHAR);
 	else if (diff <= -5)
-		act("$N wouldn't last long against you.", ch, 0, victim, TO_CHAR);
+		act("$N wouldn't last long against you.", ch, nullptr, victim, TO_CHAR);
 	else if (diff <= -2)
-		act("$N looks like an easy kill.", ch, 0, victim, TO_CHAR);
+		act("$N looks like an easy kill.", ch, nullptr, victim, TO_CHAR);
 	else if (diff <= 1)
-		act("$N is about a perfect match for you!", ch, 0, victim, TO_CHAR);
+		act("$N is about a perfect match for you!", ch, nullptr, victim, TO_CHAR);
 	else if (diff <= 4)
-		act("$N looks a little tough.", ch, 0, victim, TO_CHAR);
+		act("$N looks a little tough.", ch, nullptr, victim, TO_CHAR);
 	else if (diff <= 9)
-		act("You wouldn't last too long against $N by yourself.", ch, 0, victim, TO_CHAR);
+		act("You wouldn't last too long against $N by yourself.", ch, nullptr, victim, TO_CHAR);
 	else
-		act("You must have a fascination with death.", ch, 0, victim, TO_CHAR);
+		act("You must have a fascination with death.", ch, nullptr, victim, TO_CHAR);
 
 	diff = victim->size - ch->size;
 	if (diff > 1)
-		act("$N easily towers over you.", ch, 0, victim, TO_CHAR);
+		act("$N easily towers over you.", ch, nullptr, victim, TO_CHAR);
 	else if (diff == 1)
-		act("$N is considerably larger than you.", ch, 0, victim, TO_CHAR);
+		act("$N is considerably larger than you.", ch, nullptr, victim, TO_CHAR);
 	else if (!diff)
-		act("$N is about the same size as you.", ch, 0, victim, TO_CHAR);
+		act("$N is about the same size as you.", ch, nullptr, victim, TO_CHAR);
 	else if (diff == -1)
-		act("$N is considerably smaller than you.", ch, 0, victim, TO_CHAR);
+		act("$N is considerably smaller than you.", ch, nullptr, victim, TO_CHAR);
 	else if (diff < -1)
-		act("You tower over $N.  Be careful not to step on $M.", ch, 0, victim, TO_CHAR);
+		act("You tower over $N.  Be careful not to step on $M.", ch, nullptr, victim, TO_CHAR);
 
 	if (victim->alignment >= 1)
-		act("$N seems relatively benign.", ch, 0, victim, TO_CHAR);
+		act("$N seems relatively benign.", ch, nullptr, victim, TO_CHAR);
 }
 
 void set_title(CHAR_DATA *ch, char *title)
@@ -4432,14 +4432,14 @@ void do_practice(CHAR_DATA *ch, char *argument)
 	}
 	else if (skill_table[sn].ctype == CMD_COMMUNE || (skill_table[sn].ctype == CMD_BOTH && ch->Class()->ctype == CLASS_COMMUNER))
 	{
-		act("$n recites the prayer of $t.", mob, skill_table[sn].name, 0, TO_ROOM);
+		act("$n recites the prayer of $t.", mob, skill_table[sn].name, nullptr, TO_ROOM);
 		send_to_char("You try to memorize the fundamentals of the holy recitation.\n\r", ch);
 		act("$N watches studiously as $n demonstrates the $t prayer.", mob, skill_table[sn].name, ch, TO_NOTVICT);
 	}
 	else // if(skill_table[sn].ctype == CMD_NONE)
 	{
-		act("$n demonstrates the usage of the $t skill.", mob, skill_table[sn].name, 0, TO_ROOM);
-		act("You study the fundamental aspects of $t.", ch, skill_table[sn].name, 0, TO_CHAR);
+		act("$n demonstrates the usage of the $t skill.", mob, skill_table[sn].name, nullptr, TO_ROOM);
+		act("You study the fundamental aspects of $t.", ch, skill_table[sn].name, nullptr, TO_CHAR);
 		act("$N studiously watches $n's demonstration of the $t skill.", mob, skill_table[sn].name, ch, TO_NOTVICT);
 	}
 	if (ch->pcdata->learned[sn] >= adept)
@@ -4712,7 +4712,7 @@ void do_withdraw(CHAR_DATA *ch, char *argument)
 			if (ch->pcdata->deposited_items[i] > 0)
 			{
 				if (!bFound)
-					act("$n hands you a slip of paper with a listing of your assets.", banker, 0, ch, TO_VICT);
+					act("$n hands you a slip of paper with a listing of your assets.", banker, nullptr, ch, TO_VICT);
 
 				pIndex = get_obj_index(ch->pcdata->deposited_items[i]);
 				if (!pIndex)
@@ -4752,9 +4752,9 @@ void do_withdraw(CHAR_DATA *ch, char *argument)
 			return;
 		}
 
-		act("$n nods briefly before scurrying away.", banker, 0, ch, TO_VICT);
-		act("$n soon returns, followed by two guards hauling a heavy chest.", banker, 0, ch, TO_VICT);
-		act("$n gets out a large set of keys and unlocks the chest.", banker, 0, ch, TO_VICT);
+		act("$n nods briefly before scurrying away.", banker, nullptr, ch, TO_VICT);
+		act("$n soon returns, followed by two guards hauling a heavy chest.", banker, nullptr, ch, TO_VICT);
+		act("$n gets out a large set of keys and unlocks the chest.", banker, nullptr, ch, TO_VICT);
 
 		auto pObj = create_object(pIndex, 0);
 		if (!pObj)
@@ -4762,12 +4762,12 @@ void do_withdraw(CHAR_DATA *ch, char *argument)
 
 		if (!can_see_obj(ch, pObj))
 		{
-			act("You are unable to find what you're looking for in the chest.", ch, 0, 0, TO_CHAR);
+			act("You are unable to find what you're looking for in the chest.", ch, nullptr, nullptr, TO_CHAR);
 			extract_obj(pObj);
 			return;
 		}
 
-		act("You retrieve $p from the storage chest.", ch, pObj, 0, TO_CHAR);
+		act("You retrieve $p from the storage chest.", ch, pObj, nullptr, TO_CHAR);
 		obj_to_char(pObj, ch);
 		ch->pcdata->deposited_items[amount - 1] = 0;
 
@@ -5032,7 +5032,7 @@ void do_lore(CHAR_DATA *ch, char *argument) /* Lore by Detlef */
 
 	lorebonus = std::max(lorebonus, 0);
 
-	act("You examine $p intently.", ch, obj, 0, TO_CHAR);
+	act("You examine $p intently.", ch, obj, nullptr, TO_CHAR);
 
 	if (number_percent() < get_skill(ch, gsn_lore) + lorebonus * 15)
 	{
@@ -5153,7 +5153,7 @@ void do_lore(CHAR_DATA *ch, char *argument) /* Lore by Detlef */
 	}
 	else
 	{
-		act("You examine $p closely but fail to gain any insight into it.", ch, obj, 0, TO_CHAR);
+		act("You examine $p closely but fail to gain any insight into it.", ch, obj, nullptr, TO_CHAR);
 		check_improve(ch, gsn_lore, false, 2);
 	}
 
@@ -5357,13 +5357,13 @@ void do_trustchar(CHAR_DATA *ch, char *argument)
 			return;
 		}
 
-		act("You no longer trust $N with questionable actions.", ch, 0, trusted, TO_CHAR);
+		act("You no longer trust $N with questionable actions.", ch, nullptr, trusted, TO_CHAR);
 		ch->pcdata->trusting = nullptr;
 		return;
 	}
 
 	ch->pcdata->trusting = victim->self;
-	act("You now trust $N with questionable actions.", ch, 0, victim, TO_CHAR);
+	act("You now trust $N with questionable actions.", ch, nullptr, victim, TO_CHAR);
 }
 
 void do_role(CHAR_DATA *ch, char *argument)

--- a/code/act_info.c
+++ b/code/act_info.c
@@ -3138,7 +3138,6 @@ void do_whois(CHAR_DATA *ch, char *argument)
 void do_who(CHAR_DATA *ch, char *argument)
 {
 	std::string buffer;
-	char buf[MAX_STRING_LENGTH];
 	char buf2[MAX_STRING_LENGTH];
 	char rbuf[MAX_STRING_LENGTH];
 	char disp[MAX_STRING_LENGTH];
@@ -3315,7 +3314,6 @@ void do_who(CHAR_DATA *ch, char *argument)
 	/*
 	 * Now show matching chars.
 	 */
-	buf[0] = '\0';
 
 	auto nMatch = 0;
 	BUFFER output;
@@ -5368,14 +5366,13 @@ void do_trustchar(CHAR_DATA *ch, char *argument)
 
 void do_role(CHAR_DATA *ch, char *argument)
 {
-	char buf[MAX_BUF], arg1[MAX_BUF], obuf[MAX_BUF];
+	char arg1[MAX_BUF], obuf[MAX_BUF];
 
 	if (is_npc(ch))
 		return;
 
 	if (argument[0] != '\0')
 	{
-		buf[0] = '\0';
 		smash_tilde(argument);
 		argument = one_argument(argument, arg1);
 

--- a/code/act_move.c
+++ b/code/act_move.c
@@ -3800,7 +3800,6 @@ void track_char(CHAR_DATA *ch, CHAR_DATA *mob)
 	if (IS_SET(mob->off_flags, STATIC_TRACKING) || track_dir == -1)
 		return;
 
-	auto pexit = mob->in_room->exit[track_dir];
 
 	move_char(mob, track_dir, false, true);
 }

--- a/code/act_move.c
+++ b/code/act_move.c
@@ -4451,7 +4451,7 @@ bool bar_entry(CHAR_DATA *ch, CHAR_DATA *blocker, ROOM_INDEX_DATA *to_room)
 	char buf[MAX_STRING_LENGTH];
 	auto str = palloc_string(blocker->pIndexData->barred_entry->message);
 
-	parse_bar(buf, str, ch, blocker, to_room);
+	parse_bar(buf, sizeof(buf), str, ch, blocker, to_room);
 
 	if (blocker->pIndexData->barred_entry->msg_type == BAR_SAY)
 		do_say(blocker, buf);
@@ -4470,7 +4470,7 @@ bool bar_entry(CHAR_DATA *ch, CHAR_DATA *blocker, ROOM_INDEX_DATA *to_room)
 		{
 			char buf2[MAX_STRING_LENGTH];
 			auto strtwo = palloc_string(blocker->pIndexData->barred_entry->message_two);
-			parse_bar(buf2, strtwo, ch, blocker, to_room);
+			parse_bar(buf2, sizeof(buf2), strtwo, ch, blocker, to_room);
 
 			buf2[0] = UPPER(buf2[0]);
 
@@ -4485,17 +4485,31 @@ bool bar_entry(CHAR_DATA *ch, CHAR_DATA *blocker, ROOM_INDEX_DATA *to_room)
 	return true;
 }
 
-void parse_bar(char *buf, const char *str, CHAR_DATA *ch, CHAR_DATA *blocker, ROOM_INDEX_DATA *to_room)
+void parse_bar(char *buf, size_t size, const char *str, CHAR_DATA *ch, CHAR_DATA *blocker, ROOM_INDEX_DATA *to_room)
 {
 	const char *i = nullptr;
 	char *point;
 	char buf2[MAX_STRING_LENGTH];
 	point = buf;
+	bool truncated = false;
+	const char *const original = str;
 
-	while (*str != '\0')
+	// The message comes from area data and the substitutions splice in room and
+	// mob names, none of which is bounded. The destination size has to be passed
+	// in because this function writes into the caller's buffer. Stop one byte
+	// short so the terminator fits.
+	char *const limit = buf + size - 1;
+
+	while (*str != '\0' && !truncated)
 	{
 		if (*str != '$')
 		{
+			if (point >= limit)
+			{
+				truncated = true;
+				break;
+			}
+
 			*point++ = *str++;
 			continue;
 		}
@@ -4526,11 +4540,20 @@ void parse_bar(char *buf, const char *str, CHAR_DATA *ch, CHAR_DATA *blocker, RO
 
 		++str;
 
-		while ((*point = *i) != '\0')
+		while (*i != '\0')
 		{
-			++point, ++i;
+			if (point >= limit)
+			{
+				truncated = true;
+				break;
+			}
+
+			*point++ = *i++;
 		}
 	}
+
+	if (truncated)
+		RS.Logger.Warn("Parse_bar: message truncated to {} bytes. -- {}", (int)(point - buf), original);
 
 	*point = '\0';
 }

--- a/code/act_move.c
+++ b/code/act_move.c
@@ -687,6 +687,9 @@ void move_char(CHAR_DATA *ch, int door, bool automatic, bool fcharm)
 
 	if (is_affected_room(in_room, gsn_tripwire) && is_affected_room(to_room, gsn_tripwire))
 	{
+		// The guard above only proves each room carries a tripwire somewhere. It
+		// says nothing about the direction, and a wire strung across a different
+		// exit does not match, so both searches can come back empty.
 		ROOM_AFFECT_DATA *raf = nullptr;
 		for (auto &r : in_room->affected)
 		{
@@ -697,38 +700,47 @@ void move_char(CHAR_DATA *ch, int door, bool automatic, bool fcharm)
 			}
 		}
 
+		// This tested raf->type rather than r.type. That read raf before anything
+		// had checked it, and because raf is a tripwire by construction the test
+		// was always true once it survived, so the match rested on the direction
+		// alone and could return a room affect of any other kind.
 		ROOM_AFFECT_DATA *raf_two = nullptr;
 		for (auto &r : to_room->affected)
 		{
-			if (r.modifier == reverse_d(door) && raf->type == gsn_tripwire)
+			if (r.modifier == reverse_d(door) && r.type == gsn_tripwire)
 			{
 				raf_two = &r;
 				break;
 			}
 		}
 
-		if (is_affected_by(ch, AFF_FLYING))
-			return;
-
-		if (Deref(raf->owner) == ch)
+		// Nothing is strung across this exit, so there is nothing to trip over and
+		// the move carries on. Returning here would stop the character instead.
+		if (raf != nullptr && raf_two != nullptr)
 		{
-			act("You gracefully step over your tripwire.", ch, nullptr, nullptr, TO_CHAR);
-		}
-		else
-		{
-			twchance = (get_skill(ch, gsn_tripwire) / 5);
-			twchance += (get_curr_stat(ch, STAT_DEX) + get_curr_stat(ch, STAT_INT) - 30) * 2;
+			if (is_affected_by(ch, AFF_FLYING))
+				return;
 
-			if (!is_safe(Deref(raf->owner), ch) && (number_percent() > twchance))
+			if (Deref(raf->owner) == ch)
 			{
-				act("You trip over a wire and fall flat on your face!", ch, nullptr, nullptr, TO_CHAR);
-				act("$n trips over a wire and falls flat on $s face!", ch, nullptr, nullptr, TO_ROOM);
+				act("You gracefully step over your tripwire.", ch, nullptr, nullptr, TO_CHAR);
+			}
+			else
+			{
+				twchance = (get_skill(ch, gsn_tripwire) / 5);
+				twchance += (get_curr_stat(ch, STAT_DEX) + get_curr_stat(ch, STAT_INT) - 30) * 2;
 
-				ch->position = POS_RESTING;
-				WAIT_STATE(ch, PULSE_VIOLENCE * 2);
+				if (!is_safe(Deref(raf->owner), ch) && (number_percent() > twchance))
+				{
+					act("You trip over a wire and fall flat on your face!", ch, nullptr, nullptr, TO_CHAR);
+					act("$n trips over a wire and falls flat on $s face!", ch, nullptr, nullptr, TO_ROOM);
 
-				affect_remove_room(in_room, raf);
-				affect_remove_room(to_room, raf_two);
+					ch->position = POS_RESTING;
+					WAIT_STATE(ch, PULSE_VIOLENCE * 2);
+
+					affect_remove_room(in_room, raf);
+					affect_remove_room(to_room, raf_two);
+				}
 			}
 		}
 	}
@@ -925,19 +937,13 @@ void move_char(CHAR_DATA *ch, int door, bool automatic, bool fcharm)
 				new_affect_to_char(ch, &cvaf);
 			}
 
-			AFFECT_DATA *paf = nullptr;
-			for (auto &paf_elem : ch->affected)
+			AFFECT_DATA *paf = affect_find(ch->affected, gsn_noxious_fumes);
+
+			if (paf != nullptr)
 			{
-				if (paf_elem.type == gsn_noxious_fumes)
-				{
-					paf = &paf_elem;
-					break;
-				}
+				paf->modifier = URANGE(0, paf->modifier, 5);
+				paf->modifier++;
 			}
-
-			paf->modifier = URANGE(0, paf->modifier, 5);
-
-			paf->modifier++;
 
 			init_affect(&cvaf2);
 			cvaf2.where = TO_AFFECTS;

--- a/code/act_move.c
+++ b/code/act_move.c
@@ -108,21 +108,21 @@ void drowning_tick(CHAR_DATA *ch, AFFECT_DATA *af)
 	switch (af->duration)
 	{
 		case 0:
-			act("You drift into unconsciousness, and a sea of blackness swiftly overtakes you.", ch, 0, 0, TO_CHAR);
+			act("You drift into unconsciousness, and a sea of blackness swiftly overtakes you.", ch, nullptr, nullptr, TO_CHAR);
 			raw_kill(ch, ch);
 			break;
 		case 1:
 		case 2:
-			act("Gasping involuntarily, you take huge amounts of water into your lungs!", ch, 0, 0, TO_CHAR);
+			act("Gasping involuntarily, you take huge amounts of water into your lungs!", ch, nullptr, nullptr, TO_CHAR);
 			damage_new(ch, ch, (int)((ch->max_hit / 100) * 75), gsn_drowning, DAM_DROWNING, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "drowning");
 			break;
 		case 3:
-			act("Your heart leaps in your chest, protesting the lack of oxygen!", ch, 0, 0, TO_CHAR);
+			act("Your heart leaps in your chest, protesting the lack of oxygen!", ch, nullptr, nullptr, TO_CHAR);
 			damage_new(ch, ch, (int)((ch->max_hit / 100) * 25), gsn_drowning, DAM_DROWNING, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "asphyxiation");
 			break;
 		case 4:
-			act("Your face grows a deeper shade of red as you struggle to hold your breath!", ch, 0, 0, TO_CHAR);
-			act("$n's face grows a deeper shade of red as $e struggles to hold $s breath!", ch, 0, 0, TO_ROOM);
+			act("Your face grows a deeper shade of red as you struggle to hold your breath!", ch, nullptr, nullptr, TO_CHAR);
+			act("$n's face grows a deeper shade of red as $e struggles to hold $s breath!", ch, nullptr, nullptr, TO_ROOM);
 			break;
 	}
 }
@@ -146,8 +146,8 @@ void check_waterbreath(CHAR_DATA *ch, ROOM_INDEX_DATA *to_room)
 
 		new_affect_to_char(ch, &af);
 
-		act("You take a deep breath and hold it tight as you descend into the water.", ch, 0, 0, TO_CHAR);
-		act("$n takes a deep breath as $e descends into the water.", ch, 0, 0, TO_ROOM);
+		act("You take a deep breath and hold it tight as you descend into the water.", ch, nullptr, nullptr, TO_CHAR);
+		act("$n takes a deep breath as $e descends into the water.", ch, nullptr, nullptr, TO_ROOM);
 	}
 	else if (is_affected(ch, gsn_drowning)
 		&& (to_room->sector_type != SECT_UNDERWATER || is_affected_room(to_room, gsn_airy_water)))
@@ -181,19 +181,19 @@ void move_char(CHAR_DATA *ch, int door, bool automatic, bool fcharm)
 		{
 			if (Deref(raf->owner) == ch)
 			{
-				act("The smoke parts for you allowing you passage.", ch, 0, 0, TO_CHAR);
+				act("The smoke parts for you allowing you passage.", ch, nullptr, nullptr, TO_CHAR);
 			}
 			else
 			{
 				CHAR_DATA *master = Deref(ch->master);
 
 				if (Deref(raf->owner) == master && automatic)
-					act("You follow $N through the smoke.", ch, 0, master, TO_CHAR);
+					act("You follow $N through the smoke.", ch, nullptr, master, TO_CHAR);
 			}
 		}
 		else
 		{
-			act("You stumble around directionless in the smoke.", ch, 0, 0, TO_CHAR);
+			act("You stumble around directionless in the smoke.", ch, nullptr, nullptr, TO_CHAR);
 			door = number_range(0, 5);
 		}
 	}
@@ -345,14 +345,14 @@ void move_char(CHAR_DATA *ch, int door, bool automatic, bool fcharm)
 			paf = affect_find(ch->affected, gsn_quicksand_sinking);
 			if (number_percent() > ((get_curr_stat(ch, STAT_STR) * 4) - 5 * paf->modifier))
 			{
-				act("You struggle to escape from the quicksand, but fail to pull yourself free!", ch, 0, 0, TO_CHAR);
-				act("$n struggles to escape from the quicksand, but fails to pull $mself free!", ch, 0, 0, TO_ROOM);
+				act("You struggle to escape from the quicksand, but fail to pull yourself free!", ch, nullptr, nullptr, TO_CHAR);
+				act("$n struggles to escape from the quicksand, but fails to pull $mself free!", ch, nullptr, nullptr, TO_ROOM);
 				WAIT_STATE(ch, 2 * PULSE_VIOLENCE);
 				return;
 			}
 
-			act("You manage to pull yourself out of the quicksand.", ch, 0, 0, TO_CHAR);
-			act("$n manages to pull $mself out of the quicksand.", ch, 0, 0, TO_ROOM);
+			act("You manage to pull yourself out of the quicksand.", ch, nullptr, nullptr, TO_CHAR);
+			act("$n manages to pull $mself out of the quicksand.", ch, nullptr, nullptr, TO_ROOM);
 			affect_strip(ch, gsn_quicksand_sinking);
 		}
 
@@ -555,7 +555,7 @@ void move_char(CHAR_DATA *ch, int door, bool automatic, bool fcharm)
 		un_hide(ch, nullptr);
 
 		if (is_affected(ch, gsn_door_bash))
-			act("$n goes crashing through the door $T.", ch, 0, dir_name[door], TO_ROOM);
+			act("$n goes crashing through the door $T.", ch, nullptr, dir_name[door], TO_ROOM);
 		else
 			sprintf(exbuf, "leave");
 
@@ -656,7 +656,7 @@ void move_char(CHAR_DATA *ch, int door, bool automatic, bool fcharm)
 		}
 
 		if (is_affected(ch, gsn_door_bash))
-			act("The $T door bursts open and $n comes crashing in!", ch, 0, dir_name[door], TO_ROOM);
+			act("The $T door bursts open and $n comes crashing in!", ch, nullptr, dir_name[door], TO_ROOM);
 		else
 			act("$n $t.", ch, exbuf, nullptr, TO_ROOM);
 	}
@@ -712,7 +712,7 @@ void move_char(CHAR_DATA *ch, int door, bool automatic, bool fcharm)
 
 		if (Deref(raf->owner) == ch)
 		{
-			act("You gracefully step over your tripwire.", ch, 0, 0, TO_CHAR);
+			act("You gracefully step over your tripwire.", ch, nullptr, nullptr, TO_CHAR);
 		}
 		else
 		{
@@ -721,8 +721,8 @@ void move_char(CHAR_DATA *ch, int door, bool automatic, bool fcharm)
 
 			if (!is_safe(Deref(raf->owner), ch) && (number_percent() > twchance))
 			{
-				act("You trip over a wire and fall flat on your face!", ch, 0, 0, TO_CHAR);
-				act("$n trips over a wire and falls flat on $s face!", ch, 0, 0, TO_ROOM);
+				act("You trip over a wire and fall flat on your face!", ch, nullptr, nullptr, TO_CHAR);
+				act("$n trips over a wire and falls flat on $s face!", ch, nullptr, nullptr, TO_ROOM);
 
 				ch->position = POS_RESTING;
 				WAIT_STATE(ch, PULSE_VIOLENCE * 2);
@@ -765,12 +765,12 @@ void move_char(CHAR_DATA *ch, int door, bool automatic, bool fcharm)
 						END_COLOR(ch));
 					send_to_char(exbuf, ch);
 
-					act("$n is suddenly pulled under the surface by a violent riptide!", ch, 0, 0, TO_ROOM);
+					act("$n is suddenly pulled under the surface by a violent riptide!", ch, nullptr, nullptr, TO_ROOM);
 
 					char_from_room(ch);
 					char_to_room(ch, riptideroom);
 
-					act("$n is suddenly pulled into the room by the powerful riptide!", ch, 0, 0, TO_ROOM);
+					act("$n is suddenly pulled into the room by the powerful riptide!", ch, nullptr, nullptr, TO_ROOM);
 
 					do_look(ch, "auto");
 
@@ -798,13 +798,13 @@ void move_char(CHAR_DATA *ch, int door, bool automatic, bool fcharm)
 
 		if (number_percent() <= (5 * (get_curr_stat(ch, STAT_DEX) - 15)))
 		{
-			act("You almost lose your footing on the surprisingly-slick ground, but steady yourself.", ch, 0, 0, TO_CHAR);
-			act("$n almost loses $s footing on the frost-covered ground, but remains standing.", ch, 0, 0, TO_ROOM);
+			act("You almost lose your footing on the surprisingly-slick ground, but steady yourself.", ch, nullptr, nullptr, TO_CHAR);
+			act("$n almost loses $s footing on the frost-covered ground, but remains standing.", ch, nullptr, nullptr, TO_ROOM);
 			break;
 		}
 
-		act("You slip on an unnoticed patch of ice and crash heavily to the ground!", ch, 0, 0, TO_CHAR);
-		act("$n slips on the icy ground as he enters, collapsing in a heap!", ch, 0, 0, TO_ROOM);
+		act("You slip on an unnoticed patch of ice and crash heavily to the ground!", ch, nullptr, nullptr, TO_CHAR);
+		act("$n slips on the icy ground as he enters, collapsing in a heap!", ch, nullptr, nullptr, TO_ROOM);
 
 		WAIT_STATE(ch, (ch->carry_weight / 150) * PULSE_VIOLENCE);
 
@@ -837,8 +837,8 @@ void move_char(CHAR_DATA *ch, int door, bool automatic, bool fcharm)
 			break;
 		}
 
-		act("As you enter, the ground gives way beneath you and you sink into quicksand!", ch, 0, 0, TO_CHAR);
-		act("As $n enters, the ground gives way beneath $m and $e sinks into quicksand!", ch, 0, 0, TO_ROOM);
+		act("As you enter, the ground gives way beneath you and you sink into quicksand!", ch, nullptr, nullptr, TO_CHAR);
+		act("As $n enters, the ground gives way beneath $m and $e sinks into quicksand!", ch, nullptr, nullptr, TO_ROOM);
 		do_myell(ch, "Help!  I'm sinking in quicksand!", nullptr);
 
 		AFFECT_DATA qs;
@@ -870,8 +870,8 @@ void move_char(CHAR_DATA *ch, int door, bool automatic, bool fcharm)
 		if (is_affected(ch, gsn_ultradiffusion))
 			break;
 
-		act("An icy stalactite plummets from the ceiling above as you enter!", ch, 0, 0, TO_CHAR);
-		act("An icy stalactite plummets from the ceiling above!", ch, 0, 0, TO_ROOM);
+		act("An icy stalactite plummets from the ceiling above as you enter!", ch, nullptr, nullptr, TO_CHAR);
+		act("An icy stalactite plummets from the ceiling above!", ch, nullptr, nullptr, TO_ROOM);
 
 		do_visible(ch, "");
 
@@ -881,8 +881,8 @@ void move_char(CHAR_DATA *ch, int door, bool automatic, bool fcharm)
 		}
 		else
 		{
-			act("The mass of ice shatters on the ground as you leap out of the way!", ch, 0, 0, TO_CHAR);
-			act("The mass of ice shatters on the ground as $n leaps out of the way!", ch, 0, 0, TO_ROOM);
+			act("The mass of ice shatters on the ground as you leap out of the way!", ch, nullptr, nullptr, TO_CHAR);
+			act("The mass of ice shatters on the ground as $n leaps out of the way!", ch, nullptr, nullptr, TO_ROOM);
 			damage_new(Deref(raf->owner), ch, 0, gsn_stalactites, DAM_PIERCE, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "the falling stalactite*");
 		}
 
@@ -1226,7 +1226,7 @@ void trip_trap(CHAR_DATA *ch, ROOM_INDEX_DATA *room, TRAP_DATA *trap)
 
 	if (trap->timer)
 	{
-		act(trap->trig_echo, ch, 0, 0, TO_CHAR);
+		act(trap->trig_echo, ch, nullptr, nullptr, TO_CHAR);
 		RS.Queue.AddToQueue(trap->timer, "do_down", "trap_execute", trap_execute, nullptr, room, trap);
 	}
 	else
@@ -1243,7 +1243,7 @@ void trap_execute(CHAR_DATA *victim, ROOM_INDEX_DATA *room, TRAP_DATA *trap)
 	if (!victim)
 		return;
 
-	act(trap->exec_echo, victim, 0, 0, TO_ALL);
+	act(trap->exec_echo, victim, nullptr, nullptr, TO_ALL);
 	switch (trap->type)
 	{
 		case TRAP_DART:
@@ -1489,7 +1489,7 @@ void do_open(CHAR_DATA *ch, char *argument)
 
 		if (is_affected_obj(obj, gsn_ice_blast))
 		{
-			act("$p is frozen shut!", ch, obj, 0, TO_CHAR);
+			act("$p is frozen shut!", ch, obj, nullptr, TO_CHAR);
 			return;
 		}
 
@@ -1619,7 +1619,7 @@ void do_close(CHAR_DATA *ch, char *argument)
 
 		if (is_affected_obj(obj, gsn_ice_blast))
 		{
-			act("$p is frozen shut!", ch, obj, 0, TO_CHAR);
+			act("$p is frozen shut!", ch, obj, nullptr, TO_CHAR);
 			return;
 		}
 
@@ -2635,8 +2635,8 @@ void do_wake(CHAR_DATA *ch, char *argument)
 		return;
 	}
 
-	act("You wake $N.", ch, 0, victim, TO_CHAR);
-	act("$n wakes $N.", ch, 0, victim, TO_NOTVICT);
+	act("You wake $N.", ch, nullptr, victim, TO_CHAR);
+	act("$n wakes $N.", ch, nullptr, victim, TO_NOTVICT);
 	act_new("$n wakes you.", ch, nullptr, victim, TO_VICT, POS_SLEEPING);
 
 	do_stand(victim, "");
@@ -3027,7 +3027,7 @@ void do_creep(CHAR_DATA *ch, char *argument)
 	}
 	else
 	{
-		act("You can't creep there.", ch, nullptr, 0, TO_CHAR);
+		act("You can't creep there.", ch, nullptr, nullptr, TO_CHAR);
 	}
 
 	AFFECT_DATA af;
@@ -3171,8 +3171,8 @@ void un_earthfade(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 
 	affect_strip(ch, gsn_earthfade);
 
-	act("$n slowly emerges from the ground.", ch, 0, 0, TO_ROOM);
-	act("You slowly emerge from the ground.", ch, 0, 0, TO_CHAR);
+	act("$n slowly emerges from the ground.", ch, nullptr, nullptr, TO_ROOM);
+	act("You slowly emerge from the ground.", ch, nullptr, nullptr, TO_CHAR);
 	
 	WAIT_STATE(ch, 3 * PULSE_VIOLENCE);
 }
@@ -3184,8 +3184,8 @@ void un_blade_barrier(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 
 	affect_strip(ch, gsn_blade_barrier);
 
-	act("The whirling blades around $n vanish.", ch, 0, 0, TO_ROOM);
-	act("The whirling blades around you vanish.", ch, 0, 0, TO_CHAR);
+	act("The whirling blades around $n vanish.", ch, nullptr, nullptr, TO_ROOM);
+	act("The whirling blades around you vanish.", ch, nullptr, nullptr, TO_CHAR);
 
 	WAIT_STATE(ch, PULSE_VIOLENCE);
 }
@@ -3197,7 +3197,7 @@ void un_watermeld(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 
 	affect_strip(ch, gsn_watermeld);
 
-	act("The water swirls around you as your concealment fails you.", ch, 0, 0, TO_CHAR);
+	act("The water swirls around you as your concealment fails you.", ch, nullptr, nullptr, TO_CHAR);
 }
 
 void un_shroud(CHAR_DATA *ch, [[maybe_unused]] char *argument)
@@ -3234,7 +3234,7 @@ void do_recall(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 		return;
 	}
 
-	act("$n prays for transportation!", ch, 0, 0, TO_ROOM);
+	act("$n prays for transportation!", ch, nullptr, nullptr, TO_ROOM);
 
 	auto location = get_room_index(hometown_table[ch->hometown].recall);
 	if (location == nullptr)
@@ -3483,7 +3483,7 @@ void do_bear_call(CHAR_DATA *ch, char *argument)
 		&& ch->in_room->sector_type != SECT_HILLS
 		&& ch->in_room->sector_type != SECT_MOUNTAIN)
 	{
-		act("$n calls out into the surroundings but nothing comes.", ch, 0, 0, TO_ROOM);
+		act("$n calls out into the surroundings but nothing comes.", ch, nullptr, nullptr, TO_ROOM);
 		send_to_char("You call a bear call but nothing responds.\n\r", ch);
 		return;
 	}
@@ -3500,7 +3500,7 @@ void do_bear_call(CHAR_DATA *ch, char *argument)
 	ch->mana -= 70;
 	auto a_level = ch->level;
 
-	act("$n calls out to the wild and is heard!", ch, 0, 0, TO_ROOM);
+	act("$n calls out to the wild and is heard!", ch, nullptr, nullptr, TO_ROOM);
 	send_to_char("Your call to the wild is heard!\n\r", ch);
 
 	for (auto count = 0; count < 2; count++)
@@ -3645,7 +3645,7 @@ void do_animal_call(CHAR_DATA *ch, char *argument)
 
 	if (number_percent() > chance)
 	{
-		act("$n calls out to the wild but nothing responds.", ch, 0, 0, TO_ROOM);
+		act("$n calls out to the wild but nothing responds.", ch, nullptr, nullptr, TO_ROOM);
 		send_to_char("You call out to the wild but nothing responds.\n\r", ch);
 
 		ch->mana -= 25;
@@ -3661,7 +3661,7 @@ void do_animal_call(CHAR_DATA *ch, char *argument)
 		RS.Logger.Warn("Animal call: Bad mob vnum call {}.", type);
 
 		send_to_char("You call out to the wild but nothing responds.\n\r", ch);
-		act("$n calls out to the wild but nothing responds.", ch, 0, 0, TO_ROOM);
+		act("$n calls out to the wild but nothing responds.", ch, nullptr, nullptr, TO_ROOM);
 
 		ch->mana -= 25;
 		return;
@@ -3726,7 +3726,7 @@ void do_animal_call(CHAR_DATA *ch, char *argument)
 		RS.Logger.Warn("Bad animal call: {}.", type);
 
 		send_to_char("You call out to the wild but nothing responds.\n\r", ch);
-		act("$n calls out to the wild but nothing comes.\n\r", ch, 0, 0, TO_ROOM);
+		act("$n calls out to the wild but nothing comes.\n\r", ch, nullptr, nullptr, TO_ROOM);
 
 		ch->mana -= 25;
 		return;
@@ -3738,8 +3738,8 @@ void do_animal_call(CHAR_DATA *ch, char *argument)
 	animal1->level = ch->level;
 	animal2->level = ch->level;
 
-	act("Animals respond to $n's call!", ch, 0, animal1, TO_ROOM);
-	act("Animals respond to your call!", ch, 0, animal1, TO_CHAR);
+	act("Animals respond to $n's call!", ch, nullptr, animal1, TO_ROOM);
+	act("Animals respond to your call!", ch, nullptr, animal1, TO_CHAR);
 
 	ch->mana -= 50;
 
@@ -3795,7 +3795,7 @@ void track_char(CHAR_DATA *ch, CHAR_DATA *mob)
 	if (IS_SET(mob->act, ACT_SENTINEL))
 		return;
 
-	act("$n checks the ground for tracks.", mob, 0, 0, TO_ROOM);
+	act("$n checks the ground for tracks.", mob, nullptr, nullptr, TO_ROOM);
 
 	if (IS_SET(mob->off_flags, STATIC_TRACKING) || track_dir == -1)
 		return;
@@ -4130,7 +4130,7 @@ void do_vanish(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 		|| IS_SET(ch->in_room->room_flags, ROOM_NO_SUMMON_FROM))
 	{
 		send_to_char("You attempt to vanish without trace but fail.\n\r", ch);
-		act("$n attempts to slide into the shadows but fails.", ch, 0, 0, TO_ROOM);
+		act("$n attempts to slide into the shadows but fails.", ch, nullptr, nullptr, TO_ROOM);
 
 		check_improve(ch, gsn_vanish, false, 2);
 
@@ -4172,13 +4172,13 @@ void do_vanish(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 
 	stop_fighting(ch, true);
 
-	act("$n suddenly vanishes into the shadows!", ch, 0, 0, TO_ROOM);
+	act("$n suddenly vanishes into the shadows!", ch, nullptr, nullptr, TO_ROOM);
 	send_to_char("You slip into the shadows and vanish!\n\r", ch);
 
 	char_from_room(ch);
 	char_to_room(ch, pRoomIndex);
 
-	act("$n appears from the shadows.", ch, 0, 0, TO_ROOM);
+	act("$n appears from the shadows.", ch, nullptr, nullptr, TO_ROOM);
 
 	do_look(ch, "auto");
 
@@ -4254,11 +4254,11 @@ void do_door_bash(CHAR_DATA *ch, char *argument)
 
 	if (number_percent() > chance || IS_SET(pexit->exit_info, EX_NOBASH))
 	{
-		act("$n flies into the $T door and rebounds with a great lack of dignity!", ch, 0, dir_name[door], TO_ROOM);
-		act("You fly into the door $T but simply bounce off it like a lump of rock!", ch, 0, dir_name[door], TO_CHAR);
+		act("$n flies into the $T door and rebounds with a great lack of dignity!", ch, nullptr, dir_name[door], TO_ROOM);
+		act("You fly into the door $T but simply bounce off it like a lump of rock!", ch, nullptr, dir_name[door], TO_CHAR);
 
 		if (pexit->u1.to_room->people)
-			act("The door buckles as a heavy weight crashes against it from the other side!", pexit->u1.to_room->people, 0, 0, TO_ALL);
+			act("The door buckles as a heavy weight crashes against it from the other side!", pexit->u1.to_room->people, nullptr, nullptr, TO_ALL);
 
 		damage_new(ch, ch, dice(ch->level, 2), gsn_door_bash, DAM_BASH, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "the impact*");
 
@@ -4270,8 +4270,8 @@ void do_door_bash(CHAR_DATA *ch, char *argument)
 		return;
 	}
 
-	act("$n slams into the $T door and throws it open with a mighty crash!", ch, 0, dir_name[door], TO_ROOM);
-	act("You slam into the $T door and it cracks open with a deafening sound!", ch, 0, dir_name[door], TO_CHAR);
+	act("$n slams into the $T door and throws it open with a mighty crash!", ch, nullptr, dir_name[door], TO_ROOM);
+	act("You slam into the $T door and it cracks open with a deafening sound!", ch, nullptr, dir_name[door], TO_CHAR);
 
 	check_improve(ch, gsn_door_bash, true, 1);
 

--- a/code/act_move.c
+++ b/code/act_move.c
@@ -4535,6 +4535,11 @@ void parse_bar(char *buf, size_t size, const char *str, CHAR_DATA *ch, CHAR_DATA
 				i = buf2;
 				break;
 			default:
+				// An unknown code substitutes nothing. Leaving i alone meant it
+				// substituted the previous code's text instead, or dereferenced null
+				// when it was the first code in the message. The message comes from
+				// area data, so any typo in a barred entry reaches this.
+				i = "";
 				break;
 		}
 

--- a/code/act_move.h
+++ b/code/act_move.h
@@ -77,7 +77,7 @@ void do_door_bash (CHAR_DATA *ch,char *argument);
 void do_hometown (CHAR_DATA *ch, char *argument);
 bool check_barred (CHAR_DATA *ch, ROOM_INDEX_DATA *to_room);
 bool bar_entry (CHAR_DATA *ch, CHAR_DATA *blocker, ROOM_INDEX_DATA *to_room);
-void parse_bar (char *buf, const char *str, CHAR_DATA *ch, CHAR_DATA *blocker, ROOM_INDEX_DATA *to_room);
+void parse_bar (char *buf, size_t size, const char *str, CHAR_DATA *ch, CHAR_DATA *blocker, ROOM_INDEX_DATA *to_room);
 bool is_land (ROOM_INDEX_DATA *room);
 void add_tracks (ROOM_INDEX_DATA *room, CHAR_DATA *ch, int direction);
 void clear_tracks (ROOM_INDEX_DATA *room);

--- a/code/act_obj.c
+++ b/code/act_obj.c
@@ -1963,7 +1963,6 @@ void wear_obj(CHAR_DATA *ch, OBJ_DATA *obj, bool fReplace)
 	bool wield_primary;
 	OBJ_DATA *primary;
 	OBJ_DATA *weapon;
-	OBJ_DATA *oldobj;
 	int sn, skill;
 
 	if (can_wear(obj, ITEM_WEAR_COSMETIC))
@@ -2067,7 +2066,6 @@ void wear_obj(CHAR_DATA *ch, OBJ_DATA *obj, bool fReplace)
 			return send_to_char(buf, ch);
 		}
 
-		oldobj = (get_eq_char(ch, WEAR_HEAD));
 
 		if (!remove_obj(ch, WEAR_HEAD, fReplace))
 			return;
@@ -4541,8 +4539,6 @@ bool cabal_down_new(CHAR_DATA *ch, int cabal, bool show)
 
 bool cant_carry(CHAR_DATA *ch, OBJ_DATA *obj)
 {
-	bool status;
-	status= false;
 	return false;
 }
 
@@ -4550,8 +4546,6 @@ bool is_restricted(CHAR_DATA *ch, OBJ_DATA *obj)
 {
 	int i;
 	long restricted[MAX_BITVECTOR];
-	bool status;
-	char *race;
 
 	if (is_npc(ch) && !is_affected_by(ch, AFF_CHARM))
 		return false;
@@ -4559,10 +4553,8 @@ bool is_restricted(CHAR_DATA *ch, OBJ_DATA *obj)
 	if (str_cmp(obj->owner, "none") && !is_owner(ch, obj))
 		return true;
 
-	race = race_table[ch->race].name;
 	copy_vector(restricted, obj->pIndexData->restrict_flags);
 
-	status= false;
 
 	if (IS_ZERO_VECTOR(restricted))
 		return false;

--- a/code/act_obj.c
+++ b/code/act_obj.c
@@ -89,8 +89,8 @@ bool check_arms(CHAR_DATA *ch, OBJ_DATA *obj)
 					|| paf.type == gsn_arms_of_judgement)
 				&& Deref(paf.owner) != ch)
 			{
-				act("$p shocks you, falling from your numb hands.", ch, obj, 0, TO_CHAR);
-				act("$n drops $p.", ch, obj, 0, TO_ROOM);
+				act("$p shocks you, falling from your numb hands.", ch, obj, nullptr, TO_CHAR);
+				act("$n drops $p.", ch, obj, nullptr, TO_ROOM);
 				return true;
 			}
 		}
@@ -180,7 +180,7 @@ void get_obj(CHAR_DATA *ch, OBJ_DATA *obj, OBJ_DATA *container, bool pcheck)
 
 	if (ch->carry_number + get_obj_number(obj) > can_carry_n(ch))
 	{
-		act("$p: you can't carry that many items.", ch, obj, 0, TO_CHAR);
+		act("$p: you can't carry that many items.", ch, obj, nullptr, TO_CHAR);
 		return;
 	}
 
@@ -190,7 +190,7 @@ void get_obj(CHAR_DATA *ch, OBJ_DATA *obj, OBJ_DATA *container, bool pcheck)
 	if ((!heldIn || heldIn->carried_by != ch->self)
 		&& (get_carry_weight(ch) + get_obj_weight(obj) > can_carry_w(ch)))
 	{
-		act("$p: you can't carry that much weight.", ch, obj, 0, TO_CHAR);
+		act("$p: you can't carry that much weight.", ch, obj, nullptr, TO_CHAR);
 		return;
 	}
 
@@ -366,8 +366,8 @@ void do_get(CHAR_DATA *ch, char *argument)
 
 			if (cant_carry(ch, obj))
 			{
-				act("$n is burnt by $p and drops it.", ch, obj, 0, TO_ROOM);
-				act("You are burnt by $p and drop it.", ch, obj, 0, TO_CHAR);
+				act("$n is burnt by $p and drops it.", ch, obj, nullptr, TO_ROOM);
+				act("You are burnt by $p and drop it.", ch, obj, nullptr, TO_CHAR);
 
 				obj_from_char(obj);
 				obj_to_room(obj, ch->in_room);
@@ -392,8 +392,8 @@ void do_get(CHAR_DATA *ch, char *argument)
 
 					if (cant_carry(ch, obj))
 					{
-						act("$n is burnt by $p and drops it.", ch, obj, 0, TO_ROOM);
-						act("You are burnt by $p and drop it.", ch, obj, 0, TO_CHAR);
+						act("$n is burnt by $p and drops it.", ch, obj, nullptr, TO_ROOM);
+						act("You are burnt by $p and drop it.", ch, obj, nullptr, TO_CHAR);
 
 						obj_from_char(obj);
 						obj_to_room(obj, ch->in_room);
@@ -454,7 +454,7 @@ void do_get(CHAR_DATA *ch, char *argument)
 
 		if (is_affected_obj(container, gsn_ice_blast))
 		{
-			act("$p is frozen shut!", ch, container, 0, TO_CHAR);
+			act("$p is frozen shut!", ch, container, nullptr, TO_CHAR);
 			return;
 		}
 
@@ -498,8 +498,8 @@ void do_get(CHAR_DATA *ch, char *argument)
 
 			if (cant_carry(ch, obj))
 			{
-				act("$n is burnt by $p and drops it.", ch, obj, 0, TO_ROOM);
-				act("You are burnt by $p and drop it.", ch, obj, 0, TO_CHAR);
+				act("$n is burnt by $p and drops it.", ch, obj, nullptr, TO_ROOM);
+				act("You are burnt by $p and drop it.", ch, obj, nullptr, TO_CHAR);
 
 				obj_from_char(obj);
 				obj_to_room(obj, ch->in_room);
@@ -537,8 +537,8 @@ void do_get(CHAR_DATA *ch, char *argument)
 
 					if (cant_carry(ch, obj))
 					{
-						act("$n is burnt by $p and drops it.", ch, obj, 0, TO_ROOM);
-						act("You are burnt by $p and drop it.", ch, obj, 0, TO_CHAR);
+						act("$n is burnt by $p and drops it.", ch, obj, nullptr, TO_ROOM);
+						act("You are burnt by $p and drop it.", ch, obj, nullptr, TO_CHAR);
 
 						obj_from_char(obj);
 						obj_to_room(obj, ch->in_room);
@@ -599,7 +599,7 @@ void do_put(CHAR_DATA *ch, char *argument)
 
 	if (is_affected_obj(container, gsn_ice_blast))
 	{
-		act("$p is frozen shut!", ch, container, 0, TO_CHAR);
+		act("$p is frozen shut!", ch, container, nullptr, TO_CHAR);
 		return;
 	}
 
@@ -1056,7 +1056,7 @@ void do_give(CHAR_DATA *ch, char *argument)
 
 	if ((is_npc(victim) && victim->pIndexData->pShop != nullptr) && !IS_SET(victim->progtypes, MPROG_GIVE))
 	{
-		act("$E wouldn't want that.", ch, 0, victim, TO_CHAR);
+		act("$E wouldn't want that.", ch, nullptr, victim, TO_CHAR);
 		return;
 	}
 
@@ -1292,8 +1292,8 @@ void do_butcher(CHAR_DATA *ch, char *argument)
 		return;
 	}
 
-	act("$n butchers $p.", ch, corpse, 0, TO_ROOM);
-	act("You butcher $p.", ch, corpse, 0, TO_CHAR);
+	act("$n butchers $p.", ch, corpse, nullptr, TO_ROOM);
+	act("You butcher $p.", ch, corpse, nullptr, TO_CHAR);
 
 	name = corpse->short_descr;
 
@@ -1568,7 +1568,7 @@ void do_pour(CHAR_DATA *ch, char *argument)
 		if (out->value[2] != LIQ_WATER)
 		{
 			sprintf(buf, "%s evaporates rapidly and is gone.", liq_table[out->value[2]].liq_name);
-			act(buf, ch, 0, 0, TO_ALL);
+			act(buf, ch, nullptr, nullptr, TO_ALL);
 		}
 		else if (is_ground(ch->in_room))
 		{
@@ -1588,7 +1588,7 @@ void do_pour(CHAR_DATA *ch, char *argument)
 			affect_to_obj(puddle, &oaf);
 
 			sprintf(buf, "The water forms a puddle on the ground.");
-			act(buf, ch, 0, 0, TO_ALL);
+			act(buf, ch, nullptr, nullptr, TO_ALL);
 		}
 
 		return;
@@ -1620,7 +1620,7 @@ void do_pour(CHAR_DATA *ch, char *argument)
 
 	if (is_affected_by(on, AFF_OBJ_BURNING))
 	{
-		act("$p fizzles and is extinguished.", ch, on, 0, TO_ALL);
+		act("$p fizzles and is extinguished.", ch, on, nullptr, TO_ALL);
 
 		if (is_affected_obj(on, gsn_immolate))
 			affect_strip_obj(on, gsn_immolate);
@@ -1824,7 +1824,7 @@ void do_eat(CHAR_DATA *ch, char *argument)
 				/* The food was poisoned! */
 				AFFECT_DATA af;
 
-				act("$n chokes and gags.", ch, 0, 0, TO_ROOM);
+				act("$n chokes and gags.", ch, nullptr, nullptr, TO_ROOM);
 				send_to_char("You choke and gag.\n\r", ch);
 
 				if (!is_affected(ch, gsn_poison))
@@ -1880,7 +1880,7 @@ bool remove_obj(CHAR_DATA *ch, int iWear, bool fReplace)
 
 	if (is_affected_obj(obj, gsn_rust))
 	{
-		act("$p is covered with rust and can't be pried off!", ch, obj, 0, TO_CHAR);
+		act("$p is covered with rust and can't be pried off!", ch, obj, nullptr, TO_CHAR);
 		return false;
 	}
 
@@ -1910,8 +1910,8 @@ bool remove_obj(CHAR_DATA *ch, int iWear, bool fReplace)
 
 	if (iWear == WEAR_DUAL_WIELD)
 	{
-		act("$n stops dual wielding $p.", ch, obj, 0, TO_ROOM);
-		act("You stop dual wielding $p.", ch, obj, 0, TO_CHAR);
+		act("$n stops dual wielding $p.", ch, obj, nullptr, TO_ROOM);
+		act("You stop dual wielding $p.", ch, obj, nullptr, TO_CHAR);
 		return true;
 	}
 
@@ -2221,8 +2221,8 @@ void wear_obj(CHAR_DATA *ch, OBJ_DATA *obj, bool fReplace)
 			return;
 		}
 
-		act("$n holds $p in $s hands.", ch, obj, 0, TO_ROOM);
-		act("You hold $p in your hands.", ch, obj, 0, TO_CHAR);
+		act("$n holds $p in $s hands.", ch, obj, nullptr, TO_ROOM);
+		act("You hold $p in your hands.", ch, obj, nullptr, TO_CHAR);
 		equip_char(ch, obj, WEAR_HOLD, true);
 		return;
 	}
@@ -2257,8 +2257,8 @@ void wear_obj(CHAR_DATA *ch, OBJ_DATA *obj, bool fReplace)
 			return;
 		}
 
-		act("$n wears $p as a shield.", ch, obj, 0, TO_ROOM);
-		act("You wear $p as a shield.", ch, obj, 0, TO_CHAR);
+		act("$n wears $p as a shield.", ch, obj, nullptr, TO_ROOM);
+		act("You wear $p as a shield.", ch, obj, nullptr, TO_CHAR);
 		equip_char(ch, obj, WEAR_SHIELD, true);
 		return;
 	}
@@ -2295,8 +2295,8 @@ void wear_obj(CHAR_DATA *ch, OBJ_DATA *obj, bool fReplace)
 			return;
 		}
 
-		act("$n lights $p and holds it.", ch, obj, 0, TO_ROOM);
-		act("You light $p and hold it.", ch, obj, 0, TO_CHAR);
+		act("$n lights $p and holds it.", ch, obj, nullptr, TO_ROOM);
+		act("You light $p and hold it.", ch, obj, nullptr, TO_CHAR);
 		equip_char(ch, obj, WEAR_LIGHT, true);
 		return;
 	}
@@ -2363,8 +2363,8 @@ void wear_obj(CHAR_DATA *ch, OBJ_DATA *obj, bool fReplace)
 			{
 				if (obj->weight <= primary->weight || obj->weight < 5)
 				{
-					act("$n wields $p in $s offhand.", ch, obj, 0, TO_ROOM);
-					act("You wield $p in your offhand.", ch, obj, 0, TO_CHAR);
+					act("$n wields $p in $s offhand.", ch, obj, nullptr, TO_ROOM);
+					act("You wield $p in your offhand.", ch, obj, nullptr, TO_CHAR);
 					equip_char(ch, obj, WEAR_DUAL_WIELD, true);
 
 					switch (obj->value[0])
@@ -2404,19 +2404,19 @@ void wear_obj(CHAR_DATA *ch, OBJ_DATA *obj, bool fReplace)
 					skill = get_weapon_skill(ch, sn);
 
 					if (skill >= 100)
-						act("$p feels like a part of you!", ch, obj, 0, TO_CHAR);
+						act("$p feels like a part of you!", ch, obj, nullptr, TO_CHAR);
 					else if (skill > 85)
-						act("You feel quite confident with $p.", ch, obj, 0, TO_CHAR);
+						act("You feel quite confident with $p.", ch, obj, nullptr, TO_CHAR);
 					else if (skill > 70)
-						act("You are skilled with $p.", ch, obj, 0, TO_CHAR);
+						act("You are skilled with $p.", ch, obj, nullptr, TO_CHAR);
 					else if (skill > 50)
-						act("Your skill with $p is adequate.", ch, obj, 0, TO_CHAR);
+						act("Your skill with $p is adequate.", ch, obj, nullptr, TO_CHAR);
 					else if (skill > 25)
-						act("$p feels a little clumsy in your hands.", ch, obj, 0, TO_CHAR);
+						act("$p feels a little clumsy in your hands.", ch, obj, nullptr, TO_CHAR);
 					else if (skill > 1)
-						act("You fumble and almost drop $p.", ch, obj, 0, TO_CHAR);
+						act("You fumble and almost drop $p.", ch, obj, nullptr, TO_CHAR);
 					else
-						act("You don't even know which end is up on $p.", ch, obj, 0, TO_CHAR);
+						act("You don't even know which end is up on $p.", ch, obj, nullptr, TO_CHAR);
 
 					return;
 				}
@@ -2426,8 +2426,8 @@ void wear_obj(CHAR_DATA *ch, OBJ_DATA *obj, bool fReplace)
 				if (!remove_obj(ch, WEAR_DUAL_WIELD, fReplace))
 					return;
 
-				act("$n wields $p in $s offhand.", ch, obj, 0, TO_ROOM);
-				act("You wield $p in your offhand.", ch, obj, 0, TO_CHAR);
+				act("$n wields $p in $s offhand.", ch, obj, nullptr, TO_ROOM);
+				act("You wield $p in your offhand.", ch, obj, nullptr, TO_CHAR);
 				equip_char(ch, obj, WEAR_DUAL_WIELD, true);
 
 				switch (obj->value[0])
@@ -2467,19 +2467,19 @@ void wear_obj(CHAR_DATA *ch, OBJ_DATA *obj, bool fReplace)
 				skill = get_weapon_skill(ch, sn);
 
 				if (skill >= 100)
-					act("$p feels like a part of you!", ch, obj, 0, TO_CHAR);
+					act("$p feels like a part of you!", ch, obj, nullptr, TO_CHAR);
 				else if (skill > 85)
-					act("You feel quite confident with $p.", ch, obj, 0, TO_CHAR);
+					act("You feel quite confident with $p.", ch, obj, nullptr, TO_CHAR);
 				else if (skill > 70)
-					act("You are skilled with $p.", ch, obj, 0, TO_CHAR);
+					act("You are skilled with $p.", ch, obj, nullptr, TO_CHAR);
 				else if (skill > 50)
-					act("Your skill with $p is adequate.", ch, obj, 0, TO_CHAR);
+					act("Your skill with $p is adequate.", ch, obj, nullptr, TO_CHAR);
 				else if (skill > 25)
-					act("$p feels a little clumsy in your hands.", ch, obj, 0, TO_CHAR);
+					act("$p feels a little clumsy in your hands.", ch, obj, nullptr, TO_CHAR);
 				else if (skill > 1)
-					act("You fumble and almost drop $p.", ch, obj, 0, TO_CHAR);
+					act("You fumble and almost drop $p.", ch, obj, nullptr, TO_CHAR);
 				else
-					act("You don't even know which end is up on $p.", ch, obj, 0, TO_CHAR);
+					act("You don't even know which end is up on $p.", ch, obj, nullptr, TO_CHAR);
 
 				return;
 			}
@@ -2507,8 +2507,8 @@ void wear_obj(CHAR_DATA *ch, OBJ_DATA *obj, bool fReplace)
 						return;
 					}
 
-					act("$n wields $p.", ch, obj, 0, TO_ROOM);
-					act("You wield $p.", ch, obj, 0, TO_CHAR);
+					act("$n wields $p.", ch, obj, nullptr, TO_ROOM);
+					act("You wield $p.", ch, obj, nullptr, TO_CHAR);
 					unequip_char(ch, secondary, true);
 
 					if (secondary == nullptr)
@@ -2523,24 +2523,24 @@ void wear_obj(CHAR_DATA *ch, OBJ_DATA *obj, bool fReplace)
 
 					skill = get_weapon_skill(ch, sn);
 					if (skill >= 100)
-						act("$p feels like a part of you!", ch, obj, 0, TO_CHAR);
+						act("$p feels like a part of you!", ch, obj, nullptr, TO_CHAR);
 					else if (skill > 85)
-						act("You feel quite confident with $p.", ch, obj, 0, TO_CHAR);
+						act("You feel quite confident with $p.", ch, obj, nullptr, TO_CHAR);
 					else if (skill > 70)
-						act("You are skilled with $p.", ch, obj, 0, TO_CHAR);
+						act("You are skilled with $p.", ch, obj, nullptr, TO_CHAR);
 					else if (skill > 50)
-						act("Your skill with $p is adequate.", ch, obj, 0, TO_CHAR);
+						act("Your skill with $p is adequate.", ch, obj, nullptr, TO_CHAR);
 					else if (skill > 25)
-						act("$p feels a little clumsy in your hands.", ch, obj, 0, TO_CHAR);
+						act("$p feels a little clumsy in your hands.", ch, obj, nullptr, TO_CHAR);
 					else if (skill > 1)
-						act("You fumble and almost drop $p.", ch, obj, 0, TO_CHAR);
+						act("You fumble and almost drop $p.", ch, obj, nullptr, TO_CHAR);
 					else
-						act("You don't even know which end is up on $p.", ch, obj, 0, TO_CHAR);
+						act("You don't even know which end is up on $p.", ch, obj, nullptr, TO_CHAR);
 
 					return;
 				}
 
-				act("$p is too heavy to dual wield,", ch, obj, 0, TO_CHAR);
+				act("$p is too heavy to dual wield,", ch, obj, nullptr, TO_CHAR);
 				return;
 			}
 		}
@@ -2570,8 +2570,8 @@ void wear_obj(CHAR_DATA *ch, OBJ_DATA *obj, bool fReplace)
 			}
 		}
 
-		act("$n wields $p.", ch, obj, 0, TO_ROOM);
-		act("You wield $p.", ch, obj, 0, TO_CHAR);
+		act("$n wields $p.", ch, obj, nullptr, TO_ROOM);
+		act("You wield $p.", ch, obj, nullptr, TO_CHAR);
 		equip_char(ch, obj, WEAR_WIELD, true);
 
 		sn = get_weapon_sn(ch);
@@ -2580,19 +2580,19 @@ void wear_obj(CHAR_DATA *ch, OBJ_DATA *obj, bool fReplace)
 
 		skill = get_weapon_skill(ch, sn);
 		if (skill >= 100)
-			act("$p feels like a part of you!", ch, obj, 0, TO_CHAR);
+			act("$p feels like a part of you!", ch, obj, nullptr, TO_CHAR);
 		else if (skill > 85)
-			act("You feel quite confident with $p.", ch, obj, 0, TO_CHAR);
+			act("You feel quite confident with $p.", ch, obj, nullptr, TO_CHAR);
 		else if (skill > 70)
-			act("You are skilled with $p.", ch, obj, 0, TO_CHAR);
+			act("You are skilled with $p.", ch, obj, nullptr, TO_CHAR);
 		else if (skill > 50)
-			act("Your skill with $p is adequate.", ch, obj, 0, TO_CHAR);
+			act("Your skill with $p is adequate.", ch, obj, nullptr, TO_CHAR);
 		else if (skill > 25)
-			act("$p feels a little clumsy in your hands.", ch, obj, 0, TO_CHAR);
+			act("$p feels a little clumsy in your hands.", ch, obj, nullptr, TO_CHAR);
 		else if (skill > 1)
-			act("You fumble and almost drop $p.", ch, obj, 0, TO_CHAR);
+			act("You fumble and almost drop $p.", ch, obj, nullptr, TO_CHAR);
 		else
-			act("You don't even know which end is up on $p.", ch, obj, 0, TO_CHAR);
+			act("You don't even know which end is up on $p.", ch, obj, nullptr, TO_CHAR);
 
 		return;
 	}
@@ -2800,7 +2800,7 @@ void do_sacrifice(CHAR_DATA *ch, char *argument)
 
 	if (!can_wear(obj, ITEM_TAKE) || is_obj_stat(obj, ITEM_NO_SAC))
 	{
-		act("$p is not an acceptable sacrifice.", ch, obj, 0, TO_CHAR);
+		act("$p is not an acceptable sacrifice.", ch, obj, nullptr, TO_CHAR);
 		return;
 	}
 
@@ -2818,7 +2818,7 @@ void do_sacrifice(CHAR_DATA *ch, char *argument)
 
 	if (isCabalItem(obj) == true)
 	{
-		act("You can't do that!", ch, obj, 0, TO_CHAR);
+		act("You can't do that!", ch, obj, nullptr, TO_CHAR);
 		return;
 	}
 
@@ -3904,9 +3904,9 @@ void do_buy(CHAR_DATA *ch, char *argument)
 			check_improve(ch, gsn_haggle, true, 4);
 		}
 
-		act("$n hands some gold to $N.", ch, 0, keeper, TO_ROOM);
+		act("$n hands some gold to $N.", ch, nullptr, keeper, TO_ROOM);
 		sprintf(buf, "You hand $N %ld gold.", cost * number);
-		act(buf, ch, 0, keeper, TO_CHAR);
+		act(buf, ch, nullptr, keeper, TO_CHAR);
 
 		for (i = 0; i < number; i++)
 		{
@@ -4324,13 +4324,13 @@ void do_request(CHAR_DATA *ch, char *argument)
 
 	if (ch->carry_weight + get_obj_weight(obj) > can_carry_w(ch))
 	{
-		act("$N tells you, 'You can't carry the weight $n.'", ch, 0, victim, TO_CHAR);
+		act("$N tells you, 'You can't carry the weight $n.'", ch, nullptr, victim, TO_CHAR);
 		return;
 	}
 
 	if (ch->carry_number + 1 > can_carry_n(ch))
 	{
-		act("$N tells you, 'You can't carry that many items $n.'", ch, 0, victim, TO_CHAR);
+		act("$N tells you, 'You can't carry that many items $n.'", ch, nullptr, victim, TO_CHAR);
 		return;
 	}
 
@@ -4340,7 +4340,7 @@ void do_request(CHAR_DATA *ch, char *argument)
 		return;
 	}
 
-	act("$n requests off $N.", ch, 0, victim, TO_ROOM);
+	act("$n requests off $N.", ch, nullptr, victim, TO_ROOM);
 
 	if (obj->wear_loc != WEAR_NONE)
 	{
@@ -4446,7 +4446,7 @@ void do_embalm(CHAR_DATA *ch, char *argument)
 
 	if (corpse->item_type != ITEM_CORPSE_NPC)
 	{
-		act("$p isn't a corpse you can embalm.\n\r", ch, corpse, 0, TO_CHAR);
+		act("$p isn't a corpse you can embalm.\n\r", ch, corpse, nullptr, TO_CHAR);
 		return;
 	}
 
@@ -4458,15 +4458,15 @@ void do_embalm(CHAR_DATA *ch, char *argument)
 
 	if (number_percent() > ch->pcdata->learned[gsn_embalm])
 	{
-		act("You spill your embalming fluids all over $p, ruining it.", ch, corpse, 0, TO_CHAR);
-		act("$n spills embalming fluids over $p and ruins it.", ch, corpse, 0, TO_ROOM);
+		act("You spill your embalming fluids all over $p, ruining it.", ch, corpse, nullptr, TO_CHAR);
+		act("$n spills embalming fluids over $p and ruins it.", ch, corpse, nullptr, TO_ROOM);
 		check_improve(ch, gsn_embalm, false, 4);
 		extract_obj(corpse);
 		return;
 	}
 
-	act("$n embalms $p!", ch, corpse, 0, TO_ROOM);
-	act("You succeed in embalming $p.", ch, corpse, 0, TO_CHAR);
+	act("$n embalms $p!", ch, corpse, nullptr, TO_ROOM);
+	act("You succeed in embalming $p.", ch, corpse, nullptr, TO_CHAR);
 
 	corpse->timer += ch->level / 2;
 	corpse->value[4] = 1;
@@ -4703,13 +4703,13 @@ void do_demand(CHAR_DATA *ch, char *argument)
 
 	if (!can_see(victim, ch))
 	{
-		act("$N tells you, 'I can't give to those i can't see.'", ch, 0, victim, TO_CHAR);
+		act("$N tells you, 'I can't give to those i can't see.'", ch, nullptr, victim, TO_CHAR);
 		return;
 	}
 
 	if (!can_see_obj(victim, obj))
 	{
-		act("$N tells you, 'I can't see such an object.'", ch, 0, victim, TO_CHAR);
+		act("$N tells you, 'I can't see such an object.'", ch, nullptr, victim, TO_CHAR);
 		return;
 	}
 
@@ -4726,7 +4726,7 @@ void do_demand(CHAR_DATA *ch, char *argument)
 
 	if (ch->move < obj->level)
 	{
-		act("$N tells you, 'Hah! You couldn't even get away if i chased you!'.", ch, 0, victim, TO_CHAR);
+		act("$N tells you, 'Hah! You couldn't even get away if i chased you!'.", ch, nullptr, victim, TO_CHAR);
 
 		sprintf(buf1, "Help! I'm being attacked by %s!", victim->short_descr);
 		do_yell(ch, buf1);
@@ -4755,32 +4755,32 @@ void do_demand(CHAR_DATA *ch, char *argument)
 	if (obj->wear_loc != WEAR_NONE && IS_SET(obj->extra_flags, ITEM_NOREMOVE))
 	{
 		act("$N tells you, 'I'm unable to release $p'.", ch, obj, victim, TO_CHAR);
-		act("$N cowers back from you in fright.", ch, 0, victim, TO_CHAR);
-		act("$N cowers back from $n in fright.", ch, 0, victim, TO_NOTVICT);
+		act("$N cowers back from you in fright.", ch, nullptr, victim, TO_CHAR);
+		act("$N cowers back from $n in fright.", ch, nullptr, victim, TO_NOTVICT);
 		return;
 	}
 	if (IS_SET(obj->extra_flags, ITEM_NODROP))
 	{
 		act("$N tells you, 'I'm unable to release $p'.", ch, obj, victim, TO_CHAR);
-		act("$N cowers back from you in fright.", ch, 0, victim, TO_CHAR);
-		act("$N cowers back from $n in fright.", ch, 0, victim, TO_NOTVICT);
+		act("$N cowers back from you in fright.", ch, nullptr, victim, TO_CHAR);
+		act("$N cowers back from $n in fright.", ch, nullptr, victim, TO_NOTVICT);
 		return;
 	}
 
 	if (ch->carry_weight + get_obj_weight(obj) > can_carry_w(ch))
 	{
-		act("$N tells you, 'You can't carry the weight $n.'", ch, 0, victim, TO_CHAR);
+		act("$N tells you, 'You can't carry the weight $n.'", ch, nullptr, victim, TO_CHAR);
 		return;
 	}
 
 	if (ch->carry_number + 1 > can_carry_n(ch))
 	{
-		act("$N tells you, 'You can't carry that many items $n.'", ch, 0, victim, TO_CHAR);
+		act("$N tells you, 'You can't carry that many items $n.'", ch, nullptr, victim, TO_CHAR);
 		return;
 	}
 
-	act("$N caves in to the bully tactics of $n.", ch, 0, victim, TO_NOTVICT);
-	act("$N shivers in fright and caves in to your bully tactics.", ch, 0, victim, TO_CHAR);
+	act("$N caves in to the bully tactics of $n.", ch, nullptr, victim, TO_NOTVICT);
+	act("$N shivers in fright and caves in to your bully tactics.", ch, nullptr, victim, TO_CHAR);
 
 	if (obj->wear_loc != WEAR_NONE)
 	{
@@ -4862,24 +4862,24 @@ void report_weapon_skill(CHAR_DATA *ch, OBJ_DATA *obj)
 	if (skill >= 100)
 		act("$p feels like a part of you!", ch, obj, nullptr, TO_CHAR);
 	else if (skill > 85)
-		act("You feel quite confident with $p.", ch, obj, 0, TO_CHAR);
+		act("You feel quite confident with $p.", ch, obj, nullptr, TO_CHAR);
 	else if (skill > 70)
-		act("You are skilled with $p.", ch, obj, 0, TO_CHAR);
+		act("You are skilled with $p.", ch, obj, nullptr, TO_CHAR);
 	else if (skill > 50)
-		act("Your skill with $p is adequate.", ch, obj, 0, TO_CHAR);
+		act("Your skill with $p is adequate.", ch, obj, nullptr, TO_CHAR);
 	else if (skill > 25)
-		act("$p feels a little clumsy in your hands.", ch, obj, 0, TO_CHAR);
+		act("$p feels a little clumsy in your hands.", ch, obj, nullptr, TO_CHAR);
 	else if (skill > 1)
-		act("You fumble and almost drop $p.", ch, obj, 0, TO_CHAR);
+		act("You fumble and almost drop $p.", ch, obj, nullptr, TO_CHAR);
 	else
-		act("You don't even know which end is up on $p.", ch, obj, 0, TO_CHAR);
+		act("You don't even know which end is up on $p.", ch, obj, nullptr, TO_CHAR);
 }
 
 void wear_obj_fallen_wings(CHAR_DATA *ch, OBJ_DATA *obj)
 {
 	AFFECT_DATA af;
 
-	act("$n's shredded wings slowly beat and $s feet rise of the ground.", ch, 0, 0, TO_ROOM);
+	act("$n's shredded wings slowly beat and $s feet rise of the ground.", ch, nullptr, nullptr, TO_ROOM);
 	send_to_char("Your shredded angel wings slowly beat and your feet rise off the ground.\n\r", ch);
 
 	affect_strip(ch, skill_lookup("fly"));
@@ -4905,7 +4905,7 @@ void remove_obj_fallen_wings(CHAR_DATA *ch, OBJ_DATA *obj)
 	if (!is_affected(ch, sn_fly))
 		return;
 
-	act("$n slowly floats back to the ground.", ch, 0, 0, TO_ROOM);
+	act("$n slowly floats back to the ground.", ch, nullptr, nullptr, TO_ROOM);
 	send_to_char("Your feet slowly float back to the ground.\n\r", ch);
 	affect_strip(ch, sn_fly);
 }
@@ -4967,8 +4967,8 @@ void do_roll(CHAR_DATA *ch, char *argument)
 
 	if (argument[0] == '\0')
 	{
-		act("You roll your eyes in disgust.", ch, 0, 0, TO_CHAR);
-		act("$n rolls $s eyes, disgusted.", ch, 0, 0, TO_ROOM);
+		act("You roll your eyes in disgust.", ch, nullptr, nullptr, TO_CHAR);
+		act("$n rolls $s eyes, disgusted.", ch, nullptr, nullptr, TO_ROOM);
 		return;
 	}
 
@@ -5015,7 +5015,7 @@ void do_roll(CHAR_DATA *ch, char *argument)
 	act("You cup your hands, rattle $p around, and roll $T.", ch, obj, buf, TO_CHAR);
 	act("$n cups $s hands, rattles $p around, and rolls $T.", ch, obj, buf, TO_ROOM);
 
-	act(".\n\r.\n\r.", ch, 0, 0, TO_ALL);
+	act(".\n\r.\n\r.", ch, nullptr, nullptr, TO_ALL);
 
 	if (number == 1)
 	{
@@ -5034,7 +5034,7 @@ void do_roll(CHAR_DATA *ch, char *argument)
 		strcat(buf, ".");
 	}
 
-	act(buf, ch, 0, 0, TO_ALL);
+	act(buf, ch, nullptr, nullptr, TO_ALL);
 
 	obj_from_char(obj);
 	obj_to_room(obj, ch->in_room);
@@ -5060,16 +5060,16 @@ void do_flip(CHAR_DATA *ch, char *argument)
 		}
 		if (number_percent() < ((get_curr_stat(ch, STAT_DEX) * 10) - 150))
 		{
-			act("You perform an agile backflip, landing solidly on your feet!", ch, 0, 0, TO_CHAR);
-			act("$n suddenly performs an agile backflip, landing solidly on $s feet!", ch, 0, 0, TO_ROOM);
+			act("You perform an agile backflip, landing solidly on your feet!", ch, nullptr, nullptr, TO_CHAR);
+			act("$n suddenly performs an agile backflip, landing solidly on $s feet!", ch, nullptr, nullptr, TO_ROOM);
 
 			WAIT_STATE(ch, PULSE_VIOLENCE);
 			return;
 		}
 		else
 		{
-			act("You attempt an ill-advised backflip, and crash awkwardly to the ground!", ch, 0, 0, TO_CHAR);
-			act("$n looks foolish as $e attempts a backflip and crashes awkwardly to the ground!", ch, 0, 0, TO_ROOM);
+			act("You attempt an ill-advised backflip, and crash awkwardly to the ground!", ch, nullptr, nullptr, TO_CHAR);
+			act("$n looks foolish as $e attempts a backflip and crashes awkwardly to the ground!", ch, nullptr, nullptr, TO_ROOM);
 
 			WAIT_STATE(ch, 3 * PULSE_VIOLENCE);
 
@@ -5091,9 +5091,9 @@ void do_flip(CHAR_DATA *ch, char *argument)
 		return;
 	}
 
-	act("You flip a single gold coin high in the air, and it tumbles rapidly.", ch, 0, 0, TO_CHAR);
-	act("$n flips a single gold coin high in the air, and it tumbles rapidly.", ch, 0, 0, TO_ROOM);
-	act(".\n\r.\n\r.", ch, 0, 0, TO_ALL);
+	act("You flip a single gold coin high in the air, and it tumbles rapidly.", ch, nullptr, nullptr, TO_CHAR);
+	act("$n flips a single gold coin high in the air, and it tumbles rapidly.", ch, nullptr, nullptr, TO_ROOM);
+	act(".\n\r.\n\r.", ch, nullptr, nullptr, TO_ALL);
 
 	if (number_percent() > 50)
 		sprintf(buf, "Heads");
@@ -5102,20 +5102,20 @@ void do_flip(CHAR_DATA *ch, char *argument)
 
 	if (number_range(1, 25) <= get_curr_stat(ch, STAT_DEX))
 	{
-		act("You catch the coin in your palm and turn it over... $T!", ch, 0, buf, TO_CHAR);
-		act("$n catches the coin in $s palm and turns it over... $T!", ch, 0, buf, TO_ROOM);
+		act("You catch the coin in your palm and turn it over... $T!", ch, nullptr, buf, TO_CHAR);
+		act("$n catches the coin in $s palm and turns it over... $T!", ch, nullptr, buf, TO_ROOM);
 	}
 	else
 	{
 		if (number_range(1, 1000) == 1)
 		{
-			act("You fumble trying to catch the coin and it hits the ground. . . \n\rOh my, it landed on its EDGE!  What are the odds??", ch, 0, 0, TO_CHAR);
-			act("$n fumbles trying to catch the coin and it hits the ground. . .\n\rOh my, it landed on its EDGE!  What are the odds??", ch, 0, 0, TO_ROOM);
+			act("You fumble trying to catch the coin and it hits the ground. . . \n\rOh my, it landed on its EDGE!  What are the odds??", ch, nullptr, nullptr, TO_CHAR);
+			act("$n fumbles trying to catch the coin and it hits the ground. . .\n\rOh my, it landed on its EDGE!  What are the odds??", ch, nullptr, nullptr, TO_ROOM);
 		}
 		else
 		{
-			act("You fumble trying to catch the coin and it hits the ground, showing... $T!", ch, 0, buf, TO_CHAR);
-			act("$n fumbles trying to catch the coin and it hits the ground, showing... $T!", ch, 0, buf, TO_ROOM);
+			act("You fumble trying to catch the coin and it hits the ground, showing... $T!", ch, nullptr, buf, TO_CHAR);
+			act("$n fumbles trying to catch the coin and it hits the ground, showing... $T!", ch, nullptr, buf, TO_ROOM);
 		}
 
 		coin = create_object(get_obj_index(2), 0);

--- a/code/act_wiz.c
+++ b/code/act_wiz.c
@@ -493,7 +493,7 @@ void do_induct(CHAR_DATA *ch, char *argument)
 	}
 
 	sprintf(buf, "%s has been inducted into the %s.", victim->name, cabal_table[cabal].long_name);
-	act(buf, victim, 0, ch, TO_NOTVICT);
+	act(buf, victim, nullptr, ch, TO_NOTVICT);
 
 	strcat(buf, "\n\r");
 	send_to_char(buf, ch);
@@ -3413,7 +3413,7 @@ void reboot_now(CHAR_DATA *ch)
 
 				for (t_obj = obj->contains; t_obj != nullptr; t_obj = t_obj->next_content)
 				{
-					act_new("$p returns to you.",owner,t_obj,0,TO_CHAR,POS_DEAD);
+					act_new("$p returns to you.",owner,t_obj,nullptr,TO_CHAR,POS_DEAD);
 
 					if(t_obj->item_type==ITEM_MONEY)
 					{
@@ -4133,7 +4133,7 @@ void do_purge(CHAR_DATA *ch, char *argument)
 			return;
 		}
 
-		act("$n disintegrates $N!", ch, 0, victim, TO_NOTVICT);
+		act("$n disintegrates $N!", ch, nullptr, victim, TO_NOTVICT);
 
 		if (victim->level > 1)
 			save_char_obj(victim);
@@ -6377,7 +6377,7 @@ void do_astrip(CHAR_DATA *ch, char *argument)
 	}
 
 	if (victim != ch)
-		act("All affects stripped from $N.", ch, 0, victim, TO_CHAR);
+		act("All affects stripped from $N.", ch, nullptr, victim, TO_CHAR);
 	else
 		send_to_char("All affects stripped from yourself.\n\r", ch);
 }
@@ -6625,7 +6625,7 @@ void do_addapply(CHAR_DATA *ch, char *argument)
 
 		obj->apply.clear();
 
-		act("All affects removed from $p.", ch, obj, 0, TO_CHAR);
+		act("All affects removed from $p.", ch, obj, nullptr, TO_CHAR);
 		return;
 	}
 
@@ -7147,7 +7147,7 @@ void do_empower(CHAR_DATA *ch, char *argument)
 			REMOVE_BIT(victim->act, PLR_EMPOWERED);
 
 			send_to_char("The Immortals have revoked your empowerment!\n\r", victim);
-			act("You have UNEMPOWERED $N, until you notify $M, $E doesn't know.", ch, 0, victim, TO_CHAR);
+			act("You have UNEMPOWERED $N, until you notify $M, $E doesn't know.", ch, nullptr, victim, TO_CHAR);
 
 			sprintf(buf, "$N revokes %s's empowerment.", victim->name);
 			wiznet(buf, ch, nullptr, WIZ_PENALTIES, 0, 0);
@@ -7169,7 +7169,7 @@ void do_empower(CHAR_DATA *ch, char *argument)
 		{
 			SET_BIT(victim->act, PLR_EMPOWERED);
 
-			act("You have EMPOWERED $N, until you notify $M, $E doesn't know.", ch, 0, victim, TO_CHAR);
+			act("You have EMPOWERED $N, until you notify $M, $E doesn't know.", ch, nullptr, victim, TO_CHAR);
 
 			sprintf(buf, "$N empowers %s.", victim->name);
 			wiznet(buf, ch, nullptr, WIZ_PENALTIES, 0, 0);
@@ -7297,7 +7297,7 @@ void do_rastrip(CHAR_DATA *ch, char *argument)
 		it = next;
 	}
 
-	act("All affects stripped from '$t'.", ch, location->name, 0, TO_CHAR);
+	act("All affects stripped from '$t'.", ch, location->name, nullptr, TO_CHAR);
 }
 
 void do_aastrip(CHAR_DATA *ch, [[maybe_unused]] char *argument)
@@ -7311,7 +7311,7 @@ void do_aastrip(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 		it = next;
 	}
 
-	act("All affects stripped from '$t'.", ch, area->name, 0, TO_CHAR);
+	act("All affects stripped from '$t'.", ch, area->name, nullptr, TO_CHAR);
 }
 
 void do_oastrip(CHAR_DATA *ch, char *argument)
@@ -7347,7 +7347,7 @@ void do_oastrip(CHAR_DATA *ch, char *argument)
 		it = next;
 	}
 
-	act("All affects stripped from $p.", ch, obj, 0, TO_CHAR);
+	act("All affects stripped from $p.", ch, obj, nullptr, TO_CHAR);
 }
 
 void do_givexp(CHAR_DATA *ch, char *argument)
@@ -7479,7 +7479,7 @@ void do_clearfavors(CHAR_DATA *ch, char *argument)
 		victim->pcdata->lesserdata[i] = FAVOR_NONE;
 	}
 
-	act("$N's favors cleared.", ch, 0, victim, TO_CHAR);
+	act("$N's favors cleared.", ch, nullptr, victim, TO_CHAR);
 }
 
 void do_gsnlist(CHAR_DATA *ch, [[maybe_unused]] char *argument)

--- a/code/act_wiz.c
+++ b/code/act_wiz.c
@@ -537,7 +537,7 @@ void do_induct(CHAR_DATA *ch, char *argument)
 void do_outfit(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	OBJ_DATA *obj;
-	int i, body, arms, legs, hands, feet, shield, sn, vnum;
+	int i, body, arms, legs, hands, feet, sn, vnum;
 	AFFECT_DATA af;
 
 	if (is_affected(ch, skill_lookup("outfit")))
@@ -562,7 +562,6 @@ void do_outfit(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 		legs = 24574;
 		hands = 24576;
 		feet = 24578;
-		shield = 24580;
 	}
 	else
 	{
@@ -571,7 +570,6 @@ void do_outfit(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 		legs = 24575;
 		hands = 24577;
 		feet = 24579;
-		shield = 24580;
 	}
 
 	obj = get_eq_char(ch, WEAR_BODY);
@@ -651,6 +649,7 @@ void do_outfit(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 		obj_to_char(obj, ch);
 		wear_obj(ch, obj, false);
 	}
+
 
 	/*
 	obj = get_eq_char(ch, WEAR_ABOUT);
@@ -4209,10 +4208,10 @@ void do_advance(CHAR_DATA *ch, char *argument)
 	 *   Currently, an imp can lower another imp.
 	 *   -- Swiftest
 	 */
+	int temp_prac = -1;
+
 	if (level <= victim->level)
 	{
-		int temp_prac;
-
 		send_to_char("Lowering a player's level!\n\r", ch);
 		send_to_char("**** OOOOHHHHHHHHHH  NNNNOOOO ****\n\r", victim);
 		temp_prac = victim->practice;
@@ -4242,6 +4241,12 @@ void do_advance(CHAR_DATA *ch, char *argument)
 		victim->level += 1;
 		advance_level(victim, false);
 	}
+
+	// Only the lowering branch zeroes practices, and each advance_level above
+	// grants a fresh allowance on the way back up. Restoring the saved count
+	// puts the player back where they were instead of paying them again.
+	if (temp_prac >= 0)
+		victim->practice = temp_prac;
 
 	sprintf(buf, "You are now level %d.\n\r", victim->level);
 	send_to_char(buf, victim);

--- a/code/act_wiz.c
+++ b/code/act_wiz.c
@@ -3743,8 +3743,8 @@ void do_switch(CHAR_DATA *ch, char *argument)
 	sprintf(buf, "$N switches into %s.", victim->short_descr);
 	wiznet(buf, ch, nullptr, WIZ_SWITCHES, WIZ_SECURE, get_trust(ch));
 
-	Deref(ch->desc)->character = victim->self;
-	Deref(ch->desc)->original = ch->self;
+	connection->character = victim->self;
+	connection->original = ch->self;
 	victim->desc = ch->desc;
 	// The possessed mob borrows the immortal's pcdata (it's an NPC, so its own
 	// pcdata is null). Ownership stays with the original body; do_return calls
@@ -3793,7 +3793,12 @@ void do_return(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 	ch->pcdata.release();		// relinquish the borrowed pcdata WITHOUT freeing it
 	connection->character = connection->original;
 	connection->original = nullptr;
-	Deref(connection->character)->desc = ch->desc;
+
+	CHAR_DATA *body = Deref(connection->character);
+
+	if (body != nullptr)
+		body->desc = ch->desc;
+
 	ch->desc = nullptr;
 }
 

--- a/code/act_wiz.c
+++ b/code/act_wiz.c
@@ -7765,7 +7765,7 @@ void do_interpdump([[maybe_unused]] CHAR_DATA *ch, [[maybe_unused]] char *argume
 		if (cmd_table[i].hide == 1)
 			bit += 1;
 
-		fprintf(fp, ";%s;0;do_%s;%d;%d;%d;\n", cmd_table[i].name, cmd_table[i].name, cmd_table[i].level, cmd_table[i].log, bit);
+		fprintf(fp, ";%s;0;do_%s;%d;%d;%d;\n", cmd_table[i].name.data(), cmd_table[i].name.data(), cmd_table[i].level, cmd_table[i].log, bit);
 	}
 	fclose(fp);
 

--- a/code/aprog.c
+++ b/code/aprog.c
@@ -391,20 +391,24 @@ void pulse_prog_ruins_shark(AREA_DATA *area)
 	for (OwningListWalk<DESCRIPTOR_DATA> walk(descriptor_list); !walk.Done(); walk.Step())
 	{
 		DESCRIPTOR_DATA *d = walk.Current();
+		CHAR_DATA *wch = Deref(d->character);
+
+		if (wch == nullptr)
+			continue;
 
 		if (d->connected == CON_PLAYING
-			&& Deref(d->character)->in_room != nullptr
-			&& Deref(d->character)->in_room->area == area
+			&& wch->in_room != nullptr
+			&& wch->in_room->area == area
 			&& number_percent() > 90)
 		{
-			ch = Deref(d->character);
+			ch = wch;
 
-			if ((Deref(d->character)->hit * 2) > Deref(d->character)->max_hit)
+			if ((wch->hit * 2) > wch->max_hit)
 				continue;
 
-			if (Deref(d->character)->in_room->vnum < 20100
-				|| (Deref(d->character)->in_room->vnum > 20150 && Deref(d->character)->in_room->vnum < 20181)
-				|| Deref(d->character)->in_room->vnum > 20219)
+			if (wch->in_room->vnum < 20100
+				|| (wch->in_room->vnum > 20150 && wch->in_room->vnum < 20181)
+				|| wch->in_room->vnum > 20219)
 			{
 				continue;
 			}

--- a/code/aprog.c
+++ b/code/aprog.c
@@ -174,7 +174,7 @@ void tick_prog_academy_reset(AREA_DATA *area)
 			char buf[MSL];
 
 			send_to_char("A small contingent of guards rapidly marches up to you.\n\r", ch);
-			act("A small contingent of guards rapidly marches up to $n, marching $m off.", ch, 0, 0, TO_ROOM);
+			act("A small contingent of guards rapidly marches up to $n, marching $m off.", ch, nullptr, nullptr, TO_ROOM);
 
 			sprintf(buf, "A Royal Academy Guard says '%sBy the orders of the King, you have completed your training and must depart.%s'\n\r",
 				get_char_color(ch, "speech"),
@@ -273,7 +273,7 @@ void tick_prog_ilopheth(AREA_DATA *area)
 				sprintf(buf, "%sAs the afternoon sun drops lower in the sky a single shaft of sunlight shines through a gap in the stones, coming to rest directly on the white marble pedestal.%s",
 					get_char_color(pedroom->people, "yellow"),
 					END_COLOR(pedroom->people));
-				act(buf, pedroom->people, 0, 0, TO_ALL);
+				act(buf, pedroom->people, nullptr, nullptr, TO_ALL);
 			}
 		}
 		else
@@ -283,7 +283,7 @@ void tick_prog_ilopheth(AREA_DATA *area)
 				sprintf(buf, "%sAs the afternoon sun drops lower in the sky a single shaft of sunlight shines through a gap in the stones, coming to rest directly on the white marble pedestal.%s",
 					get_char_color(pedroom->people, "yellow"),
 					END_COLOR(pedroom->people));
-				act(buf, pedroom->people, 0, 0, TO_ALL);
+				act(buf, pedroom->people, nullptr, nullptr, TO_ALL);
 
 				RS.Queue.AddToQueue(4, "tick_prog_ilopheth", "act_queue", act_queue, "The opacity of the crystal sphere appears to fade, and it begins to glow a brilliant white!", pedroom->people, nullptr, nullptr, TO_ALL);
 				RS.Queue.AddToQueue(7, "tick_prog_ilopheth", "act_queue", act_queue, "To the northwest, an immense pillar of light ascends from the forest into the heavens!", pedroom->people, nullptr, nullptr, TO_ALL);
@@ -307,7 +307,7 @@ void tick_prog_ilopheth(AREA_DATA *area)
 				if (portroom->people)
 				{
 					sprintf(buf, "The mass of energy begins to glow a brilliant white, and releases an immense pillar of energy which streaks into the heavens.  The disturbance seems to stabilize into an arched, opalescent portal.");
-					act(buf, portroom->people, 0, 0, TO_ALL);
+					act(buf, portroom->people, nullptr, nullptr, TO_ALL);
 				}
 
 				obj_from_room(old_portal);
@@ -323,7 +323,7 @@ void tick_prog_ilopheth(AREA_DATA *area)
 	if (time_info.hour == 17)
 	{
 		if (pedroom->people)
-			act("As the sun descends toward the horizon, the shaft of light illuminating the pedestal fades to a spot, and disappears.", pedroom->people, 0, 0, TO_ALL);
+			act("As the sun descends toward the horizon, the shaft of light illuminating the pedestal fades to a spot, and disappears.", pedroom->people, nullptr, nullptr, TO_ALL);
 
 		for (obj = portroom->contents; obj; obj = obj->next_content)
 		{
@@ -341,7 +341,7 @@ void tick_prog_ilopheth(AREA_DATA *area)
 		else
 		{
 			if (portroom->people)
-				act("The opalescent gateway begins to break down, its edges flexing and twisting wildly.", portroom->people, 0, 0, TO_ALL);
+				act("The opalescent gateway begins to break down, its edges flexing and twisting wildly.", portroom->people, nullptr, nullptr, TO_ALL);
 
 			obj_from_room(new_portal);
 			extract_obj(new_portal);
@@ -412,7 +412,7 @@ void pulse_prog_ruins_shark(AREA_DATA *area)
 			shark = create_mobile(get_mob_index(20111));
 
 			char_to_room(shark, ch->in_room);
-			act("Drawn by the scent of blood in the water, a fierce shark swims in and attacks!", ch, 0, 0, TO_ALL);
+			act("Drawn by the scent of blood in the water, a fierce shark swims in and attacks!", ch, nullptr, nullptr, TO_ALL);
 
 			do_murder(shark, ch->name);
 			return;

--- a/code/cabal.c
+++ b/code/cabal.c
@@ -205,7 +205,7 @@ void spell_epic(int sn, int level, CHAR_DATA *ch, [[maybe_unused]] SpellTarget v
 	affect_to_char(ch, &af);
 
 	send_to_char("Strength surges through your body as you prepare for battle.\n\r", ch);
-	act("$n concentrates intently for a moment, getting a wild look in $s eyes.", ch, 0, 0, TO_ROOM);
+	act("$n concentrates intently for a moment, getting a wild look in $s eyes.", ch, nullptr, nullptr, TO_ROOM);
 }
 
 void spell_calm(int sn, int level, CHAR_DATA *ch, [[maybe_unused]] SpellTarget vo, [[maybe_unused]] CastMode mode)
@@ -281,7 +281,7 @@ void spell_rage(int sn, int level, CHAR_DATA *ch, [[maybe_unused]] SpellTarget v
 	sprintf(buf, "You feel your rage grow as the spirit of the %s surges through you!\n\r", capitalize(tribe_table[ch->pcdata->tribe].name));
 	send_to_char(buf, ch);
 
-	act("$n starts growling and frothing as $s battle rage overtakes $m!", ch, 0, 0, TO_ROOM);
+	act("$n starts growling and frothing as $s battle rage overtakes $m!", ch, nullptr, nullptr, TO_ROOM);
 
 	if (is_affected(ch, gsn_sanctuary) || is_affected(ch, gsn_protective_shield))
 	{
@@ -770,7 +770,7 @@ void spell_hire_mercenary(int sn, int level, CHAR_DATA *ch, SpellTarget /* vo */
 	}
 
 	sprintf(buf, "The mercenary's guild charges you %i gold for your hired mercenary.\n\r", amount);
-	act("$n hires $N.", ch, 0, merc, TO_ROOM);
+	act("$n hires $N.", ch, nullptr, merc, TO_ROOM);
 
 	send_to_char(buf, ch);
 
@@ -831,7 +831,7 @@ void spell_hunters_strength(int sn, int level, CHAR_DATA *ch, SpellTarget /* vo 
 	affect_to_char(ch, &af);
 
 	send_to_char("You feel your body surge with the newfound strength of a hunter seeking his prey!\n\r", ch);
-	act("$n seems to move with a newfound strength and agility.", ch, 0, 0, TO_ROOM);
+	act("$n seems to move with a newfound strength and agility.", ch, nullptr, nullptr, TO_ROOM);
 }
 
 void spell_hunters_awareness(int sn, int level, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
@@ -872,15 +872,15 @@ void spell_hunters_awareness(int sn, int level, CHAR_DATA *ch, SpellTarget /* vo
 		{
 			ch->mana -= 100;
 
-			act("You stalk $N relentlessly, pursuing $M with all the tools at your disposal.", ch, 0, victim, TO_CHAR);
+			act("You stalk $N relentlessly, pursuing $M with all the tools at your disposal.", ch, nullptr, victim, TO_CHAR);
 
 			if (saves_spell(level + 8, victim, DAM_OTHER))
 			{
-				act("You are unable to get an accurate fix on $N.", ch, 0, victim, TO_CHAR);
+				act("You are unable to get an accurate fix on $N.", ch, nullptr, victim, TO_CHAR);
 				return;
 			}
 
-			act("You manage to get an accurate perception of $N's surroundings.", ch, 0, victim, TO_CHAR);
+			act("You manage to get an accurate perception of $N's surroundings.", ch, nullptr, victim, TO_CHAR);
 
 			send_to_char(get_room_description(victim->in_room), ch);
 			send_to_char("\n\r", ch);
@@ -928,15 +928,15 @@ void spell_web(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]
 
 	if (saves_spell(level + 5, victim, DAM_OTHER) || number_range(20, 35) < get_curr_stat(victim, STAT_DEX))
 	{
-		act("$n tries to entangle you in a sticky web, but you avoid it.", ch, 0, victim, TO_VICT);
-		act("$n tries to entangle $N in a sticky web, but $E avoids it.", ch, 0, victim, TO_NOTVICT);
-		act("You try to entangle $N, but $E avoids it.", ch, 0, victim, TO_CHAR);
+		act("$n tries to entangle you in a sticky web, but you avoid it.", ch, nullptr, victim, TO_VICT);
+		act("$n tries to entangle $N in a sticky web, but $E avoids it.", ch, nullptr, victim, TO_NOTVICT);
+		act("You try to entangle $N, but $E avoids it.", ch, nullptr, victim, TO_CHAR);
 		return;
 	}
 
-	act("$n releases a sticky web at you, impeding your mobility!", ch, 0, victim, TO_VICT);
-	act("$n releases a sticky web at $N!", ch, 0, victim, TO_NOTVICT);
-	act("You release a sticky web at $N!", ch, 0, victim, TO_CHAR);
+	act("$n releases a sticky web at you, impeding your mobility!", ch, nullptr, victim, TO_VICT);
+	act("$n releases a sticky web at $N!", ch, nullptr, victim, TO_NOTVICT);
+	act("You release a sticky web at $N!", ch, nullptr, victim, TO_CHAR);
 
 	victim->move /= 2;
 
@@ -969,7 +969,7 @@ void spell_informant(int /* sn */, int level, CHAR_DATA *ch, SpellTarget /* vo *
 
 	if (saves_spell(level + 8, victim, DAM_OTHER) || is_npc(victim) || is_immortal(victim))
 	{
-		act("Your spies are unable to locate $N.", ch, 0, victim, TO_CHAR);
+		act("Your spies are unable to locate $N.", ch, nullptr, victim, TO_CHAR);
 		return;
 	}
 
@@ -1035,13 +1035,13 @@ void do_howl(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 
 	if (number_percent() > get_skill(ch, gsn_howl) || exits == 0)
 	{
-		act("$n opens $s mouth to scream, but his voice sounds stripped.", ch, 0, 0, TO_ROOM);
+		act("$n opens $s mouth to scream, but his voice sounds stripped.", ch, nullptr, nullptr, TO_ROOM);
 		send_to_char("Your howl seems to be rather weak.\n\r", ch);
 		check_improve(ch, gsn_howl, false, 2);
 	}
 	else
 	{
-		act("$n opens $s mouth and startles you with an animal-like howl!", ch, 0, 0, TO_ROOM);
+		act("$n opens $s mouth and startles you with an animal-like howl!", ch, nullptr, nullptr, TO_ROOM);
 		send_to_char("You scream at the top of your lungs like an animal!\n\r", ch);
 		check_improve(ch, gsn_howl, true, 2);
 
@@ -1054,7 +1054,7 @@ void do_howl(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 				&& Deref(vch->fighting) == ch
 				&& (!is_npc(vch) || (is_npc(vch) && !IS_SET(vch->act, ACT_SENTINEL))))
 			{
-				act("$n looks frightened and tries to run!", vch, 0, 0, TO_ROOM);
+				act("$n looks frightened and tries to run!", vch, nullptr, nullptr, TO_ROOM);
 				do_flee(vch, "");
 			}
 		}
@@ -1074,9 +1074,9 @@ void spell_mana_transfer(int sn, int /* level */, CHAR_DATA *ch, SpellTarget vo,
 		return;
 	}
 
-	act("You transfer part of your energy to $N!", ch, 0, victim, TO_CHAR);
-	act("$n transfers part of $s energy to you!", ch, 0, victim, TO_VICT);
-	act("$n transfers part of $s energy to $N!", ch, 0, victim, TO_NOTVICT);
+	act("You transfer part of your energy to $N!", ch, nullptr, victim, TO_CHAR);
+	act("$n transfers part of $s energy to you!", ch, nullptr, victim, TO_VICT);
+	act("$n transfers part of $s energy to $N!", ch, nullptr, victim, TO_NOTVICT);
 
 	damage_new(ch, ch, mod, sn, DAM_MENTAL, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "mana transfer");
 
@@ -1116,7 +1116,7 @@ void spell_scribe(int /* sn */, int level, CHAR_DATA *ch, SpellTarget /* vo */, 
 
 	if (obj == nullptr)
 	{
-		act("You do not have a blank scroll to scribe on.", ch, 0, 0, TO_CHAR);
+		act("You do not have a blank scroll to scribe on.", ch, nullptr, nullptr, TO_CHAR);
 		return;
 	}
 
@@ -1129,7 +1129,7 @@ void spell_scribe(int /* sn */, int level, CHAR_DATA *ch, SpellTarget /* vo */, 
 
 	if ((ch->mana - cost) < 0)
 	{
-		act("You do not have the mana to scribe a scroll.", ch, 0, 0, TO_CHAR);
+		act("You do not have the mana to scribe a scroll.", ch, nullptr, nullptr, TO_CHAR);
 		return;
 	}
 	else
@@ -1139,19 +1139,19 @@ void spell_scribe(int /* sn */, int level, CHAR_DATA *ch, SpellTarget /* vo */, 
 
 	if (get_skill(ch, skill) == 0)
 	{
-		act("You are not even learned in $t.", ch, skill_table[skill].name, 0, TO_CHAR);
+		act("You are not even learned in $t.", ch, skill_table[skill].name, nullptr, TO_CHAR);
 		return;
 	}
 
 	if (get_skill(ch, skill) < 90)
 	{
-		act("You are not sufficiently learned in $t to properly scribe it.", ch, skill_table[skill].name, 0, TO_CHAR);
+		act("You are not sufficiently learned in $t to properly scribe it.", ch, skill_table[skill].name, nullptr, TO_CHAR);
 		return;
 	}
 
 	if (skill_table[skill].skill_level[ch->Class()->GetIndex()] >= 30)
 	{
-		act("That spell is too high level to be scribed!", ch, 0, 0, TO_CHAR);
+		act("That spell is too high level to be scribed!", ch, nullptr, nullptr, TO_CHAR);
 		return;
 	}
 
@@ -1169,8 +1169,8 @@ void spell_scribe(int /* sn */, int level, CHAR_DATA *ch, SpellTarget /* vo */, 
 	free_pstring(obj->description);
 	obj->description = palloc_string("You see a scroll marked with some strange arcane symbols.");
 
-	act("You scribe the $t spell onto the scroll!", ch, skill_table[skill].name, 0, TO_CHAR);
-	act("$n makes detailed inscriptions on a scroll in $s possession.", ch, skill_table[skill].name, 0, TO_ROOM);
+	act("You scribe the $t spell onto the scroll!", ch, skill_table[skill].name, nullptr, TO_CHAR);
+	act("$n makes detailed inscriptions on a scroll in $s possession.", ch, skill_table[skill].name, nullptr, TO_ROOM);
 }
 
 void spell_deny_magic([[maybe_unused]] int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
@@ -1184,9 +1184,9 @@ void spell_deny_magic([[maybe_unused]] int sn, int level, CHAR_DATA *ch, SpellTa
 		return;
 	}
 
-	act("You gesture at $N and $E is surrounded by a faint blue aura.", ch, 0, victim, TO_CHAR);
-	act("$n gestures at you, and a faint blue aura forms around you.", ch, 0, victim, TO_VICT);
-	act("$n gestures at $N, and a faint blue aura forms around $M.", ch, 0, victim, TO_NOTVICT);
+	act("You gesture at $N and $E is surrounded by a faint blue aura.", ch, nullptr, victim, TO_CHAR);
+	act("$n gestures at you, and a faint blue aura forms around you.", ch, nullptr, victim, TO_VICT);
+	act("$n gestures at $N, and a faint blue aura forms around $M.", ch, nullptr, victim, TO_NOTVICT);
 
 	init_affect(&af);
 	af.where = TO_AFFECTS;
@@ -1203,8 +1203,8 @@ bool check_deny_magic(CHAR_DATA *ch)
 	if (!is_affected(ch, gsn_deny_magic))
 		return false;
 
-	act("The light blue aura around you flares and your magic does nothing.", ch, 0, 0, TO_CHAR);
-	act("The light blue aura around $n flares.", ch, 0, 0, TO_ROOM);
+	act("The light blue aura around you flares and your magic does nothing.", ch, nullptr, nullptr, TO_CHAR);
+	act("The light blue aura around $n flares.", ch, nullptr, nullptr, TO_ROOM);
 
 	return true;
 }
@@ -1217,9 +1217,9 @@ void spell_bane([[maybe_unused]] int sn, int level, CHAR_DATA *ch, SpellTarget v
 	if (IS_SET(victim->act, PLR_IGNORANT))
 	{
 		damage = 3 * dice(level, 3);
-		act("Your mental assault tears at $N's ignorance!", ch, 0, victim, TO_CHAR);
-		act("$n's mental assault tears at your ignorance!", ch, 0, victim, TO_VICT);
-		act("$n's mental assault tears at $N's ignorance!", ch, 0, victim, TO_NOTVICT);
+		act("Your mental assault tears at $N's ignorance!", ch, nullptr, victim, TO_CHAR);
+		act("$n's mental assault tears at your ignorance!", ch, nullptr, victim, TO_VICT);
+		act("$n's mental assault tears at $N's ignorance!", ch, nullptr, victim, TO_NOTVICT);
 	}
 	else
 	{
@@ -1235,7 +1235,7 @@ void spell_repose(int /* sn */, int /* level */, CHAR_DATA *ch, SpellTarget /* v
 
 	if (is_affected(ch, gsn_repose))
 	{
-		act("You are already able to rest quickly.", ch, 0, 0, TO_CHAR);
+		act("You are already able to rest quickly.", ch, nullptr, nullptr, TO_CHAR);
 	}
 	else
 	{
@@ -1246,7 +1246,7 @@ void spell_repose(int /* sn */, int /* level */, CHAR_DATA *ch, SpellTarget /* v
 		af.duration = ch->level;
 		af.mod_name = MOD_MOVEMENT;
 		new_affect_to_char(ch, &af);
-		act("You feel lighter on your feet.", ch, 0, 0, TO_CHAR);
+		act("You feel lighter on your feet.", ch, nullptr, nullptr, TO_CHAR);
 	}
 }
 
@@ -1257,7 +1257,7 @@ void spell_medicine(int /* sn */, int level, CHAR_DATA *ch, SpellTarget /* vo */
 
 	if (is_affected(ch, gsn_medicine))
 	{
-		act("You cannot apply medicine again so soon.", ch, 0, 0, TO_CHAR);
+		act("You cannot apply medicine again so soon.", ch, nullptr, nullptr, TO_CHAR);
 		return;
 	}
 
@@ -1277,14 +1277,14 @@ void spell_medicine(int /* sn */, int level, CHAR_DATA *ch, SpellTarget /* vo */
 
 		if (vch == ch)
 		{
-			act("You apply medicine to your wounds.", ch, 0, 0, TO_CHAR);
-			act("$n applies medicine to $s wounds.", ch, 0, 0, TO_ROOM);
+			act("You apply medicine to your wounds.", ch, nullptr, nullptr, TO_CHAR);
+			act("$n applies medicine to $s wounds.", ch, nullptr, nullptr, TO_ROOM);
 		}
 		else
 		{
-			act("You apply medicine to $N's wounds.", ch, 0, vch, TO_CHAR);
-			act("$n applies medicine to your wounds.", ch, 0, vch, TO_VICT);
-			act("$n applies medicine to $N's wounds.", ch, 0, vch, TO_NOTVICT);
+			act("You apply medicine to $N's wounds.", ch, nullptr, vch, TO_CHAR);
+			act("$n applies medicine to your wounds.", ch, nullptr, vch, TO_VICT);
+			act("$n applies medicine to $N's wounds.", ch, nullptr, vch, TO_NOTVICT);
 		}
 	}
 }
@@ -1346,7 +1346,7 @@ void spell_horde_communion(int /* sn */, int level, CHAR_DATA *ch, SpellTarget v
 		|| victim->Class()->name == "shapeshifter"
 		|| victim->Class()->name == "chronomancer")
 	{
-		act("$N is not fit to partake in the rites of communion.", ch, 0, victim, TO_CHAR);
+		act("$N is not fit to partake in the rites of communion.", ch, nullptr, victim, TO_CHAR);
 		return;
 	}
 
@@ -1358,9 +1358,9 @@ void spell_horde_communion(int /* sn */, int level, CHAR_DATA *ch, SpellTarget v
 		return;
 	}
 
-	act("You prepare $N for communion with the animal spirits of Horde.", ch, 0, victim, TO_CHAR);
-	act("A tranquil calm washes over you as your skin tingles slightly.", ch, 0, victim, TO_VICT);
-	act("A gentle breeze sweeps through, as an eerie silence falls over the area.", ch, 0, victim, TO_NOTVICT);
+	act("You prepare $N for communion with the animal spirits of Horde.", ch, nullptr, victim, TO_CHAR);
+	act("A tranquil calm washes over you as your skin tingles slightly.", ch, nullptr, victim, TO_VICT);
+	act("A gentle breeze sweeps through, as an eerie silence falls over the area.", ch, nullptr, victim, TO_NOTVICT);
 
 	init_affect(&af);
 	af.where = TO_AFFECTS;
@@ -1422,8 +1422,8 @@ void do_exile(CHAR_DATA *ch, char *argument)
 		return;
 	}
 
-	act("You exile $N from the Horde and mark $M as a betrayer to you and your brethren!", ch, 0, victim, TO_CHAR);
-	act("You have been exiled from the Longhouse and marked a betrayer of your brethren!", ch, 0, victim, TO_VICT);
+	act("You exile $N from the Horde and mark $M as a betrayer to you and your brethren!", ch, nullptr, victim, TO_CHAR);
+	act("You have been exiled from the Longhouse and marked a betrayer of your brethren!", ch, nullptr, victim, TO_VICT);
 
 	victim->cabal = CABAL_NONE;
 
@@ -1468,8 +1468,8 @@ void spell_piety(int /* sn */, int level, CHAR_DATA *ch, SpellTarget /* vo */, C
 	af.duration = level / 5;
 	affect_to_char(ch, &af);
 
-	act("Your righteous wrath at the impure surges through you.", ch, 0, 0, TO_CHAR);
-	act("$n stands taller as $s righteous wrath infuses $m.", ch, 0, 0, TO_ROOM);
+	act("Your righteous wrath at the impure surges through you.", ch, nullptr, nullptr, TO_CHAR);
+	act("$n stands taller as $s righteous wrath infuses $m.", ch, nullptr, nullptr, TO_ROOM);
 }
 
 void spell_fervor(int /* sn */, int level, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
@@ -1508,8 +1508,8 @@ void spell_fervor(int /* sn */, int level, CHAR_DATA *ch, SpellTarget /* vo */, 
 
 	new_affect_to_char(ch, &af);
 
-	act("$n's eyes blaze with light for a moment before fading to a dull glow.", ch, 0, 0, TO_ROOM);
-	act("You feel your spirit rejoice as holy fervor enters you.", ch, 0, 0, TO_CHAR);
+	act("$n's eyes blaze with light for a moment before fading to a dull glow.", ch, nullptr, nullptr, TO_ROOM);
+	act("You feel your spirit rejoice as holy fervor enters you.", ch, nullptr, nullptr, TO_CHAR);
 }
 
 void spell_spiritual_healing(int /* sn */, int level, CHAR_DATA *ch, SpellTarget vo, CastMode /* mode */)
@@ -1525,7 +1525,7 @@ void spell_spiritual_healing(int /* sn */, int level, CHAR_DATA *ch, SpellTarget
 
 	if (!is_good(victim))
 	{
-		act("$N is too impure!", ch, 0, victim, TO_CHAR);
+		act("$N is too impure!", ch, nullptr, victim, TO_CHAR);
 		return;
 	}
 
@@ -1533,26 +1533,26 @@ void spell_spiritual_healing(int /* sn */, int level, CHAR_DATA *ch, SpellTarget
 
 	if (ch != victim)
 	{
-		act("$n utters a quiet prayer and places $s hand on your forehead.", ch, 0, victim, TO_VICT);
-		act("You quietly say a prayer, placing your hand on $N's forehead.", ch, 0, victim, TO_CHAR);
-		act("$n places a hand on $N's forehead.", ch, 0, victim, TO_NOTVICT);
+		act("$n utters a quiet prayer and places $s hand on your forehead.", ch, nullptr, victim, TO_VICT);
+		act("You quietly say a prayer, placing your hand on $N's forehead.", ch, nullptr, victim, TO_CHAR);
+		act("$n places a hand on $N's forehead.", ch, nullptr, victim, TO_NOTVICT);
 	}
 	else
 	{
-		act("You pray quietly for healing.", ch, 0, victim, TO_CHAR);
-		act("$n utters a quiet prayer.", ch, 0, 0, TO_ROOM);
+		act("You pray quietly for healing.", ch, nullptr, victim, TO_CHAR);
+		act("$n utters a quiet prayer.", ch, nullptr, nullptr, TO_ROOM);
 	}
 
 	if (check_dispel(ch->level, victim, gsn_poison))
 	{
 		send_to_char("Your fever subsides as the poison leaves your body.\n\r", ch);
-		act("$n looks better.", ch, 0, 0, TO_ROOM);
+		act("$n looks better.", ch, nullptr, nullptr, TO_ROOM);
 	}
 
 	if (check_dispel(ch->level, victim, gsn_plague))
 	{
 		send_to_char("Your plague sores vanish.\n\r", ch);
-		act("$n looks relieved as his sores vanish.", ch, 0, 0, TO_ROOM);
+		act("$n looks relieved as his sores vanish.", ch, nullptr, nullptr, TO_ROOM);
 	}
 
 	if (check_dispel(ch->level, victim, gsn_blindness))
@@ -1585,8 +1585,8 @@ void spell_shroud_of_light(int sn, int level, CHAR_DATA *ch, SpellTarget /* vo *
 		return;
 	}
 
-	act("A feeling of warmth fills your body as you become shrouded in crackling light.", ch, 0, 0, TO_CHAR);
-	act("A veil of sparkling luminescence crackles into existence around $n.", ch, 0, 0, TO_ROOM);
+	act("A feeling of warmth fills your body as you become shrouded in crackling light.", ch, nullptr, nullptr, TO_CHAR);
+	act("A veil of sparkling luminescence crackles into existence around $n.", ch, nullptr, nullptr, TO_ROOM);
 
 	init_affect(&af);
 	af.where = TO_AFFECTS;
@@ -1626,10 +1626,10 @@ void spell_crimson_martyr(int sn, int level, CHAR_DATA *ch, SpellTarget /* vo */
 		return;
 	}
 
-	act("Raising $s arms to the heavens in supplication, $n calls down judgement upon the impure!", ch, 0, 0, TO_ROOM);
-	act("$n blazes with blinding incandescence as the wrath of the Light falls upon you!", ch, 0, 0, TO_ROOM);
-	act("Raising your arms to the heavens in supplication, you call down judgement upon the impure!", ch, 0, 0, TO_CHAR);
-	act("You feel the infinite power of the Light surge through you, burning you alive!", ch, 0, 0, TO_CHAR);
+	act("Raising $s arms to the heavens in supplication, $n calls down judgement upon the impure!", ch, nullptr, nullptr, TO_ROOM);
+	act("$n blazes with blinding incandescence as the wrath of the Light falls upon you!", ch, nullptr, nullptr, TO_ROOM);
+	act("Raising your arms to the heavens in supplication, you call down judgement upon the impure!", ch, nullptr, nullptr, TO_CHAR);
+	act("You feel the infinite power of the Light surge through you, burning you alive!", ch, nullptr, nullptr, TO_CHAR);
 
 	for (vch = ch->in_room->people; vch; vch = vch_next)
 	{
@@ -1664,11 +1664,11 @@ void spell_crimson_martyr(int sn, int level, CHAR_DATA *ch, SpellTarget /* vo */
 			// Correcting it turns on healing that has never applied to anyone
 			// short of full, so the magnitude needs a balance decision first.
 			vch->hit = std::min((int)vch->max_hit, vch->hit + (level * 10 * (ch->hit / ch->max_hit)));
-			act("$n's sacrifice infuses you with newfound vigor!", ch, 0, vch, TO_VICT);
+			act("$n's sacrifice infuses you with newfound vigor!", ch, nullptr, vch, TO_VICT);
 		}
 	}
 
-	act("$n slumps to the ground, crimson blood streaming from $s body.", ch, 0, 0, TO_ROOM);
+	act("$n slumps to the ground, crimson blood streaming from $s body.", ch, nullptr, nullptr, TO_ROOM);
 	send_to_char("You fall to the ground as the searing ravages of your martyrdom take their toll.\n\r", ch);
 
 	stop_fighting(ch, true);
@@ -1716,9 +1716,9 @@ void spell_retribution(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe
 	af.owner = ch->self;
 	affect_to_char(victim, &af);
 
-	act("You unleash the vengeance of the Phalanx upon $N!", ch, 0, victim, TO_CHAR);
-	act("$n unleashes the vengeance of the Phalanx upon $N!", ch, 0, victim, TO_NOTVICT);
-	act("$n unleashes the vengeance of the Phalanx upon you!", ch, 0, victim, TO_VICT);
+	act("You unleash the vengeance of the Phalanx upon $N!", ch, nullptr, victim, TO_CHAR);
+	act("$n unleashes the vengeance of the Phalanx upon $N!", ch, nullptr, victim, TO_NOTVICT);
+	act("$n unleashes the vengeance of the Phalanx upon you!", ch, nullptr, victim, TO_VICT);
 
 	af.tick_fun = nullptr;
 	af.duration = level - 5;
@@ -1768,16 +1768,16 @@ void do_phalanx(CHAR_DATA *ch, char *argument)
 		victim->pcdata->cabal_level = 2;
 		update_cskills(victim);
 
-		act("$N is now a Keeper of the Fire.", ch, 0, victim, TO_CHAR);
-		act("You are now a Keeper of the Fire.", ch, 0, victim, TO_VICT);
+		act("$N is now a Keeper of the Fire.", ch, nullptr, victim, TO_CHAR);
+		act("You are now a Keeper of the Fire.", ch, nullptr, victim, TO_VICT);
 	}
 	else if (!str_cmp(argument, "inquisitor"))
 	{
 		victim->pcdata->cabal_level = 3;
 		update_cskills(victim);
 
-		act("$N is now an Inquisitor of the Fire.", ch, 0, victim, TO_CHAR);
-		act("You are now an Inquisitor of the Fire.", ch, 0, victim, TO_VICT);
+		act("$N is now an Inquisitor of the Fire.", ch, nullptr, victim, TO_CHAR);
+		act("You are now an Inquisitor of the Fire.", ch, nullptr, victim, TO_VICT);
 	}
 	else
 	{
@@ -1798,15 +1798,15 @@ void spell_safehaven(int /* sn */, int /* level */, CHAR_DATA *ch, SpellTarget v
 		}
 		else
 		{
-			act("$N is not healthy enough to return to the safe haven.", ch, 0, victim, TO_CHAR);
+			act("$N is not healthy enough to return to the safe haven.", ch, nullptr, victim, TO_CHAR);
 			return;
 		}
 	}
 
 	if (ch == victim)
 	{
-		act("You call upon the power of Light to transport yourself to the safe haven.", ch, 0, 0, TO_CHAR);
-		act("$n disappears in a flash of light.", ch, 0, 0, TO_ROOM);
+		act("You call upon the power of Light to transport yourself to the safe haven.", ch, nullptr, nullptr, TO_CHAR);
+		act("$n disappears in a flash of light.", ch, nullptr, nullptr, TO_ROOM);
 
 		char_from_room(ch);
 		char_to_room(ch, get_room_index(3699));
@@ -1823,9 +1823,9 @@ void spell_safehaven(int /* sn */, int /* level */, CHAR_DATA *ch, SpellTarget v
 			return;
 		}
 
-		act("You call upon the power of Light to transport $N to the safe haven.", ch, 0, victim, TO_CHAR);
-		act("$n calls upon the Light and you are transported to the safe haven.", ch, 0, victim, TO_VICT);
-		act("$n vanishes in a flash of light.", victim, 0, ch, TO_ROOM);
+		act("You call upon the power of Light to transport $N to the safe haven.", ch, nullptr, victim, TO_CHAR);
+		act("$n calls upon the Light and you are transported to the safe haven.", ch, nullptr, victim, TO_VICT);
+		act("$n vanishes in a flash of light.", victim, nullptr, ch, TO_ROOM);
 
 		char_from_room(victim);
 		char_to_room(victim, get_room_index(3699));

--- a/code/characterClasses/ap.c
+++ b/code/characterClasses/ap.c
@@ -102,8 +102,8 @@ void spell_indomitability(int /* sn */, int level, CHAR_DATA *ch, SpellTarget /*
 {
 	AFFECT_DATA af;
 
-	act("You call upon the force of your will, using it to maintain your body's current state.", ch, 0, 0, TO_CHAR);
-	act("$n looks more determined.", ch, 0, 0, TO_ROOM);
+	act("You call upon the force of your will, using it to maintain your body's current state.", ch, nullptr, nullptr, TO_CHAR);
+	act("$n looks more determined.", ch, nullptr, nullptr, TO_ROOM);
 
 	init_affect(&af);
 	af.where = TO_AFFECTS;
@@ -145,9 +145,9 @@ void do_taunt(CHAR_DATA *ch, char *argument)
 
 	if (number_percent() < chance)
 	{
-		act("You shout and jeer at $N, angering $M until $E attacks!", ch, 0, victim, TO_CHAR);
-		act("$n shouts insults and curses at you and you attack $m in a fit of rage!", ch, 0, victim, TO_VICT);
-		act("$n shouts and curses at $N, angering $M until $E attacks!", ch, 0, victim, TO_NOTVICT);
+		act("You shout and jeer at $N, angering $M until $E attacks!", ch, nullptr, victim, TO_CHAR);
+		act("$n shouts insults and curses at you and you attack $m in a fit of rage!", ch, nullptr, victim, TO_VICT);
+		act("$n shouts and curses at $N, angering $M until $E attacks!", ch, nullptr, victim, TO_NOTVICT);
 
 		do_murder(victim, ch->name);
 
@@ -155,9 +155,9 @@ void do_taunt(CHAR_DATA *ch, char *argument)
 	}
 	else
 	{
-		act("You shout and jeer at $N, but $E shrugs it off.", ch, 0, victim, TO_CHAR);
-		act("$n shouts insults and curses at you, but you calmly ignore $m.", ch, 0, victim, TO_VICT);
-		act("$n shouts and curses at $N, but $N ignores $m.", ch, 0, victim, TO_NOTVICT);
+		act("You shout and jeer at $N, but $E shrugs it off.", ch, nullptr, victim, TO_CHAR);
+		act("$n shouts insults and curses at you, but you calmly ignore $m.", ch, nullptr, victim, TO_VICT);
+		act("$n shouts and curses at $N, but $N ignores $m.", ch, nullptr, victim, TO_NOTVICT);
 
 		check_improve(ch, skill_lookup("taunt"), false, 1);
 	}
@@ -176,9 +176,9 @@ void spell_wrack(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unuse
 		return;
 	}
 
-	act("You infuse $N's body with your anger, causing $M to be vulnerable to attack!", ch, 0, victim, TO_CHAR);
-	act("You feel a sudden surge of anger, followed by wracking pain.", ch, 0, victim, TO_VICT);
-	act("$n infuses $s anger into $N, leaving $M vulnerable.", ch, 0, victim, TO_NOTVICT);
+	act("You infuse $N's body with your anger, causing $M to be vulnerable to attack!", ch, nullptr, victim, TO_CHAR);
+	act("You feel a sudden surge of anger, followed by wracking pain.", ch, nullptr, victim, TO_VICT);
+	act("$n infuses $s anger into $N, leaving $M vulnerable.", ch, nullptr, victim, TO_NOTVICT);
 
 	init_affect(&af);
 	af.where = TO_AFFECTS;
@@ -207,8 +207,8 @@ void spell_radiance(int sn, int level, CHAR_DATA *ch, [[maybe_unused]] SpellTarg
 {
 	AFFECT_DATA af;
 
-	act("You channel your magic towards augmenting your beauty.", ch, 0, 0, TO_CHAR);
-	act("$n appears to glow momentarily.", ch, 0, 0, TO_ROOM);
+	act("You channel your magic towards augmenting your beauty.", ch, nullptr, nullptr, TO_CHAR);
+	act("$n appears to glow momentarily.", ch, nullptr, nullptr, TO_ROOM);
 
 	if (is_affected(ch, sn))
 	{
@@ -256,8 +256,8 @@ void spell_inspire_lust(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[mayb
 
 	if ((victim != ch) && (!saves_spell(level, victim, DAM_NEGATIVE)))
 	{
-		act("You call upon your unholy powers to taint $N's mind with greed!", ch, 0, victim, TO_CHAR);
-		act("A dark flash of greed fills your mind with thoughts of riches.", ch, 0, victim, TO_VICT);
+		act("You call upon your unholy powers to taint $N's mind with greed!", ch, nullptr, victim, TO_CHAR);
+		act("A dark flash of greed fills your mind with thoughts of riches.", ch, nullptr, victim, TO_VICT);
 
 		init_affect(&af);
 		af.where = TO_AFFECTS;
@@ -274,7 +274,7 @@ void spell_inspire_lust(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[mayb
 	}
 	else if (victim != ch)
 	{
-		act("You failed to fill $N's mind with greed.", ch, 0, victim, TO_CHAR);
+		act("You failed to fill $N's mind with greed.", ch, nullptr, victim, TO_CHAR);
 
 		if (!is_npc(victim))
 		{
@@ -288,7 +288,7 @@ void spell_inspire_lust(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[mayb
 
 	if (victim == ch)
 	{
-		act("A dark flash of greed fills your mind with thoughts of riches.", ch, 0, victim, TO_CHAR);
+		act("A dark flash of greed fills your mind with thoughts of riches.", ch, nullptr, victim, TO_CHAR);
 
 		init_affect(&af);
 		af.where = TO_AFFECTS;
@@ -329,7 +329,7 @@ void lust_pulse(CHAR_DATA *ch, [[maybe_unused]] AFFECT_DATA *af)
 			if (steal->wear_loc != WEAR_NONE || !can_see_obj(ch, steal) || number_percent() < 95)
 				continue;
 
-			act("Overcome by greed, you suddenly reach for $N's pack!", ch, 0, victim, TO_CHAR);
+			act("Overcome by greed, you suddenly reach for $N's pack!", ch, nullptr, victim, TO_CHAR);
 
 			if (number_percent() > skill)
 			{
@@ -427,14 +427,14 @@ void do_consume(CHAR_DATA *ch, char *argument)
 
 	if (number_percent() > skill)
 	{
-		act("You tear at $p with your teeth, but fail to heal yourself from it.", ch, corpse, 0, TO_CHAR);
-		act("$n tears at $p with $s teeth and comes up looking angry.", ch, corpse, 0, TO_ROOM);
+		act("You tear at $p with your teeth, but fail to heal yourself from it.", ch, corpse, nullptr, TO_CHAR);
+		act("$n tears at $p with $s teeth and comes up looking angry.", ch, corpse, nullptr, TO_ROOM);
 		extract_obj(corpse);
 	}
 	else
 	{
-		act("You tear at $p with your teeth and heal yourself with its blood.", ch, corpse, 0, TO_CHAR);
-		act("$n tears at $p with $s teeth and suddenly looks better.", ch, corpse, 0, TO_ROOM);
+		act("You tear at $p with your teeth and heal yourself with its blood.", ch, corpse, nullptr, TO_CHAR);
+		act("$n tears at $p with $s teeth and suddenly looks better.", ch, corpse, nullptr, TO_ROOM);
 		ch->hit += dice(corpse->level, 2);
 		extract_obj(corpse);
 	}
@@ -478,7 +478,7 @@ void spell_baals_mastery(int /* sn */, int /* level */, CHAR_DATA *ch, SpellTarg
 		return;
 	}
 
-	act("In a terrifying flash of dark insight, your Lord grants you mastery of $ts.", ch, target_name, 0, TO_CHAR);
+	act("In a terrifying flash of dark insight, your Lord grants you mastery of $ts.", ch, target_name, nullptr, TO_CHAR);
 
 	init_affect(&af);
 	af.where = TO_AFFECTS;
@@ -527,37 +527,37 @@ void check_baals_mastery(CHAR_DATA *ch, CHAR_DATA *victim)
 	switch (af->modifier)
 	{
 		case WEAPON_AXE:
-			act("With a rush of unholy might, you hack brutally with your axe at $N's flesh!", ch, 0, victim, TO_CHAR);
-			act("A wicked grin flashes across $n's face as $s axe rends your flesh!", ch, 0, victim, TO_VICT);
-			act("A wicked grin flashes across $n's face as $s axe rends $N's flesh!", ch, 0, victim, TO_NOTVICT);
+			act("With a rush of unholy might, you hack brutally with your axe at $N's flesh!", ch, nullptr, victim, TO_CHAR);
+			act("A wicked grin flashes across $n's face as $s axe rends your flesh!", ch, nullptr, victim, TO_VICT);
+			act("A wicked grin flashes across $n's face as $s axe rends $N's flesh!", ch, nullptr, victim, TO_NOTVICT);
 
 			one_hit_new(ch, victim, TYPE_UNDEFINED, HIT_NOSPECIALS, HIT_UNBLOCKABLE, HIT_NOADD, 150, nullptr);
 			break;
 		case WEAPON_SWORD:
-			act("With a surge of unholy vigor, your drive your blade deep into $N!", ch, 0, victim, TO_CHAR);
-			act("A wicked grin flashes across $n's face as $e plunges $s sword into you!", ch, 0, victim, TO_VICT);
-			act("A wicked grin flashes across $n's face as $e plunges $s sword into $N!", ch, 0, victim, TO_NOTVICT);
+			act("With a surge of unholy vigor, your drive your blade deep into $N!", ch, nullptr, victim, TO_CHAR);
+			act("A wicked grin flashes across $n's face as $e plunges $s sword into you!", ch, nullptr, victim, TO_VICT);
+			act("A wicked grin flashes across $n's face as $e plunges $s sword into $N!", ch, nullptr, victim, TO_NOTVICT);
 
 			one_hit_new(ch, victim, TYPE_UNDEFINED, HIT_NOSPECIALS, HIT_UNBLOCKABLE, HIT_NOADD, 150, nullptr);
 			break;
 		case WEAPON_MACE:
-			act("With a surge of unholy might, you bring your mace crashing down upon $N!", ch, 0, victim, TO_CHAR);
-			act("A wicked grin flashes across $n's face as $e brings $s mace down upon you!", ch, 0, victim, TO_VICT);
-			act("A wicked grin flashes across $n's face as $e brings $s mace down upon $N!", ch, 0, victim, TO_NOTVICT);
+			act("With a surge of unholy might, you bring your mace crashing down upon $N!", ch, nullptr, victim, TO_CHAR);
+			act("A wicked grin flashes across $n's face as $e brings $s mace down upon you!", ch, nullptr, victim, TO_VICT);
+			act("A wicked grin flashes across $n's face as $e brings $s mace down upon $N!", ch, nullptr, victim, TO_NOTVICT);
 
 			one_hit_new(ch, victim, TYPE_UNDEFINED, HIT_NOSPECIALS, HIT_UNBLOCKABLE, HIT_NOADD, 150, nullptr);
 			break;
 		case WEAPON_SPEAR:
-			act("With a surge of unholy might, you thrust your spear through $N's guard!", ch, 0, victim, TO_CHAR);
-			act("A wicked grin flashes across $n's face as $e drives $s spear into you!", ch, 0, victim, TO_VICT);
-			act("A wicked grin flashes across $n's face as $e drives $s spear into $N!", ch, 0, victim, TO_NOTVICT);
+			act("With a surge of unholy might, you thrust your spear through $N's guard!", ch, nullptr, victim, TO_CHAR);
+			act("A wicked grin flashes across $n's face as $e drives $s spear into you!", ch, nullptr, victim, TO_VICT);
+			act("A wicked grin flashes across $n's face as $e drives $s spear into $N!", ch, nullptr, victim, TO_NOTVICT);
 
 			one_hit_new(ch, victim, TYPE_UNDEFINED, HIT_NOSPECIALS, HIT_UNBLOCKABLE, HIT_NOADD, 200, nullptr);
 
 			if (number_percent() < 40 && !is_affected(victim, gsn_bleeding))
 			{
-				act("Your dark heart exults as blood fountains forth from the wound!", ch, 0, victim, TO_CHAR);
-				act("$n's eyes flicker darkly as blood fountains forth from the wound!", ch, 0, victim, TO_ROOM);
+				act("Your dark heart exults as blood fountains forth from the wound!", ch, nullptr, victim, TO_CHAR);
+				act("$n's eyes flicker darkly as blood fountains forth from the wound!", ch, nullptr, victim, TO_ROOM);
 				init_affect(&af2);
 				af2.where = TO_AFFECTS;
 				af2.aftype = AFT_MALADY;
@@ -574,9 +574,9 @@ void check_baals_mastery(CHAR_DATA *ch, CHAR_DATA *victim)
 
 			break;
 		case WEAPON_FLAIL:
-			act("With a surge of unholy might, you bring your flail crashing down upon $N!", ch, 0, victim, TO_CHAR);
-			act("A wicked grin flashes across $n's face as $e brings $s flail down upon you!", ch, 0, victim, TO_VICT);
-			act("A wicked grin flashes across $n's face as $e brings $s flail down upon $N!", ch, 0, victim, TO_NOTVICT);
+			act("With a surge of unholy might, you bring your flail crashing down upon $N!", ch, nullptr, victim, TO_CHAR);
+			act("A wicked grin flashes across $n's face as $e brings $s flail down upon you!", ch, nullptr, victim, TO_VICT);
+			act("A wicked grin flashes across $n's face as $e brings $s flail down upon $N!", ch, nullptr, victim, TO_NOTVICT);
 
 			one_hit_new(ch, victim, TYPE_UNDEFINED, HIT_NOSPECIALS, HIT_UNBLOCKABLE, HIT_NOADD, 175, nullptr);
 			break;
@@ -657,8 +657,8 @@ void spell_word_of_command(int /* sn */, int level, CHAR_DATA *ch, SpellTarget /
 	{
 		send_to_char("What the hell do you think you're doing?\n\r", ch);
 
-		act("A bolt from the heavens smites you!", ch, 0, 0, TO_CHAR);
-		act("A bolt from the heavens smites $n!", ch, 0, 0, TO_ROOM);
+		act("A bolt from the heavens smites you!", ch, nullptr, nullptr, TO_CHAR);
+		act("A bolt from the heavens smites $n!", ch, nullptr, nullptr, TO_ROOM);
 
 		ch->hit /= 2;
 		return;
@@ -666,8 +666,8 @@ void spell_word_of_command(int /* sn */, int level, CHAR_DATA *ch, SpellTarget /
 
 	if (saves_spell(level + 20 - get_curr_stat(victim, STAT_INT), victim, DAM_CHARM))
 	{
-		act("$N's mind resists your word of command.", ch, 0, victim, TO_CHAR);
-		act("You fend off a dark mental assault by $n!", ch, 0, victim, TO_VICT);
+		act("$N's mind resists your word of command.", ch, nullptr, victim, TO_CHAR);
+		act("You fend off a dark mental assault by $n!", ch, nullptr, victim, TO_VICT);
 
 		sprintf(buf, "Die, %s you sorcerous dog!", ch->name);
 		do_myell(victim, buf, ch);
@@ -676,7 +676,7 @@ void spell_word_of_command(int /* sn */, int level, CHAR_DATA *ch, SpellTarget /
 		return;
 	}
 
-	act("You successfully implant a word of command in $N's malleable mind.", ch, 0, victim, TO_CHAR);
+	act("You successfully implant a word of command in $N's malleable mind.", ch, nullptr, victim, TO_CHAR);
 
 	arg2[strlen(arg2)] = '\0';
 
@@ -752,9 +752,9 @@ void spell_mark_of_wrath(int /* sn */, int level, CHAR_DATA *ch, SpellTarget vo,
 		return;
 	}
 
-	act("You intone unholy words and a flaming brand appears on $N's forehead!", ch, 0, victim, TO_CHAR);
-	act("A wave of rage clouds your thoughts as $n chants in an unintelligible tongue.", ch, 0, victim, TO_VICT);
-	act("A flaming brand appears on $N's forehead, radiating malevolence.", ch, 0, victim, TO_NOTVICT);
+	act("You intone unholy words and a flaming brand appears on $N's forehead!", ch, nullptr, victim, TO_CHAR);
+	act("A wave of rage clouds your thoughts as $n chants in an unintelligible tongue.", ch, nullptr, victim, TO_VICT);
+	act("A flaming brand appears on $N's forehead, radiating malevolence.", ch, nullptr, victim, TO_NOTVICT);
 
 	init_affect(&af);
 	af.where = TO_AFFECTS;
@@ -788,8 +788,8 @@ void spell_living_blade(int /* sn */, int level, CHAR_DATA *ch, SpellTarget vo, 
 		return;
 	}
 
-	act("You call upon the power of Baal to imbue $p with a dark vitality.", ch, weapon, 0, TO_CHAR);
-	act("$p writhes briefly in $n's grasp.", ch, weapon, 0, TO_ROOM);
+	act("You call upon the power of Baal to imbue $p with a dark vitality.", ch, weapon, nullptr, TO_CHAR);
+	act("$p writhes briefly in $n's grasp.", ch, weapon, nullptr, TO_ROOM);
 
 	init_affect_obj(&oaf);
 	oaf.where = TO_OBJ_APPLY;
@@ -826,13 +826,13 @@ void living_blade_pulse(OBJ_DATA *obj, OBJ_AFFECT_DATA *af)
 			switch (number_range(1, 3))
 			{
 				case 1:
-					act("$p hisses at you: 'Insignificant whelp, you are unworthy of my power!'", ch, obj, 0, TO_CHAR);
+					act("$p hisses at you: 'Insignificant whelp, you are unworthy of my power!'", ch, obj, nullptr, TO_CHAR);
 					break;
 				case 2:
-					act("$p writhes in your grasp as you hear a faint cry of outrage.", ch, obj, 0, TO_CHAR);
+					act("$p writhes in your grasp as you hear a faint cry of outrage.", ch, obj, nullptr, TO_CHAR);
 					break;
 				case 3:
-					act("$p whispers menacingly: 'My master will devour your soul, blasphemer.'", ch, obj, 0, TO_CHAR);
+					act("$p whispers menacingly: 'My master will devour your soul, blasphemer.'", ch, obj, nullptr, TO_CHAR);
 					break;
 			}
 		}
@@ -869,7 +869,7 @@ void living_blade_pulse(OBJ_DATA *obj, OBJ_AFFECT_DATA *af)
 					break;
 			}
 
-			act("$p twists in your grasp, hissing caustically:", ch, obj, 0, TO_CHAR);
+			act("$p twists in your grasp, hissing caustically:", ch, obj, nullptr, TO_CHAR);
 			send_to_char(buf, ch);
 		}
 	}
@@ -941,13 +941,13 @@ void living_blade_pulse(OBJ_DATA *obj, OBJ_AFFECT_DATA *af)
 		switch (number_range(1, 3))
 		{
 			case 1:
-				act("A hollow laughter reaches your ears as $p pulses in your grasp.", ch, obj, 0, TO_CHAR);
+				act("A hollow laughter reaches your ears as $p pulses in your grasp.", ch, obj, nullptr, TO_CHAR);
 				break;
 			case 2:
-				act("$p writhes as you faintly hear sounds not unlike cries of carnal ecstasy.", ch, obj, 0, TO_CHAR);
+				act("$p writhes as you faintly hear sounds not unlike cries of carnal ecstasy.", ch, obj, nullptr, TO_CHAR);
 				break;
 			case 3:
-				act("$p cries with glee: 'Yes!  Yes!  Tear their heart out!'", ch, obj, 0, TO_CHAR);
+				act("$p cries with glee: 'Yes!  Yes!  Tear their heart out!'", ch, obj, nullptr, TO_CHAR);
 				break;
 		}
 	}
@@ -963,7 +963,7 @@ void living_blade_end(OBJ_DATA *obj, OBJ_AFFECT_DATA *af)
 	if (carrier == nullptr)
 		return;
 
-	act("$p ceases its slight writhing and seems less animated.", carrier, obj, 0, TO_CHAR);
+	act("$p ceases its slight writhing and seems less animated.", carrier, obj, nullptr, TO_CHAR);
 }
 
 void traitor_pulse(CHAR_DATA *ch, AFFECT_DATA *af)
@@ -1083,7 +1083,7 @@ void spell_dark_familiar(int /* sn */, int /* level */, CHAR_DATA *ch, SpellTarg
 		get_char_color(ch, "red"),
 		END_COLOR(ch));
 
-	act(buf, ch, 0, fam, TO_ALL);
+	act(buf, ch, nullptr, fam, TO_ALL);
 
 	init_affect(&af);
 	af.where = TO_AFFECTS;
@@ -1124,8 +1124,8 @@ void spell_unholy_communion(int /* sn */, int level, CHAR_DATA *ch, SpellTarget 
 		return;
 	}
 
-	act("A chill breeze sweeps through the area as the shadows flicker malevolently.", ch, 0, 0, TO_ROOM);
-	act("A sudden chill runs down your spine as you call upon the powers of darkness.", ch, 0, 0, TO_CHAR);
+	act("A chill breeze sweeps through the area as the shadows flicker malevolently.", ch, nullptr, nullptr, TO_ROOM);
+	act("A sudden chill runs down your spine as you call upon the powers of darkness.", ch, nullptr, nullptr, TO_CHAR);
 
 	init_affect(&af);
 	af.where = TO_AFFECTS;
@@ -1286,7 +1286,7 @@ void check_unholy_communion(CHAR_DATA *ch, char *argument)
 
 	WAIT_STATE(ch, 5 * PULSE_VIOLENCE);
 
-	act("As the name of the $t demon escapes your lips, the shadows writhe violently.", ch, (type == LESSER_DEMON) ? "lesser" : "greater", 0, TO_CHAR);
+	act("As the name of the $t demon escapes your lips, the shadows writhe violently.", ch, (type == LESSER_DEMON) ? "lesser" : "greater", nullptr, TO_CHAR);
 
 	RS.Queue.AddToQueue(2, "check_unholy_communion", "act_queue", act_queue, "A sonorous throbbing fills your surroundings, and then all is deathly silent.", ch, nullptr, nullptr, TO_ALL);
 
@@ -1308,22 +1308,22 @@ void demon_appear(CHAR_DATA *ch, int demon, int type)
 		{
 			case LESSER_BARBAS:
 				vnum = MOB_VNUM_BARBAS;
-				act("Frothing at the mouth, a livid lesser demon materializes before you!", ch, 0, 0, TO_ALL);
+				act("Frothing at the mouth, a livid lesser demon materializes before you!", ch, nullptr, nullptr, TO_ALL);
 				break;
 			case LESSER_AAMON:
 				vnum = MOB_VNUM_AAMON;
-				act("With a peal of laughter like the sound of a dying goat, a lesser demon appears!", ch, 0, 0, TO_ALL);
+				act("With a peal of laughter like the sound of a dying goat, a lesser demon appears!", ch, nullptr, nullptr, TO_ALL);
 				break;
 			case LESSER_MALAPHAR:
 				vnum = MOB_VNUM_MALAPHAR;
-				act("A well-dressed man with a wicked twinkle in his eye steps from the shadows!", ch, 0, 0, TO_ALL);
+				act("A well-dressed man with a wicked twinkle in his eye steps from the shadows!", ch, nullptr, nullptr, TO_ALL);
 				break;
 			case LESSER_FURCAS:
 				vnum = MOB_VNUM_FURCAS;
-				act("A shivering lesser demon materializes before you, keeping to the shadows.", ch, 0, 0, TO_ALL);
+				act("A shivering lesser demon materializes before you, keeping to the shadows.", ch, nullptr, nullptr, TO_ALL);
 				break;
 			case LESSER_IPOS:
-				act("With a soft 'pop' and a flash of subdued reddish light, a horned demon appears!", ch, 0, 0, TO_ALL);
+				act("With a soft 'pop' and a flash of subdued reddish light, a horned demon appears!", ch, nullptr, nullptr, TO_ALL);
 				vnum = MOB_VNUM_IPOS;
 				break;
 			default:
@@ -1337,23 +1337,23 @@ void demon_appear(CHAR_DATA *ch, int demon, int type)
 		switch (demon)
 		{
 			case GREATER_OZE:
-				act("With a great sucking sound and a fine mist of blood, a fearsome demon appears!", ch, 0, 0, TO_ALL);
+				act("With a great sucking sound and a fine mist of blood, a fearsome demon appears!", ch, nullptr, nullptr, TO_ALL);
 				vnum = MOB_VNUM_OZE;
 				break;
 			case GREATER_GAMYGYN:
-				act("A deceptively mellifluous chorus heralds the arrival of a massive darkened form!", ch, 0, 0, TO_ALL);
+				act("A deceptively mellifluous chorus heralds the arrival of a massive darkened form!", ch, nullptr, nullptr, TO_ALL);
 				vnum = MOB_VNUM_GAMYGYN;
 				break;
 			case GREATER_OROBAS:
-				act("In a flurry of blurred hands, feet, heads and hair, a gruesome demon appears!", ch, 0, 0, TO_ALL);
+				act("In a flurry of blurred hands, feet, heads and hair, a gruesome demon appears!", ch, nullptr, nullptr, TO_ALL);
 				vnum = MOB_VNUM_OROBAS;
 				break;
 			case GREATER_GERYON:
-				act("A swirl of mist rises and falls, revealing a terrible demon in its place!", ch, 0, 0, TO_ALL);
+				act("A swirl of mist rises and falls, revealing a terrible demon in its place!", ch, nullptr, nullptr, TO_ALL);
 				vnum = MOB_VNUM_GERYON;
 				break;
 			case GREATER_CIMERIES:
-				act("A huge demon materializes in mid-air and crashes unceremoniously to the ground.", ch, 0, 0, TO_ALL);
+				act("A huge demon materializes in mid-air and crashes unceremoniously to the ground.", ch, nullptr, nullptr, TO_ALL);
 				vnum = MOB_VNUM_CIMERIES;
 				break;
 			default:
@@ -1548,7 +1548,7 @@ void lesser_demon_tick(CHAR_DATA *mob, AFFECT_DATA *af)
 				sprintf(buf, "%s We give up... it cannnot find us... a pity, yes.  Goodbye, it.", Deref(af->owner)->name);
 				do_tell(mob, buf);
 
-				act("$n vanishes in a crimson flash!", mob, 0, 0, TO_ROOM);
+				act("$n vanishes in a crimson flash!", mob, nullptr, nullptr, TO_ROOM);
 
 				Deref(af->owner)->pcdata->lesserdata[LESSER_FURCAS] = FAVOR_FAILED;
 				extract_char(mob, true);
@@ -1580,7 +1580,7 @@ void lesser_demon_tick(CHAR_DATA *mob, AFFECT_DATA *af)
 			if (af->duration == 1)
 			{
 				do_say(mob, "My friend, I have better things to do with my time.  A pity.");
-				act("$n vanishes in a crimson flash!", mob, 0, 0, TO_ROOM);
+				act("$n vanishes in a crimson flash!", mob, nullptr, nullptr, TO_ROOM);
 
 				Deref(af->owner)->pcdata->lesserdata[LESSER_MALAPHAR] = FAVOR_FAILED;
 				extract_char(mob, true);
@@ -1590,7 +1590,7 @@ void lesser_demon_tick(CHAR_DATA *mob, AFFECT_DATA *af)
 			if (af->duration == 1)
 			{
 				do_say(mob, "I've better things to do with my time, than wait for you to mumble a rhyme!");
-				act("$n vanishes in a crimson flash!", mob, 0, 0, TO_ROOM);
+				act("$n vanishes in a crimson flash!", mob, nullptr, nullptr, TO_ROOM);
 
 				Deref(af->owner)->pcdata->lesserdata[LESSER_IPOS] = FAVOR_FAILED;
 				extract_char(mob, true);
@@ -1619,7 +1619,7 @@ void greater_demon_tick(CHAR_DATA *mob, AFFECT_DATA *af)
 
 			if (af->duration == 3)
 			{
-				act("Crying out suddenly, Oze begins to liquefy, giving off a hideous odor.", mob, 0, 0, TO_ROOM);
+				act("Crying out suddenly, Oze begins to liquefy, giving off a hideous odor.", mob, nullptr, nullptr, TO_ROOM);
 				break;
 			}
 
@@ -1628,7 +1628,7 @@ void greater_demon_tick(CHAR_DATA *mob, AFFECT_DATA *af)
 				sprintf(buf, "The abyss will not forget this treachery, %s.", Deref(af->owner)->name);
 				do_whisper(mob, buf);
 
-				act("The puddle of gore before you which was once a greater demon seeps downward.", mob, 0, 0, TO_ROOM);
+				act("The puddle of gore before you which was once a greater demon seeps downward.", mob, nullptr, nullptr, TO_ROOM);
 				Deref(af->owner)->pcdata->greaterdata[GREATER_OZE] = FAVOR_FAILED;
 
 				extract_char(mob, true);
@@ -1642,7 +1642,7 @@ void greater_demon_tick(CHAR_DATA *mob, AFFECT_DATA *af)
 				sprintf(buf, "%s You fool.  You utter fool.  You know not what power you have squandered.", Deref(af->owner)->name);
 				do_tell(mob, buf);
 
-				act("Flashing a great dark light, $n vanishes from sight.", mob, 0, 0, TO_ROOM);
+				act("Flashing a great dark light, $n vanishes from sight.", mob, nullptr, nullptr, TO_ROOM);
 				extract_char(mob, true);
 				break;
 			}
@@ -1654,7 +1654,7 @@ void greater_demon_tick(CHAR_DATA *mob, AFFECT_DATA *af)
 				sprintf(buf, "%s, you fool.  You utter fool.  You know not what power you have squandered!", Deref(af->owner)->name);
 				do_say(mob, buf);
 
-				act("With a fierce snarl, and many assorted whispers, Orobas streaks into the sky.", mob, 0, 0, TO_ROOM);
+				act("With a fierce snarl, and many assorted whispers, Orobas streaks into the sky.", mob, nullptr, nullptr, TO_ROOM);
 				extract_char(mob, true);
 				break;
 
@@ -1670,12 +1670,12 @@ void greater_demon_tick(CHAR_DATA *mob, AFFECT_DATA *af)
 
 			if (af->duration == 3)
 			{
-				act("Exploding suddenly, $n's face darkens and his eyes seethe an angry red!", mob, 0, 0, TO_ALL);
+				act("Exploding suddenly, $n's face darkens and his eyes seethe an angry red!", mob, nullptr, nullptr, TO_ALL);
 
 				do_yell(mob, "WHY, BY THE FIVE DEVILS, MUST I BE SADDLED WITH SUCH INCOMPETENCE?!");
 				do_emote(mob, "draws his howling visage close to your own, a mask of impenetrable hate.");
 
-				act("Very suddenly, the greater demon composes himself and smiles firmly once more.", mob, 0, 0, TO_ALL);
+				act("Very suddenly, the greater demon composes himself and smiles firmly once more.", mob, nullptr, nullptr, TO_ALL);
 				break;
 			}
 
@@ -1690,7 +1690,7 @@ void greater_demon_tick(CHAR_DATA *mob, AFFECT_DATA *af)
 			{
 				do_say(mob, "Very well, fool.  The lords of the abyss will hear of this.");
 
-				act("Turning coldly and melting into a cool mist, $n wafts away on a breeze.", mob, 0, 0, TO_ALL);
+				act("Turning coldly and melting into a cool mist, $n wafts away on a breeze.", mob, nullptr, nullptr, TO_ALL);
 
 				Deref(af->owner)->pcdata->greaterdata[GREATER_GERYON] = FAVOR_FAILED;
 
@@ -1707,15 +1707,15 @@ void greater_demon_tick(CHAR_DATA *mob, AFFECT_DATA *af)
 
 			if (af->duration == 2)
 			{
-				act("As blood trickles down your neck, your mind races to decide:  ear or nose?", mob, 0, Deref(af->owner),
+				act("As blood trickles down your neck, your mind races to decide:  ear or nose?", mob, nullptr, Deref(af->owner),
 					TO_VICT);
 				break;
 
 			}
 			if (af->duration == 1)
 			{
-				act("In disgust, $n rips his claws free and moves his massive frame back.", mob, 0, 0, TO_ROOM);
-				act("Slowly, the monstrous demon fades into shadows and dissipates.", mob, 0, 0, TO_ROOM);
+				act("In disgust, $n rips his claws free and moves his massive frame back.", mob, nullptr, nullptr, TO_ROOM);
+				act("Slowly, the monstrous demon fades into shadows and dissipates.", mob, nullptr, nullptr, TO_ROOM);
 
 				Deref(af->owner)->pcdata->greaterdata[GREATER_CIMERIES] = FAVOR_FAILED;
 				extract_char(mob, true);
@@ -1759,7 +1759,7 @@ void spell_insanity(int sn, int level, CHAR_DATA *ch, [[maybe_unused]] SpellTarg
 {
 	AFFECT_DATA af;
 
-	act("You feel a rush of dark power take over your body!", ch, 0, 0, TO_CHAR);
+	act("You feel a rush of dark power take over your body!", ch, nullptr, nullptr, TO_CHAR);
 
 	init_affect(&af);
 	af.where = TO_AFFECTS;
@@ -1813,27 +1813,27 @@ void insanity_pulse(CHAR_DATA *ch, [[maybe_unused]] AFFECT_DATA *af)
 		switch (number_range(1, 5))
 		{
 			case 1:
-				act("With a wild look in $s eyes, $n charges into battle!", ch, 0, 0, TO_ROOM);
-				act("A touch of froth escapes your lips as you charge into $N.", ch, 0, victim, TO_CHAR);
+				act("With a wild look in $s eyes, $n charges into battle!", ch, nullptr, nullptr, TO_ROOM);
+				act("A touch of froth escapes your lips as you charge into $N.", ch, nullptr, victim, TO_CHAR);
 				do_bash(ch, victim->name);
 				break;
 			case 2:
-				act("With a wild look in $s eyes, $n charges into battle!", ch, 0, 0, TO_ROOM);
-				act("A touch of froth escapes your lips as you charge into $N.", ch, 0, victim, TO_CHAR);
+				act("With a wild look in $s eyes, $n charges into battle!", ch, nullptr, nullptr, TO_ROOM);
+				act("A touch of froth escapes your lips as you charge into $N.", ch, nullptr, victim, TO_CHAR);
 				do_murder(ch, victim->name);
 				break;
 			case 3:
-				act("$n flashes a quick grin, $s eyes gleaming with a dark madness.", ch, 0, 0, TO_ROOM);
-				act("Coalesced energy erupts from $n's body, covering the area in flames.", ch, 0, 0, TO_ROOM);
-				act("You utter arcane words as a ball of fire erupts from your body.", ch, 0, 0, TO_CHAR);
+				act("$n flashes a quick grin, $s eyes gleaming with a dark madness.", ch, nullptr, nullptr, TO_ROOM);
+				act("Coalesced energy erupts from $n's body, covering the area in flames.", ch, nullptr, nullptr, TO_ROOM);
+				act("You utter arcane words as a ball of fire erupts from your body.", ch, nullptr, nullptr, TO_CHAR);
 				spell_fireball(skill_lookup("fireball"), ch->level, ch, SpellTarget(), CastMode::Spell);
 				break;
 			case 4:
 				insanity_two(ch, room);
 				break;
 			case 5:
-				act("With a wild look in $s eyes, $n charges into battle!", ch, 0, 0, TO_ROOM);
-				act("A touch of froth escapes your lips as you charge into $N.", ch, 0, victim, TO_CHAR);
+				act("With a wild look in $s eyes, $n charges into battle!", ch, nullptr, nullptr, TO_ROOM);
+				act("A touch of froth escapes your lips as you charge into $N.", ch, nullptr, victim, TO_CHAR);
 				do_cleave(ch, victim->name);
 				break;
 		}
@@ -1952,17 +1952,17 @@ void insanity_fight(CHAR_DATA *ch)
 			if (get_eq_char(ch, WEAR_WIELD) == nullptr)
 				break;
 
-			act("$n brutally drives $s weapon into your chest!", ch, 0, victim, TO_VICT);
-			act("You brutally drive your weapon into $N's chest!", ch, 0, victim, TO_CHAR);
-			act("$n brutally drives $s weapon into $N's chest!", ch, 0, victim, TO_NOTVICT);
+			act("$n brutally drives $s weapon into your chest!", ch, nullptr, victim, TO_VICT);
+			act("You brutally drive your weapon into $N's chest!", ch, nullptr, victim, TO_CHAR);
+			act("$n brutally drives $s weapon into $N's chest!", ch, nullptr, victim, TO_NOTVICT);
 
 			one_hit_new(ch, victim, TYPE_UNDEFINED, HIT_NOSPECIALS, HIT_UNBLOCKABLE, HIT_NOADD, 125, "crushing assault");
 
 			if (number_percent() > 25)
 			{
-				act("Your head hits the ground as $n sweeps your legs from under you.", ch, 0, victim, TO_VICT);
-				act("As $N recovers from your attack, you swiftly knock $S legs out from under $M.", ch, 0, victim, TO_CHAR);
-				act("As $N sways under the force of $n's attack, $n knocks $S legs out from under $M.", ch, 0, victim, TO_NOTVICT);
+				act("Your head hits the ground as $n sweeps your legs from under you.", ch, nullptr, victim, TO_VICT);
+				act("As $N recovers from your attack, you swiftly knock $S legs out from under $M.", ch, nullptr, victim, TO_CHAR);
+				act("As $N sways under the force of $n's attack, $n knocks $S legs out from under $M.", ch, nullptr, victim, TO_NOTVICT);
 
 				LAG_CHAR(victim, (int)(1.5 * PULSE_VIOLENCE));
 			}
@@ -1973,15 +1973,15 @@ void insanity_fight(CHAR_DATA *ch)
 			do_bash(ch, victim->name);
 			break;
 		case 3:
-			act("$n grunts and growls unintelligible words.", ch, 0, 0, TO_ROOM);
-			act("You grunt and growl unintelligible words.", ch, 0, 0, TO_CHAR);
+			act("$n grunts and growls unintelligible words.", ch, nullptr, nullptr, TO_ROOM);
+			act("You grunt and growl unintelligible words.", ch, nullptr, nullptr, TO_CHAR);
 			break;
 		case 4:
 			do_trip(ch, victim->name);
 			break;
 		case 5:
-			act("$n screams arcane words of power in a fit of rage.", ch, 0, 0, TO_ROOM);
-			act("As your insanity overtakes you, you scream arcane words in rage.", ch, 0, 0, TO_CHAR);
+			act("$n screams arcane words of power in a fit of rage.", ch, nullptr, nullptr, TO_ROOM);
+			act("As your insanity overtakes you, you scream arcane words in rage.", ch, nullptr, nullptr, TO_CHAR);
 
 			switch (number_range(0, 3))
 			{
@@ -1999,9 +1999,9 @@ void insanity_fight(CHAR_DATA *ch)
 					break;
 			}
 
-			act("As $n finishes $s incantation, $e charges you!", ch, 0, victim, TO_VICT);
-			act("As $n finishes $s incantation, $e charges $N!", ch, 0, victim, TO_NOTVICT);
-			act("Finishing your spell, you charge $N!", ch, 0, victim, TO_CHAR);
+			act("As $n finishes $s incantation, $e charges you!", ch, nullptr, victim, TO_VICT);
+			act("As $n finishes $s incantation, $e charges $N!", ch, nullptr, victim, TO_NOTVICT);
+			act("Finishing your spell, you charge $N!", ch, nullptr, victim, TO_CHAR);
 
 			do_bash(ch, victim->name);
 			break;
@@ -2026,12 +2026,12 @@ void gamygyn_tick(CHAR_DATA *ch, AFFECT_DATA *af)
 	{
 		WAIT_STATE(ch, PULSE_VIOLENCE * 2);
 
-		act("You feel a sudden wrenching pain from within, and collapse in agony.", ch, 0, 0, TO_CHAR);
-		act("$n's face twists in sudden agony as $e collapses to the ground, writhing.", ch, 0, 0, TO_ROOM);
-		act("Pure horror sweeps over you as you recall your bargain with the fiend Gamygyn!", ch, 0, 0, TO_CHAR);
-		act("A razor-clawed hand bursts from your belly as the world fades to black....", ch, 0, 0, TO_CHAR);
-		act("Blood fountains from $n's body as a clawed hand emerges from $s belly!", ch, 0, 0, TO_ROOM);
-		act("A dripping demon emerges from the mangled remains and vanishes into the earth.", ch, 0, 0, TO_ROOM);
+		act("You feel a sudden wrenching pain from within, and collapse in agony.", ch, nullptr, nullptr, TO_CHAR);
+		act("$n's face twists in sudden agony as $e collapses to the ground, writhing.", ch, nullptr, nullptr, TO_ROOM);
+		act("Pure horror sweeps over you as you recall your bargain with the fiend Gamygyn!", ch, nullptr, nullptr, TO_CHAR);
+		act("A razor-clawed hand bursts from your belly as the world fades to black....", ch, nullptr, nullptr, TO_CHAR);
+		act("Blood fountains from $n's body as a clawed hand emerges from $s belly!", ch, nullptr, nullptr, TO_ROOM);
+		act("A dripping demon emerges from the mangled remains and vanishes into the earth.", ch, nullptr, nullptr, TO_ROOM);
 
 		raw_kill(ch, ch);
 
@@ -2069,12 +2069,12 @@ void orobas_tick(CHAR_DATA *ch, AFFECT_DATA *af)
 
 	if (af->duration == 1)
 	{
-		act("You feel a sudden wrenching pain from within, and collapse in agony.", ch, 0, 0, TO_CHAR);
-		act("$n's face twists in sudden agony as $e collapses to the ground, writhing.", ch, 0, 0, TO_ROOM);
-		act("Pure horror sweeps over you as you recall your bargain with the fiend Orobas!", ch, 0, 0, TO_CHAR);
-		act("A razor-clawed hand bursts from your belly as the world fades to black....", ch, 0, 0, TO_CHAR);
-		act("Blood fountains from $n's body as a clawed hand emerges from $s belly!", ch, 0, 0, TO_ROOM);
-		act("A dripping demon emerges from the mangled remains and vanishes into the earth.", ch, 0, 0, TO_ROOM);
+		act("You feel a sudden wrenching pain from within, and collapse in agony.", ch, nullptr, nullptr, TO_CHAR);
+		act("$n's face twists in sudden agony as $e collapses to the ground, writhing.", ch, nullptr, nullptr, TO_ROOM);
+		act("Pure horror sweeps over you as you recall your bargain with the fiend Orobas!", ch, nullptr, nullptr, TO_CHAR);
+		act("A razor-clawed hand bursts from your belly as the world fades to black....", ch, nullptr, nullptr, TO_CHAR);
+		act("Blood fountains from $n's body as a clawed hand emerges from $s belly!", ch, nullptr, nullptr, TO_ROOM);
+		act("A dripping demon emerges from the mangled remains and vanishes into the earth.", ch, nullptr, nullptr, TO_ROOM);
 
 		raw_kill(ch, ch);
 
@@ -2144,8 +2144,8 @@ void do_breath_mephisto(CHAR_DATA *ch, char *argument)
 		return;
 	}
 
-	act("You begin building up the intense cold within you.", ch, 0, 0, TO_CHAR);
-	act("$n's skin shifts to a shade of blue.", ch, 0, 0, TO_ROOM);
+	act("You begin building up the intense cold within you.", ch, nullptr, nullptr, TO_CHAR);
+	act("$n's skin shifts to a shade of blue.", ch, nullptr, nullptr, TO_ROOM);
 
 	RS.Queue.AddToQueue(3, "do_breath_mephisto", "mephisto_two", mephisto_two, ch, victim, argument);
 }
@@ -2156,17 +2156,17 @@ void mephisto_two(CHAR_DATA *ch, CHAR_DATA *victim, char *argument)
 
 	if (!(Deref(ch->fighting)) && !(get_char_room(ch, argument)))
 	{
-		act("You let the intense cold dissipate, your target having escaped.", ch, 0, 0, TO_CHAR);
+		act("You let the intense cold dissipate, your target having escaped.", ch, nullptr, nullptr, TO_CHAR);
 		return;
 	}
 
-	act("$n opens $s mouth and a plume of deathly cold issues forth!", ch, 0, 0, TO_ROOM);
-	act("You open your mouth and unleash your icy fury!", ch, 0, 0, TO_CHAR);
+	act("$n opens $s mouth and a plume of deathly cold issues forth!", ch, nullptr, nullptr, TO_ROOM);
+	act("You open your mouth and unleash your icy fury!", ch, nullptr, nullptr, TO_CHAR);
 
 	damage_new(ch, victim, ch->level * 3, TYPE_UNDEFINED, DAM_COLD, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "icy breath");
 
-	act("$n freezes in $s tracks under the icy onslaught.", victim, 0, ch, TO_ROOM);
-	act("The intense cold shocks you into temporary immobility!", ch, 0, victim, TO_VICT);
+	act("$n freezes in $s tracks under the icy onslaught.", victim, nullptr, ch, TO_ROOM);
+	act("The intense cold shocks you into temporary immobility!", ch, nullptr, victim, TO_VICT);
 
 	WAIT_STATE(ch, PULSE_VIOLENCE * 2);
 	LAG_CHAR(victim, PULSE_VIOLENCE * 4);
@@ -2235,9 +2235,9 @@ void do_touch(CHAR_DATA *ch, char *argument)
 	{
 		WAIT_STATE(ch, PULSE_VIOLENCE * 2);
 
-		act("You reach out and lay your hand on $N as $E bursts into flames!", ch, 0, victim, TO_CHAR);
-		act("$n places his hand on you as you feel fire engulf your body!", ch, 0, victim, TO_VICT);
-		act("$n places his hand on $N as $N bursts into flames!", ch, 0, victim, TO_NOTVICT);
+		act("You reach out and lay your hand on $N as $E bursts into flames!", ch, nullptr, victim, TO_CHAR);
+		act("$n places his hand on you as you feel fire engulf your body!", ch, nullptr, victim, TO_VICT);
+		act("$n places his hand on $N as $N bursts into flames!", ch, nullptr, victim, TO_NOTVICT);
 
 		damage_new(ch, victim, ch->level * 2, TYPE_UNDEFINED, DAM_FIRE, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "burning touch");
 
@@ -2258,9 +2258,9 @@ void do_touch(CHAR_DATA *ch, char *argument)
 	}
 	else
 	{
-		act("You reach out for $N, but $E twists away from you.", ch, 0, victim, TO_CHAR);
-		act("$n reaches for you, but you twist away from $m.", ch, 0, victim, TO_VICT);
-		act("$n reaches for $N, but $E twists away from $m.", ch, 0, victim, TO_NOTVICT);
+		act("You reach out for $N, but $E twists away from you.", ch, nullptr, victim, TO_CHAR);
+		act("$n reaches for you, but you twist away from $m.", ch, nullptr, victim, TO_VICT);
+		act("$n reaches for $N, but $E twists away from $m.", ch, nullptr, victim, TO_NOTVICT);
 		WAIT_STATE(ch, PULSE_VIOLENCE * 2);
 	}
 }
@@ -2285,13 +2285,13 @@ void check_orobas_gamygyn(CHAR_DATA *ch, CHAR_DATA *victim)
 
 	if (is_affected(ch, gsn_orobas_soul) && victim->Class()->name == "anti-paladin")
 	{
-		act("With a sound of rending flesh, something tears itself from your body!", ch, 0, 0, TO_CHAR);
-		act("With a sound of rending flesh, something tears itself from $n's body!", ch, 0, 0, TO_ROOM);
-		act("You fall to your knees, bellowing in horror and pain!", ch, 0, 0, TO_CHAR);
-		act("$n falls to $s knees, bellowing in horror and pain!", ch, 0, 0, TO_ROOM);
-		act("A flailing multi-armed demon rends hungrily at $N's corpse with its many arms!", ch, 0, victim, TO_ALL);
-		act("Orobas turns to face you for a moment, and you feel infused with power!", ch, 0, 0, TO_CHAR);
-		act("The monstrosity streaks away in a blur, cradling the corpse in its hands.", ch, 0, 0, TO_ALL);
+		act("With a sound of rending flesh, something tears itself from your body!", ch, nullptr, nullptr, TO_CHAR);
+		act("With a sound of rending flesh, something tears itself from $n's body!", ch, nullptr, nullptr, TO_ROOM);
+		act("You fall to your knees, bellowing in horror and pain!", ch, nullptr, nullptr, TO_CHAR);
+		act("$n falls to $s knees, bellowing in horror and pain!", ch, nullptr, nullptr, TO_ROOM);
+		act("A flailing multi-armed demon rends hungrily at $N's corpse with its many arms!", ch, nullptr, victim, TO_ALL);
+		act("Orobas turns to face you for a moment, and you feel infused with power!", ch, nullptr, nullptr, TO_CHAR);
+		act("The monstrosity streaks away in a blur, cradling the corpse in its hands.", ch, nullptr, nullptr, TO_ALL);
 		ch->pcdata->greaterdata[GREATER_OROBAS] = FAVOR_GRANTED;
 		ch->pcdata->learned[skill_lookup("traitors luck")] = 1;
 		extract_obj(corpse);
@@ -2300,9 +2300,9 @@ void check_orobas_gamygyn(CHAR_DATA *ch, CHAR_DATA *victim)
 
 	if (is_affected(ch, gsn_gamygyn_soul) && is_good(victim))
 	{
-		act("With a terrible wail, a figure composed of gloomy light springs from your torso!", ch, 0, 0, TO_CHAR);
-		act("Suddenly, a figure composed of gloomy light springs from from $n's torso!", ch, 0, 0, TO_ROOM);
-		act("Leaping upon the fresh corpse, the fiend howls with delight and devours it.", ch, 0, 0, TO_ALL);
+		act("With a terrible wail, a figure composed of gloomy light springs from your torso!", ch, nullptr, nullptr, TO_CHAR);
+		act("Suddenly, a figure composed of gloomy light springs from from $n's torso!", ch, nullptr, nullptr, TO_ROOM);
+		act("Leaping upon the fresh corpse, the fiend howls with delight and devours it.", ch, nullptr, nullptr, TO_ALL);
 		extract_obj(corpse);
 
 		sprintf(buf, "Gamygyn tells you '%sYou have met your end of the bargain, mortal, and now I shall meet mine.%s'\n\r",
@@ -2311,7 +2311,7 @@ void check_orobas_gamygyn(CHAR_DATA *ch, CHAR_DATA *victim)
 
 		send_to_char(buf, ch);
 		send_to_char("You feel an influx of power at Gamygyn's words.\n\r", ch);
-		act("Enveloped in a black glow, the demon vanishes from sight.", ch, 0, 0, TO_ALL);
+		act("Enveloped in a black glow, the demon vanishes from sight.", ch, nullptr, nullptr, TO_ALL);
 
 		ch->pcdata->greaterdata[GREATER_GAMYGYN] = FAVOR_GRANTED;
 		ch->pcdata->learned[skill_lookup("bloodlust")] = 1;
@@ -2334,8 +2334,8 @@ void burning_pulse(CHAR_DATA *ch, AFFECT_DATA *af)
 	if (number_percent() > 50)
 		return;
 
-	act("You scream in pain as fire erupts from within your body!", ch, 0, 0, TO_CHAR);
-	act("$n screams in pain as fire erupts from within $s body!", ch, 0, 0, TO_ROOM);
+	act("You scream in pain as fire erupts from within your body!", ch, nullptr, nullptr, TO_CHAR);
+	act("$n screams in pain as fire erupts from within $s body!", ch, nullptr, nullptr, TO_ROOM);
 	damage_new(owner, ch, owner->level / 2, skill_lookup("burning touch"), DAM_FIRE, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "the consuming fire*");
 }
 
@@ -2379,7 +2379,7 @@ void do_darksight(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 
 	WAIT_STATE(ch, PULSE_VIOLENCE);
 
-	act("Dark power surges through your eyes as you focus upon the shadows.", ch, 0, 0, TO_CHAR);
+	act("Dark power surges through your eyes as you focus upon the shadows.", ch, nullptr, nullptr, TO_CHAR);
 	ch->mana -= 40;
 
 	init_affect(&af);
@@ -2462,9 +2462,9 @@ void spell_dark_insight(int /* sn */, int /* level */, CHAR_DATA *ch, SpellTarge
 	float dammod;
 	CHAR_DATA *victim = vo.AsChar();
 
-	act("You call upon the dark powers to reveal $N's weaknesses.", ch, 0, victim, TO_CHAR);
-	act("$n utters arcane words as $e looks you over.", ch, 0, victim, TO_VICT);
-	act("$n utters arcane words as $e looks $N over.", ch, 0, victim, TO_NOTVICT);
+	act("You call upon the dark powers to reveal $N's weaknesses.", ch, nullptr, victim, TO_CHAR);
+	act("$n utters arcane words as $e looks you over.", ch, nullptr, victim, TO_VICT);
+	act("$n utters arcane words as $e looks $N over.", ch, nullptr, victim, TO_NOTVICT);
 
 	act("$N appears to be resistant to $t.", ch, (char *)get_insight_line(victim->res_flags), victim, TO_CHAR);
 	found++;
@@ -2492,19 +2492,19 @@ void spell_dark_insight(int /* sn */, int /* level */, CHAR_DATA *ch, SpellTarge
 		dammod *= 1.3;
 
 	if (victim->dam_mod < 20)
-		act("$N is virtually impervious to harm!", ch, 0, victim, TO_CHAR);
+		act("$N is virtually impervious to harm!", ch, nullptr, victim, TO_CHAR);
 	else if (victim->dam_mod <= 40)
-		act("$N has extensive protection from all sorts of harm.", ch, 0, victim, TO_CHAR);
+		act("$N has extensive protection from all sorts of harm.", ch, nullptr, victim, TO_CHAR);
 	else if (victim->dam_mod <= 60)
-		act("$N is well protected from all sorts of harm.", ch, 0, victim, TO_CHAR);
+		act("$N is well protected from all sorts of harm.", ch, nullptr, victim, TO_CHAR);
 	else if (victim->dam_mod <= 80)
-		act("$N is somewhat protected from all sorts of harm.", ch, 0, victim, TO_CHAR);
+		act("$N is somewhat protected from all sorts of harm.", ch, nullptr, victim, TO_CHAR);
 	else if (victim->dam_mod <= 99)
-		act("$N's susceptibility to damage is slightly reduced.", ch, 0, victim, TO_CHAR);
+		act("$N's susceptibility to damage is slightly reduced.", ch, nullptr, victim, TO_CHAR);
 	else if (victim->dam_mod <= 100)
-		act("$N does not appear to have any special protections.", ch, 0, victim, TO_CHAR);
+		act("$N does not appear to have any special protections.", ch, nullptr, victim, TO_CHAR);
 	else
-		act("$N is highly susceptible to all damage.", ch, 0, victim, TO_CHAR);
+		act("$N is highly susceptible to all damage.", ch, nullptr, victim, TO_CHAR);
 
 	found++;
 

--- a/code/characterClasses/ap.c
+++ b/code/characterClasses/ap.c
@@ -1214,11 +1214,16 @@ void check_unholy_communion(CHAR_DATA *ch, char *argument)
 	{
 		DESCRIPTOR_DATA *d = walk.Current();
 
+		CHAR_DATA *wch = Deref(d->character);
+
+		if (wch == nullptr)
+			continue;
+
 		if (d->connected == CON_PLAYING 
-			&& !is_immortal(Deref(d->character))
-			&& !is_npc(Deref(d->character))
-			&& Deref(d->character)->in_room->area == ch->in_room->area
-			&& Deref(d->character) != ch)
+			&& !is_immortal(wch)
+			&& !is_npc(wch)
+			&& wch->in_room->area == ch->in_room->area
+			&& wch != ch)
 		{
 			send_to_char("A voice hisses in your mind: 'Ssssolitude, mortal.  There are othersss near...'\n\r", ch);
 			return;

--- a/code/characterClasses/ap.c
+++ b/code/characterClasses/ap.c
@@ -1529,6 +1529,23 @@ void demon_appear(CHAR_DATA *ch, int demon, int type)
 	}
 }
 
+// A pact's owner can be a mob, and pcdata is null for every NPC, so there is no
+// favor record to write to. The owner is resolved here rather than once at the
+// top of the callers because do_tell and act reach write_to_buffer, which can
+// close the socket and take the character with it.
+void set_pact_favor(AFFECT_DATA *af, bool greater, int demon, int favor)
+{
+	CHAR_DATA *owner = Deref(af->owner);
+
+	if (owner == nullptr || is_npc(owner))
+		return;
+
+	if (greater)
+		owner->pcdata->greaterdata[demon] = favor;
+	else
+		owner->pcdata->lesserdata[demon] = favor;
+}
+
 void lesser_demon_tick(CHAR_DATA *mob, AFFECT_DATA *af)
 {
 	char buf[MSL];
@@ -1555,7 +1572,7 @@ void lesser_demon_tick(CHAR_DATA *mob, AFFECT_DATA *af)
 
 				act("$n vanishes in a crimson flash!", mob, nullptr, nullptr, TO_ROOM);
 
-				Deref(af->owner)->pcdata->lesserdata[LESSER_FURCAS] = FAVOR_FAILED;
+				set_pact_favor(af, false, LESSER_FURCAS, FAVOR_FAILED);
 				extract_char(mob, true);
 			}
 
@@ -1587,7 +1604,7 @@ void lesser_demon_tick(CHAR_DATA *mob, AFFECT_DATA *af)
 				do_say(mob, "My friend, I have better things to do with my time.  A pity.");
 				act("$n vanishes in a crimson flash!", mob, nullptr, nullptr, TO_ROOM);
 
-				Deref(af->owner)->pcdata->lesserdata[LESSER_MALAPHAR] = FAVOR_FAILED;
+				set_pact_favor(af, false, LESSER_MALAPHAR, FAVOR_FAILED);
 				extract_char(mob, true);
 			}
 			break;
@@ -1597,7 +1614,7 @@ void lesser_demon_tick(CHAR_DATA *mob, AFFECT_DATA *af)
 				do_say(mob, "I've better things to do with my time, than wait for you to mumble a rhyme!");
 				act("$n vanishes in a crimson flash!", mob, nullptr, nullptr, TO_ROOM);
 
-				Deref(af->owner)->pcdata->lesserdata[LESSER_IPOS] = FAVOR_FAILED;
+				set_pact_favor(af, false, LESSER_IPOS, FAVOR_FAILED);
 				extract_char(mob, true);
 			}
 			break;
@@ -1634,7 +1651,7 @@ void greater_demon_tick(CHAR_DATA *mob, AFFECT_DATA *af)
 				do_whisper(mob, buf);
 
 				act("The puddle of gore before you which was once a greater demon seeps downward.", mob, nullptr, nullptr, TO_ROOM);
-				Deref(af->owner)->pcdata->greaterdata[GREATER_OZE] = FAVOR_FAILED;
+				set_pact_favor(af, true, GREATER_OZE, FAVOR_FAILED);
 
 				extract_char(mob, true);
 				break;
@@ -1697,7 +1714,7 @@ void greater_demon_tick(CHAR_DATA *mob, AFFECT_DATA *af)
 
 				act("Turning coldly and melting into a cool mist, $n wafts away on a breeze.", mob, nullptr, nullptr, TO_ALL);
 
-				Deref(af->owner)->pcdata->greaterdata[GREATER_GERYON] = FAVOR_FAILED;
+				set_pact_favor(af, true, GREATER_GERYON, FAVOR_FAILED);
 
 				extract_char(mob, true);
 				break;
@@ -1722,7 +1739,7 @@ void greater_demon_tick(CHAR_DATA *mob, AFFECT_DATA *af)
 				act("In disgust, $n rips his claws free and moves his massive frame back.", mob, nullptr, nullptr, TO_ROOM);
 				act("Slowly, the monstrous demon fades into shadows and dissipates.", mob, nullptr, nullptr, TO_ROOM);
 
-				Deref(af->owner)->pcdata->greaterdata[GREATER_CIMERIES] = FAVOR_FAILED;
+				set_pact_favor(af, true, GREATER_CIMERIES, FAVOR_FAILED);
 				extract_char(mob, true);
 			}
 			break;
@@ -2325,17 +2342,18 @@ void check_orobas_gamygyn(CHAR_DATA *ch, CHAR_DATA *victim)
 
 void burning_pulse(CHAR_DATA *ch, AFFECT_DATA *af)
 {
-	// TODO: owner is null once the character who lit the burn is gone, and
-	// owner->level below is read without a guard, so the pulse dereferences
-	// null. The fix is not mechanical because the owner's level is the only
-	// thing scaling the damage. Ending the burn early is one answer, and it
-	// matches what the mark of wrath and the track listing now do with a
-	// vanished owner. Letting it burn on is the other, and that needs a source
-	// to attribute the damage to, because damage_new reads ch->level itself and
-	// is_npc returns false for null rather than guarding it. The affect already
-	// carries a finite duration, so this decides the ticks in between rather
-	// than whether the burn ever stops. Needs a game design decision.
 	CHAR_DATA *owner = Deref(af->owner);
+
+	// The owner is gone once the character who lit the burn has been extracted,
+	// and everything below needs them. Their level is the only thing scaling
+	// the damage, and damage_new reads the source's own level besides, so there
+	// is no attacker to attribute a hit to. The burn stops doing anything and
+	// runs out its remaining duration quietly, which is what a mark of wrath
+	// with a vanished owner does in the track listing. Removing the affect here
+	// instead would mean mutating the list this tick is being walked from.
+	if (owner == nullptr)
+		return;
+
 	if (number_percent() > 50)
 		return;
 

--- a/code/characterClasses/ap.h
+++ b/code/characterClasses/ap.h
@@ -37,6 +37,7 @@ void spell_unholy_communion (int sn, int level, CHAR_DATA *ch, SpellTarget vo, C
 void communion_end (CHAR_DATA *ch, AFFECT_DATA *af);
 void check_unholy_communion (CHAR_DATA *ch, char *argument);
 void demon_appear (CHAR_DATA *ch, int demon, int type);
+void set_pact_favor (AFFECT_DATA *af, bool greater, int demon, int favor);
 void lesser_demon_tick (CHAR_DATA *mob, AFFECT_DATA *af);
 void greater_demon_tick (CHAR_DATA *mob, AFFECT_DATA *af);
 void furcas_vanish (CHAR_DATA *ch, CHAR_DATA *mob);

--- a/code/characterClasses/chrono.c
+++ b/code/characterClasses/chrono.c
@@ -354,7 +354,10 @@ void do_rune(CHAR_DATA *ch, char *argument)
 	{
 		vo = (ROOM_INDEX_DATA *)ch->in_room;
 		act("$n moves $s hands slowly, tracing a glowing rune in midair.", ch, nullptr, nullptr, TO_ROOM);
-		act("Slowly tracing a glowing pattern in front of you, you create a rune in midair.", ch, pexit->keyword, nullptr, TO_CHAR);
+		// A room rune has no door, so pexit is still null on this path. The
+		// message carries no $t either, so the argument was only ever read and
+		// discarded, which is why the crash was in the read rather than the act.
+		act("Slowly tracing a glowing pattern in front of you, you create a rune in midair.", ch, nullptr, nullptr, TO_CHAR);
 	}
 	else
 	{

--- a/code/characterClasses/chrono.c
+++ b/code/characterClasses/chrono.c
@@ -64,8 +64,8 @@ void spell_stasis_wall(int sn, int level, CHAR_DATA *ch, SpellTarget vo, CastMod
 		rune.function = trigger_stasis_wall; // this is what's called when the rune is triggered
 		apply_rune(&rune);
 
-		act("$n gestures and an immovable barrier snaps into existence to the $t!", ch, direction_table[dir].name, 0, TO_ROOM);
-		act("You gesture and a stasis wall forms to the $t!", ch, direction_table[dir].name, 0, TO_CHAR);
+		act("$n gestures and an immovable barrier snaps into existence to the $t!", ch, direction_table[dir].name, nullptr, TO_ROOM);
+		act("You gesture and a stasis wall forms to the $t!", ch, direction_table[dir].name, nullptr, TO_CHAR);
 		return;
 	}
 
@@ -115,8 +115,8 @@ bool trigger_stasis_wall(void *vo, void *vo2, void *vo3, [[maybe_unused]] void *
 	if (is_safe_new(ch, victim, false))
 		return false;
 
-	act("You try to move to the $t but a stasis wall flickers and holds you back!", victim, direction_table[dir].name, 0, TO_CHAR);
-	act("$n tries to move to the $t but is halted by a stasis wall!", victim, direction_table[dir].name, 0, TO_ROOM);
+	act("You try to move to the $t but a stasis wall flickers and holds you back!", victim, direction_table[dir].name, nullptr, TO_CHAR);
+	act("$n tries to move to the $t but is halted by a stasis wall!", victim, direction_table[dir].name, nullptr, TO_ROOM);
 
 	return true;
 }
@@ -145,8 +145,8 @@ bool activate_stasis_wall(void *vo, void *vo2, void *vo3, [[maybe_unused]] void 
 	if (is_safe_new(ch, victim, false))
 		return false;
 
-	act("As you pass through the $t, a stasis wall snaps into existence behind you!", victim, pexit->keyword, 0, TO_CHAR);
-	act("As $n passes through the $t, a stasis wall snaps into existence behind $m!", victim, pexit->keyword, 0, TO_ROOM);
+	act("As you pass through the $t, a stasis wall snaps into existence behind you!", victim, pexit->keyword, nullptr, TO_CHAR);
+	act("As $n passes through the $t, a stasis wall snaps into existence behind $m!", victim, pexit->keyword, nullptr, TO_ROOM);
 
 	new_rune.level = rune->level;
 	new_rune.placed_on = pexit;
@@ -185,12 +185,12 @@ void draw_rune(std::unique_ptr<RUNE_DATA> rune)
 
 	if (number_percent() > get_skill(ch, rune->type))
 	{
-		act("The rune flares brightly before vanishing!", ch, 0, 0, TO_ROOM);
+		act("The rune flares brightly before vanishing!", ch, nullptr, nullptr, TO_ROOM);
 		send_to_char("The improperly scribed rune flares brightly before vanishing!\n\r", ch);
 		return;
 	}
 
-	act("The rune flares $t!", ch, skill_table[rune->type].msg_off, 0, TO_ALL);
+	act("The rune flares $t!", ch, skill_table[rune->type].msg_off, nullptr, TO_ALL);
 	apply_rune(rune.get());
 }
 
@@ -334,8 +334,8 @@ void do_rune(CHAR_DATA *ch, char *argument)
 
 		vo = obj;
 
-		act("$n carefully begins to scribe an intricate rune on $p.", ch, obj, 0, TO_ROOM);
-		act("You carefully begin to scribe an intricate rune on $p.", ch, obj, 0, TO_CHAR);
+		act("$n carefully begins to scribe an intricate rune on $p.", ch, obj, nullptr, TO_ROOM);
+		act("You carefully begin to scribe an intricate rune on $p.", ch, obj, nullptr, TO_CHAR);
 	}
 	else if (target == RUNE_DOOR)
 	{
@@ -347,14 +347,14 @@ void do_rune(CHAR_DATA *ch, char *argument)
 
 		vo = SpellTarget::Direction(where);
 
-		act("$n carefully begins to scribe an intricate rune on the $t.", ch, strcmp(pexit->keyword, "") ? pexit->keyword : "door", 0, TO_ROOM);
-		act("You carefully begin to scribe an intricate rune on the $t.", ch, strcmp(pexit->keyword, "") ? pexit->keyword : "door", 0, TO_CHAR);
+		act("$n carefully begins to scribe an intricate rune on the $t.", ch, strcmp(pexit->keyword, "") ? pexit->keyword : "door", nullptr, TO_ROOM);
+		act("You carefully begin to scribe an intricate rune on the $t.", ch, strcmp(pexit->keyword, "") ? pexit->keyword : "door", nullptr, TO_CHAR);
 	}
 	else if (target == RUNE_ROOM)
 	{
 		vo = (ROOM_INDEX_DATA *)ch->in_room;
-		act("$n moves $s hands slowly, tracing a glowing rune in midair.", ch, 0, 0, TO_ROOM);
-		act("Slowly tracing a glowing pattern in front of you, you create a rune in midair.", ch, pexit->keyword, 0, TO_CHAR);
+		act("$n moves $s hands slowly, tracing a glowing rune in midair.", ch, nullptr, nullptr, TO_ROOM);
+		act("Slowly tracing a glowing pattern in front of you, you create a rune in midair.", ch, pexit->keyword, nullptr, TO_CHAR);
 	}
 	else
 	{
@@ -372,7 +372,7 @@ void do_rune(CHAR_DATA *ch, char *argument)
 	ch->mana -= mana;
 	if (IS_SET(ch->in_room->room_flags, ROOM_NO_MAGIC) && !(ch->level > LEVEL_HERO))
 	{
-		act("$n's spell fizzles.", ch, 0, 0, TO_ROOM);
+		act("$n's spell fizzles.", ch, nullptr, nullptr, TO_ROOM);
 		send_to_char("Your spell fizzles and dies.\n\r", ch);
 		return;
 	}

--- a/code/characterClasses/healer.c
+++ b/code/characterClasses/healer.c
@@ -37,14 +37,14 @@ void spell_healing_sleep(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[may
 
 	if (ch != victim)
 	{
-		act("You put $N into a deep healing sleep.", ch, 0, victim, TO_CHAR);
-		act("You fall into a deep healing sleep.", ch, 0, victim, TO_VICT);
-		act("$N falls into a deep healing sleep.", ch, 0, victim, TO_NOTVICT);
+		act("You put $N into a deep healing sleep.", ch, nullptr, victim, TO_CHAR);
+		act("You fall into a deep healing sleep.", ch, nullptr, victim, TO_VICT);
+		act("$N falls into a deep healing sleep.", ch, nullptr, victim, TO_NOTVICT);
 	}
 	else
 	{
-		act("You put yourself into a deep healing sleep.", ch, 0, 0, TO_CHAR);
-		act("$n falls into a deep healing sleep.", ch, 0, 0, TO_ROOM);
+		act("You put yourself into a deep healing sleep.", ch, nullptr, nullptr, TO_CHAR);
+		act("$n falls into a deep healing sleep.", ch, nullptr, nullptr, TO_ROOM);
 	}
 
 	victim->position = POS_SLEEPING;
@@ -82,6 +82,6 @@ void healing_sleep_end(CHAR_DATA *ch, [[maybe_unused]] AFFECT_DATA *af)
 	ch->mana = ch->max_mana;
 	ch->move = ch->max_move;
 
-	act("You wake up feeling completely healed and cured of all ailments.", ch, 0, 0, TO_CHAR);
-	act("$n wakes and looks to be completely healed.", ch, 0, 0, TO_ROOM);
+	act("You wake up feeling completely healed and cured of all ailments.", ch, nullptr, nullptr, TO_CHAR);
+	act("$n wakes and looks to be completely healed.", ch, nullptr, nullptr, TO_ROOM);
 }

--- a/code/characterClasses/necro.c
+++ b/code/characterClasses/necro.c
@@ -915,7 +915,7 @@ void ritual_four(CHAR_DATA *ch, CHAR_DATA *victim)
 
 void spell_ritual_flesh(int /* sn */, int /* level */, CHAR_DATA *ch, SpellTarget vo, CastMode /* mode */)
 {
-	CHAR_DATA *search, *victim = vo.AsChar();
+	CHAR_DATA *victim = vo.AsChar();
 
 	for (OwningListWalk<CHAR_DATA> walk(char_list); !walk.Done(); walk.Step())
 	{

--- a/code/characterClasses/necro.c
+++ b/code/characterClasses/necro.c
@@ -82,7 +82,7 @@ void spell_dark_vessel(int /* sn */, int /* level */, CHAR_DATA *ch, SpellTarget
 
 	WAIT_STATE(ch, PULSE_VIOLENCE * 2);
 
-	act("$n plunges a hand into $p's chest cavity, and removes the heart.", ch, corpse, 0, TO_ROOM);
+	act("$n plunges a hand into $p's chest cavity, and removes the heart.", ch, corpse, nullptr, TO_ROOM);
 
 	RS.Queue.AddToQueue(2, "spell_dark_vessel", "act_queue", act_queue, "$n holds the heart aloft as it visibly begins to harden.", ch, nullptr, nullptr, TO_ROOM);
 	send_to_char("You remove the corpse's heart and squeeze the blood out of it, hardening it into a solid object.\n\r", ch);
@@ -101,8 +101,8 @@ void make_urn(CHAR_DATA *ch, OBJ_DATA *corpse)
 {
 	char buf[MSL];
 
-	act("When this morbid sculpting is complete, $n is holding a solid receptacle.", ch, 0, 0, TO_ROOM);
-	act("You craft a morbid urn from the coagulated blood of $p!", ch, corpse, 0, TO_CHAR);
+	act("When this morbid sculpting is complete, $n is holding a solid receptacle.", ch, nullptr, nullptr, TO_ROOM);
+	act("You craft a morbid urn from the coagulated blood of $p!", ch, corpse, nullptr, TO_CHAR);
 
 	if (corpse->item_type == ITEM_CORPSE_NPC)
 	{
@@ -207,9 +207,9 @@ void spell_siphon([[maybe_unused]] int sn, int level, CHAR_DATA *ch, SpellTarget
 		return;
 	}
 
-	act("$n siphons the blood from $N's body in a sudden crimson burst!", ch, 0, victim, TO_NOTVICT);
-	act("$n siphons the blood right out of your body in a crimson burst!", ch, 0, victim, TO_VICT);
-	act("You siphon the blood out of $N's body in a crimson burst!", ch, 0, victim, TO_CHAR);
+	act("$n siphons the blood from $N's body in a sudden crimson burst!", ch, nullptr, victim, TO_NOTVICT);
+	act("$n siphons the blood right out of your body in a crimson burst!", ch, nullptr, victim, TO_VICT);
+	act("You siphon the blood out of $N's body in a crimson burst!", ch, nullptr, victim, TO_CHAR);
 
 	damage_new(ch, victim, dam, TYPE_UNDEFINED, DAM_NEGATIVE, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "siphoning");
 
@@ -241,17 +241,17 @@ void spell_hex(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]
 	if (is_affected(victim, sn))
 		return send_to_char("They are already hexed.\n\r", ch);
 
-	act("$n grins maniacally and spits out an archaic word, unleashing a hex upon $N!", ch, 0, victim, TO_NOTVICT);
-	act("$n grins maniacally and spits out an archaic word, unleashing a hex upon you!", ch, 0, victim, TO_VICT);
-	act("You grin maniacally and spit out an archaic word, unleashing a hex upon $N!", ch, 0, victim, TO_CHAR);
+	act("$n grins maniacally and spits out an archaic word, unleashing a hex upon $N!", ch, nullptr, victim, TO_NOTVICT);
+	act("$n grins maniacally and spits out an archaic word, unleashing a hex upon you!", ch, nullptr, victim, TO_VICT);
+	act("You grin maniacally and spit out an archaic word, unleashing a hex upon $N!", ch, nullptr, victim, TO_CHAR);
 
 	chance = get_skill(ch, sn);
 	roll = number_percent();
 
 	if (saves_spell(level + 2, victim, DAM_NEGATIVE) && ((chance * 0.80) < roll))
 	{
-		act("$n staggers for a moment, but resists the hex.", victim, 0, 0, TO_ROOM);
-		act("You stagger as the power of the hex strikes you, but manage to resist it.", victim, 0, 0, TO_CHAR);
+		act("$n staggers for a moment, but resists the hex.", victim, nullptr, nullptr, TO_ROOM);
+		act("You stagger as the power of the hex strikes you, but manage to resist it.", victim, nullptr, nullptr, TO_CHAR);
 		return;
 	}
 
@@ -313,17 +313,17 @@ void spell_hex(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]
 
 	if (severity > 1 && severity < 4)
 	{
-		act("$n sags as the hex strikes him powerfully!", victim, 0, 0, TO_ROOM);
-		act("You slump as the hex strikes you powerfully.", victim, 0, 0, TO_CHAR);
+		act("$n sags as the hex strikes him powerfully!", victim, nullptr, nullptr, TO_ROOM);
+		act("You slump as the hex strikes you powerfully.", victim, nullptr, nullptr, TO_CHAR);
 	}
 
 	if (severity == 4)
 	{
-		act("$n screams in utter agony as the full power of the hex strangles $s soul!", victim, 0, 0, TO_ROOM);
-		act("You scream in utter agony as the full power of the hex strangles your soul!", victim, 0, 0, TO_CHAR);
+		act("$n screams in utter agony as the full power of the hex strangles $s soul!", victim, nullptr, nullptr, TO_ROOM);
+		act("You scream in utter agony as the full power of the hex strangles your soul!", victim, nullptr, nullptr, TO_CHAR);
 	}
 
-	act("You feel drained from the power of your hex.", ch, 0, 0, TO_CHAR);
+	act("You feel drained from the power of your hex.", ch, nullptr, nullptr, TO_CHAR);
 	drain_factor = 1 - (0.97 - (0.035 * severity));
 	drain = (int)(drain_factor * ch->hit);
 	ch->hit -= drain;
@@ -400,8 +400,8 @@ void spell_animate_dead(int sn, int level, CHAR_DATA *ch, SpellTarget /* vo */, 
 
 	ch->disrupted= false;
 
-	act("You kneel before $p, chanting softly in an arcane language.", ch, corpse, 0, TO_CHAR);
-	act("$n kneels before $p, chanting softly in an unintelligible language.", ch, corpse, 0, TO_ROOM);
+	act("You kneel before $p, chanting softly in an arcane language.", ch, corpse, nullptr, TO_CHAR);
+	act("$n kneels before $p, chanting softly in an unintelligible language.", ch, corpse, nullptr, TO_ROOM);
 
 	RS.Queue.AddToQueue(2, "spell_animate_dead", "animate_two", animate_two, ch, corpse);
 }
@@ -483,7 +483,7 @@ void animate_four(CHAR_DATA *ch, OBJ_DATA *corpse)
 
 	if (number_percent() > corpse->value[4])
 	{
-		act("The magics fail to take hold, leaving the corpse a worthless pile of entrails.", ch, 0, 0, TO_CHAR);
+		act("The magics fail to take hold, leaving the corpse a worthless pile of entrails.", ch, nullptr, nullptr, TO_CHAR);
 		act("$n's efforts to animate $p result only in a disgusting pile of entrails.", ch, corpse, nullptr, TO_ROOM);
 
 		extract_obj(corpse);
@@ -500,8 +500,8 @@ void animate_four(CHAR_DATA *ch, OBJ_DATA *corpse)
 	af.location = 0;
 	affect_to_char(ch, &af);
 
-	act("$p convulses slightly and rises to its feet to serve $n!", ch, corpse, 0, TO_ROOM);
-	act("$p convulses slightly and rises to its feet to serve you!", ch, corpse, 0, TO_CHAR);
+	act("$p convulses slightly and rises to its feet to serve $n!", ch, corpse, nullptr, TO_ROOM);
+	act("$p convulses slightly and rises to its feet to serve you!", ch, corpse, nullptr, TO_CHAR);
 
 	ch->wait = 0;
 
@@ -519,9 +519,9 @@ void animate_four(CHAR_DATA *ch, OBJ_DATA *corpse)
 	if (corpse->item_type == ITEM_CORPSE_PC && corpse->level > 25)
 		soul_add(ch, 1);
 	else if (corpse->item_type == ITEM_CORPSE_PC && corpse->level <= 25)
-		act("The essence of $p was too weak for your studies.", ch, corpse, 0, TO_CHAR);
+		act("The essence of $p was too weak for your studies.", ch, corpse, nullptr, TO_CHAR);
 	else
-		act("The raising was successful, but $p had no soul to steal.", ch, corpse, 0, TO_CHAR);
+		act("The raising was successful, but $p had no soul to steal.", ch, corpse, nullptr, TO_CHAR);
 
 	zombie->hit = zombie->max_hit;
 	zombie->damage[DICE_NUMBER] = (corpse->level - ((int)(corpse->level / 2.5)));
@@ -602,8 +602,8 @@ void spell_black_circle(int sn, int /* level */, CHAR_DATA *ch, SpellTarget /* v
 	if (is_affected(ch, sn))
 		return send_to_char("You cannot summon your minions again yet.\n\r", ch);
 
-	act("$n draws a black circle on the ground and falls into deep concentration.", ch, 0, 0, TO_ROOM);
-	act("You draw a black circle on the ground and fall into deep concentration.", ch, 0, 0, TO_CHAR);
+	act("$n draws a black circle on the ground and falls into deep concentration.", ch, nullptr, nullptr, TO_ROOM);
+	act("You draw a black circle on the ground and fall into deep concentration.", ch, nullptr, nullptr, TO_CHAR);
 
 	for (OwningListWalk<CHAR_DATA> walk(char_list); !walk.Done(); walk.Step())
 	{
@@ -613,13 +613,13 @@ void spell_black_circle(int sn, int /* level */, CHAR_DATA *ch, SpellTarget /* v
 		{
 			stop_fighting(pet, true);
 
-			act("$n disappears suddenly.", pet, 0, 0, TO_ROOM);
+			act("$n disappears suddenly.", pet, nullptr, nullptr, TO_ROOM);
 
 			char_from_room(pet);
 			char_to_room(pet, ch->in_room);
 
 			act("$N arrives suddenly, kneeling before you outside the circle.", ch, nullptr, pet, TO_CHAR);
-			act("$N arrives suddenly, kneeling before $n outside the circle.", ch, 0, pet, TO_ROOM);
+			act("$N arrives suddenly, kneeling before $n outside the circle.", ch, nullptr, pet, TO_ROOM);
 
 			found = true;
 		}
@@ -687,8 +687,8 @@ void spell_visceral(int sn, int /* level */, CHAR_DATA *ch, SpellTarget /* vo */
 
 	ch->disrupted= false;
 
-	act("$n slices open three corpses, spreading their entrails upon the ground.", ch, 0, 0, TO_ROOM);
-	act("You slice open three corpses, spreading their entrails upon the ground.", ch, 0, 0, TO_CHAR);
+	act("$n slices open three corpses, spreading their entrails upon the ground.", ch, nullptr, nullptr, TO_ROOM);
+	act("You slice open three corpses, spreading their entrails upon the ground.", ch, nullptr, nullptr, TO_CHAR);
 
 	RS.Queue.AddToQueue(6, "spell_visceral", "visceral_two", visceral_two, ch);
 }
@@ -702,8 +702,8 @@ void visceral_two(CHAR_DATA *ch)
 		return;
 	}
 
-	act("Upon this gore, $n pours a generous amount of blood, saturating it.", ch, 0, 0, TO_ROOM);
-	act("Upon this gore, you pour a generous amount of blood, saturating it.", ch, 0, 0, TO_CHAR);
+	act("Upon this gore, $n pours a generous amount of blood, saturating it.", ch, nullptr, nullptr, TO_ROOM);
+	act("Upon this gore, you pour a generous amount of blood, saturating it.", ch, nullptr, nullptr, TO_CHAR);
 
 	RS.Queue.AddToQueue(6, "visceral_two", "visceral_three", visceral_three, ch);
 }
@@ -725,8 +725,8 @@ void visceral_three(CHAR_DATA *ch)
 		return;
 	}
 
-	act("$n and $s minions blissfully writhe in the carnage, praising the Dark Gods.", ch, 0, 0, TO_ROOM);
-	act("You blissfully writhe in the carnage, praising the Dark Gods.", ch, 0, 0, TO_CHAR);
+	act("$n and $s minions blissfully writhe in the carnage, praising the Dark Gods.", ch, nullptr, nullptr, TO_ROOM);
+	act("You blissfully writhe in the carnage, praising the Dark Gods.", ch, nullptr, nullptr, TO_CHAR);
 
 	RS.Queue.AddToQueue(6, "visceral_three", "visceral_four", visceral_four, ch);
 }
@@ -750,8 +750,8 @@ void visceral_four(CHAR_DATA *ch)
 		return;
 	}
 
-	act("Emerging from this loathsome orgy, $n and $s creatures surge with new strength.", ch, 0, 0, TO_ROOM);
-	act("Emerging from this loathsome orgy, you feel new strength surge through you.", ch, 0, 0, TO_CHAR);
+	act("Emerging from this loathsome orgy, $n and $s creatures surge with new strength.", ch, nullptr, nullptr, TO_ROOM);
+	act("Emerging from this loathsome orgy, you feel new strength surge through you.", ch, nullptr, nullptr, TO_CHAR);
 
 	init_affect(&af);
 	af.where = TO_AFFECTS;
@@ -776,7 +776,7 @@ void visceral_four(CHAR_DATA *ch)
 			af.location = APPLY_DAMROLL;
 			af.modifier = (ch->level / 2) - 5;
 			affect_to_char(mob, &af);
-			act("$n's eyes glow with unholy fervor.", mob, 0, 0, TO_ROOM);
+			act("$n's eyes glow with unholy fervor.", mob, nullptr, nullptr, TO_ROOM);
 		}
 	}
 }
@@ -810,8 +810,8 @@ void spell_ritual_soul(int /* sn */, int /* level */, CHAR_DATA *ch, SpellTarget
 
 	ch->disrupted= false;
 
-	act("$n begins to spread out some infernal relics and charms.", ch, 0, 0, TO_ROOM);
-	act("You begin to spread out some infernal relics and charms.", ch, 0, 0, TO_CHAR);
+	act("$n begins to spread out some infernal relics and charms.", ch, nullptr, nullptr, TO_ROOM);
+	act("You begin to spread out some infernal relics and charms.", ch, nullptr, nullptr, TO_CHAR);
 
 	RS.Queue.AddToQueue(3, "spell_ritual_soul", "ritual_two", ritual_two, ch, victim);
 }
@@ -829,8 +829,8 @@ void ritual_two(CHAR_DATA *ch, CHAR_DATA *victim)
 		return;
 	}
 
-	act("$n pours some blood onto the floor from $s urn, and chants quietly.", ch, 0, 0, TO_ROOM);
-	act("You spill out blood from your urn, chanting softly in an arcane tongue.", ch, 0, 0, TO_CHAR);
+	act("$n pours some blood onto the floor from $s urn, and chants quietly.", ch, nullptr, nullptr, TO_ROOM);
+	act("You spill out blood from your urn, chanting softly in an arcane tongue.", ch, nullptr, nullptr, TO_CHAR);
 
 	RS.Queue.AddToQueue(3, "ritual_two", "ritual_three", ritual_three, ch, victim);
 }
@@ -848,8 +848,8 @@ void ritual_three(CHAR_DATA *ch, CHAR_DATA *victim)
 		return;
 	}
 
-	act("$n calls upon the dark gods, and forfeits part of $s spirit in unholy sacrifice!", ch, 0, victim, TO_ROOM);
-	act("You forfeit part of your spirit in an unholy sacrifice before the Dark Gods!", ch, 0, 0, TO_CHAR);
+	act("$n calls upon the dark gods, and forfeits part of $s spirit in unholy sacrifice!", ch, nullptr, victim, TO_ROOM);
+	act("You forfeit part of your spirit in an unholy sacrifice before the Dark Gods!", ch, nullptr, nullptr, TO_CHAR);
 
 	ch->mana = (short)(ch->mana * .8);
 	ch->move = (short)(ch->move * .5);
@@ -874,8 +874,8 @@ void ritual_four(CHAR_DATA *ch, CHAR_DATA *victim)
 		return;
 	}
 
-	act("$n points at $N and the rotting body crumbles to ashes!", ch, 0, victim, TO_ROOM);
-	act("You point at $N and the rotting body crumbles to ashes!", ch, 0, victim, TO_CHAR);
+	act("$n points at $N and the rotting body crumbles to ashes!", ch, nullptr, victim, TO_ROOM);
+	act("You point at $N and the rotting body crumbles to ashes!", ch, nullptr, victim, TO_CHAR);
 
 	mob = create_mobile(get_mob_index(number_range(2940, 2942)));
 
@@ -897,7 +897,7 @@ void ritual_four(CHAR_DATA *ch, CHAR_DATA *victim)
 
 	extract_char(victim, true);
 
-	act("From the ashes rises $n!", mob, 0, ch, TO_ALL);
+	act("From the ashes rises $n!", mob, nullptr, ch, TO_ALL);
 
 	add_follower(mob, ch);
 
@@ -943,7 +943,7 @@ void spell_ritual_flesh(int /* sn */, int /* level */, CHAR_DATA *ch, SpellTarge
 	ch->disrupted= false;
 
 	RS.Queue.AddToQueue(3, "spell_ritual_flesh", "flesh_two", flesh_two, ch, victim);
-	act("You prepare to make an unholy sacrifice to the Dark Gods!", ch, 0, 0, TO_CHAR);
+	act("You prepare to make an unholy sacrifice to the Dark Gods!", ch, nullptr, nullptr, TO_CHAR);
 }
 
 void flesh_two(CHAR_DATA *ch, CHAR_DATA *victim)
@@ -955,8 +955,8 @@ void flesh_two(CHAR_DATA *ch, CHAR_DATA *victim)
 		return;
 	}
 
-	act("$n pours blood onto the floor, chanting softly in an undecipherable tongue.", ch, 0, 0, TO_ROOM);
-	act("You pour blood onto the floor, chanting softly in an arcane tongue.", ch, 0, 0, TO_CHAR);
+	act("$n pours blood onto the floor, chanting softly in an undecipherable tongue.", ch, nullptr, nullptr, TO_ROOM);
+	act("You pour blood onto the floor, chanting softly in an arcane tongue.", ch, nullptr, nullptr, TO_CHAR);
 
 	RS.Queue.AddToQueue(3, "flesh_two", "flesh_three", flesh_three, ch, victim);
 }
@@ -972,8 +972,8 @@ void flesh_three(CHAR_DATA *ch, CHAR_DATA *victim)
 		ch->disrupted = true;
 	}
 
-	act("$n calls upon the Dark Gods and forfeits part of $s vitality in sacrifice!", ch, 0, 0, TO_ROOM);
-	act("You call upon the Dark Gods and offer part of your vitality as sacrifice!", ch, 0, 0, TO_CHAR);
+	act("$n calls upon the Dark Gods and forfeits part of $s vitality in sacrifice!", ch, nullptr, nullptr, TO_ROOM);
+	act("You call upon the Dark Gods and offer part of your vitality as sacrifice!", ch, nullptr, nullptr, TO_CHAR);
 
 	ch->hit = (short)(ch->hit * 0.8);
 
@@ -1009,8 +1009,8 @@ void flesh_four(CHAR_DATA *ch, CHAR_DATA *victim)
 	mob->damage[DICE_TYPE] = 2;
 	mob->damroll = victim->level - URANGE(-50, (short)(2.5 * (victim->level - ch->level)), 50);
 
-	act("$n points at $N and its rotting body crumbles into grey ashes.", ch, 0, victim, TO_ROOM);
-	act("You point at $N and its rotting body crumbles into ashes.", ch, 0, victim, TO_CHAR);
+	act("$n points at $N and its rotting body crumbles into grey ashes.", ch, nullptr, victim, TO_ROOM);
+	act("You point at $N and its rotting body crumbles into ashes.", ch, nullptr, victim, TO_CHAR);
 
 	if (is_affected(victim, gsn_unholy_bond))
 	{
@@ -1024,8 +1024,8 @@ void flesh_four(CHAR_DATA *ch, CHAR_DATA *victim)
 
 	extract_char(victim, true);
 
-	act("Suddenly, the pile of ashes is scattered as $N arises to kneel before you!", ch, 0, mob, TO_CHAR);
-	act("Suddenly, the pile of ashes is scattered as $N arises to kneel before $n!", ch, 0, mob, TO_ROOM);
+	act("Suddenly, the pile of ashes is scattered as $N arises to kneel before you!", ch, nullptr, mob, TO_CHAR);
+	act("Suddenly, the pile of ashes is scattered as $N arises to kneel before $n!", ch, nullptr, mob, TO_ROOM);
 
 	add_follower(mob, ch);
 
@@ -1052,9 +1052,9 @@ void spell_decrepify(int sn, [[maybe_unused]] int level, CHAR_DATA *ch, SpellTar
 	if (saves_spell(ch->level, victim, DAM_MENTAL))
 		mv /= 2;
 
-	act("$N suddenly looks very worn out.", 0, 0, victim, TO_NOTVICT);
-	act("You suddenly feel sluggish.", ch, 0, victim, TO_VICT);
-	act("$N suddenly looks very worn out.", ch, 0, victim, TO_CHAR);
+	act("$N suddenly looks very worn out.", 0, nullptr, victim, TO_NOTVICT);
+	act("You suddenly feel sluggish.", ch, nullptr, victim, TO_VICT);
+	act("$N suddenly looks very worn out.", ch, nullptr, victim, TO_CHAR);
 
 	victim->move -= mv;
 
@@ -1149,7 +1149,7 @@ void spell_corrupt_flesh(int sn, int /* level */, CHAR_DATA *ch, SpellTarget /* 
 	{
 		if (!(obj2 = get_eq_char(victim, WEAR_WIELD)))
 		{
-			act("$N is not wielding a weapon.", ch, 0, victim, TO_CHAR);
+			act("$N is not wielding a weapon.", ch, nullptr, victim, TO_CHAR);
 			return;
 		}
 
@@ -1246,8 +1246,8 @@ void spell_corrupt_flesh(int sn, int /* level */, CHAR_DATA *ch, SpellTarget /* 
 
 		char_to_room(mob, ch->in_room);
 
-		act("The flesh of $p withers away rapidly as you sap its remaining life force.", ch, obj, 0, TO_CHAR);
-		act("The flesh of $p withers away rapidly, leaving $n holding a putrid skull.", ch, obj, 0, TO_ROOM);
+		act("The flesh of $p withers away rapidly as you sap its remaining life force.", ch, obj, nullptr, TO_CHAR);
+		act("The flesh of $p withers away rapidly, leaving $n holding a putrid skull.", ch, obj, nullptr, TO_ROOM);
 
 		obj_from_char(obj);
 		extract_obj(obj);
@@ -1304,7 +1304,7 @@ void spell_corpse_trap(int sn, int /* level */, CHAR_DATA *ch, SpellTarget /* vo
 	if (number_percent() > chance)
 	{
 		send_to_char("Your magic accelerates the decaying process too quickly, destroying the corpse.\n\r", ch);
-		act("$p decays rapidly, leaving nothing but dust.", ch, corpse, 0, TO_ROOM);
+		act("$p decays rapidly, leaving nothing but dust.", ch, corpse, nullptr, TO_ROOM);
 
 		extract_obj(corpse);
 		return;
@@ -1319,8 +1319,8 @@ void spell_corpse_trap(int sn, int /* level */, CHAR_DATA *ch, SpellTarget /* vo
 
 	SET_BIT(trap->extra_flags, CORPSE_NO_ANIMATE);
 
-	act("You carefully accelerate the decay rate of $p, preparing it to explode.", ch, corpse, 0, TO_CHAR);
-	act("$p's skin begins to wrinkle and fold.", ch, corpse, 0, TO_ROOM);
+	act("You carefully accelerate the decay rate of $p, preparing it to explode.", ch, corpse, nullptr, TO_CHAR);
+	act("$p's skin begins to wrinkle and fold.", ch, corpse, nullptr, TO_ROOM);
 
 	extract_obj(corpse);
 	obj_to_room(trap, ch->in_room);
@@ -1448,8 +1448,8 @@ void spell_lesser_golem(int sn, int /* level */, CHAR_DATA *ch, SpellTarget /* v
 
 	char_to_room(mob, ch->in_room);
 
-	act("$n pours some blood on the floor.  It begins shifting and changing, finally forming $N!", ch, 0, mob, TO_ROOM);
-	act("You pour some blood on the floor.  It begins shifting and changing, finally forming $N!", ch, 0, mob, TO_CHAR);
+	act("$n pours some blood on the floor.  It begins shifting and changing, finally forming $N!", ch, nullptr, mob, TO_ROOM);
+	act("You pour some blood on the floor.  It begins shifting and changing, finally forming $N!", ch, nullptr, mob, TO_CHAR);
 }
 
 void spell_greater_golem(int sn, int /* level */, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
@@ -1520,8 +1520,8 @@ void spell_greater_golem(int sn, int /* level */, CHAR_DATA *ch, SpellTarget /* 
 
 		vnum = 2961;
 
-		act("$n fashions a golem from a lifeless hunk of glass!", ch, 0, 0, TO_ROOM);
-		act("You fashion a golem from $p.", ch, obj, 0, TO_CHAR);
+		act("$n fashions a golem from a lifeless hunk of glass!", ch, nullptr, nullptr, TO_ROOM);
+		act("You fashion a golem from $p.", ch, obj, nullptr, TO_CHAR);
 		extract_obj(obj);
 	}
 
@@ -1535,8 +1535,8 @@ void spell_greater_golem(int sn, int /* level */, CHAR_DATA *ch, SpellTarget /* 
 
 		vnum = 2959;
 
-		act("$n fashions a golem from a mass of stone!", ch, 0, 0, TO_ROOM);
-		act("You fashion a golem from a mass of stone.", ch, 0, 0, TO_CHAR);
+		act("$n fashions a golem from a mass of stone!", ch, nullptr, nullptr, TO_ROOM);
+		act("You fashion a golem from a mass of stone.", ch, nullptr, nullptr, TO_CHAR);
 	}
 
 	if (!str_cmp(type, "shadow"))
@@ -1549,8 +1549,8 @@ void spell_greater_golem(int sn, int /* level */, CHAR_DATA *ch, SpellTarget /* 
 
 		vnum = 2960;
 
-		act("$n gives life to the shadows around him!", ch, 0, 0, TO_ROOM);
-		act("You give life to the shadows around you.", ch, 0, 0, TO_CHAR);
+		act("$n gives life to the shadows around him!", ch, nullptr, nullptr, TO_ROOM);
+		act("You give life to the shadows around you.", ch, nullptr, nullptr, TO_CHAR);
 	}
 
 	init_affect(&af);
@@ -1631,8 +1631,8 @@ void do_drain(CHAR_DATA *ch, char *argument)
 
 	if (chance > number_percent())
 	{
-		act("You successfully drain $p of its blood!", ch, corpse, 0, TO_CHAR);
-		act("$n crouches over $p, chanting softly as $e desiccates it.", ch, corpse, 0, TO_ROOM);
+		act("You successfully drain $p of its blood!", ch, corpse, nullptr, TO_CHAR);
+		act("$n crouches over $p, chanting softly as $e desiccates it.", ch, corpse, nullptr, TO_ROOM);
 
 		long modifier = corpse->item_type == ITEM_CORPSE_PC ? 4 : 8;
 		long minBloodScore = 1;
@@ -1650,8 +1650,8 @@ void do_drain(CHAR_DATA *ch, char *argument)
 	}
 	else
 	{
-		act("You fail to drain the blood of $p and render it useless!", ch, corpse, 0, TO_CHAR);
-		act("$n attempts to drain the blood from $p, but ruins it, blood spilling everywhere.", ch, corpse, 0, TO_ROOM);
+		act("You fail to drain the blood of $p and render it useless!", ch, corpse, nullptr, TO_CHAR);
+		act("$n attempts to drain the blood from $p, but ruins it, blood spilling everywhere.", ch, corpse, nullptr, TO_ROOM);
 
 		SET_BIT(corpse->extra_flags, CORPSE_NO_ANIMATE);
 
@@ -1676,9 +1676,9 @@ bool check_bond(CHAR_DATA *ch, CHAR_DATA *mob)
 		af.aftype = AFT_SKILL;
 		affect_to_char(mob, &af);
 
-		act("The zombie's eyes suddenly flare a deep crimson, which rapidly fades away.", ch, 0, mob, TO_ROOM);
-		act("The zombie's eyes suddenly flare a deep crimson, which rapidly fades away.", ch, 0, mob, TO_CHAR);
-		act("You form a successful bond with $N!", ch, 0, mob, TO_CHAR);
+		act("The zombie's eyes suddenly flare a deep crimson, which rapidly fades away.", ch, nullptr, mob, TO_ROOM);
+		act("The zombie's eyes suddenly flare a deep crimson, which rapidly fades away.", ch, nullptr, mob, TO_CHAR);
+		act("You form a successful bond with $N!", ch, nullptr, mob, TO_CHAR);
 
 		check_improve(ch, gsn_unholy_bond, true, 1);
 		return true;
@@ -1708,10 +1708,10 @@ bool check_zombie_summon(CHAR_DATA *ch)
 				return false;
 
 			stop_fighting(mob, true);
-			act("$n disappears suddenly.", mob, 0, 0, TO_ROOM);
+			act("$n disappears suddenly.", mob, nullptr, nullptr, TO_ROOM);
 			char_from_room(mob);
 			char_to_room(mob, ch->in_room);
-			act("$n arrives suddenly.", mob, 0, 0, TO_ROOM);
+			act("$n arrives suddenly.", mob, nullptr, nullptr, TO_ROOM);
 			return true;
 		}
 	}

--- a/code/characterClasses/paladin.c
+++ b/code/characterClasses/paladin.c
@@ -82,8 +82,8 @@ void spell_rites_of_preparation(int sn, int /* level */, CHAR_DATA *ch, SpellTar
 	}
 	else
 	{
-		act("You recite some prayers to those in your party, bolstering their confidence and preparing them for battle.", ch, 0, 0, TO_CHAR);
-		act("$n recites some prayers in a loud and confident voice, preparing you for righteous battle.", ch, 0, 0, TO_GROUP);
+		act("You recite some prayers to those in your party, bolstering their confidence and preparing them for battle.", ch, nullptr, nullptr, TO_CHAR);
+		act("$n recites some prayers in a loud and confident voice, preparing you for righteous battle.", ch, nullptr, nullptr, TO_GROUP);
 
 		init_affect(&af);
 		af.where = TO_AFFECTS;
@@ -110,21 +110,21 @@ void spell_spiritual_hammer(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[
 
 	if (is_evil(victim))
 	{
-		act("A brilliant hammer descends from the heavens, striking you with great force!", ch, 0, victim, TO_VICT);
-		act("A brilliant hammer descends from the heavens, striking $N with great force!", ch, 0, victim, TO_NOTVICT);
+		act("A brilliant hammer descends from the heavens, striking you with great force!", ch, nullptr, victim, TO_VICT);
+		act("A brilliant hammer descends from the heavens, striking $N with great force!", ch, nullptr, victim, TO_NOTVICT);
 		dam *= 1.5;
 	}
 	else if (is_good(victim))
 	{
-		act("A flickering hammer fades into existence above you and hesitantly descends.", ch, 0, victim, TO_VICT);
-		act("A flickering hammer fades into existence above $N and slowly descends upon $M.", ch, 0, victim,
+		act("A flickering hammer fades into existence above you and hesitantly descends.", ch, nullptr, victim, TO_VICT);
+		act("A flickering hammer fades into existence above $N and slowly descends upon $M.", ch, nullptr, victim,
 			TO_NOTVICT);
 		dam *= .3;
 	}
 	else
 	{
-		act("A great hammer fades into existence above you and strikes down!", ch, 0, victim, TO_VICT);
-		act("A great hammer fades into existence above $N and strikes down!", ch, 0, victim, TO_NOTVICT);
+		act("A great hammer fades into existence above you and strikes down!", ch, nullptr, victim, TO_VICT);
+		act("A great hammer fades into existence above $N and strikes down!", ch, nullptr, victim, TO_NOTVICT);
 	}
 
 	if (saves_spell(level, victim, DAM_HOLY))
@@ -160,8 +160,8 @@ void do_turn_undead(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 		return;
 	}
 
-	act("You raise your hands aloft and extend an aura of purity about you.", ch, 0, 0, TO_CHAR);
-	act("$n raises $s hands aloft, and a faint aura billows out from $s form.", ch, 0, 0, TO_ROOM);
+	act("You raise your hands aloft and extend an aura of purity about you.", ch, nullptr, nullptr, TO_CHAR);
+	act("$n raises $s hands aloft, and a faint aura billows out from $s form.", ch, nullptr, nullptr, TO_ROOM);
 
 	for (victim = ch->in_room->people; victim != nullptr; victim = v_next)
 	{
@@ -175,21 +175,21 @@ void do_turn_undead(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 			set_fighting(ch, victim);
 		if (difference >= 10 && is_npc(victim))
 		{
-			act("Horrible screams of undeath fill the air as $n is reduced to scattered ashes by brilliant white flames.", victim, 0, ch, TO_ROOM);
+			act("Horrible screams of undeath fill the air as $n is reduced to scattered ashes by brilliant white flames.", victim, nullptr, ch, TO_ROOM);
 			raw_kill(ch, victim);
 			forceflee= false;
 		}
 		else if (difference > 1)
 		{
 			dam = dice(ch->level, 20);
-			act("$n is suddenly engulfed by holy fire!", victim, 0, ch, TO_ROOM);
+			act("$n is suddenly engulfed by holy fire!", victim, nullptr, ch, TO_ROOM);
 			damage_new(ch, victim, dam, gsn_turn_undead, DAM_HOLY, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, nullptr);
 			forceflee = true;
 		}
 		else if (difference > -5)
 		{
 			dam = dice(ch->level, 10);
-			act("$n is burned by holy fire!", victim, 0, ch, TO_ROOM);
+			act("$n is burned by holy fire!", victim, nullptr, ch, TO_ROOM);
 
 			if (number_percent() > 50)
 				forceflee = true;
@@ -200,8 +200,8 @@ void do_turn_undead(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 		{
 			if (!is_affected_by(victim, AFF_CHARM))
 			{
-				act("$N shrieks in unholy fury and bounds toward you!", ch, 0, victim, TO_CHAR);
-				act("$n shrieks in unholy fury and bounds toward $N!", victim, 0, ch, TO_ROOM);
+				act("$N shrieks in unholy fury and bounds toward you!", ch, nullptr, victim, TO_CHAR);
+				act("$n shrieks in unholy fury and bounds toward $N!", victim, nullptr, ch, TO_ROOM);
 				multi_hit(victim, ch, TYPE_UNDEFINED);
 				forceflee= false;
 			}
@@ -213,8 +213,8 @@ void do_turn_undead(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 
 		if (forceflee == true && !IS_SET(victim->act, ACT_SENTINEL))
 		{
-			act("$n shambles away in hopes of escaping $N's holy aura!", victim, 0, ch, TO_ROOM);
-			act("$n shambles away from your holy presence!", ch, 0, victim, TO_CHAR);
+			act("$n shambles away in hopes of escaping $N's holy aura!", victim, nullptr, ch, TO_ROOM);
+			act("$n shambles away from your holy presence!", ch, nullptr, victim, TO_CHAR);
 			do_flee(victim, "");
 		}
 	}
@@ -238,7 +238,7 @@ bool check_benevolence(CHAR_DATA *ch, CHAR_DATA *keeper)
 	if (number_percent() > get_skill(ch, gsn_benevolence))
 		return false;
 
-	act("$N smiles warmly at you and bows slightly, offering you a large discount.", ch, 0, keeper, TO_CHAR);
+	act("$N smiles warmly at you and bows slightly, offering you a large discount.", ch, nullptr, keeper, TO_CHAR);
 
 	return true;
 }
@@ -306,17 +306,17 @@ bool check_intercept(CHAR_DATA *ch, CHAR_DATA *victim, CHAR_DATA *paladin, int d
 	sprintf(buf1, "You thrust your shield between %s's %s and $N.",
 		is_npc(ch) ? ch->short_descr : ch->name,
 		attack);
-	act(buf1, paladin, 0, victim, TO_CHAR);
+	act(buf1, paladin, nullptr, victim, TO_CHAR);
 
 	sprintf(buf2, "%s thrusts $s shield in front of you, deflecting $N's %s.",
 		is_npc(paladin) ? paladin->short_descr : paladin->name,
 		attack);
-	act(buf2, victim, 0, ch, TO_CHAR);
+	act(buf2, victim, nullptr, ch, TO_CHAR);
 
 	sprintf(buf3, "$n thrusts $s shield in front of %s, deflecting your %s.",
 		is_npc(victim) ? victim->short_descr : victim->name,
 		attack);
-	act(buf3, ch, 0, paladin, TO_CHAR);
+	act(buf3, ch, nullptr, paladin, TO_CHAR);
 
 	check_improve(paladin, gsn_intercept, true, 4);
 	return true;
@@ -328,8 +328,8 @@ void spell_blinding_orb(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[mayb
 	AFFECT_DATA af;
 	int dam, hitroll, duration, b_hitroll, b_duration;
 
-	act("You bring forth an orb of blinding light to sear the eyes of your foes!", ch, 0, 0, TO_CHAR);
-	act("$n calls forth a brilliant orb of radiant light!", ch, 0, 0, TO_ROOM);
+	act("You bring forth an orb of blinding light to sear the eyes of your foes!", ch, nullptr, nullptr, TO_CHAR);
+	act("$n calls forth a brilliant orb of radiant light!", ch, nullptr, nullptr, TO_ROOM);
 
 	for (victim = ch->in_room->people; victim != nullptr; victim = vch_next)
 	{
@@ -378,8 +378,8 @@ void spell_blinding_orb(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[mayb
 
 		if (!saves_spell(ch->level, victim, DAM_LIGHT) && !is_affected_by(victim, AFF_BLIND))
 		{
-			act("$n falters as the light sears $s eyes.", victim, 0, ch, TO_ROOM);
-			act("You are blinded by the bright light!", ch, 0, victim, TO_VICT);
+			act("$n falters as the light sears $s eyes.", victim, nullptr, ch, TO_ROOM);
+			act("You are blinded by the bright light!", ch, nullptr, victim, TO_VICT);
 
 			init_affect(&af);
 			af.where = TO_AFFECTS;
@@ -400,8 +400,8 @@ void spell_voice_of_damnation(int sn, int /* level */, CHAR_DATA *ch, SpellTarge
 {
 	CHAR_DATA *victim = vo.AsChar(), *vch_next;
 
-	act("Imbued with the strength of your god, you threaten those around you with eternal damnation!", ch, 0, victim, TO_CHAR);
-	act("$N shouts threats of damnation in a strange and powerful voice!", victim, 0, ch, TO_ROOM);
+	act("Imbued with the strength of your god, you threaten those around you with eternal damnation!", ch, nullptr, victim, TO_CHAR);
+	act("$N shouts threats of damnation in a strange and powerful voice!", victim, nullptr, ch, TO_ROOM);
 
 	for (victim = ch->in_room->people; victim != nullptr; victim = vch_next)
 	{
@@ -419,11 +419,11 @@ void spell_voice_of_damnation(int sn, int /* level */, CHAR_DATA *ch, SpellTarge
 			|| (!is_npc(victim) && (is_good(victim) || is_neutral(victim))
 				&& (victim->pcdata->kills[PK_GOOD] <= victim->pcdata->kills[PK_EVIL])))
 		{
-			act("Knowing that you have not persecuted the righteous in the past, you are not concerned.", ch, 0, victim, TO_VICT);
+			act("Knowing that you have not persecuted the righteous in the past, you are not concerned.", ch, nullptr, victim, TO_VICT);
 			continue;
 		}
 
-		act("The terrifying voice resounds in your head, filling you with fear about your fate!", ch, 0, victim, TO_VICT);
+		act("The terrifying voice resounds in your head, filling you with fear about your fate!", ch, nullptr, victim, TO_VICT);
 		damage_new(ch, victim, dice(ch->level, 5), sn, DAM_MENTAL, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, nullptr);
 		WAIT_STATE(victim, PULSE_VIOLENCE * 1);
 	}
@@ -446,8 +446,8 @@ void spell_seraphic_mantle(int sn, int /* level */, CHAR_DATA *ch, SpellTarget v
 		return;
 	}
 
-	act("A shining mantle of light descends upon your shoulders, protecting you from harm.", ch, 0, 0, TO_CHAR);
-	act("A shining mantle of light descends upon $n, lending $m an angelic presence.", ch, 0, 0, TO_ROOM);
+	act("A shining mantle of light descends upon your shoulders, protecting you from harm.", ch, nullptr, nullptr, TO_CHAR);
+	act("A shining mantle of light descends upon $n, lending $m an angelic presence.", ch, nullptr, nullptr, TO_ROOM);
 
 	init_affect(&af);
 	af.aftype = AFT_COMMUNE;
@@ -514,8 +514,8 @@ void spell_arms_of_light(int sn, int level, CHAR_DATA *ch, SpellTarget /* vo */,
 	oaf.owner = ch->self;
 	affect_to_obj(weapon, &oaf);
 
-	act("A bright glow begins to emanate from $n's $p.", ch, weapon, 0, TO_ROOM);
-	act("You enchant $p with holy light.", ch, weapon, 0, TO_CHAR);
+	act("A bright glow begins to emanate from $n's $p.", ch, weapon, nullptr, TO_ROOM);
+	act("You enchant $p with holy light.", ch, weapon, nullptr, TO_CHAR);
 
 	init_affect(&af);
 	af.where = TO_AFFECTS;
@@ -575,8 +575,8 @@ void spell_arms_of_purity(int sn, int level, CHAR_DATA *ch, SpellTarget /* vo */
 	oaf.owner = ch->self;
 	affect_to_obj(weapon, &oaf);
 
-	act("Rippling waves of warm energy play up and down $n's $p.", ch, weapon, 0, TO_ROOM);
-	act("You enchant $p with righteous purity.", ch, weapon, 0, TO_CHAR);
+	act("Rippling waves of warm energy play up and down $n's $p.", ch, weapon, nullptr, TO_ROOM);
+	act("You enchant $p with righteous purity.", ch, weapon, nullptr, TO_CHAR);
 
 	init_affect(&af);
 	af.where = TO_AFFECTS;
@@ -638,8 +638,8 @@ void spell_arms_of_wrath(int sn, int level, CHAR_DATA *ch, SpellTarget /* vo */,
 	oaf.owner = ch->self;
 	affect_to_obj(weapon, &oaf);
 
-	act("$n's $p is set ablaze with white flames!", ch, weapon, 0, TO_ROOM);
-	act("You enchant $p with holy wrath.", ch, weapon, 0, TO_CHAR);
+	act("$n's $p is set ablaze with white flames!", ch, weapon, nullptr, TO_ROOM);
+	act("You enchant $p with holy wrath.", ch, weapon, nullptr, TO_CHAR);
 
 	init_affect(&af);
 	af.where = TO_AFFECTS;
@@ -700,8 +700,8 @@ void spell_arms_of_judgement(int sn, int level, CHAR_DATA *ch, SpellTarget /* vo
 	oaf.owner = ch->self;
 	affect_to_obj(weapon, &oaf);
 
-	act("Bright golden light radiates from $n's $p!", ch, weapon, 0, TO_ROOM);
-	act("You enchant $p with the power of divine judgement.", ch, weapon, 0, TO_CHAR);
+	act("Bright golden light radiates from $n's $p!", ch, weapon, nullptr, TO_ROOM);
+	act("You enchant $p with the power of divine judgement.", ch, weapon, nullptr, TO_CHAR);
 
 	init_affect(&af);
 	af.where = TO_AFFECTS;
@@ -737,15 +737,15 @@ void do_strike_of_virtue(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 
 	if (get_skill(ch, gsn_strike_of_virtue) * .85 > number_percent())
 	{
-		act("$n brings $s $p around for a particularly brutal blow!", ch, weapon, 0, TO_ROOM);
-		act("You deliver a brutal blow to $N!", ch, 0, victim, TO_CHAR);
+		act("$n brings $s $p around for a particularly brutal blow!", ch, weapon, nullptr, TO_ROOM);
+		act("You deliver a brutal blow to $N!", ch, nullptr, victim, TO_CHAR);
 
 		one_hit_new(ch, victim, gsn_strike_of_virtue, HIT_SPECIALS, HIT_UNBLOCKABLE, HIT_NOADD, 125, nullptr);
 		check_improve(ch, gsn_strike_of_virtue, true, 1);
 	}
 	else
 	{
-		act("You swing hard, but fail to connect with your opponent.", ch, 0, 0, TO_CHAR);
+		act("You swing hard, but fail to connect with your opponent.", ch, nullptr, nullptr, TO_CHAR);
 		damage(ch, victim, 0, gsn_strike_of_virtue, DAM_NONE, true);
 		check_improve(ch, gsn_strike_of_virtue, false, 1);
 	}
@@ -763,8 +763,8 @@ void spell_divine_frenzy(int sn, int /* level */, CHAR_DATA *ch, SpellTarget /* 
 		return;
 	}
 
-	act("You go into a vengeful rage against the wicked!", ch, 0, 0, TO_CHAR);
-	act("$n begins to breathe heavily as a vengeful look spreads across $s face.", ch, 0, 0, TO_ROOM);
+	act("You go into a vengeful rage against the wicked!", ch, nullptr, nullptr, TO_CHAR);
+	act("$n begins to breathe heavily as a vengeful look spreads across $s face.", ch, nullptr, nullptr, TO_ROOM);
 
 	init_affect(&af);
 	af.type = sn;
@@ -869,8 +869,8 @@ void do_group_retreat(CHAR_DATA *ch, char *argument)
 	{
 		direction = flag_name_lookup(dir, direction_table);
 
-		act("You quickly position yourself to cover your group's retreat!", ch, 0, 0, TO_CHAR);
-		act("$n positions $mself to cover $s group's retreat!", ch, 0, 0, TO_ROOM);
+		act("You quickly position yourself to cover your group's retreat!", ch, nullptr, nullptr, TO_CHAR);
+		act("$n positions $mself to cover $s group's retreat!", ch, nullptr, nullptr, TO_ROOM);
 
 		for (to = ch->in_room->people; to != nullptr; to = vch_next)
 		{
@@ -883,14 +883,14 @@ void do_group_retreat(CHAR_DATA *ch, char *argument)
 			{
 				stop_fighting(to, true);
 				act("$n retreats to the $t under $N's cover!", ch, direction, to, TO_NOTVICT);
-				act("$N retreats under your cover!", ch, 0, to, TO_CHAR);
-				act("You retreat under $n's cover.", ch, 0, to, TO_VICT);
+				act("$N retreats under your cover!", ch, nullptr, to, TO_CHAR);
+				act("You retreat under $n's cover.", ch, nullptr, to, TO_VICT);
 				char_from_room(to);
 				char_to_room(to, to_room);
 			}
 		}
 
-		act("$s group having retreated, $n follows suit!", ch, 0, 0, TO_ROOM);
+		act("$s group having retreated, $n follows suit!", ch, nullptr, nullptr, TO_ROOM);
 		stop_fighting(ch, true);
 
 		char_from_room(ch);
@@ -952,9 +952,9 @@ void do_valiant_charge(CHAR_DATA *ch, char *argument)
 		return;
 	}
 
-	act("$n charges into combat with $N, bursting through $S defenses!", ch, 0, victim, TO_ROOM);
-	act("$n drops his guard and charges directly into you!", ch, 0, victim, TO_VICT);
-	act("You charge into combat, opening the way for others to strike!", ch, 0, victim, TO_CHAR);
+	act("$n charges into combat with $N, bursting through $S defenses!", ch, nullptr, victim, TO_ROOM);
+	act("$n drops his guard and charges directly into you!", ch, nullptr, victim, TO_VICT);
+	act("You charge into combat, opening the way for others to strike!", ch, nullptr, victim, TO_CHAR);
 
 	for (to = ch->in_room->people; to != nullptr; to = to->next_in_room)
 	{
@@ -981,8 +981,8 @@ void spell_awe(int /* level */, int /* sn */, CHAR_DATA *ch, SpellTarget /* vo *
 		return;
 	}
 
-	act("Holy energy crackles about your frame, forming a shimmering aura of light!", ch, 0, 0, TO_CHAR);
-	act("Godly light suddenly explodes from within $n, finally settling into an incredible and almost intoxicating aura of power!", ch, 0, 0, TO_ROOM);
+	act("Holy energy crackles about your frame, forming a shimmering aura of light!", ch, nullptr, nullptr, TO_CHAR);
+	act("Godly light suddenly explodes from within $n, finally settling into an incredible and almost intoxicating aura of power!", ch, nullptr, nullptr, TO_ROOM);
 
 	init_affect(&af);
 	af.level = ch->level;
@@ -1016,8 +1016,8 @@ void spell_shield_of_faith(int /* level */, int /* sn */, CHAR_DATA *ch, SpellTa
 		return;
 	}
 
-	act("A pearly white barrier flickers into existence around you.", to, 0, 0, TO_CHAR);
-	act("A pearly white barrier flickers into existence around $n.", to, 0, 0, TO_ROOM);
+	act("A pearly white barrier flickers into existence around you.", to, nullptr, nullptr, TO_CHAR);
+	act("A pearly white barrier flickers into existence around $n.", to, nullptr, nullptr, TO_ROOM);
 
 	init_affect(&af);
 	af.level = ch->level;
@@ -1051,8 +1051,8 @@ void spell_holy_shroud(int /* level */, int /* sn */, CHAR_DATA *ch, SpellTarget
 		return;
 	}
 
-	act("A luminescent veil of white mist slowly drapes itself about your frame.", to, 0, 0, TO_CHAR);
-	act("A luminescent veil of white mist slowly drapes itself about $n's frame.", to, 0, 0, TO_ROOM);
+	act("A luminescent veil of white mist slowly drapes itself about your frame.", to, nullptr, nullptr, TO_CHAR);
+	act("A luminescent veil of white mist slowly drapes itself about $n's frame.", to, nullptr, nullptr, TO_ROOM);
 
 	init_affect(&af);
 	af.level = ch->level;
@@ -1075,12 +1075,12 @@ int check_arms(CHAR_DATA *ch, OBJ_DATA *wield, bool bOncePerRound)
 	{
 		if (bOncePerRound == true && number_percent() > 90)
 		{
-			act("$p suddenly flares brightly!", 0, wield, 0, TO_ROOM);
+			act("$p suddenly flares brightly!", 0, wield, nullptr, TO_ROOM);
 
 			if (!saves_spell(ch->level, victim, DAM_LIGHT))
 			{
-				act("$n appears to be blinded.", victim, 0, 0, TO_ROOM);
-				act("You are blinded!", ch, 0, victim, TO_VICT);
+				act("$n appears to be blinded.", victim, nullptr, nullptr, TO_ROOM);
+				act("You are blinded!", ch, nullptr, victim, TO_VICT);
 
 				init_affect(&af);
 				af.where = TO_AFFECTS;
@@ -1104,7 +1104,7 @@ int check_arms(CHAR_DATA *ch, OBJ_DATA *wield, bool bOncePerRound)
 	{
 		if (number_percent() > 96 && victim)
 		{
-			act("$p explodes in holy flames!", ch, wield, 0, TO_ALL);
+			act("$p explodes in holy flames!", ch, wield, nullptr, TO_ALL);
 			damage_new(ch, victim, dice(ch->level, 2), 0, DAM_HOLY, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "holy wrath");
 
 			if (number_percent() < ch->level / 2)
@@ -1116,8 +1116,8 @@ int check_arms(CHAR_DATA *ch, OBJ_DATA *wield, bool bOncePerRound)
 	{
 		if (bOncePerRound == true && number_percent() > 75)
 		{
-			act("$p glows softly and grows warm in your hands.", ch, wield, 0, TO_CHAR);
-			act("$n's $p glows softly.", ch, wield, 0, TO_ROOM);
+			act("$p glows softly and grows warm in your hands.", ch, wield, nullptr, TO_CHAR);
+			act("$n's $p glows softly.", ch, wield, nullptr, TO_ROOM);
 			obj_cast_spell(skill_lookup("cure critical"), ch->level, ch, ch, wield);
 		}
 	}
@@ -1131,11 +1131,11 @@ int check_arms(CHAR_DATA *ch, OBJ_DATA *wield, bool bOncePerRound)
 		{
 			if (!saves_spell(ch->level, victim, DAM_HOLY))
 			{
-				act("Brilliant light, followed by a loud booming noise emanates from $n's $p!", ch, wield, 0, TO_ROOM);
-				act("$p shakes violently in your hands, exploding with holy vengeance!", ch, wield, 0, TO_CHAR);
-				act("An invisible force bears down upon you.", ch, 0, victim, TO_VICT);
-				act("$n staggers and reels, overcome by an invisible force!", victim, 0, 0, TO_ROOM);
-				act("You succumb to the force, becoming temporarily paralyzed!", victim, 0, 0, TO_CHAR);
+				act("Brilliant light, followed by a loud booming noise emanates from $n's $p!", ch, wield, nullptr, TO_ROOM);
+				act("$p shakes violently in your hands, exploding with holy vengeance!", ch, wield, nullptr, TO_CHAR);
+				act("An invisible force bears down upon you.", ch, nullptr, victim, TO_VICT);
+				act("$n staggers and reels, overcome by an invisible force!", victim, nullptr, nullptr, TO_ROOM);
+				act("You succumb to the force, becoming temporarily paralyzed!", victim, nullptr, nullptr, TO_CHAR);
 				WAIT_STATE(victim, PULSE_VIOLENCE * 2);
 			}
 		}
@@ -1164,9 +1164,9 @@ void spell_empathy(int /* level */, int /* sn */, CHAR_DATA *ch, SpellTarget vo,
 		return;
 	}
 
-	act("You touch your hand to $N's forehead and form a spiritual link.", ch, 0, vict, TO_CHAR);
-	act("$n touches $s hand to your forehead and forms a spiritual link.", ch, 0, vict, TO_VICT);
-	act("$n touches $N on $S forehead forming a spiritual link.", ch, 0, vict, TO_ROOM);
+	act("You touch your hand to $N's forehead and form a spiritual link.", ch, nullptr, vict, TO_CHAR);
+	act("$n touches $s hand to your forehead and forms a spiritual link.", ch, nullptr, vict, TO_VICT);
+	act("$n touches $N on $S forehead forming a spiritual link.", ch, nullptr, vict, TO_ROOM);
 
 	init_affect(&af);
 	af.owner = ch->self;
@@ -1185,7 +1185,7 @@ void empathy_end(CHAR_DATA *ch, AFFECT_DATA *af)
 {
 	// ch=char with empathy, af->owner = paladin
 	if (Deref(af->owner))
-		act("You feel pained as your spiritual link with $n is severed!", Deref(af->owner), 0, ch, TO_VICT);
+		act("You feel pained as your spiritual link with $n is severed!", Deref(af->owner), nullptr, ch, TO_VICT);
 }
 
 void spell_tower_of_fortitude(int /* level */, int /* sn */, CHAR_DATA *ch, SpellTarget vo, CastMode /* mode */)
@@ -1199,8 +1199,8 @@ void spell_tower_of_fortitude(int /* level */, int /* sn */, CHAR_DATA *ch, Spel
 		return;
 	}
 
-	act("You center your body and relax your muscles ready for incoming attacks.", ch, 0, 0, TO_CHAR);
-	act("$n centers $mself and readies for combat.", ch, 0, 0, TO_ROOM);
+	act("You center your body and relax your muscles ready for incoming attacks.", ch, nullptr, nullptr, TO_CHAR);
+	act("$n centers $mself and readies for combat.", ch, nullptr, nullptr, TO_ROOM);
 
 	init_affect(&af);
 	af.owner = ch->self;
@@ -1226,8 +1226,8 @@ void spell_indomitable_spirit(int /* level */, int /* sn */, CHAR_DATA *ch, Spel
 		return;
 	}
 
-	act("You call upon your deity to raise your spirit.", ch, 0, 0, TO_CHAR);
-	act("$n calls up on $s deity to raise his spirit.", ch, 0, 0, TO_ROOM);
+	act("You call upon your deity to raise your spirit.", ch, nullptr, nullptr, TO_CHAR);
+	act("$n calls up on $s deity to raise his spirit.", ch, nullptr, nullptr, TO_ROOM);
 
 	init_affect(&af);
 	af.owner = ch->self;
@@ -1257,9 +1257,9 @@ void ispirit_beat(CHAR_DATA *ch, AFFECT_DATA *af)
 			af->end_fun = nullptr;
 			affect_strip(ch, gsn_indomitable_spirit);
 
-			act("Your body collapses under the strain of your spiritual exertion.", ch, 0, 0, TO_CHAR);
-			act("$n's body collapses under the strain of $s spiritual exertion!", ch, 0, 0, TO_ROOM);
-			act("$n is DEAD!!", ch, 0, 0, TO_ROOM);
+			act("Your body collapses under the strain of your spiritual exertion.", ch, nullptr, nullptr, TO_CHAR);
+			act("$n's body collapses under the strain of $s spiritual exertion!", ch, nullptr, nullptr, TO_ROOM);
+			act("$n is DEAD!!", ch, nullptr, nullptr, TO_ROOM);
 
 			if (Deref(ch->fighting))
 				raw_kill(Deref(ch->fighting), ch);
@@ -1273,9 +1273,9 @@ void ispirit_end(CHAR_DATA *ch, [[maybe_unused]] AFFECT_DATA *af)
 {
 	if (ch->hit < 0)
 	{
-		act("Your body collapses under the strain of your spiritual exertion.", ch, 0, 0, TO_CHAR);
-		act("$n's body collapses under the strain of $s spiritual exertion!", ch, 0, 0, TO_ROOM);
-		act("$n is DEAD!!", ch, 0, 0, TO_ROOM);
+		act("Your body collapses under the strain of your spiritual exertion.", ch, nullptr, nullptr, TO_CHAR);
+		act("$n's body collapses under the strain of $s spiritual exertion!", ch, nullptr, nullptr, TO_ROOM);
+		act("$n is DEAD!!", ch, nullptr, nullptr, TO_ROOM);
 		raw_kill(ch, ch);
 	}
 }
@@ -1326,7 +1326,7 @@ void spell_altruism(int /* level */, int /* sn */, CHAR_DATA *ch, SpellTarget vo
 		it = next;
 	}
 
-	act("You absorb all of $N's maledictions.", ch, 0, vict, TO_CHAR);
-	act("You feel cleansed as $n absorbs your maledictions.", ch, 0, vict, TO_VICT);
-	act("$n absorbs all of $N's maledictions.", ch, 0, vict, TO_ROOM);
+	act("You absorb all of $N's maledictions.", ch, nullptr, vict, TO_CHAR);
+	act("You feel cleansed as $n absorbs your maledictions.", ch, nullptr, vict, TO_VICT);
+	act("$n absorbs all of $N's maledictions.", ch, nullptr, vict, TO_ROOM);
 }

--- a/code/characterClasses/paladin.c
+++ b/code/characterClasses/paladin.c
@@ -138,7 +138,6 @@ void do_turn_undead(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 	int dam;
 	int difference = 0;
 	CHAR_DATA *victim, *v_next;
-	OBJ_DATA *corpse;
 	AFFECT_DATA af;
 	bool forceflee= false;
 
@@ -787,7 +786,7 @@ void do_group_retreat(CHAR_DATA *ch, char *argument)
 {
 	char arg[MAX_INPUT_LENGTH];
 	CHAR_DATA *to = nullptr;
-	CHAR_DATA *vch, *vch_next;
+	CHAR_DATA *vch_next;
 	CHAR_DATA *victim = Deref(ch->fighting);
 	ROOM_INDEX_DATA *to_room = nullptr;
 	EXIT_DATA *pexit;
@@ -1188,10 +1187,9 @@ void empathy_end(CHAR_DATA *ch, AFFECT_DATA *af)
 		act("You feel pained as your spiritual link with $n is severed!", Deref(af->owner), nullptr, ch, TO_VICT);
 }
 
-void spell_tower_of_fortitude(int /* level */, int /* sn */, CHAR_DATA *ch, SpellTarget vo, CastMode /* mode */)
+void spell_tower_of_fortitude(int /* level */, int /* sn */, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
 	AFFECT_DATA af;
-	CHAR_DATA *vict = vo.AsChar();
 
 	if (is_affected(ch, gsn_tower_of_fortitude))
 	{
@@ -1215,10 +1213,9 @@ void spell_tower_of_fortitude(int /* level */, int /* sn */, CHAR_DATA *ch, Spel
 	affect_to_char(ch, &af);
 }
 
-void spell_indomitable_spirit(int /* level */, int /* sn */, CHAR_DATA *ch, SpellTarget vo, CastMode /* mode */)
+void spell_indomitable_spirit(int /* level */, int /* sn */, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
 	AFFECT_DATA af;
-	CHAR_DATA *vict = vo.AsChar();
 
 	if (is_affected(ch, gsn_indomitable_spirit))
 	{

--- a/code/characterClasses/sorcerer.c
+++ b/code/characterClasses/sorcerer.c
@@ -127,8 +127,8 @@ void spell_scorch(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unus
 	if (saves_spell(level, victim, DAM_FIRE))
 		dam /= 2;
 
-	act("Waves of heat ripple through the air as $n's flesh crackles.", victim, 0, ch, TO_ROOM);
-	act("Waves of heat ripple through the air towards you.\n\rYou feel your skin crackling.", ch, 0, victim, TO_VICT);
+	act("Waves of heat ripple through the air as $n's flesh crackles.", victim, nullptr, ch, TO_ROOM);
+	act("Waves of heat ripple through the air towards you.\n\rYou feel your skin crackling.", ch, nullptr, victim, TO_VICT);
 	damage_new(ch, victim, dam, sn, DAM_FIRE, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, nullptr);
 }
 
@@ -175,7 +175,7 @@ void spell_gravity_well(int sn, int level, CHAR_DATA *ch, SpellTarget /* vo */, 
 		return;
 	}
 
-	act("$p folds in upon itself, warping the space around it as it shrinks until no more than the tiniest speck remains.", ch, well, 0, TO_ALL);
+	act("$p folds in upon itself, warping the space around it as it shrinks until no more than the tiniest speck remains.", ch, well, nullptr, TO_ALL);
 	gwell = create_object(get_obj_index(2950), 0);
 	gwell->weight = well->weight;
 	obj_to_room(gwell, ch->in_room);
@@ -244,7 +244,7 @@ void gravity_well_explode(ROOM_INDEX_DATA *room, ROOM_AFFECT_DATA *af)
 	send_to_char("You lose control of your gravity well and it ruptures violently!\n\r", ch);
 
 	if (well->in_room->people)
-		act("The gravity well flares brightly and explodes, sending waves of force rippling outward!", well->in_room->people, 0, 0, TO_ALL);
+		act("The gravity well flares brightly and explodes, sending waves of force rippling outward!", well->in_room->people, nullptr, nullptr, TO_ALL);
 
 	extract_obj(well);
 	affect_strip_room(room, gsn_gravity_well);
@@ -326,7 +326,7 @@ void spell_cyclone(int /* sn */, int level, CHAR_DATA *ch, SpellTarget /* vo */,
 	affect_to_char(ch, &af);
 
 	send_to_char("As you feed energy into the air overhead, powerful, swirling currents begin to develop.\n\r", ch);
-	act("$n concentrates intently and the surrounding winds seem to pick up slightly.", ch, 0, 0, TO_ROOM);
+	act("$n concentrates intently and the surrounding winds seem to pick up slightly.", ch, nullptr, nullptr, TO_ROOM);
 }
 
 void cyclone_begin(AREA_DATA *area, AREA_AFFECT_DATA *af)
@@ -366,7 +366,7 @@ void spell_chill(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unuse
 	CHAR_DATA *victim = vo.AsChar();
 	AFFECT_DATA af;
 
-	act("You draw the heat out of $N's flesh, chilling $M.", ch, 0, victim, TO_CHAR);
+	act("You draw the heat out of $N's flesh, chilling $M.", ch, nullptr, victim, TO_CHAR);
 
 	int dam = dice(5, 4) + level;
 
@@ -387,8 +387,8 @@ void spell_chill(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unuse
 		else
 			affect_to_char(victim, &af);
 
-		act("$n's flesh turns purple as he shivers!", victim, 0, ch, TO_ROOM);
-		act("You begin shivering violently.", 0, 0, victim, TO_VICT);
+		act("$n's flesh turns purple as he shivers!", victim, nullptr, ch, TO_ROOM);
+		act("You begin shivering violently.", 0, nullptr, victim, TO_VICT);
 		damage_new(ch, victim, dam, TYPE_UNDEFINED, DAM_COLD, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "chill");
 	}
 	else
@@ -526,7 +526,7 @@ void spell_conflagration(int sn, int level, CHAR_DATA *ch, SpellTarget /* vo */,
 	af.modifier = 0;
 	affect_to_char(ch, &af);
 
-	act("The room erupts in a fiery explosion and is engulfed in searing flames!", ch, 0, 0, TO_ALL);
+	act("The room erupts in a fiery explosion and is engulfed in searing flames!", ch, nullptr, nullptr, TO_ALL);
 	zone_echo(ch->in_room->area, "The crackling roar of fire reaches your ears.\n\r");
 }
 
@@ -932,8 +932,8 @@ void spell_heat_metal([[maybe_unused]] int sn, int level, CHAR_DATA *ch, SpellTa
 	if (obj2 != nullptr)
 	{
 		unequip_char(victim, obj2, false);
-		act("You hastily swap $p into your primary hand.", ch, obj2, 0, TO_CHAR);
-		act("$n hastily swaps $p into $s primary hand.", ch, obj2, 0, TO_ROOM);
+		act("You hastily swap $p into your primary hand.", ch, obj2, nullptr, TO_CHAR);
+		act("$n hastily swaps $p into $s primary hand.", ch, obj2, nullptr, TO_ROOM);
 		equip_char(victim, obj2, WEAR_WIELD, false);
 	}
 }
@@ -979,14 +979,14 @@ void spell_knock(int /* sn */, int /* level */, CHAR_DATA *ch, SpellTarget /* vo
 		if (IS_SET(pexit->exit_info, EX_NOPASS))
 		{
 			direction = flag_name_lookup(door, direction_table);
-			act("You rapidly heat the $T door, causing it to expand within its confines.", ch, 0, direction, TO_CHAR);
-			act("The $T door buckles slightly, but remains intact.", ch, 0, direction, TO_ALL);
+			act("You rapidly heat the $T door, causing it to expand within its confines.", ch, nullptr, direction, TO_CHAR);
+			act("The $T door buckles slightly, but remains intact.", ch, nullptr, direction, TO_ALL);
 			return;
 		}
 
 		direction = flag_name_lookup(door, direction_table);
-		act("You rapidly heat the $T door, causing it to expand within its confines.", ch, 0, direction, TO_CHAR);
-		act("The $T door suddenly buckles on its hinges and bursts open!", ch, 0, direction, TO_ALL);
+		act("You rapidly heat the $T door, causing it to expand within its confines.", ch, nullptr, direction, TO_CHAR);
+		act("The $T door suddenly buckles on its hinges and bursts open!", ch, nullptr, direction, TO_ALL);
 
 		REMOVE_BIT(pexit->exit_info, EX_LOCKED);
 		REMOVE_BIT(pexit->exit_info, EX_CLOSED);
@@ -1007,7 +1007,7 @@ void spell_knock(int /* sn */, int /* level */, CHAR_DATA *ch, SpellTarget /* vo
 
 		for (fch = to_room->people; fch != nullptr; fch = fch->next_in_room)
 		{
-			act("The $T door suddenly buckles on its hinges and bursts open!", fch, 0, direction, TO_ALL);
+			act("The $T door suddenly buckles on its hinges and bursts open!", fch, nullptr, direction, TO_ALL);
 			break;
 		}
 	}
@@ -1045,8 +1045,8 @@ void spell_vacuum(int sn, int level, CHAR_DATA *ch, [[maybe_unused]] SpellTarget
 		return;
 	}
 
-	act("Concentrating intently, you force all the air out of the area!", ch, 0, 0, TO_CHAR);
-	act("$n raises $s arms, and in a violent rush, all the air is torn from the surrounding area!", ch, 0, 0, TO_ROOM);
+	act("Concentrating intently, you force all the air out of the area!", ch, nullptr, nullptr, TO_CHAR);
+	act("$n raises $s arms, and in a violent rush, all the air is torn from the surrounding area!", ch, nullptr, nullptr, TO_ROOM);
 
 	init_affect_room(&raf);
 	raf.where = TO_ROOM_AFFECTS;
@@ -1092,7 +1092,7 @@ void spell_vacuum(int sn, int level, CHAR_DATA *ch, [[maybe_unused]] SpellTarget
 			if (to_room->people)
 			{
 				direction = flag_name_lookup(reverse_d(i), direction_table);
-				act("A sudden blast of air rushes in from the $T!", to_room->people, 0, direction, TO_ALL);
+				act("A sudden blast of air rushes in from the $T!", to_room->people, nullptr, direction, TO_ALL);
 			}
 		}
 
@@ -1109,7 +1109,7 @@ void vacuum_end_fun(ROOM_INDEX_DATA *room, ROOM_AFFECT_DATA *af)
 	OBJ_DATA *obj, *obj_next;
 
 	if (room->people)
-		act("Air rushes back into the area in a fierce torrent!", room->people, 0, 0, TO_ALL);
+		act("Air rushes back into the area in a fierce torrent!", room->people, nullptr, nullptr, TO_ALL);
 
 	auto i = 0;
 
@@ -1126,7 +1126,7 @@ void vacuum_end_fun(ROOM_INDEX_DATA *room, ROOM_AFFECT_DATA *af)
 		if (to_room != nullptr && to_room->people)
 		{
 			direction = flag_name_lookup(reverse_d(i), direction_table);
-			act("Air rushes back $Tward!", to_room->people, 0, direction, TO_ALL);
+			act("Air rushes back $Tward!", to_room->people, nullptr, direction, TO_ALL);
 		}
 
 		i++;
@@ -1168,7 +1168,7 @@ void vacuum_end_fun(ROOM_INDEX_DATA *room, ROOM_AFFECT_DATA *af)
 					if (get_true_weight(obj) < 5 && IS_SET(obj->wear_flags, ITEM_TAKE))
 					{
 						if (to_room->people)
-							act("$p is sucked out of the room!", to_room->people, obj, 0, TO_ALL);
+							act("$p is sucked out of the room!", to_room->people, obj, nullptr, TO_ALL);
 
 						obj_from_room(obj);
 						obj_to_room(obj, room);
@@ -1192,8 +1192,8 @@ void vacuum_end_fun(ROOM_INDEX_DATA *room, ROOM_AFFECT_DATA *af)
 						if (!smacked)
 							break;
 
-						act("$p is sucked into the room, striking $n!", smacked, obj, 0, TO_ROOM);
-						act("$p is sucked into the room, striking you!", smacked, obj, 0, TO_CHAR);
+						act("$p is sucked into the room, striking $n!", smacked, obj, nullptr, TO_ROOM);
+						act("$p is sucked into the room, striking you!", smacked, obj, nullptr, TO_CHAR);
 						damage_new(Deref(af->owner), smacked, dice(get_true_weight(obj) + 1, 9), TYPE_UNDEFINED, DAM_BASH, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "the flying debris*");
 						objcount++;
 					}
@@ -1227,16 +1227,16 @@ void vacuum_end_fun(ROOM_INDEX_DATA *room, ROOM_AFFECT_DATA *af)
 
 					direction = flag_name_lookup(reverse_d(i), direction_table);
 
-					act("A torrent of air pulls $n $T!", vch, 0, direction, TO_ROOM);
+					act("A torrent of air pulls $n $T!", vch, nullptr, direction, TO_ROOM);
 
 					char_from_room(vch);
 					char_to_room(vch, room);
 
-					act("A torrent of air pulls you unexpectedly $T!", vch, 0, direction, TO_CHAR);
+					act("A torrent of air pulls you unexpectedly $T!", vch, nullptr, direction, TO_CHAR);
 					do_look(vch, "auto");
 
 					direction = flag_name_lookup(i, direction_table);
-					act("The torrent of air pulls $n into the room from the $T!", vch, 0, direction, TO_ROOM);
+					act("The torrent of air pulls $n into the room from the $T!", vch, nullptr, direction, TO_ROOM);
 				}
 			}
 
@@ -1314,9 +1314,9 @@ void spell_diuretic(int /* sn */, int level, CHAR_DATA *ch, SpellTarget /* vo */
 
 	if (!trusts(ch, victim) && saves_spell(level, victim, DAM_OTHER))
 	{
-		act("$N resists the effects.", ch, 0, victim, TO_CHAR);
-		act_new("You feel a rush of warmth, but it fades.", ch, 0, victim, TO_VICT, POS_SLEEPING);
-		act("$N looks flushed for a moment, but it passes.", ch, 0, victim, TO_NOTVICT);
+		act("$N resists the effects.", ch, nullptr, victim, TO_CHAR);
+		act_new("You feel a rush of warmth, but it fades.", ch, nullptr, victim, TO_VICT, POS_SLEEPING);
+		act("$N looks flushed for a moment, but it passes.", ch, nullptr, victim, TO_NOTVICT);
 
 		if (!trusts(ch, victim))
 			multi_hit(victim, ch, TYPE_UNDEFINED);
@@ -1326,9 +1326,9 @@ void spell_diuretic(int /* sn */, int level, CHAR_DATA *ch, SpellTarget /* vo */
 
 	if (ch != victim)
 	{
-		act("You infuse $N with a rush of healing warmth.", ch, 0, victim, TO_CHAR);
+		act("You infuse $N with a rush of healing warmth.", ch, nullptr, victim, TO_CHAR);
 		act_new("A feeling of warmth washes over you.", victim, nullptr, nullptr, TO_CHAR, POS_SLEEPING);
-		act("$n looks flushed for a moment.", ch, 0, victim, TO_NOTVICT);
+		act("$n looks flushed for a moment.", ch, nullptr, victim, TO_NOTVICT);
 	}
 
 	if (ch == victim)
@@ -1343,7 +1343,7 @@ void spell_diuretic(int /* sn */, int level, CHAR_DATA *ch, SpellTarget /* vo */
 		}
 
 		send_to_char("The flow of blood from your wounds intensifies.\n\r", victim);
-		act("The blood seems to gush from $n's wounds more rapidly.", victim, 0, 0, TO_ROOM);
+		act("The blood seems to gush from $n's wounds more rapidly.", victim, nullptr, nullptr, TO_ROOM);
 	}
 
 	heal = dice(2, 8) + level / 2;
@@ -1365,7 +1365,7 @@ void spell_corona(int sn, int level, CHAR_DATA *ch, [[maybe_unused]] SpellTarget
 		return;
 	}
 
-	act("$n is surrounded by a corona of flames that rapidly fades away.", ch, 0, 0, TO_ROOM);
+	act("$n is surrounded by a corona of flames that rapidly fades away.", ch, nullptr, nullptr, TO_ROOM);
 	send_to_char("You form heat energy into a protective barrier surrounding you.\n\r", ch);
 
 	init_affect(&af);
@@ -1413,7 +1413,7 @@ void spell_heatshield(int /* sn */, int level, CHAR_DATA *ch, SpellTarget /* vo 
 	affect_to_char(ch, &af);
 
 	send_to_char("The air around you ripples with heat.\n\r", ch);
-	act("The air around $n ripples with heat.", ch, 0, 0, TO_ROOM);
+	act("The air around $n ripples with heat.", ch, nullptr, nullptr, TO_ROOM);
 }
 
 void spell_immolate([[maybe_unused]] int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
@@ -1423,9 +1423,9 @@ void spell_immolate([[maybe_unused]] int sn, int level, CHAR_DATA *ch, SpellTarg
 	OBJ_DATA *obj;
 	int dam = 0;
 
-	act("You concentrate intently, unleashing a burst of heat upon $N's armor.", ch, 0, victim, TO_CHAR);
-	act("$n extends $s hand towards you, releasing an oppressive wave of heat that washes over you.", ch, 0, victim, TO_VICT);
-	act("$n extends $s hand towards $N, releasing a burst of heat that washes over $M!", ch, 0, victim, TO_NOTVICT);
+	act("You concentrate intently, unleashing a burst of heat upon $N's armor.", ch, nullptr, victim, TO_CHAR);
+	act("$n extends $s hand towards you, releasing an oppressive wave of heat that washes over you.", ch, nullptr, victim, TO_VICT);
+	act("$n extends $s hand towards $N, releasing a burst of heat that washes over $M!", ch, nullptr, victim, TO_NOTVICT);
 
 	for (obj = victim->carrying; obj != nullptr; obj = obj->next_content)
 	{
@@ -1453,7 +1453,7 @@ void spell_immolate([[maybe_unused]] int sn, int level, CHAR_DATA *ch, SpellTarg
 			oaf.tick_fun = nullptr;
 			affect_to_obj(obj, &oaf);
 
-			act("$p bursts into flames!", victim, obj, 0, TO_ALL);
+			act("$p bursts into flames!", victim, obj, nullptr, TO_ALL);
 			dam += dice(6, 6);
 		}
 	}
@@ -1461,16 +1461,16 @@ void spell_immolate([[maybe_unused]] int sn, int level, CHAR_DATA *ch, SpellTarg
 	if (dam)
 		damage_new(ch, victim, dam, TYPE_UNDEFINED, DAM_FIRE, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "immolation");
 	else
-		act("You failed to ignite any of $N's armor.", ch, 0, victim, TO_CHAR);
+		act("You failed to ignite any of $N's armor.", ch, nullptr, victim, TO_CHAR);
 }
 
 void immolate_end(OBJ_DATA *obj, [[maybe_unused]] OBJ_AFFECT_DATA *af)
 {
 	if (CHAR_DATA *carrier = Deref(obj->carried_by))
-		act("$p stops burning.", carrier, obj, 0, TO_CHAR);
+		act("$p stops burning.", carrier, obj, nullptr, TO_CHAR);
 
 	if (obj->in_room && obj->in_room->people)
-		act("$p stops burning.", obj->in_room->people, obj, 0, TO_ALL);
+		act("$p stops burning.", obj->in_room->people, obj, nullptr, TO_ALL);
 }
 
 void spell_scathing(int sn, int level, CHAR_DATA *ch, [[maybe_unused]] SpellTarget vo, [[maybe_unused]] CastMode mode)
@@ -1481,7 +1481,7 @@ void spell_scathing(int sn, int level, CHAR_DATA *ch, [[maybe_unused]] SpellTarg
 	char buf[MSL];
 
 	send_to_char("You create violent, scorching gusts of wind to sweep across the area.\n\r", ch);
-	act("Heat radiates from $n's fingertips as a scathing wind sweeps across the area.", ch, 0, 0, TO_ROOM);
+	act("Heat radiates from $n's fingertips as a scathing wind sweeps across the area.", ch, nullptr, nullptr, TO_ROOM);
 
 	init_affect(&af);
 	af.where = TO_AFFECTS;
@@ -1517,7 +1517,7 @@ void spell_scathing(int sn, int level, CHAR_DATA *ch, [[maybe_unused]] SpellTarg
 			&& !is_affected(vch, sn)
 			&& !(IS_SET(vch->act, ACT_UNDEAD) || IS_SET(vch->form, FORM_UNDEAD)))
 		{
-			act("The heated air sears $n's eyes, blinding $m!", vch, 0, 0, TO_ROOM);
+			act("The heated air sears $n's eyes, blinding $m!", vch, nullptr, nullptr, TO_ROOM);
 			send_to_char("The heated air sears your eyes, blinding you!\n\r", vch);
 			affect_to_char(vch, &af);
 		}
@@ -1544,7 +1544,7 @@ void spell_earthquake(int sn, int level, CHAR_DATA *ch, [[maybe_unused]] SpellTa
 		return;
 	}
 
-	act("The earth beneath you rumbles violently!", ch, 0, 0, TO_ALL);
+	act("The earth beneath you rumbles violently!", ch, nullptr, nullptr, TO_ALL);
 
 	for (vch = ch->in_room->people; vch != nullptr; vch = vch_next)
 	{
@@ -1565,7 +1565,7 @@ void spell_earthquake(int sn, int level, CHAR_DATA *ch, [[maybe_unused]] SpellTa
 			do_myell(vch, buf, ch);
 		}
 
-		act("You lose your footing amidst the shaking and fall to the ground!", vch, 0, 0, TO_CHAR);
+		act("You lose your footing amidst the shaking and fall to the ground!", vch, nullptr, nullptr, TO_CHAR);
 
 		WAIT_STATE(vch, PULSE_VIOLENCE);
 		damage_new(ch, vch, dice(10, 3), sn, DAM_BASH, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, nullptr);
@@ -1580,14 +1580,14 @@ void spell_earthquake(int sn, int level, CHAR_DATA *ch, [[maybe_unused]] SpellTa
 		case SECT_ROAD:
 			break;
 		case SECT_HILLS:
-			act("Loose rocks and earth tumbles down from the hills around you!", ch, 0, 0, TO_ALL);
+			act("Loose rocks and earth tumbles down from the hills around you!", ch, nullptr, nullptr, TO_ALL);
 
 			// The cave case below re-guards on the sector, so hills gets the
 			// shared damage loop without the cave message.
 			[[fallthrough]];
 		case SECT_CAVE:
 			if (ch->in_room->sector_type != SECT_HILLS)
-				act("Loose rocks and earth tumbles down from the cave around you!", ch, 0, 0, TO_ALL);
+				act("Loose rocks and earth tumbles down from the cave around you!", ch, nullptr, nullptr, TO_ALL);
 
 			for (vch = ch->in_room->people; vch != nullptr; vch = vch_next)
 			{
@@ -1608,7 +1608,7 @@ void spell_earthquake(int sn, int level, CHAR_DATA *ch, [[maybe_unused]] SpellTa
 				if (is_same_group(vch, ch) || is_safe(ch, vch) || is_same_cabal(ch, vch))
 					continue;
 
-				act("Loose bricks and mortar tumble down from the buildings around you!", vch, 0, 0, TO_CHAR);
+				act("Loose bricks and mortar tumble down from the buildings around you!", vch, nullptr, nullptr, TO_CHAR);
 				damage_new(ch, vch, dice(10, 10), sn, DAM_BASH, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "the falling debris*");
 			}
 
@@ -1622,7 +1622,7 @@ void spell_earthquake(int sn, int level, CHAR_DATA *ch, [[maybe_unused]] SpellTa
 					continue;
 
 				ADD_WAIT_STATE(vch, PULSE_VIOLENCE);
-				act("Nearby trees topple, crushing you beneath their weight!", vch, 0, 0, TO_CHAR);
+				act("Nearby trees topple, crushing you beneath their weight!", vch, nullptr, nullptr, TO_CHAR);
 				damage_new(ch, vch, dice(10, 15), sn, DAM_BASH, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "the falling trees*$");
 			}
 
@@ -1648,7 +1648,7 @@ void spell_earthquake(int sn, int level, CHAR_DATA *ch, [[maybe_unused]] SpellTa
 				if (is_safe(ch, vch))
 					continue;
 
-				act("A torrential downpour of stone and debris pours down from the ceiling above!", vch, 0, 0, TO_CHAR);
+				act("A torrential downpour of stone and debris pours down from the ceiling above!", vch, nullptr, nullptr, TO_CHAR);
 
 				if (is_same_group(vch, ch) || is_same_cabal(ch, vch))
 					damage_new(ch, vch, dice(10, 15), sn, DAM_BASH, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "the falling debris*");
@@ -1681,35 +1681,35 @@ void spell_electrocute(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe
 		tconduct += material_table[obj->pIndexData->material_index].mat_conductivity;
 	}
 
-	act("You attempt to send an electric current though $N's armor.", ch, 0, victim, TO_CHAR);
-	act("$n attempts to send an electric current though your armor.", ch, 0, victim, TO_VICT);
-	act("$n attempts to send an electric current though $N's armor.", ch, 0, victim, TO_NOTVICT);
+	act("You attempt to send an electric current though $N's armor.", ch, nullptr, victim, TO_CHAR);
+	act("$n attempts to send an electric current though your armor.", ch, nullptr, victim, TO_VICT);
+	act("$n attempts to send an electric current though $N's armor.", ch, nullptr, victim, TO_NOTVICT);
 
 	if (tconduct <= 0)
 	{
-		act("Your armor harmlessly absorbs the electric charge.", victim, 0, 0, TO_CHAR);
-		act("$n's armor harmlessly absorbs the electric charge.", victim, 0, 0, TO_ROOM);
+		act("Your armor harmlessly absorbs the electric charge.", victim, nullptr, nullptr, TO_CHAR);
+		act("$n's armor harmlessly absorbs the electric charge.", victim, nullptr, nullptr, TO_ROOM);
 		return;
 	}
 	else if (tconduct < 15)
 	{
-		act("You experience a brief jolt of pain as electricity hits your armor.", victim, 0, 0, TO_CHAR);
-		act("$n jerks slightly as $s armor crackles with electricity.", victim, 0, 0, TO_ROOM);
+		act("You experience a brief jolt of pain as electricity hits your armor.", victim, nullptr, nullptr, TO_CHAR);
+		act("$n jerks slightly as $s armor crackles with electricity.", victim, nullptr, nullptr, TO_ROOM);
 	}
 	else if (tconduct < 30)
 	{
-		act("Your body is wracked with pain as electricity surges through you!", victim, 0, 0, TO_CHAR);
-		act("$n convulses as bursts of electricity explode through $s armor!", victim, 0, 0, TO_ROOM);
+		act("Your body is wracked with pain as electricity surges through you!", victim, nullptr, nullptr, TO_CHAR);
+		act("$n convulses as bursts of electricity explode through $s armor!", victim, nullptr, nullptr, TO_ROOM);
 	}
 	else if (tconduct < 45)
 	{
-		act("You open your mouth in a silent scream as raw electricity explodes through your joints!", victim, 0, 0, TO_CHAR);
-		act("$n's face contorts in agony as $e convulses, briefly paralyzed!", victim, 0, 0, TO_ROOM);
+		act("You open your mouth in a silent scream as raw electricity explodes through your joints!", victim, nullptr, nullptr, TO_CHAR);
+		act("$n's face contorts in agony as $e convulses, briefly paralyzed!", victim, nullptr, nullptr, TO_ROOM);
 	}
 	else
 	{
-		act("Every inch of your body explodes with pain, your flesh melting as electricity courses into your body!", victim, 0, 0, TO_CHAR);
-		act("$n lets out a horrible shriek as the electric current roasts $m alive within $s armor!", victim, 0, 0, TO_ROOM);
+		act("Every inch of your body explodes with pain, your flesh melting as electricity courses into your body!", victim, nullptr, nullptr, TO_CHAR);
+		act("$n lets out a horrible shriek as the electric current roasts $m alive within $s armor!", victim, nullptr, nullptr, TO_ROOM);
 	}
 
 	damage_new(ch, victim, dice((level / 15) * tconduct, 4), sn, DAM_LIGHTNING, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, nullptr);
@@ -1726,12 +1726,12 @@ void spell_induce_pain(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe
 
 	if (get_curr_stat(victim, STAT_INT) > 10 && number_range(0, 200) < (pow(get_curr_stat(victim, STAT_INT) - 10, 2)))
 	{
-		act("Pain courses through your body, but you faintly realize that it is an illusion.", victim, 0, 0, TO_CHAR);
+		act("Pain courses through your body, but you faintly realize that it is an illusion.", victim, nullptr, nullptr, TO_CHAR);
 		dam /= 2;
 	}
 	else
 	{
-		act("Your vision clouds as searing pain courses through your body!", victim, 0, 0, TO_CHAR);
+		act("Your vision clouds as searing pain courses through your body!", victim, nullptr, nullptr, TO_CHAR);
 	}
 
 	damage_new(ch, victim, dam, sn, DAM_OTHER, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, nullptr);
@@ -1793,9 +1793,9 @@ void spell_mana_conduit(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[mayb
 	affect_to_char(victim, &af);
 
 	if (ch != victim)
-		act("You enhance $N's ability to channel mana.", ch, 0, victim, TO_CHAR);
+		act("You enhance $N's ability to channel mana.", ch, nullptr, victim, TO_CHAR);
 
-	act("You feel energized, mana flowing more easily through your body.", victim, 0, 0, TO_CHAR);
+	act("You feel energized, mana flowing more easily through your body.", victim, nullptr, nullptr, TO_CHAR);
 }
 
 void spell_synaptic_enhancement(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
@@ -1828,8 +1828,8 @@ void spell_synaptic_enhancement(int sn, int level, CHAR_DATA *ch, SpellTarget vo
 	af.mod_name = MOD_CONC;
 	affect_to_char(victim, &af);
 
-	act("$n twitches as $e suddenly looks more aware.", victim, 0, 0, TO_ROOM);
-	act("Your mind suddenly feels much clearer and your reflexes sharpen.", victim, 0, 0, TO_CHAR);
+	act("$n twitches as $e suddenly looks more aware.", victim, nullptr, nullptr, TO_ROOM);
+	act("Your mind suddenly feels much clearer and your reflexes sharpen.", victim, nullptr, nullptr, TO_CHAR);
 }
 
 void spell_synaptic_impairment(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
@@ -1868,9 +1868,9 @@ void spell_synaptic_impairment(int sn, int level, CHAR_DATA *ch, SpellTarget vo,
 	af.mod_name = MOD_CONC;
 	affect_to_char(victim, &af);
 
-	act("You disrupt $N's ability to focus with a controlled electrical burst!", ch, 0, victim, TO_CHAR);
-	act("$n disrupts $N's ability to focus with a controlled electrical burst!", ch, 0, victim, TO_NOTVICT);
-	act("Your mind clouds and you find concentration somewhat more difficult.", ch, 0, victim, TO_VICT);
+	act("You disrupt $N's ability to focus with a controlled electrical burst!", ch, nullptr, victim, TO_CHAR);
+	act("$n disrupts $N's ability to focus with a controlled electrical burst!", ch, nullptr, victim, TO_NOTVICT);
+	act("Your mind clouds and you find concentration somewhat more difficult.", ch, nullptr, victim, TO_VICT);
 }
 
 void spell_elecshield(int sn, int level, CHAR_DATA *ch, [[maybe_unused]] SpellTarget vo, [[maybe_unused]] CastMode mode)
@@ -1895,7 +1895,7 @@ void spell_elecshield(int sn, int level, CHAR_DATA *ch, [[maybe_unused]] SpellTa
 	affect_to_char(ch, &af);
 
 	send_to_char("You create an electrically-charged sphere around you.\n\r", ch);
-	act("A crackling sphere of electricity briefly surrounds $n.", ch, 0, 0, TO_ROOM);
+	act("A crackling sphere of electricity briefly surrounds $n.", ch, nullptr, nullptr, TO_ROOM);
 }
 
 void spell_scramble_neurons(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
@@ -1936,16 +1936,16 @@ void spell_mana_leech(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_
 	CHAR_DATA *victim = vo.AsChar();
 	int drain;
 
-	act("You extend tendrils of electricity towards $N.", ch, 0, victim, TO_CHAR);
-	act("$n extends tendrils of electricity towards you.", ch, 0, victim, TO_VICT);
-	act("$n extends tendrils of electricity towards $N.", ch, 0, victim, TO_NOTVICT);
+	act("You extend tendrils of electricity towards $N.", ch, nullptr, victim, TO_CHAR);
+	act("$n extends tendrils of electricity towards you.", ch, nullptr, victim, TO_VICT);
+	act("$n extends tendrils of electricity towards $N.", ch, nullptr, victim, TO_NOTVICT);
 
 	damage_new(ch, victim, dice(5, 2), sn, DAM_ENERGY, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, nullptr);
 
 	if (saves_spell(level, victim, DAM_ENERGY))
 	{
-		act("You fail to siphon away any of $N's mana.", ch, 0, victim, TO_CHAR);
-		act("You feel a brief tingling sensation, but it quickly dissipates.", ch, 0, victim, TO_VICT);
+		act("You fail to siphon away any of $N's mana.", ch, nullptr, victim, TO_CHAR);
+		act("You feel a brief tingling sensation, but it quickly dissipates.", ch, nullptr, victim, TO_VICT);
 		return;
 	}
 	else
@@ -1953,9 +1953,9 @@ void spell_mana_leech(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_
 		if (victim->mana <= 1)
 			return;
 
-		act("You siphon away $N's mana energy!", ch, 0, victim, TO_CHAR);
-		act("You feel weak as mana energy is ripped from your body!", ch, 0, victim, TO_VICT);
-		act("$N looks drained as the tendrils lash across his body!", ch, 0, victim, TO_NOTVICT);
+		act("You siphon away $N's mana energy!", ch, nullptr, victim, TO_CHAR);
+		act("You feel weak as mana energy is ripped from your body!", ch, nullptr, victim, TO_VICT);
+		act("$N looks drained as the tendrils lash across his body!", ch, nullptr, victim, TO_NOTVICT);
 
 		drain = dice(20, 15);
 
@@ -2053,13 +2053,13 @@ void spell_dehydrate(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_u
 
 	if (!is_npc(victim) && victim->pcdata->condition[COND_THIRST] > COND_HUNGRY)
 	{
-		act("$N is already too dehydrated to be affected.", ch, 0, victim, TO_CHAR);
+		act("$N is already too dehydrated to be affected.", ch, nullptr, victim, TO_CHAR);
 		return;
 	}
 
-	act("You attempt to draw fluids from $N's body.", ch, 0, victim, TO_CHAR);
-	act("A wave of nausea overcomes you as your gut clenches and sweat gushes from your pores.\n\rYou feel desperately thirsty.", ch, 0, victim, TO_VICT);
-	act("$N doubles over in agony as rolls of sweat drip from $S body.", ch, 0, victim, TO_NOTVICT);
+	act("You attempt to draw fluids from $N's body.", ch, nullptr, victim, TO_CHAR);
+	act("A wave of nausea overcomes you as your gut clenches and sweat gushes from your pores.\n\rYou feel desperately thirsty.", ch, nullptr, victim, TO_VICT);
+	act("$N doubles over in agony as rolls of sweat drip from $S body.", ch, nullptr, victim, TO_NOTVICT);
 
 	if (is_npc(victim))
 	{
@@ -2079,8 +2079,8 @@ void spell_drown(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unuse
 	CHAR_DATA *victim = vo.AsChar();
 	int dam = dice(level + 10, 4);
 
-	act("You choke and gasp for air as your lungs fill with water!", victim, 0, 0, TO_CHAR);
-	act("$n sputters and clutches $s chest as $s lungs fill with water!", victim, 0, 0, TO_ROOM);
+	act("You choke and gasp for air as your lungs fill with water!", victim, nullptr, nullptr, TO_CHAR);
+	act("$n sputters and clutches $s chest as $s lungs fill with water!", victim, nullptr, nullptr, TO_ROOM);
 
 	if (ch->in_room->sector_type == SECT_WATER || ch->in_room->sector_type == SECT_UNDERWATER)
 		dam *= 2;
@@ -2178,18 +2178,18 @@ void spell_hydration(int /* sn */, int /* level */, CHAR_DATA *ch, SpellTarget v
 	}
 
 	if (victim == ch)
-		act("You draw upon the water in your surroundings to revitalize yourself.", ch, 0, victim, TO_CHAR);
+		act("You draw upon the water in your surroundings to revitalize yourself.", ch, nullptr, victim, TO_CHAR);
 	else
-		act("You draw upon the water in your surroundings to revitalize $N.", ch, 0, victim, TO_CHAR);
+		act("You draw upon the water in your surroundings to revitalize $N.", ch, nullptr, victim, TO_CHAR);
 
 	if (heal == 0)
-		act("The flames burn up all moisture around you!", victim, 0, 0, TO_CHAR);
+		act("The flames burn up all moisture around you!", victim, nullptr, nullptr, TO_CHAR);
 	else if (heal <= 30)
-		act("You feel slightly more vigorous as moisture bathes your skin.", victim, 0, 0, TO_CHAR);
+		act("You feel slightly more vigorous as moisture bathes your skin.", victim, nullptr, nullptr, TO_CHAR);
 	else if (heal <= 80)
-		act("A renewed energy surges through your limbs as the healing waters wash over you.", victim, 0, 0, TO_CHAR);
+		act("A renewed energy surges through your limbs as the healing waters wash over you.", victim, nullptr, nullptr, TO_CHAR);
 	else
-		act("You feel your wounds mending rapidly as the life-giving water fills you with vigor!", victim, 0, 0, TO_CHAR);
+		act("You feel your wounds mending rapidly as the life-giving water fills you with vigor!", victim, nullptr, nullptr, TO_CHAR);
 
 	victim->hit = std::min(victim->hit + heal, (int)victim->max_hit);
 }
@@ -2204,7 +2204,7 @@ void spell_regeneration(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[mayb
 		if (ch == victim)
 			send_to_char("You can not aid your regeneration any further.\n\r", ch);
 		else
-			act("You can not aid $N's regeneration any further.", ch, 0, victim, TO_VICT);
+			act("You can not aid $N's regeneration any further.", ch, nullptr, victim, TO_VICT);
 
 		return;
 	}
@@ -2221,9 +2221,9 @@ void spell_regeneration(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[mayb
 	affect_to_char(victim, &af);
 
 	if (victim != ch)
-		act("You harness the restorative powers of water to aid $N's regeneration.", ch, 0, victim, TO_CHAR);
+		act("You harness the restorative powers of water to aid $N's regeneration.", ch, nullptr, victim, TO_CHAR);
 	else
-		act("You harness the restorative powers of water to aid your regeneration.", ch, 0, victim, TO_CHAR);
+		act("You harness the restorative powers of water to aid your regeneration.", ch, nullptr, victim, TO_CHAR);
 
 	send_to_char("A soothing coolness washes over you as you feel a surge of vitality.\n\r", victim);
 }
@@ -2250,7 +2250,7 @@ void spell_watershield(int /* sn */, int level, CHAR_DATA *ch, SpellTarget /* vo
 	affect_to_char(ch, &af);
 
 	send_to_char("You form a shield of swirling water around you.\n\r", ch);
-	act("A magical sphere of swirling water briefly surrounds $n.", ch, 0, 0, TO_ROOM);
+	act("A magical sphere of swirling water briefly surrounds $n.", ch, nullptr, nullptr, TO_ROOM);
 }
 
 void spell_flood(int sn, int level, CHAR_DATA *ch, [[maybe_unused]] SpellTarget vo, [[maybe_unused]] CastMode mode)
@@ -2325,12 +2325,12 @@ void spell_flood(int sn, int level, CHAR_DATA *ch, [[maybe_unused]] SpellTarget 
 		}
 
 		direction = flag_name_lookup(door, direction_table);
-		act("You gather the water around you and direct it to overflow the bank to the $T!", ch, 0, direction, TO_CHAR);
+		act("You gather the water around you and direct it to overflow the bank to the $T!", ch, nullptr, direction, TO_CHAR);
 
 		if (to_room->people)
 		{
 			direction = flag_name_lookup(reverse_d(door), direction_table);
-			act("A torrent of water rushes in from the $T, flooding the room!", to_room->people, 0, direction, TO_ALL);
+			act("A torrent of water rushes in from the $T, flooding the room!", to_room->people, nullptr, direction, TO_ALL);
 		}
 
 		duration = 24;
@@ -2493,12 +2493,12 @@ void spell_tidalwave(int sn, int level, CHAR_DATA *ch, [[maybe_unused]] SpellTar
 		to_room = pexit->u1.to_room;
 	}
 
-	act("You gather the waters around you into a massive tidal wave!", ch, 0, 0, TO_CHAR);
-	act("As $n gestures, a massive wave rises from the waters before him.", ch, 0, 0, TO_ROOM);
+	act("You gather the waters around you into a massive tidal wave!", ch, nullptr, nullptr, TO_CHAR);
+	act("As $n gestures, a massive wave rises from the waters before him.", ch, nullptr, nullptr, TO_ROOM);
 
 	direction = flag_name_lookup(door, direction_table);
 
-	act("The tidal wave surges $T, leaving havoc in its wake!", ch, 0, direction, TO_ALL);
+	act("The tidal wave surges $T, leaving havoc in its wake!", ch, nullptr, direction, TO_ALL);
 
 	for (vch = ch->in_room->people; vch != nullptr; vch = v_next)
 	{
@@ -2587,7 +2587,7 @@ void spell_riptide(int sn, int level, CHAR_DATA *ch, [[maybe_unused]] SpellTarge
 			return;
 		}
 
-		act("You shape the water currents around you to flow into this area.", ch, 0, 0, TO_CHAR);
+		act("You shape the water currents around you to flow into this area.", ch, nullptr, nullptr, TO_CHAR);
 
 		init_affect(&af);
 		af.where = TO_AFFECTS;
@@ -2626,8 +2626,8 @@ void spell_riptide(int sn, int level, CHAR_DATA *ch, [[maybe_unused]] SpellTarge
 			return;
 		}
 
-		act("Faint eddies disturb the surface of the water as you create a dangerous riptide.", ch, 0, 0, TO_CHAR);
-		act("The water near $n ripples slightly.", ch, 0, 0, TO_ROOM);
+		act("Faint eddies disturb the surface of the water as you create a dangerous riptide.", ch, nullptr, nullptr, TO_CHAR);
+		act("The water near $n ripples slightly.", ch, nullptr, nullptr, TO_ROOM);
 
 		init_affect_room(&nraf);
 		nraf.where = TO_ROOM_AFFECTS;
@@ -2805,9 +2805,9 @@ void spell_disruption(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_
 	if (saves_spell(level, victim, DAM_INTERNAL))
 		dam /= 2;
 
-	act("You concentrate and briefly disrupt the molecular structure of $N's organs!", ch, 0, victim, TO_CHAR);
-	act("$n extends a hand towards you and you feel a horrible rending pain deep within you!", ch, 0, victim, TO_VICT);
-	act("$n extends a hand towards $N, who lurches in agony despite no visible injury!", ch, 0, victim, TO_NOTVICT);
+	act("You concentrate and briefly disrupt the molecular structure of $N's organs!", ch, nullptr, victim, TO_CHAR);
+	act("$n extends a hand towards you and you feel a horrible rending pain deep within you!", ch, nullptr, victim, TO_VICT);
+	act("$n extends a hand towards $N, who lurches in agony despite no visible injury!", ch, nullptr, victim, TO_NOTVICT);
 
 	damage_new(ch, victim, dam, sn, DAM_INTERNAL, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, nullptr);
 }
@@ -2837,7 +2837,7 @@ void spell_anchor(int /* sn */, int level, CHAR_DATA *ch, SpellTarget /* vo */, 
 
 	if (oldanchor)
 	{
-		act("$n dissipates harmlessly.", oldanchor, 0, 0, TO_ROOM);
+		act("$n dissipates harmlessly.", oldanchor, nullptr, nullptr, TO_ROOM);
 		extract_char(oldanchor, true);
 	}
 
@@ -2846,8 +2846,8 @@ void spell_anchor(int /* sn */, int level, CHAR_DATA *ch, SpellTarget /* vo */, 
 	anchor->level = level;
 	anchor->hunting = ch->self;
 
-	act("You harness the energy in the surrounding air to anchor your essence to this spot.", ch, 0, 0, TO_CHAR);
-	act("$n concentrates intently, and a small funnel cloud begins to spin in place beside $m.", ch, 0, 0, TO_ROOM);
+	act("You harness the energy in the surrounding air to anchor your essence to this spot.", ch, nullptr, nullptr, TO_CHAR);
+	act("$n concentrates intently, and a small funnel cloud begins to spin in place beside $m.", ch, nullptr, nullptr, TO_ROOM);
 }
 
 void spell_aerial_transferrence(int sn, int /* level */, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
@@ -2882,14 +2882,14 @@ void spell_aerial_transferrence(int sn, int /* level */, CHAR_DATA *ch, SpellTar
 
 	if (anchor)
 	{
-		act("As you call upon the power of the winds, a large funnel cloud materializes to carry you off into the air!", ch, 0, 0, TO_CHAR);
-		act("A large funnel cloud materializes out of nowhere and carries $n soaring into the sky!", ch, 0, 0, TO_ROOM);
+		act("As you call upon the power of the winds, a large funnel cloud materializes to carry you off into the air!", ch, nullptr, nullptr, TO_CHAR);
+		act("A large funnel cloud materializes out of nowhere and carries $n soaring into the sky!", ch, nullptr, nullptr, TO_ROOM);
 
 		char_from_room(ch);
 		char_to_room(ch, anchor->in_room);
 
-		act("You soar through the air and are soon set down beside your anchor.", ch, 0, 0, TO_CHAR);
-		act("$n suddenly drops gently to the ground, beside the small funnel cloud.", ch, 0, 0, TO_ROOM);
+		act("You soar through the air and are soon set down beside your anchor.", ch, nullptr, nullptr, TO_CHAR);
+		act("$n suddenly drops gently to the ground, beside the small funnel cloud.", ch, nullptr, nullptr, TO_ROOM);
 
 		do_look(ch, "auto");
 		check_plasma_thread(ch, -1);
@@ -2912,14 +2912,14 @@ void spell_aerial_transferrence(int sn, int /* level */, CHAR_DATA *ch, SpellTar
 				break;
 		}
 
-		act("As you call upon the power of the winds, a large funnel cloud materializes to carry you off into the air!", ch, 0, 0, TO_CHAR);
-		act("A large funnel cloud materializes out of nowhere and carries $n soaring into the sky!", ch, 0, 0, TO_ROOM);
+		act("As you call upon the power of the winds, a large funnel cloud materializes to carry you off into the air!", ch, nullptr, nullptr, TO_CHAR);
+		act("A large funnel cloud materializes out of nowhere and carries $n soaring into the sky!", ch, nullptr, nullptr, TO_ROOM);
 
 		char_from_room(ch);
 		char_to_room(ch, pRoomIndex);
 
-		act("Without an anchor to secure you, the winds fling you haphazardly through the sky! ", ch, 0, 0, TO_CHAR);
-		act("$n plummets suddenly from the sky, hitting the ground hard!", ch, 0, 0, TO_ROOM);
+		act("Without an anchor to secure you, the winds fling you haphazardly through the sky! ", ch, nullptr, nullptr, TO_CHAR);
+		act("$n plummets suddenly from the sky, hitting the ground hard!", ch, nullptr, nullptr, TO_ROOM);
 
 		do_look(ch, "auto");
 		damage_new(ch, ch, dice(10, 10), sn, DAM_BASH, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, nullptr);
@@ -2955,7 +2955,7 @@ void spell_airshield(int /* sn */, int level, CHAR_DATA *ch, SpellTarget /* vo *
 	affect_to_char(ch, &af);
 
 	send_to_char("The air begins to swirl rapidly around you.\n\r", ch);
-	act("$n raises $s arms, and swirling winds surround $m.", ch, 0, 0, TO_ROOM);
+	act("$n raises $s arms, and swirling winds surround $m.", ch, nullptr, nullptr, TO_ROOM);
 }
 
 /* Earth spells */
@@ -2978,8 +2978,8 @@ void spell_hardenfist(int sn, int level, CHAR_DATA *ch, [[maybe_unused]] SpellTa
 		af.end_fun = nullptr;
 		new_affect_to_char(ch, &af);
 
-		act("$n clenches $s fists tightly as the flesh seems to take on a stony pallor.", ch, 0, 0, TO_ROOM);
-		act("As you clench your fist, it becomes as hard as granite.", ch, 0, 0, TO_CHAR);
+		act("$n clenches $s fists tightly as the flesh seems to take on a stony pallor.", ch, nullptr, nullptr, TO_ROOM);
+		act("As you clench your fist, it becomes as hard as granite.", ch, nullptr, nullptr, TO_CHAR);
 	}
 	else
 	{
@@ -3008,7 +3008,7 @@ void spell_stability(int sn, int level, CHAR_DATA *ch, [[maybe_unused]] SpellTar
 	af.mod_name = MOD_LEVITATION;
 	affect_to_char(ch, &af);
 
-	act("$n suddenly seems much more sure of $s balance.", ch, 0, 0, TO_ROOM);
+	act("$n suddenly seems much more sure of $s balance.", ch, nullptr, nullptr, TO_ROOM);
 	send_to_char("You focus on manipulating your own mass, steadying your balance.\n\r", ch);
 }
 
@@ -3022,9 +3022,9 @@ void spell_crush(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unuse
 	if (saves_spell(level, victim, DAM_BASH))
 		dam /= 2;
 
-	act("You concentrate and briefly disrupt the molecular structure of $N's organs!", ch, 0, victim, TO_CHAR);
-	act("$n extends a hand towards you and you feel a horrible rending pain deep within you!", ch, 0, victim, TO_VICT);
-	act("$n extends a hand towards $N, who lurches in agony despite no visible injury!", ch, 0, victim, TO_NOTVICT);
+	act("You concentrate and briefly disrupt the molecular structure of $N's organs!", ch, nullptr, victim, TO_CHAR);
+	act("$n extends a hand towards you and you feel a horrible rending pain deep within you!", ch, nullptr, victim, TO_VICT);
+	act("$n extends a hand towards $N, who lurches in agony despite no visible injury!", ch, nullptr, victim, TO_NOTVICT);
 
 	damage_new(ch, victim, dam, sn, DAM_INTERNAL, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "crushing force");
 }
@@ -3048,7 +3048,7 @@ void spell_sensevibrations(int sn, int level, CHAR_DATA *ch, SpellTarget /* vo *
 		af.mod_name = MOD_PERCEPTION;
 		new_affect_to_char(ch, &af);
 
-		act("You attune your senses to the vibrations of the ground beneath you.", ch, 0, 0, TO_CHAR);
+		act("You attune your senses to the vibrations of the ground beneath you.", ch, nullptr, nullptr, TO_CHAR);
 	}
 	else
 	{
@@ -3076,8 +3076,8 @@ void spell_diamondskin(int sn, int level, CHAR_DATA *ch, SpellTarget /* vo */, C
 			af.mod_name = MOD_PROTECTION;
 			new_affect_to_char(ch, &af);
 
-			act("$n concentrates, and $s skin hardens into a diamond-like carapace.", ch, 0, 0, TO_ROOM);
-			act("The outer layers of your skin become almost impossibly hard.", ch, 0, 0, TO_CHAR);
+			act("$n concentrates, and $s skin hardens into a diamond-like carapace.", ch, nullptr, nullptr, TO_ROOM);
+			act("The outer layers of your skin become almost impossibly hard.", ch, nullptr, nullptr, TO_CHAR);
 			if (is_affected(ch, gsn_stoneskin))
 				affect_strip(ch, gsn_stoneskin);
 			if (is_affected(ch, gsn_ironskin))
@@ -3155,14 +3155,14 @@ void spell_overbear(int sn, [[maybe_unused]] int level, CHAR_DATA *ch, SpellTarg
 
 	if (number_percent() >= chance)
 	{
-		act("An invisible weight presses down upon you, but you shrug it off.", victim, 0, 0, TO_CHAR);
-		act("$n staggers slightly for a moment, but maintains $s balance.", victim, 0, 0, TO_ROOM);
+		act("An invisible weight presses down upon you, but you shrug it off.", victim, nullptr, nullptr, TO_CHAR);
+		act("$n staggers slightly for a moment, but maintains $s balance.", victim, nullptr, nullptr, TO_ROOM);
 		return;
 	}
 	else
 	{
-		act("An invisible weight bears down upon you, forcing you to your knees!", victim, 0, 0, TO_CHAR);
-		act("$n loses his footing, staggering under an unseen burden!", victim, 0, 0, TO_ROOM);
+		act("An invisible weight bears down upon you, forcing you to your knees!", victim, nullptr, nullptr, TO_CHAR);
+		act("$n loses his footing, staggering under an unseen burden!", victim, nullptr, nullptr, TO_ROOM);
 
 		damage_new(ch, victim, dice(2, 6), sn, DAM_BASH, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "overbearing force");
 		victim->position = POS_RESTING;
@@ -3196,7 +3196,7 @@ void spell_reduce([[maybe_unused]] int sn, int level, CHAR_DATA *ch, SpellTarget
 	if (is_affected(victim, gsn_enlarge))
 	{
 		send_to_char("You shrink down to your normal size.\n\r", victim);
-		act("$n shrinks down to $s normal size.", victim, 0, 0, TO_ROOM);
+		act("$n shrinks down to $s normal size.", victim, nullptr, nullptr, TO_ROOM);
 
 		affect_strip(victim, gsn_enlarge);
 		return;
@@ -3218,7 +3218,7 @@ void spell_reduce([[maybe_unused]] int sn, int level, CHAR_DATA *ch, SpellTarget
 	affect_to_char(victim, &af);
 
 	send_to_char("Your entire body suddenly contracts, leaving you significantly smaller but somehow sturdier.\n\r", victim);
-	act("$n rapidly shrinks to two-thirds of $s original size!", victim, 0, 0, TO_ROOM);
+	act("$n rapidly shrinks to two-thirds of $s original size!", victim, nullptr, nullptr, TO_ROOM);
 
 	if (!trusts(ch, victim))
 	{
@@ -3250,7 +3250,7 @@ void spell_earthshield(int /* sn */, int level, CHAR_DATA *ch, SpellTarget /* vo
 	affect_to_char(ch, &af);
 
 	send_to_char("You ready a shield of solid matter to deflect the bodies of your foes.\n\r", ch);
-	act("$n's form is suddenly masked by an opaque gray shield that vanishes as quickly as it appeared.", ch, 0, 0, TO_ROOM);
+	act("$n's form is suddenly masked by an opaque gray shield that vanishes as quickly as it appeared.", ch, nullptr, nullptr, TO_ROOM);
 }
 
 void spell_coldshield(int sn, int level, CHAR_DATA *ch, [[maybe_unused]] SpellTarget vo, [[maybe_unused]] CastMode mode)
@@ -3275,7 +3275,7 @@ void spell_coldshield(int sn, int level, CHAR_DATA *ch, [[maybe_unused]] SpellTa
 	affect_to_char(ch, &af);
 
 	send_to_char("The air around you rapidly chills.\n\r", ch);
-	act("The air around $n suddenly turns frigid.", ch, 0, 0, TO_ROOM);
+	act("The air around $n suddenly turns frigid.", ch, nullptr, nullptr, TO_ROOM);
 }
 
 void spell_coagulate(int /* sn */, int level, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
@@ -3306,16 +3306,16 @@ void spell_coagulate(int /* sn */, int level, CHAR_DATA *ch, SpellTarget /* vo *
 
 	int dam = dice(5, 4) + level;
 
-	act("You draw heat out of $N's bloodstream.", ch, 0, victim, TO_CHAR);
-	act("Your blood chills as $n extends a hand towards you.", ch, 0, victim, TO_VICT);
+	act("You draw heat out of $N's bloodstream.", ch, nullptr, victim, TO_CHAR);
+	act("Your blood chills as $n extends a hand towards you.", ch, nullptr, victim, TO_VICT);
 
 	if (damage_new(ch, victim, dam, TYPE_UNDEFINED, DAM_COLD, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "coagulation") == -1)
 		return;
 
 	if (is_affected(victim, gsn_bleeding))
 	{
-		act("$N's blood congeals, and $S bleeding stops.", ch, 0, victim, TO_CHAR);
-		act("You shiver slightly from the cold, but your bleeding stops.", ch, 0, victim, TO_VICT);
+		act("$N's blood congeals, and $S bleeding stops.", ch, nullptr, victim, TO_CHAR);
+		act("You shiver slightly from the cold, but your bleeding stops.", ch, nullptr, victim, TO_VICT);
 		affect_strip(victim, gsn_bleeding);
 	}
 }
@@ -3330,7 +3330,7 @@ void spell_hypothermia(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe
 		|| saves_spell(level - 1, victim, DAM_COLD)
 		|| IS_SET(victim->imm_flags, IMM_SLEEP))
 	{
-		act("$N resisted your hypothermia spell.", ch, 0, victim, TO_CHAR);
+		act("$N resisted your hypothermia spell.", ch, nullptr, victim, TO_CHAR);
 		return;
 	}
 
@@ -3352,7 +3352,7 @@ void spell_hypothermia(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe
 	{
 		if (is_affected(victim, gsn_indom))
 		{
-			act("$N's body's state is maintained by the force of $S will.", ch, 0, victim, TO_CHAR);
+			act("$N's body's state is maintained by the force of $S will.", ch, nullptr, victim, TO_CHAR);
 			return;
 		}
 
@@ -3431,8 +3431,8 @@ void spell_frigidaura(int sn, int level, CHAR_DATA *ch, [[maybe_unused]] SpellTa
 
 	affect_to_char(ch, &af);
 
-	act("You chill the air around you, prepared to lash out at any who come near.", ch, 0, 0, TO_CHAR);
-	act("$n is briefly surrounded by an aura of ice, which rapidly fades away.", ch, 0, 0, TO_ROOM);
+	act("You chill the air around you, prepared to lash out at any who come near.", ch, nullptr, nullptr, TO_CHAR);
+	act("$n is briefly surrounded by an aura of ice, which rapidly fades away.", ch, nullptr, nullptr, TO_ROOM);
 }
 
 ///
@@ -3459,7 +3459,7 @@ void spell_enervate_agitate_helper(int sn, int level, CHAR_DATA *ch, [[maybe_unu
 
 	if (is_npc(victim))
 	{
-		act("You lack the necessary understanding of $N's structure to accomplish that.", ch, 0, victim, TO_CHAR);
+		act("You lack the necessary understanding of $N's structure to accomplish that.", ch, nullptr, victim, TO_CHAR);
 		return;
 	}
 
@@ -3475,9 +3475,9 @@ void spell_enervate_agitate_helper(int sn, int level, CHAR_DATA *ch, [[maybe_unu
 		if (saves_spell(level, victim, (sn == gsn_agitate) ? DAM_FIRE : DAM_COLD))
 		{
 			if (iDir > 0)
-				act("You failed to accelerate the particles of $N.", ch, 0, victim, TO_CHAR);
+				act("You failed to accelerate the particles of $N.", ch, nullptr, victim, TO_CHAR);
 			else
-				act("You failed to decelerate the particles of $N.", ch, 0, victim, TO_CHAR);
+				act("You failed to decelerate the particles of $N.", ch, nullptr, victim, TO_CHAR);
 
 			multi_hit(victim, ch, TYPE_UNDEFINED);
 			return;
@@ -3497,13 +3497,13 @@ void spell_enervate_agitate_helper(int sn, int level, CHAR_DATA *ch, [[maybe_unu
 
 	if (iDir > 0)
 	{
-		act("You infuse the particles of $N's body with kinetic energy.", ch, 0, victim, TO_CHAR);
-		act("$n focuses intense energy upon $N's body!", ch, 0, victim, TO_NOTVICT);
+		act("You infuse the particles of $N's body with kinetic energy.", ch, nullptr, victim, TO_CHAR);
+		act("$n focuses intense energy upon $N's body!", ch, nullptr, victim, TO_NOTVICT);
 	}
 	else
 	{
-		act("Drawing heat from $N's body in large quantity, you slow down $s particles.", ch, 0, victim, TO_CHAR);
-		act("$n draws energy from $N's body!", ch, 0, victim, TO_NOTVICT);
+		act("Drawing heat from $N's body in large quantity, you slow down $s particles.", ch, nullptr, victim, TO_CHAR);
+		act("$n draws energy from $N's body!", ch, nullptr, victim, TO_NOTVICT);
 	}
 
 	if (iDir > 0)
@@ -3527,7 +3527,7 @@ void spell_enervate_agitate_helper(int sn, int level, CHAR_DATA *ch, [[maybe_unu
 							"realize you are about to die.\n\r", victim);
 				break;
 			default:
-				act("$n infuses your body with powerful heat energy!", ch, 0, victim, TO_VICT);
+				act("$n infuses your body with powerful heat energy!", ch, nullptr, victim, TO_VICT);
 				break;
 		}
 	}
@@ -3551,7 +3551,7 @@ void spell_enervate_agitate_helper(int sn, int level, CHAR_DATA *ch, [[maybe_unu
 				send_to_char("Your body grinds to a halt as you lose control of the last of your mobility.\n\r", victim);
 				break;
 			default:
-				act("$n infuses your body with frigid cold energy!", ch, 0, victim, TO_VICT);
+				act("$n infuses your body with frigid cold energy!", ch, nullptr, victim, TO_VICT);
 				break;
 		}
 	}
@@ -3650,7 +3650,7 @@ void agitate_tick(CHAR_DATA *ch, AFFECT_DATA *af)
 
 	if (ch->pcdata->energy_state > 4)
 	{
-		act("$n collapses in a heap, wisps of smoke rising from $s charred corpse.", ch, 0, 0, TO_ROOM);
+		act("$n collapses in a heap, wisps of smoke rising from $s charred corpse.", ch, nullptr, nullptr, TO_ROOM);
 		send_to_char("You crumple to the ground, your consciousness fading away, as your body collapses under the heat.\n\r", ch);
 
 		if (Deref(af->owner))
@@ -3681,9 +3681,9 @@ void spell_freezemetal(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe
 	OBJ_DATA *obj;
 	int iWear, highchance, crushdam, piercedam;
 
-	act("The air around you suddenly turns ice cold.", ch, 0, victim, TO_VICT);
-	act("You attempt to siphon heat away from $N's armor.", ch, 0, victim, TO_CHAR);
-	act("$n extends a hand toward $N, as a chill fills the air.", ch, 0, victim, TO_NOTVICT);
+	act("The air around you suddenly turns ice cold.", ch, nullptr, victim, TO_VICT);
+	act("You attempt to siphon heat away from $N's armor.", ch, nullptr, victim, TO_CHAR);
+	act("$n extends a hand toward $N, as a chill fills the air.", ch, nullptr, victim, TO_NOTVICT);
 
 	crushdam = 0;
 	piercedam = 0;
@@ -3754,9 +3754,9 @@ void spell_frostbite(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_u
 			return;
 		}
 
-		act("$N's arm goes limp as you draw heat from it.", ch, 0, victim, TO_CHAR);
-		act_new("Your arm goes limp as $n draws heat from it.", ch, 0, victim, TO_VICT, POS_SLEEPING);
-		act("$N's arm goes limp as $n draws heat from it.", ch, 0, victim, TO_NOTVICT);
+		act("$N's arm goes limp as you draw heat from it.", ch, nullptr, victim, TO_CHAR);
+		act_new("Your arm goes limp as $n draws heat from it.", ch, nullptr, victim, TO_VICT, POS_SLEEPING);
+		act("$N's arm goes limp as $n draws heat from it.", ch, nullptr, victim, TO_NOTVICT);
 
 		for (auto it = victim->affected.begin(); it != victim->affected.end(); )
 		{
@@ -3780,9 +3780,9 @@ void spell_frostbite(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_u
 
 		if (!saves_spell(level - 2, victim, DAM_COLD))
 		{
-			act("$N's screams in pain as $S arm, now a pale bluish-white color, dangles uselessly at $S side!", ch, 0, victim, TO_CHAR);
-			act_new("Shooting pains run through your arm as $n chills it, and then suddenly, you have no feeling in it at all.", ch, 0, victim, TO_VICT, POS_SLEEPING);
-			act("$N's screams in pain as $S arm, now a pale bluish-white color, dangles uselessly at $S side!", ch, 0, victim, TO_NOTVICT);
+			act("$N's screams in pain as $S arm, now a pale bluish-white color, dangles uselessly at $S side!", ch, nullptr, victim, TO_CHAR);
+			act_new("Shooting pains run through your arm as $n chills it, and then suddenly, you have no feeling in it at all.", ch, nullptr, victim, TO_VICT, POS_SLEEPING);
+			act("$N's screams in pain as $S arm, now a pale bluish-white color, dangles uselessly at $S side!", ch, nullptr, victim, TO_NOTVICT);
 
 			init_affect(&af);
 			af.where = TO_AFFECTS;
@@ -3803,9 +3803,9 @@ void spell_frostbite(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_u
 			return;
 		}
 
-		act("$N's leg goes limp as you draw heat from it.", ch, 0, victim, TO_CHAR);
-		act_new("Your leg goes limp as $n draws heat from it.", ch, 0, victim, TO_VICT, POS_SLEEPING);
-		act("$N's leg goes limp as $n draws heat from it.", ch, 0, victim, TO_NOTVICT);
+		act("$N's leg goes limp as you draw heat from it.", ch, nullptr, victim, TO_CHAR);
+		act_new("Your leg goes limp as $n draws heat from it.", ch, nullptr, victim, TO_VICT, POS_SLEEPING);
+		act("$N's leg goes limp as $n draws heat from it.", ch, nullptr, victim, TO_NOTVICT);
 
 		for (auto it = victim->affected.begin(); it != victim->affected.end(); )
 		{
@@ -3829,9 +3829,9 @@ void spell_frostbite(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_u
 
 		if (!saves_spell(level - 2, victim, DAM_COLD))
 		{
-			act("$N nearly collapses to the ground as $S leg is frozen solid!", ch, 0, victim, TO_CHAR);
-			act_new("Shooting pains run through your leg as $n chills it, and then suddenly, you have no feeling in it at all.", ch, 0, victim, TO_VICT, POS_SLEEPING);
-			act("$N nearly collapses to the ground as $S leg is frozen solid!", ch, 0, victim, TO_NOTVICT);
+			act("$N nearly collapses to the ground as $S leg is frozen solid!", ch, nullptr, victim, TO_CHAR);
+			act_new("Shooting pains run through your leg as $n chills it, and then suddenly, you have no feeling in it at all.", ch, nullptr, victim, TO_VICT, POS_SLEEPING);
+			act("$N nearly collapses to the ground as $S leg is frozen solid!", ch, nullptr, victim, TO_NOTVICT);
 
 			init_affect(&af);
 			af.where = TO_AFFECTS;
@@ -3946,32 +3946,32 @@ void spell_acid_stream(int /* sn */, int level, CHAR_DATA *ch, SpellTarget vo, C
 	if (ch != victim)
 	{
 		buffer = fmt::format("You spray a stream of hissing acid at $N, striking $S {}!", bodypart);
-		act(buffer.c_str(), ch, 0, victim, TO_CHAR);
+		act(buffer.c_str(), ch, nullptr, victim, TO_CHAR);
 
 		buffer = fmt::format("$n sprays a stream of hissing acid at you, striking your {}!", bodypart);
-		act(buffer.c_str(), ch, 0, victim, TO_VICT);
+		act(buffer.c_str(), ch, nullptr, victim, TO_VICT);
 
 		buffer = fmt::format("$n sprays a stream of hissing acid at $N, striking $S {}!", bodypart);
-		act(buffer.c_str(), ch, 0, victim, TO_NOTVICT);
+		act(buffer.c_str(), ch, nullptr, victim, TO_NOTVICT);
 	}
 	else
 	{
 		buffer = fmt::format("A stream of hissing acid hits you, striking your %s!", bodypart);
-		act(buffer.c_str(), ch, 0, 0, TO_CHAR);
+		act(buffer.c_str(), ch, nullptr, nullptr, TO_CHAR);
 
 		buffer = fmt::format("A stream of hissing acid hits $n, striking $s %s!", bodypart);
-		act(buffer.c_str(), ch, 0, 0, TO_ROOM);
+		act(buffer.c_str(), ch, nullptr, nullptr, TO_ROOM);
 	}
 
 	if (ch != victim)
 	{
-		act(tochar2, ch, 0, victim, TO_CHAR);
-		act(tovict2, ch, 0, victim, TO_VICT);
+		act(tochar2, ch, nullptr, victim, TO_CHAR);
+		act(tovict2, ch, nullptr, victim, TO_VICT);
 	}
 	else
-		act(tovict2, ch, 0, 0, TO_CHAR);
+		act(tovict2, ch, nullptr, nullptr, TO_CHAR);
 
-	act(toroom2, ch, 0, victim, TO_NOTVICT);
+	act(toroom2, ch, nullptr, victim, TO_NOTVICT);
 
 	if (hardness > 3 || (armor != nullptr && number_percent() > 50))
 	{
@@ -4035,15 +4035,15 @@ void spell_acid_stream(int /* sn */, int level, CHAR_DATA *ch, SpellTarget vo, C
 	{
 		if (ch != victim)
 		{
-			act(tochar3, ch, 0, victim, TO_CHAR);
-			act(tovict3, ch, 0, victim, TO_VICT);
+			act(tochar3, ch, nullptr, victim, TO_CHAR);
+			act(tovict3, ch, nullptr, victim, TO_VICT);
 		}
 		else
 		{
-			act(tovict3, ch, 0, 0, TO_CHAR);
+			act(tovict3, ch, nullptr, nullptr, TO_CHAR);
 		}
 
-		act(toroom3, ch, 0, victim, TO_NOTVICT);
+		act(toroom3, ch, nullptr, victim, TO_NOTVICT);
 	}
 
 	if (ch != victim)
@@ -4092,23 +4092,23 @@ void spell_acid_vein(int sn, int level, CHAR_DATA *ch, [[maybe_unused]] SpellTar
 	oaf.owner = ch->self;
 	affect_to_obj(weapon, &oaf);
 
-	act("You coat $p with acid.", ch, weapon, 0, TO_CHAR);
+	act("You coat $p with acid.", ch, weapon, nullptr, TO_CHAR);
 	WAIT_STATE(ch, PULSE_VIOLENCE * 2);
 }
 
 void acid_end(OBJ_DATA *obj, [[maybe_unused]] OBJ_AFFECT_DATA *af)
 {
 	if (CHAR_DATA *carrier = Deref(obj->carried_by))
-		act("$p is dissolved by the acid coating it.", carrier, obj, 0, TO_CHAR);
+		act("$p is dissolved by the acid coating it.", carrier, obj, nullptr, TO_CHAR);
 
 	if (obj->in_room && obj->in_room->people)
-		act("$p is dissolved by the acid coating it.", obj->in_room->people, obj, 0, TO_ALL);
+		act("$p is dissolved by the acid coating it.", obj->in_room->people, obj, nullptr, TO_ALL);
 
 	OBJ_DATA *container = Deref(obj->in_obj);
 	CHAR_DATA *containerCarrier = container != nullptr ? Deref(container->carried_by) : nullptr;
 
 	if (containerCarrier != nullptr)
-		act("You hear a faint hissing sound coming from $p.", containerCarrier, container, 0, TO_CHAR);
+		act("You hear a faint hissing sound coming from $p.", containerCarrier, container, nullptr, TO_CHAR);
 
 	extract_obj(obj);
 }
@@ -4510,7 +4510,7 @@ void spell_thunderclap(int sn, int level, CHAR_DATA *ch, SpellTarget /* vo */, C
 	AFFECT_DATA af;
 	char buf[MSL];
 	send_to_char("As you gesture, a booming thunderclap rips through the air!\n\r", ch);
-	act("As $n gestures, a booming thunderclap rips through the air!", ch, 0, 0, TO_ROOM);
+	act("As $n gestures, a booming thunderclap rips through the air!", ch, nullptr, nullptr, TO_ROOM);
 
 	init_affect(&af);
 	af.where = TO_AFFECTS;
@@ -4537,7 +4537,7 @@ void spell_thunderclap(int sn, int level, CHAR_DATA *ch, SpellTarget /* vo */, C
 
 		if (!saves_spell(level, vch, DAM_OTHER) && !saves_spell(level, vch, DAM_OTHER) && !is_affected(vch, sn))
 		{
-			act("$n staggers, dazed by the force of the deafening thunderclap!", vch, 0, 0, TO_ROOM);
+			act("$n staggers, dazed by the force of the deafening thunderclap!", vch, nullptr, nullptr, TO_ROOM);
 			send_to_char("The thunderclap resonates in your ears, deafening you!\n\r", vch);
 			affect_to_char(vch, &af);
 		}
@@ -4553,12 +4553,12 @@ void spell_neutralize([[maybe_unused]] int sn, int level, CHAR_DATA *ch, SpellTa
 
 	if (is_affected(victim, gsn_neutralize))
 	{
-		act("$N is already neutralized.", ch, 0, victim, TO_CHAR);
+		act("$N is already neutralized.", ch, nullptr, victim, TO_CHAR);
 		return;
 	}
 
 	send_to_char("Your body becomes tempered against acids.\n\r", victim);
-	act("$n's skin flushes slightly green for a moment, then returns to normal.", victim, 0, 0, TO_ROOM);
+	act("$n's skin flushes slightly green for a moment, then returns to normal.", victim, nullptr, nullptr, TO_ROOM);
 
 	init_affect(&af);
 	af.where = TO_IMMUNE;
@@ -4639,7 +4639,7 @@ void spell_caustic_vapor(int sn, int level, CHAR_DATA *ch, SpellTarget /* vo */,
 	af.modifier = 0;
 	affect_to_char(ch, &af);
 
-	act("Vapors of acidic mist rise from the ground and begin to engulf the room.", ch, 0, 0, TO_ALL);
+	act("Vapors of acidic mist rise from the ground and begin to engulf the room.", ch, nullptr, nullptr, TO_ALL);
 	zone_echo(ch->in_room->area, "You hear a massive hissing sound.");
 }
 
@@ -4689,7 +4689,7 @@ void spell_smokescreen(int sn, int level, CHAR_DATA *ch, SpellTarget /* vo */, C
 	af.duration = 20;
 	affect_to_char(ch, &af);
 
-	act("Dense smoke fills the room, concealing any way out!", ch, 0, 0, TO_ALL);
+	act("Dense smoke fills the room, concealing any way out!", ch, nullptr, nullptr, TO_ALL);
 }
 
 void smokescreen_end(ROOM_INDEX_DATA *room, [[maybe_unused]] ROOM_AFFECT_DATA *af)
@@ -4703,9 +4703,9 @@ void spell_smother(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unu
 	CHAR_DATA *victim = vo.AsChar();
 	AFFECT_DATA af;
 
-	act("$N chokes and gasps for air as you smother $M with thick smoke!", ch, 0, victim, TO_CHAR);
-	act("You choke and gasp for air as $n smothers you with thick smoke!", ch, 0, victim, TO_VICT);
-	act("$N chokes and gasps for air as $n smothers $M with thick smoke!", ch, 0, victim, TO_NOTVICT);
+	act("$N chokes and gasps for air as you smother $M with thick smoke!", ch, nullptr, victim, TO_CHAR);
+	act("You choke and gasp for air as $n smothers you with thick smoke!", ch, nullptr, victim, TO_VICT);
+	act("$N chokes and gasps for air as $n smothers $M with thick smoke!", ch, nullptr, victim, TO_NOTVICT);
 
 	if (number_percent() > 6 * (get_curr_stat(victim, STAT_CON) - 12))
 	{
@@ -4738,7 +4738,7 @@ void spell_putrid_air(int /* sn */, int /* level */, CHAR_DATA *ch, SpellTarget 
 		return;
 	}
 
-	act("A wave of putrid air sweeps through the area!", ch, 0, 0, TO_ALL);
+	act("A wave of putrid air sweeps through the area!", ch, nullptr, nullptr, TO_ALL);
 
 	for (vch = ch->in_room->people; vch != nullptr; vch = vch_next)
 	{
@@ -4773,9 +4773,9 @@ void spell_asphyxiate(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_
 		return;
 	}
 
-	act("$N gasps as you corrupt the air $E is breathing!", ch, 0, victim, TO_CHAR);
-	act("You gasp as $n corrupts the air you are breathing!", ch, 0, victim, TO_VICT);
-	act("$N gasps as $n corrupts the air $E is breathing!", ch, 0, victim, TO_NOTVICT);
+	act("$N gasps as you corrupt the air $E is breathing!", ch, nullptr, victim, TO_CHAR);
+	act("You gasp as $n corrupts the air you are breathing!", ch, nullptr, victim, TO_VICT);
+	act("$N gasps as $n corrupts the air $E is breathing!", ch, nullptr, victim, TO_NOTVICT);
 
 	if (saves_spell(level, victim, DAM_INTERNAL))
 		dam /= 2;
@@ -4799,8 +4799,8 @@ void spell_shroud_of_secrecy(int sn, int level, CHAR_DATA *ch, SpellTarget /* vo
 		return;
 	}
 
-	act("A shroud of smoke bursts out around you, concealing your presence.", ch, 0, 0, TO_CHAR);
-	act("A shroud of smoke bursts out around $n, concealing $s presence.", ch, 0, 0, TO_ROOM);
+	act("A shroud of smoke bursts out around you, concealing your presence.", ch, nullptr, nullptr, TO_CHAR);
+	act("A shroud of smoke bursts out around $n, concealing $s presence.", ch, nullptr, nullptr, TO_ROOM);
 
 	free_pstring(ch->name);
 	ch->name = palloc_string("Someone");
@@ -4823,8 +4823,8 @@ void shroud_end(CHAR_DATA *ch, [[maybe_unused]] AFFECT_DATA *af)
 	free_pstring(ch->name);
 	ch->name = palloc_string(ch->true_name);
 
-	act("The shroud of smoke concealing you dissipates.", ch, 0, 0, TO_CHAR);
-	act("The shroud of smoke concealing $n dissipates.", ch, 0, 0, TO_ROOM);
+	act("The shroud of smoke concealing you dissipates.", ch, nullptr, nullptr, TO_CHAR);
+	act("The shroud of smoke concealing $n dissipates.", ch, nullptr, nullptr, TO_ROOM);
 }
 
 void spell_noxious_ward(int sn, int level, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
@@ -4848,7 +4848,7 @@ void spell_noxious_ward(int sn, int level, CHAR_DATA *ch, SpellTarget /* vo */, 
 	af.mod_name = MOD_PROTECTION;
 	affect_to_char(ch, &af);
 
-	act("You feel protected by a noxious ward.", ch, 0, 0, TO_CHAR);
+	act("You feel protected by a noxious ward.", ch, nullptr, nullptr, TO_CHAR);
 }
 
 void spell_molten_stones(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
@@ -4873,9 +4873,9 @@ void spell_molten_stones(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[may
 	if (saves_spell(level, victim, DAM_FIRE))
 		fire /= 2;
 
-	act("$n grabs a large stone, liquefies it in a flash and sends it flying at $N!", ch, 0, victim, TO_NOTVICT);
-	act("You grab a large stone, liquify it with a burst of heat, and send it flying at $N!", ch, 0, victim, TO_CHAR);
-	act("$n grabs a large stone, liquefies it in a flash and sends it flying at you!", ch, 0, victim, TO_VICT);
+	act("$n grabs a large stone, liquefies it in a flash and sends it flying at $N!", ch, nullptr, victim, TO_NOTVICT);
+	act("You grab a large stone, liquify it with a burst of heat, and send it flying at $N!", ch, nullptr, victim, TO_CHAR);
+	act("$n grabs a large stone, liquefies it in a flash and sends it flying at you!", ch, nullptr, victim, TO_VICT);
 
 	damage_new(ch, victim, blunt, sn, DAM_BASH, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "molten stone");
 
@@ -4898,8 +4898,8 @@ void spell_heat_earth(int /* sn */, int level, CHAR_DATA *ch, SpellTarget /* vo 
 
 	dam = dice(level, 7);
 
-	act("You superheat the earth in the area, searing your foes!", ch, 0, 0, TO_CHAR);
-	act("$n waves $s arm at the ground and waves of heat radiate upward from beneath you!", ch, 0, 0, TO_ROOM);
+	act("You superheat the earth in the area, searing your foes!", ch, nullptr, nullptr, TO_CHAR);
+	act("$n waves $s arm at the ground and waves of heat radiate upward from beneath you!", ch, nullptr, nullptr, TO_ROOM);
 
 	for (vch = ch->in_room->people; vch; vch = vch_next)
 	{
@@ -4990,14 +4990,14 @@ void spell_blanket(int sn, int level, CHAR_DATA *ch, [[maybe_unused]] SpellTarge
 
 	clear_tracks(ch->in_room);
 
-	act("A sudden gust sweeps through, bearing heavy snowflakes that rapidly blanket the ground.", ch, 0, 0, TO_ALL);
+	act("A sudden gust sweeps through, bearing heavy snowflakes that rapidly blanket the ground.", ch, nullptr, nullptr, TO_ALL);
 }
 
 void blanket_melt(ROOM_INDEX_DATA *room, [[maybe_unused]] ROOM_AFFECT_DATA *af)
 {
 	for (CHAR_DATA *rch = room->people; rch != nullptr; rch = rch->next_in_room)
 	{
-		act("The layer of snow blanketing the earth fades away as the magic dissipates.", rch, 0, 0, TO_CHAR);
+		act("The layer of snow blanketing the earth fades away as the magic dissipates.", rch, nullptr, nullptr, TO_CHAR);
 	}
 
 	clear_tracks(room);
@@ -5094,8 +5094,8 @@ void spell_concave_shell(int /* sn */, int /* level */, CHAR_DATA *ch, SpellTarg
 
 	RS.Queue.AddToQueue(6, "spell_concave_shell", "concave_shell_move", concave_shell_move, ch, dir, ch->in_room);
 
-	act("Air begins to swirl rapidly around you.", ch, 0, 0, TO_CHAR);
-	act("Swirling winds begin to mass near $n.", ch, 0, 0, TO_ROOM);
+	act("Air begins to swirl rapidly around you.", ch, nullptr, nullptr, TO_CHAR);
+	act("Swirling winds begin to mass near $n.", ch, nullptr, nullptr, TO_ROOM);
 }
 
 void concave_shell_move(CHAR_DATA *ch, int dir, ROOM_INDEX_DATA *oldroom)
@@ -5112,7 +5112,7 @@ void concave_shell_move(CHAR_DATA *ch, int dir, ROOM_INDEX_DATA *oldroom)
 
 	if (ch->disrupted)
 	{
-		act("The shell of air dissipates with no effect.", ch, 0, 0, TO_ALL);
+		act("The shell of air dissipates with no effect.", ch, nullptr, nullptr, TO_ALL);
 		return;
 	}
 
@@ -5125,8 +5125,8 @@ void concave_shell_move(CHAR_DATA *ch, int dir, ROOM_INDEX_DATA *oldroom)
 	range = ch->level / 3;
 
 	direction = flag_name_lookup(dir, direction_table);
-	act("The shell of air finishes forming and rushes $tward, taking you with it!", ch, direction, 0, TO_CHAR);
-	act("The shell of air finishes forming and rushes $tward, taking $n with it!", ch, direction, 0, TO_ROOM);
+	act("The shell of air finishes forming and rushes $tward, taking you with it!", ch, direction, nullptr, TO_CHAR);
+	act("The shell of air finishes forming and rushes $tward, taking $n with it!", ch, direction, nullptr, TO_ROOM);
 
 	if (!IS_SET(ch->comm, COMM_BRIEF))
 	{
@@ -5141,7 +5141,7 @@ void concave_shell_move(CHAR_DATA *ch, int dir, ROOM_INDEX_DATA *oldroom)
 		|| (IS_SET(pexit->exit_info, EX_CLOSED) && !is_affected_by(ch, AFF_PASS_DOOR))
 		|| (IS_SET(pexit->exit_info, EX_CLOSED) && IS_SET(pexit->exit_info, EX_NOPASS)))
 	{
-		act("Since the exit $t has become obstructed, the swirling winds dissipate.", ch, direction, 0, TO_ALL);
+		act("Since the exit $t has become obstructed, the swirling winds dissipate.", ch, direction, nullptr, TO_ALL);
 		return;
 	}
 
@@ -5157,7 +5157,7 @@ void concave_shell_move(CHAR_DATA *ch, int dir, ROOM_INDEX_DATA *oldroom)
 			|| (IS_SET(pexit->exit_info, EX_CLOSED) && IS_SET(pexit->exit_info, EX_NOPASS)))
 		{
 			send_to_char("Your rapid motion comes to a crashing halt as you strike an obstacle!\n\r", ch);
-			act("$n flies into the room and crashes into the obstruction $tward!", ch, direction, 0, TO_ROOM);
+			act("$n flies into the room and crashes into the obstruction $tward!", ch, direction, nullptr, TO_ROOM);
 
 			damage_new(ch, ch, dice(10, 10), gsn_bash, DAM_BASH, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "bone-jarring collision");
 			WAIT_STATE(ch, PULSE_VIOLENCE * 2);
@@ -5209,8 +5209,8 @@ void spell_frost_glaze(int sn, int level, CHAR_DATA *ch, SpellTarget /* vo */, C
 		return;
 	}
 
-	act("Your armor becomes covered in frost.", ch, 0, 0, TO_CHAR);
-	act("$n's armor becomes covered in frost.", ch, 0, 0, TO_ROOM);
+	act("Your armor becomes covered in frost.", ch, nullptr, nullptr, TO_CHAR);
+	act("$n's armor becomes covered in frost.", ch, nullptr, nullptr, TO_ROOM);
 
 	acmod = level / 2;
 
@@ -5265,22 +5265,22 @@ void spell_unbreakable(int /* sn */, int level, CHAR_DATA *ch, SpellTarget vo, C
 	{
 		if (victim == ch)
 		{
-			act("You painfully freeze your weapon to your hand!", ch, 0, victim, TO_CHAR);
-			act("$n's fist turns a rigid white as $e grips $s weapon tightly.", ch, 0, 0, TO_ROOM);
+			act("You painfully freeze your weapon to your hand!", ch, nullptr, victim, TO_CHAR);
+			act("$n's fist turns a rigid white as $e grips $s weapon tightly.", ch, nullptr, nullptr, TO_ROOM);
 		}
 		else
 		{
-			act("You freeze $N's weapon to $S hand.", ch, 0, victim, TO_CHAR);
-			act("$n painfully freezes your weapon to your hand!", ch, 0, victim, TO_VICT);
-			act("$N's fist turns a rigid white as $E grips $S weapon tightly.", ch, 0, victim, TO_NOTVICT);
+			act("You freeze $N's weapon to $S hand.", ch, nullptr, victim, TO_CHAR);
+			act("$n painfully freezes your weapon to your hand!", ch, nullptr, victim, TO_VICT);
+			act("$N's fist turns a rigid white as $E grips $S weapon tightly.", ch, nullptr, victim, TO_NOTVICT);
 		}
 	}
 	else
 	{
 		if (victim == ch)
-			act("You are not wielding a weapon!", ch, 0, 0, TO_CHAR);
+			act("You are not wielding a weapon!", ch, nullptr, nullptr, TO_CHAR);
 		else
-			act("$N is not wielding a weapon!", ch, 0, victim, TO_CHAR);
+			act("$N is not wielding a weapon!", ch, nullptr, victim, TO_CHAR);
 
 		return;
 	}
@@ -5296,7 +5296,7 @@ void spell_unbreakable(int /* sn */, int level, CHAR_DATA *ch, SpellTarget vo, C
 		}
 		else
 		{
-			act("$N's weapon is already frozen to $S hand!", ch, 0, victim, TO_CHAR);
+			act("$N's weapon is already frozen to $S hand!", ch, nullptr, victim, TO_CHAR);
 			send_to_char("Your weapon is already frozen to your hand!\n\r", victim);
 			return;
 		}
@@ -5435,7 +5435,7 @@ void spell_frigid_breeze(int /* sn */, int /* level */, CHAR_DATA *ch, SpellTarg
 		return;
 	}
 
-	act("A wave of chilled air sweeps through the area!", ch, 0, 0, TO_ALL);
+	act("A wave of chilled air sweeps through the area!", ch, nullptr, nullptr, TO_ALL);
 
 	for (vch = ch->in_room->people; vch != nullptr; vch = vch_next)
 	{
@@ -5496,7 +5496,7 @@ void spell_pure_air(int /* sn */, int /* level */, CHAR_DATA *ch, SpellTarget /*
 		return;
 	}
 
-	act("A gentle breeze of icy air sweeps through the area.", ch, 0, 0, TO_ALL);
+	act("A gentle breeze of icy air sweeps through the area.", ch, nullptr, nullptr, TO_ALL);
 
 	for (vch = ch->in_room->people; vch != nullptr; vch = vch->next_in_room)
 	{
@@ -5530,7 +5530,7 @@ void spell_pure_air(int /* sn */, int /* level */, CHAR_DATA *ch, SpellTarget /*
 			affect_strip_room(ch->in_room, purify_type);
 
 		if (cleansed)
-			act("The air around $n is purified.", vch, 0, 0, TO_ROOM);
+			act("The air around $n is purified.", vch, nullptr, nullptr, TO_ROOM);
 	}
 }
 
@@ -5549,9 +5549,9 @@ void spell_icelance(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_un
 	if (saves_spell(level, victim, DAM_COLD))
 		dam /= 2;
 
-	act("You gesture at the ground and a jagged lance of ice erupts, impaling $N!", ch, 0, victim, TO_CHAR);
-	act("$n gestures at the ground and a jagged lance of ice erupts, impaling you!", ch, 0, victim, TO_VICT);
-	act("$n gestures at the ground and a jagged lance of ice erupts, impaling $N!", ch, 0, victim, TO_NOTVICT);
+	act("You gesture at the ground and a jagged lance of ice erupts, impaling $N!", ch, nullptr, victim, TO_CHAR);
+	act("$n gestures at the ground and a jagged lance of ice erupts, impaling you!", ch, nullptr, victim, TO_VICT);
+	act("$n gestures at the ground and a jagged lance of ice erupts, impaling $N!", ch, nullptr, victim, TO_NOTVICT);
 
 	damage_new(ch, victim, dam, sn, DAM_PIERCE, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, nullptr);
 
@@ -5570,8 +5570,8 @@ void spell_icelance(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_un
 		af.owner = ch->self;
 		new_affect_to_char(victim, &af);
 
-		act("Blood spills forth from your gaping wound!", victim, 0, 0, TO_CHAR);
-		act("Blood begins to pour from $n's gaping wound!", victim, 0, 0, TO_ROOM);
+		act("Blood spills forth from your gaping wound!", victim, nullptr, nullptr, TO_CHAR);
+		act("Blood begins to pour from $n's gaping wound!", victim, nullptr, nullptr, TO_ROOM);
 	}
 }
 
@@ -5604,8 +5604,8 @@ void spell_freeze_door(int /* sn */, int level, CHAR_DATA *ch, SpellTarget /* vo
 	}
 
 	direction = flag_name_lookup(door, direction_table);
-	act("You cover the $T door with a thick frost, freezing it shut.", ch, 0, direction, TO_CHAR);
-	act("$n covers the $T door with a thick frost, freezing it shut.", ch, 0, direction, TO_ROOM);
+	act("You cover the $T door with a thick frost, freezing it shut.", ch, nullptr, direction, TO_CHAR);
+	act("$n covers the $T door with a thick frost, freezing it shut.", ch, nullptr, direction, TO_ROOM);
 
 	SET_BIT(pexit->exit_info, EX_JAMMED);
 
@@ -5642,7 +5642,7 @@ void door_unfreeze(ROOM_INDEX_DATA *room, ROOM_AFFECT_DATA *af)
 	if (room->people)
 	{
 		direction = flag_name_lookup(af->modifier, direction_table);
-		act("The frost covering the door $T thaws.", room->people, 0, direction, TO_ALL);
+		act("The frost covering the door $T thaws.", room->people, nullptr, direction, TO_ALL);
 	}
 
 	REMOVE_BIT(pexit->exit_info, EX_JAMMED);
@@ -5658,8 +5658,8 @@ void spell_frost_growth(int /* sn */, int level, CHAR_DATA *ch, SpellTarget /* v
 		return;
 	}
 
-	act("As you gesture, a barely-visible slick frost covers the ground beneath you.", ch, 0, 0, TO_CHAR);
-	act("As $n gestures, a barely-visible slick frost covers the ground beneath you.", ch, 0, 0, TO_ROOM);
+	act("As you gesture, a barely-visible slick frost covers the ground beneath you.", ch, nullptr, nullptr, TO_CHAR);
+	act("As $n gestures, a barely-visible slick frost covers the ground beneath you.", ch, nullptr, nullptr, TO_ROOM);
 
 	init_affect_room(&raf);
 	raf.where = TO_ROOM_AFFECTS;
@@ -5675,7 +5675,7 @@ void spell_frost_growth(int /* sn */, int level, CHAR_DATA *ch, SpellTarget /* v
 void ground_thaw(ROOM_INDEX_DATA *room, [[maybe_unused]] ROOM_AFFECT_DATA *af)
 {
 	if (room->people)
-		act("The fine layer of frost coating the ground melts away.", room->people, 0, 0, TO_ALL);
+		act("The fine layer of frost coating the ground melts away.", room->people, nullptr, nullptr, TO_ALL);
 }
 
 void spell_bind_feet([[maybe_unused]] int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
@@ -5697,14 +5697,14 @@ void spell_bind_feet([[maybe_unused]] int sn, int level, CHAR_DATA *ch, SpellTar
 
 	if (saves_spell(level, victim, DAM_COLD))
 	{
-		act("A chill runs through your feet.", victim, 0, 0, TO_CHAR);
-		act("$n's legs stiffen briefly before resuming their motion.", victim, 0, 0, TO_ROOM);
+		act("A chill runs through your feet.", victim, nullptr, nullptr, TO_CHAR);
+		act("$n's legs stiffen briefly before resuming their motion.", victim, nullptr, nullptr, TO_ROOM);
 		return;
 	}
 
-	act("You gesture at $N's legs and a thick frost binds $N's feet to the ground!", ch, 0, victim, TO_CHAR);
-	act("$n gestures at your legs and a thick frost binds your feet to the ground!", ch, 0, victim, TO_VICT);
-	act("$n gestures at $N's legs and a thick frost binds $S feet to the ground!", ch, 0, victim, TO_NOTVICT);
+	act("You gesture at $N's legs and a thick frost binds $N's feet to the ground!", ch, nullptr, victim, TO_CHAR);
+	act("$n gestures at your legs and a thick frost binds your feet to the ground!", ch, nullptr, victim, TO_VICT);
+	act("$n gestures at $N's legs and a thick frost binds $S feet to the ground!", ch, nullptr, victim, TO_NOTVICT);
 
 	init_affect(&af);
 	af.where = TO_AFFECTS;
@@ -5746,13 +5746,13 @@ void spell_glaciate(int /* sn */, int level, CHAR_DATA *ch, SpellTarget /* vo */
 	raf.tick_fun = nullptr;
 	new_affect_to_room(room, &raf);
 
-	act("The water beneath you suddenly congeals into glacial ice.", ch, 0, 0, TO_CHAR);
+	act("The water beneath you suddenly congeals into glacial ice.", ch, nullptr, nullptr, TO_CHAR);
 }
 
 void glaciate_melt(ROOM_INDEX_DATA *room, [[maybe_unused]] ROOM_AFFECT_DATA *raf)
 {
 	if (room->people)
-		act("The ice beneath you melts into water as the magic dissipates.", room->people, 0, 0, TO_ALL);
+		act("The ice beneath you melts into water as the magic dissipates.", room->people, nullptr, nullptr, TO_ALL);
 }
 
 void spell_hailstorm(int /* sn */, int level, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
@@ -5766,8 +5766,8 @@ void spell_hailstorm(int /* sn */, int level, CHAR_DATA *ch, SpellTarget /* vo *
 	if (is_outside(ch))
 		dam = (int)((float)dam * 1.75);
 
-	act("You conjure a rain of deadly hailstones to pelt the area!", ch, 0, 0, TO_CHAR);
-	act("$n throws $s arms in the air, calling a rain of deadly hailstones upon the area!", ch, 0, 0, TO_ROOM);
+	act("You conjure a rain of deadly hailstones to pelt the area!", ch, nullptr, nullptr, TO_CHAR);
+	act("$n throws $s arms in the air, calling a rain of deadly hailstones upon the area!", ch, nullptr, nullptr, TO_ROOM);
 
 	for (vch = ch->in_room->people; vch; vch = vch_next)
 	{
@@ -5805,8 +5805,8 @@ void spell_stalactites(int /* sn */, int level, CHAR_DATA *ch, SpellTarget /* vo
 		return;
 	}
 
-	act("You cause razor-sharp stalactites to sprout from the ceiling above.", ch, 0, 0, TO_CHAR);
-	act("$n raises one arm and icy stalactites form on the ceiling above.", ch, 0, 0, TO_ROOM);
+	act("You cause razor-sharp stalactites to sprout from the ceiling above.", ch, nullptr, nullptr, TO_CHAR);
+	act("$n raises one arm and icy stalactites form on the ceiling above.", ch, nullptr, nullptr, TO_ROOM);
 
 	init_affect_room(&raf);
 	raf.where = TO_ROOM_AFFECTS;
@@ -5828,9 +5828,9 @@ void spell_ice_blast([[maybe_unused]] int sn, int level, CHAR_DATA *ch, SpellTar
 	OBJ_DATA *obj, *obj_next;
 	OBJ_AFFECT_DATA oaf;
 
-	act("You extend an arm toward $N and send forth a frigid blast!", ch, 0, victim, TO_CHAR);
-	act("$n extends an arm toward you and sends forth a frigid blast!", ch, 0, victim, TO_VICT);
-	act("$n extends an arm toward $N and sends forth a frigid blast!", ch, 0, victim, TO_NOTVICT);
+	act("You extend an arm toward $N and send forth a frigid blast!", ch, nullptr, victim, TO_CHAR);
+	act("$n extends an arm toward you and sends forth a frigid blast!", ch, nullptr, victim, TO_VICT);
+	act("$n extends an arm toward $N and sends forth a frigid blast!", ch, nullptr, victim, TO_NOTVICT);
 
 	damage_new(ch, victim, dice(level, 3), gsn_ice_blast, DAM_COLD, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, nullptr);
 
@@ -5843,7 +5843,7 @@ void spell_ice_blast([[maybe_unused]] int sn, int level, CHAR_DATA *ch, SpellTar
 			case ITEM_DRINK_CON:
 				if (number_percent() <= 75)
 				{
-					act("$p freezes and shatters!", victim, obj, 0, TO_ALL);
+					act("$p freezes and shatters!", victim, obj, nullptr, TO_ALL);
 					extract_obj(obj);
 				}
 
@@ -5851,7 +5851,7 @@ void spell_ice_blast([[maybe_unused]] int sn, int level, CHAR_DATA *ch, SpellTar
 			case ITEM_POTION:
 				if (number_percent() <= 45)
 				{
-					act("$p freezes and shatters!", victim, obj, 0, TO_ALL);
+					act("$p freezes and shatters!", victim, obj, nullptr, TO_ALL);
 					extract_obj(obj);
 				}
 
@@ -5859,7 +5859,7 @@ void spell_ice_blast([[maybe_unused]] int sn, int level, CHAR_DATA *ch, SpellTar
 			case ITEM_CONTAINER:
 				if (number_percent() <= 15)
 				{
-					act("$p is frozen shut by a thick layer of ice!", victim, obj, 0, TO_ALL);
+					act("$p is frozen shut by a thick layer of ice!", victim, obj, nullptr, TO_ALL);
 					init_affect_obj(&oaf);
 					oaf.where = TO_OBJ_AFFECTS;
 					oaf.aftype = AFT_SPELL;
@@ -5884,7 +5884,7 @@ void spell_ice_blast([[maybe_unused]] int sn, int level, CHAR_DATA *ch, SpellTar
 void container_defrost(OBJ_DATA *obj, [[maybe_unused]] OBJ_AFFECT_DATA *af)
 {
 	if (CHAR_DATA *carrier = Deref(obj->carried_by))
-		act("The ice sealing $p melts.", carrier, obj, 0, TO_CHAR);
+		act("The ice sealing $p melts.", carrier, obj, nullptr, TO_CHAR);
 }
 
 void spell_icy_carapace(int /* sn */, int level, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
@@ -5919,21 +5919,21 @@ void spell_icy_carapace(int /* sn */, int level, CHAR_DATA *ch, SpellTarget /* v
 
 	if (fountain)
 	{
-		act("Water flows up from $p, forming an icy carapace around you.", ch, obj, 0, TO_CHAR);
-		act("Water flows up from $p, solidifying as ice around $n.", ch, obj, 0, TO_ROOM);
+		act("Water flows up from $p, forming an icy carapace around you.", ch, obj, nullptr, TO_CHAR);
+		act("Water flows up from $p, solidifying as ice around $n.", ch, obj, nullptr, TO_ROOM);
 	}
 	else if (puddle)
 	{
-		act("Water flows up from the puddle on the ground, forming an icy carapace around you.", ch, 0, 0, TO_CHAR);
-		act("Water flows up from the puddle on the ground, solidifying as ice around $n.", ch, 0, 0, TO_ROOM);
+		act("Water flows up from the puddle on the ground, forming an icy carapace around you.", ch, nullptr, nullptr, TO_CHAR);
+		act("Water flows up from the puddle on the ground, solidifying as ice around $n.", ch, nullptr, nullptr, TO_ROOM);
 
 		if (obj)
 			extract_obj(obj);
 	}
 	else
 	{
-		act("A shell of water flows up around you and solidifies into an icy carapace.", ch, 0, 0, TO_CHAR);
-		act("A shell of water flows up around $n and solidifies into an icy carapace.", ch, 0, 0, TO_ROOM);
+		act("A shell of water flows up around you and solidifies into an icy carapace.", ch, nullptr, nullptr, TO_CHAR);
+		act("A shell of water flows up around $n and solidifies into an icy carapace.", ch, nullptr, nullptr, TO_ROOM);
 	}
 
 	init_affect(&af);
@@ -6017,7 +6017,7 @@ void spell_sheath_of_ice(int /* sn */, int level, CHAR_DATA *ch, SpellTarget vo,
 void ice_sheath_melt(OBJ_DATA *obj, [[maybe_unused]] OBJ_AFFECT_DATA *af)
 {
 	if (CHAR_DATA *carrier = Deref(obj->carried_by))
-		act("The ice surrounding $p melts.", carrier, obj, 0, TO_CHAR);
+		act("The ice surrounding $p melts.", carrier, obj, nullptr, TO_CHAR);
 }
 
 void spell_ironskin(int /* sn */, int level, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
@@ -6030,8 +6030,8 @@ void spell_ironskin(int /* sn */, int level, CHAR_DATA *ch, SpellTarget /* vo */
 		return;
 	}
 
-	act("Your skin hardens and takes on a metallic tone.", ch, 0, 0, TO_CHAR);
-	act("$n's skin hardens and takes on a metallic tone.", ch, 0, 0, TO_ROOM);
+	act("Your skin hardens and takes on a metallic tone.", ch, nullptr, nullptr, TO_CHAR);
+	act("$n's skin hardens and takes on a metallic tone.", ch, nullptr, nullptr, TO_ROOM);
 
 	init_affect(&af);
 	af.where = TO_AFFECTS;
@@ -6115,15 +6115,15 @@ void spell_burden([[maybe_unused]] int sn, int level, CHAR_DATA *ch, SpellTarget
 
 	if (saves_spell(level, victim, DAM_OTHER))
 	{
-		act("$N resisted your spell.", ch, 0, victim, TO_CHAR);
-		act("You feel a weight bearing down upon you briefly, but it goes away.", ch, 0, victim, TO_VICT);
-		act("$N seems slightly weighed down for a moment, but it passes.", ch, 0, victim, TO_NOTVICT);
+		act("$N resisted your spell.", ch, nullptr, victim, TO_CHAR);
+		act("You feel a weight bearing down upon you briefly, but it goes away.", ch, nullptr, victim, TO_VICT);
+		act("$N seems slightly weighed down for a moment, but it passes.", ch, nullptr, victim, TO_NOTVICT);
 		return;
 	}
 	else
 	{
-		act("$n staggers beneath an unseen burden, struggling to remain standing.", victim, 0, 0, TO_ROOM);
-		act("You stagger beneath an unseen burden, struggling to remain standing.", victim, 0, 0, TO_CHAR);
+		act("$n staggers beneath an unseen burden, struggling to remain standing.", victim, nullptr, nullptr, TO_ROOM);
+		act("You stagger beneath an unseen burden, struggling to remain standing.", victim, nullptr, nullptr, TO_CHAR);
 	}
 
 	init_affect(&af);
@@ -6192,14 +6192,14 @@ void spell_fortify_weapon(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[ma
 	}
 	else if (diff > -25)
 	{
-		act("Your magic fails to take hold on $p.", ch, weapon, 0, TO_CHAR);
-		act("$p hums very briefly in $n's hands.", ch, weapon, 0, TO_ROOM);
+		act("Your magic fails to take hold on $p.", ch, weapon, nullptr, TO_CHAR);
+		act("$p hums very briefly in $n's hands.", ch, weapon, nullptr, TO_ROOM);
 		return;
 	}
 	else
 	{
-		act("$p shudders and explodes in your hands!", ch, weapon, 0, TO_CHAR);
-		act("$p shudders and explodes in $n's hands!", ch, weapon, 0, TO_ROOM);
+		act("$p shudders and explodes in your hands!", ch, weapon, nullptr, TO_CHAR);
+		act("$p shudders and explodes in $n's hands!", ch, weapon, nullptr, TO_ROOM);
 		damage_new(ch, ch, dice(weapon->level, 5), TYPE_UNDEFINED, DAM_ENERGY, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "the explosion*");
 		extract_obj(weapon);
 		return;
@@ -6268,15 +6268,15 @@ void spell_fortify_weapon(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[ma
 		if (number_percent() < chance)
 		{
 			hitapp->modifier += 1;
-			act("You feel $p's balance improve in your hands as it is infused with magic.", ch, weapon, 0, TO_CHAR);
-			act("$p rings with a light piercing tone as $n's magic works upon it.", ch, weapon, 0, TO_ROOM);
+			act("You feel $p's balance improve in your hands as it is infused with magic.", ch, weapon, nullptr, TO_CHAR);
+			act("$p rings with a light piercing tone as $n's magic works upon it.", ch, weapon, nullptr, TO_ROOM);
 		}
 		else
 		{
 			if (number_percent() > chance)
 			{
-				act("$p shudders and explodes in your hands!", ch, weapon, 0, TO_CHAR);
-				act("$p shudders and explodes in $n's hands!", ch, weapon, 0, TO_ROOM);
+				act("$p shudders and explodes in your hands!", ch, weapon, nullptr, TO_CHAR);
+				act("$p shudders and explodes in $n's hands!", ch, weapon, nullptr, TO_ROOM);
 				damage_new(ch, ch, dice(weapon->level, 5), TYPE_UNDEFINED, DAM_ENERGY, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "the explosion*");
 				extract_obj(weapon);
 				return;
@@ -6284,8 +6284,8 @@ void spell_fortify_weapon(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[ma
 			else
 			{
 				hitapp->modifier -= 1;
-				act("You feel $p twist in your hands as the magic goes awry.", ch, weapon, 0, TO_CHAR);
-				act("$p emits a discordant tone as $n's magic works upon it.", ch, weapon, 0, TO_ROOM);
+				act("You feel $p twist in your hands as the magic goes awry.", ch, weapon, nullptr, TO_CHAR);
+				act("$p emits a discordant tone as $n's magic works upon it.", ch, weapon, nullptr, TO_ROOM);
 			}
 		}
 	}
@@ -6295,15 +6295,15 @@ void spell_fortify_weapon(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[ma
 		if (number_percent() < chance)
 		{
 			damapp->modifier += 1;
-			act("You feel $p grow sturdier in your hands as it is infused with magic.", ch, weapon, 0, TO_CHAR);
-			act("$p flickers with a cerulean glow as $n's magic works upon it.", ch, weapon, 0, TO_ROOM);
+			act("You feel $p grow sturdier in your hands as it is infused with magic.", ch, weapon, nullptr, TO_CHAR);
+			act("$p flickers with a cerulean glow as $n's magic works upon it.", ch, weapon, nullptr, TO_ROOM);
 		}
 		else
 		{
 			if (number_percent() > chance)
 			{
-				act("$p shudders and explodes in your hands!", ch, weapon, 0, TO_CHAR);
-				act("$p shudders and explodes in $n's hands!", ch, weapon, 0, TO_ROOM);
+				act("$p shudders and explodes in your hands!", ch, weapon, nullptr, TO_CHAR);
+				act("$p shudders and explodes in $n's hands!", ch, weapon, nullptr, TO_ROOM);
 				damage_new(ch, ch, dice(weapon->level, 5), TYPE_UNDEFINED, DAM_ENERGY, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "the explosion*");
 				extract_obj(weapon);
 				return;
@@ -6311,8 +6311,8 @@ void spell_fortify_weapon(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[ma
 			else
 			{
 				damapp->modifier -= 1;
-				act("You feel $p grow frail in your hands as the magic goes awry.", ch, weapon, 0, TO_CHAR);
-				act("$p flickers with a crimson glow as $n's magic works upon it.", ch, weapon, 0, TO_ROOM);
+				act("You feel $p grow frail in your hands as the magic goes awry.", ch, weapon, nullptr, TO_CHAR);
+				act("$p flickers with a crimson glow as $n's magic works upon it.", ch, weapon, nullptr, TO_ROOM);
 			}
 		}
 	}
@@ -6384,8 +6384,8 @@ void spell_fortify_armor(int /* sn */, int level, CHAR_DATA *ch, SpellTarget vo,
 				armor->weight++;
 			}
 
-			act("$p feels sturdier in your hands, fortified by your magic.", ch, armor, 0, TO_CHAR);
-			act("$n focuses intently and $p glows briefly with an inner light.", ch, armor, 0, TO_ROOM);
+			act("$p feels sturdier in your hands, fortified by your magic.", ch, armor, nullptr, TO_CHAR);
+			act("$n focuses intently and $p glows briefly with an inner light.", ch, armor, nullptr, TO_ROOM);
 		}
 		else
 		{
@@ -6394,14 +6394,14 @@ void spell_fortify_armor(int /* sn */, int level, CHAR_DATA *ch, SpellTarget vo,
 				armor->value[i]--;
 			}
 
-			act("The magic goes awry, leaving $p feeling brittle in your hands.", ch, armor, 0, TO_CHAR);
-			act("$n focuses intently and a shadow briefly flickers across $p.", ch, armor, 0, TO_ROOM);
+			act("The magic goes awry, leaving $p feeling brittle in your hands.", ch, armor, nullptr, TO_CHAR);
+			act("$n focuses intently and a shadow briefly flickers across $p.", ch, armor, nullptr, TO_ROOM);
 		}
 	}
 	else
 	{
-		act("$p shudders and explodes in your hands!", ch, armor, 0, TO_CHAR);
-		act("$p shudders and explodes in $n's hands!", ch, armor, 0, TO_ROOM);
+		act("$p shudders and explodes in your hands!", ch, armor, nullptr, TO_CHAR);
+		act("$p shudders and explodes in $n's hands!", ch, armor, nullptr, TO_ROOM);
 		damage_new(ch, ch, dice(armor->level, 5), TYPE_UNDEFINED, DAM_ENERGY, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "the explosion*");
 		extract_obj(armor);
 	}
@@ -6480,14 +6480,14 @@ void spell_alter_metal(int /* sn */, int /* level */, CHAR_DATA *ch, SpellTarget
 		free_pstring(obj->material);
 		obj->material = palloc_string(arg2);
 
-		act("$p writhes in your grasp as the magic courses through it.", ch, obj, 0, TO_CHAR);
+		act("$p writhes in your grasp as the magic courses through it.", ch, obj, nullptr, TO_CHAR);
 		act("$p is reconstituted into $T!", ch, obj, arg2, TO_CHAR);
-		act("$p writhes in $n's grasp, altered somehow.", ch, obj, 0, TO_ROOM);
+		act("$p writhes in $n's grasp, altered somehow.", ch, obj, nullptr, TO_ROOM);
 	}
 	else
 	{
-		act("$p shudders and explodes in your hands!", ch, obj, 0, TO_CHAR);
-		act("$p shudders and explodes in $n's hands!", ch, obj, 0, TO_ROOM);
+		act("$p shudders and explodes in your hands!", ch, obj, nullptr, TO_CHAR);
+		act("$p shudders and explodes in $n's hands!", ch, obj, nullptr, TO_ROOM);
 		damage_new(ch, ch, dice(obj->level, 5), TYPE_UNDEFINED, DAM_ENERGY, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "the explosion*");
 		extract_obj(obj);
 	}
@@ -6503,8 +6503,8 @@ void spell_cloak_of_mist(int /* sn */, int level, CHAR_DATA *ch, SpellTarget /* 
 		return;
 	}
 
-	act("You gather a thick cloak of mist around yourself.", ch, 0, 0, TO_CHAR);
-	act("A thick cloak of mist gathers around $n.", ch, 0, 0, TO_ROOM);
+	act("You gather a thick cloak of mist around yourself.", ch, nullptr, nullptr, TO_CHAR);
+	act("A thick cloak of mist gathers around $n.", ch, nullptr, nullptr, TO_ROOM);
 
 	init_affect(&af);
 	af.where = TO_AFFECTS;
@@ -6536,8 +6536,8 @@ void spell_vigorize(int /* sn */, int level, CHAR_DATA *ch, SpellTarget /* vo */
 	if (ch->in_room->area->temp == Temperature::Hot || ch->in_room->area->temp == Temperature::Cold)
 		refresh /= 2;
 
-	act("You blanket the area with a soothing mist.", ch, 0, 0, TO_CHAR);
-	act("$n blankets the area with a soothing mist.", ch, 0, 0, TO_ROOM);
+	act("You blanket the area with a soothing mist.", ch, nullptr, nullptr, TO_CHAR);
+	act("$n blankets the area with a soothing mist.", ch, nullptr, nullptr, TO_ROOM);
 
 	for (vch = ch->in_room->people; vch; vch = vch->next_in_room)
 	{
@@ -6562,15 +6562,15 @@ void spell_creeping_tomb(int /* sn */, int level, CHAR_DATA *ch, SpellTarget vo,
 
 	if (saves_spell(level - 5, victim, DAM_OTHER))
 	{
-		act("$N resisted your spell.", ch, 0, victim, TO_CHAR);
-		act("Damp earth cakes briefly on your legs but crumbles rapidly to dust.", ch, 0, victim, TO_VICT);
-		act("Damp earth cakes briefly on $N's legs but crumbles rapidly to dust.", ch, 0, victim, TO_NOTVICT);
+		act("$N resisted your spell.", ch, nullptr, victim, TO_CHAR);
+		act("Damp earth cakes briefly on your legs but crumbles rapidly to dust.", ch, nullptr, victim, TO_VICT);
+		act("Damp earth cakes briefly on $N's legs but crumbles rapidly to dust.", ch, nullptr, victim, TO_NOTVICT);
 		return;
 	}
 
-	act("A mass of living ooze begins to slowly encircle $N's legs.", ch, 0, victim, TO_CHAR);
-	act("A mass of living ooze coalesces beneath you and begins to creep up your legs!", ch, 0, victim, TO_VICT);
-	act("A mass of living ooze coalesces beneath $N and begins to creep up $S legs!", ch, 0, victim, TO_NOTVICT);
+	act("A mass of living ooze begins to slowly encircle $N's legs.", ch, nullptr, victim, TO_CHAR);
+	act("A mass of living ooze coalesces beneath you and begins to creep up your legs!", ch, nullptr, victim, TO_VICT);
+	act("A mass of living ooze coalesces beneath $N and begins to creep up $S legs!", ch, nullptr, victim, TO_NOTVICT);
 
 	init_affect(&af);
 	af.where = TO_AFFECTS;
@@ -6592,24 +6592,24 @@ void creeping_tomb_tick(CHAR_DATA *ch, AFFECT_DATA *af)
 	switch (af->duration)
 	{
 		case 4:
-			act("The living ooze ascends further, threatening to completely engulf you!", ch, 0, 0, TO_CHAR);
-			act("$n squirms uncomfortably as the living ooze covering $m creeps upward.", ch, 0, 0, TO_ROOM);
+			act("The living ooze ascends further, threatening to completely engulf you!", ch, nullptr, nullptr, TO_CHAR);
+			act("$n squirms uncomfortably as the living ooze covering $m creeps upward.", ch, nullptr, nullptr, TO_ROOM);
 			af->modifier--;
 			return;
 		case 3:
-			act("The living ooze suddenly solidifies, entombing you from head to toe!", ch, 0, 0, TO_CHAR);
-			act("The mass of living ooze surrounding $n suddenly solidifies, entombing $m!", ch, 0, 0, TO_ROOM);
+			act("The living ooze suddenly solidifies, entombing you from head to toe!", ch, nullptr, nullptr, TO_CHAR);
+			act("The mass of living ooze surrounding $n suddenly solidifies, entombing $m!", ch, nullptr, nullptr, TO_ROOM);
 			return;
 		case 2:
 		case 1:
-			act("The ooze that has hardened around you begins to crumble.", ch, 0, 0, TO_CHAR);
+			act("The ooze that has hardened around you begins to crumble.", ch, nullptr, nullptr, TO_CHAR);
 			return;
 		case 0:
 		case -1:
 			return;
 		default:
-			act("The living ooze covering you continues to creep inexorably upward.", ch, 0, 0, TO_CHAR);
-			act("$n squirms uncomfortably as the living ooze covering $m creeps upward.", ch, 0, 0, TO_ROOM);
+			act("The living ooze covering you continues to creep inexorably upward.", ch, nullptr, nullptr, TO_CHAR);
+			act("$n squirms uncomfortably as the living ooze covering $m creeps upward.", ch, nullptr, nullptr, TO_ROOM);
 			af->modifier--;
 			return;
 	}
@@ -6657,8 +6657,8 @@ void spell_quicksand(int /* sn */, int level, CHAR_DATA *ch, SpellTarget /* vo *
 		return;
 	}
 
-	act("You gesture at the ground beneath you, liquefying it to trap the unsuspecting.", ch, 0, 0, TO_CHAR);
-	act("$n gestures at the ground, which seems to ripple ominously for a moment.", ch, 0, 0, TO_ROOM);
+	act("You gesture at the ground beneath you, liquefying it to trap the unsuspecting.", ch, nullptr, nullptr, TO_CHAR);
+	act("$n gestures at the ground, which seems to ripple ominously for a moment.", ch, nullptr, nullptr, TO_ROOM);
 
 	init_affect_room(&raf);
 	raf.where = TO_ROOM_AFFECTS;
@@ -6686,7 +6686,7 @@ void spell_quicksand(int /* sn */, int level, CHAR_DATA *ch, SpellTarget /* vo *
 void quicksand_end(ROOM_INDEX_DATA *room, [[maybe_unused]] ROOM_AFFECT_DATA *af)
 {
 	if (room->people)
-		act("The ground beneath you solidifies.", room->people, 0, 0, TO_ALL);
+		act("The ground beneath you solidifies.", room->people, nullptr, nullptr, TO_ALL);
 }
 
 void quicksand_pulse_sink(CHAR_DATA *ch, AFFECT_DATA *af)
@@ -6722,9 +6722,9 @@ void spell_sap_endurance(int /* sn */, int level, CHAR_DATA *ch, SpellTarget vo,
 		return;
 	}
 
-	act("A tendril of ooze springs from the earth to sap $N's endurance!", ch, 0, victim, TO_CHAR);
-	act("A tendril of ooze springs from the earth to sap your endurance!", ch, 0, victim, TO_VICT);
-	act("A tendril of ooze springs from the earth to sap $N's endurance!", ch, 0, victim, TO_NOTVICT);
+	act("A tendril of ooze springs from the earth to sap $N's endurance!", ch, nullptr, victim, TO_CHAR);
+	act("A tendril of ooze springs from the earth to sap your endurance!", ch, nullptr, victim, TO_VICT);
+	act("A tendril of ooze springs from the earth to sap $N's endurance!", ch, nullptr, victim, TO_NOTVICT);
 
 	victim->move = std::max(0, victim->move - number_range((int)((float)level * .9), (int)((float)level * 1.1)));
 }
@@ -6739,8 +6739,8 @@ void spell_emulsify(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_un
 	if (saves_spell(level, victim, DAM_INTERNAL))
 		dam /= 2;
 
-	act("$n writhes in agony as $s midsection suddenly distends.", victim, 0, 0, TO_ROOM);
-	act("Your insides twist with pain, as your organs begin to dissolve into viscous pools.", ch, 0, victim, TO_VICT);
+	act("$n writhes in agony as $s midsection suddenly distends.", victim, nullptr, nullptr, TO_ROOM);
+	act("Your insides twist with pain, as your organs begin to dissolve into viscous pools.", ch, nullptr, victim, TO_VICT);
 
 	damage_new(ch, victim, dam, sn, DAM_INTERNAL, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "emulsification");
 }
@@ -6751,17 +6751,17 @@ void spell_rust([[maybe_unused]] int sn, int level, CHAR_DATA *ch, SpellTarget v
 	OBJ_DATA *eq;
 	OBJ_AFFECT_DATA oaf;
 
-	act("You conjure a cloud of mist in an attempt to rust $N's armor!", ch, 0, victim, TO_CHAR);
+	act("You conjure a cloud of mist in an attempt to rust $N's armor!", ch, nullptr, victim, TO_CHAR);
 
 	if (saves_spell(level, victim, DAM_OTHER))
 	{
-		act("A cloud of mist envelops you, but dissipates rapidly.", victim, 0, 0, TO_CHAR);
-		act("A misty fog envelops $n, but dissipates rapidly.", victim, 0, 0, TO_ROOM);
+		act("A cloud of mist envelops you, but dissipates rapidly.", victim, nullptr, nullptr, TO_CHAR);
+		act("A misty fog envelops $n, but dissipates rapidly.", victim, nullptr, nullptr, TO_ROOM);
 		return;
 	}
 
-	act("A thick cloud of mist envelops you, swirling around your garments.", ch, 0, victim, TO_VICT);
-	act("A thick cloud of mist envelops $N, swirling around $S garments.", ch, 0, victim, TO_NOTVICT);
+	act("A thick cloud of mist envelops you, swirling around your garments.", ch, nullptr, victim, TO_VICT);
+	act("A thick cloud of mist envelops $N, swirling around $S garments.", ch, nullptr, victim, TO_NOTVICT);
 
 	init_affect_obj(&oaf);
 	oaf.where = TO_OBJ_APPLY;
@@ -6821,8 +6821,8 @@ void spell_rust([[maybe_unused]] int sn, int level, CHAR_DATA *ch, SpellTarget v
 				continue;
 		}
 
-		act("$p is covered with a thick patina of rust!", victim, eq, 0, TO_CHAR);
-		act("$p is covered with a thick patina of rust!", ch, eq, 0, TO_CHAR);
+		act("$p is covered with a thick patina of rust!", victim, eq, nullptr, TO_CHAR);
+		act("$p is covered with a thick patina of rust!", ch, eq, nullptr, TO_CHAR);
 
 		affect_to_obj(eq, &oaf);
 	}
@@ -6845,8 +6845,8 @@ void spell_airy_water(int /* sn */, int level, CHAR_DATA *ch, SpellTarget /* vo 
 		return;
 	}
 
-	act("You infuse the water around you with air, making it breathable.", ch, 0, 0, TO_CHAR);
-	act("Bubbles fill the water as $n infuses the area with breathable air.", ch, 0, 0, TO_ROOM);
+	act("You infuse the water around you with air, making it breathable.", ch, nullptr, nullptr, TO_CHAR);
+	act("Bubbles fill the water as $n infuses the area with breathable air.", ch, nullptr, nullptr, TO_ROOM);
 
 	init_affect_room(&raf);
 	raf.where = TO_ROOM_AFFECTS;
@@ -6874,10 +6874,10 @@ void spell_cooling_mist(int /* sn */, int level, CHAR_DATA *ch, SpellTarget vo, 
 	}
 
 	if (ch != victim)
-		act("You conjure a soothing mist to refresh $N and shelter $M from heat.", ch, 0, victim, TO_CHAR);
+		act("You conjure a soothing mist to refresh $N and shelter $M from heat.", ch, nullptr, victim, TO_CHAR);
 
-	act("A soothing mist envelops you, sheltering you from heat.", victim, 0, 0, TO_CHAR);
-	act("A light mist envelops $n as $e appears soothed.", victim, 0, 0, TO_ROOM);
+	act("A soothing mist envelops you, sheltering you from heat.", victim, nullptr, nullptr, TO_CHAR);
+	act("A light mist envelops $n as $e appears soothed.", victim, nullptr, nullptr, TO_ROOM);
 
 	init_affect(&af);
 	af.where = TO_RESIST;
@@ -6904,15 +6904,15 @@ void spell_prismatic_spray(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[m
 	int color = number_range(1, 7), dam = 0;
 	bool poisoned = false, disint = false, blinded = false;
 
-	act("You send a diffuse spray of varicolored light streaking towards $N!", ch, 0, victim, TO_CHAR);
-	act("$n sends a diffuse spray of varicolored light streaking towards you!", ch, 0, victim, TO_VICT);
-	act("$n sends a diffuse spray of varicolored light streaking towards $N!", ch, 0, victim, TO_NOTVICT);
+	act("You send a diffuse spray of varicolored light streaking towards $N!", ch, nullptr, victim, TO_CHAR);
+	act("$n sends a diffuse spray of varicolored light streaking towards you!", ch, nullptr, victim, TO_VICT);
+	act("$n sends a diffuse spray of varicolored light streaking towards $N!", ch, nullptr, victim, TO_NOTVICT);
 
 	switch (color)
 	{
 		case 1:
-			act("A red beam of light strikes $n!", victim, 0, 0, TO_ROOM);
-			act("A red beam of light strikes you!", victim, 0, 0, TO_CHAR);
+			act("A red beam of light strikes $n!", victim, nullptr, nullptr, TO_ROOM);
+			act("A red beam of light strikes you!", victim, nullptr, nullptr, TO_CHAR);
 
 			dam = dice(level, 2);
 
@@ -6921,8 +6921,8 @@ void spell_prismatic_spray(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[m
 
 			break;
 		case 2:
-			act("An orange beam of light strikes $n!", victim, 0, 0, TO_ROOM);
-			act("An orange beam of light strikes you!", victim, 0, 0, TO_CHAR);
+			act("An orange beam of light strikes $n!", victim, nullptr, nullptr, TO_ROOM);
+			act("An orange beam of light strikes you!", victim, nullptr, nullptr, TO_CHAR);
 
 			dam = dice(level, 4);
 
@@ -6931,8 +6931,8 @@ void spell_prismatic_spray(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[m
 
 			break;
 		case 3:
-			act("A yellow beam of light strikes $n!", victim, 0, 0, TO_ROOM);
-			act("A yellow beam of light strikes you!", victim, 0, 0, TO_CHAR);
+			act("A yellow beam of light strikes $n!", victim, nullptr, nullptr, TO_ROOM);
+			act("A yellow beam of light strikes you!", victim, nullptr, nullptr, TO_CHAR);
 
 			dam = dice(level, 7);
 
@@ -6941,8 +6941,8 @@ void spell_prismatic_spray(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[m
 
 			break;
 		case 4:
-			act("A green beam of light strikes $n!", victim, 0, 0, TO_ROOM);
-			act("A green beam of light strikes you!", victim, 0, 0, TO_CHAR);
+			act("A green beam of light strikes $n!", victim, nullptr, nullptr, TO_ROOM);
+			act("A green beam of light strikes you!", victim, nullptr, nullptr, TO_CHAR);
 
 			dam = dice(level, 3);
 
@@ -6954,8 +6954,8 @@ void spell_prismatic_spray(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[m
 
 			break;
 		case 5:
-			act("A blue beam of light strikes $n!", victim, 0, 0, TO_ROOM);
-			act("A blue beam of light strikes you!", victim, 0, 0, TO_CHAR);
+			act("A blue beam of light strikes $n!", victim, nullptr, nullptr, TO_ROOM);
+			act("A blue beam of light strikes you!", victim, nullptr, nullptr, TO_CHAR);
 
 			dam = dice(level, 3);
 
@@ -6965,8 +6965,8 @@ void spell_prismatic_spray(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[m
 			LAG_CHAR(victim, 2 * PULSE_VIOLENCE);
 			break;
 		case 6:
-			act("A indigo beam of light strikes $n!", victim, 0, 0, TO_ROOM);
-			act("A indigo beam of light strikes you!", victim, 0, 0, TO_CHAR);
+			act("A indigo beam of light strikes $n!", victim, nullptr, nullptr, TO_ROOM);
+			act("A indigo beam of light strikes you!", victim, nullptr, nullptr, TO_CHAR);
 
 			dam = dice(level, 3);
 
@@ -6978,8 +6978,8 @@ void spell_prismatic_spray(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[m
 
 			break;
 		case 7:
-			act("A violet beam of light strikes $n!", victim, 0, 0, TO_ROOM);
-			act("A violet beam of light strikes you!", victim, 0, 0, TO_CHAR);
+			act("A violet beam of light strikes $n!", victim, nullptr, nullptr, TO_ROOM);
+			act("A violet beam of light strikes you!", victim, nullptr, nullptr, TO_CHAR);
 
 			dam = dice(level, 3);
 
@@ -6993,8 +6993,8 @@ void spell_prismatic_spray(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[m
 
 	if (poisoned && !is_affected(victim, gsn_poison))
 	{
-		act("Poison creeps into your veins as the sickly light washes over you.", victim, 0, 0, TO_CHAR);
-		act("$n looks very ill.", victim, 0, 0, TO_ROOM);
+		act("Poison creeps into your veins as the sickly light washes over you.", victim, nullptr, nullptr, TO_CHAR);
+		act("$n looks very ill.", victim, nullptr, nullptr, TO_ROOM);
 
 		init_affect(&af);
 		af.where = TO_AFFECTS;
@@ -7015,8 +7015,8 @@ void spell_prismatic_spray(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[m
 
 	if (blinded)
 	{
-		act("The intense indigo light sears your eyes, blinding you!", victim, 0, 0, TO_CHAR);
-		act("$n appears to be blinded.", victim, 0, 0, TO_ROOM);
+		act("The intense indigo light sears your eyes, blinding you!", victim, nullptr, nullptr, TO_CHAR);
+		act("$n appears to be blinded.", victim, nullptr, nullptr, TO_ROOM);
 
 		init_affect(&af);
 		af.where = TO_AFFECTS;
@@ -7037,13 +7037,13 @@ void spell_prismatic_spray(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[m
 
 	if (disint)
 	{
-		act("You feel a piercing pain in your chest as the violet light washes over you!", victim, 0, 0, TO_CHAR);
-		act("$n writhes in agony as the violet light passes through $m!", victim, 0, 0, TO_ROOM);
+		act("You feel a piercing pain in your chest as the violet light washes over you!", victim, nullptr, nullptr, TO_CHAR);
+		act("$n writhes in agony as the violet light passes through $m!", victim, nullptr, nullptr, TO_ROOM);
 
 		if (victim->level < ch->level - 9)
 		{
-			act("You gasp in horror as your body disintegrates into nothingness.", victim, 0, 0, TO_CHAR);
-			act("A final look of horror crosses $n's face before $e disintegrates into dust.", victim, 0, 0, TO_ROOM);
+			act("You gasp in horror as your body disintegrates into nothingness.", victim, nullptr, nullptr, TO_CHAR);
+			act("A final look of horror crosses $n's face before $e disintegrates into dust.", victim, nullptr, nullptr, TO_ROOM);
 			raw_kill(ch, victim);
 		}
 		else
@@ -7084,8 +7084,8 @@ void spell_earthfade(int /* sn */, int level, CHAR_DATA *ch, SpellTarget /* vo *
 		return;
 	}
 
-	act("The ground beneath $n liquefies and $e vanishes below the surface!", ch, 0, 0, TO_ROOM);
-	act("You liquify the ground beneath you and conceal yourself within.", ch, 0, 0, TO_CHAR);
+	act("The ground beneath $n liquefies and $e vanishes below the surface!", ch, nullptr, nullptr, TO_ROOM);
+	act("You liquify the ground beneath you and conceal yourself within.", ch, nullptr, nullptr, TO_CHAR);
 
 	init_affect(&af);
 	af.where = TO_AFFECTS;
@@ -7169,8 +7169,8 @@ void spell_plasma_bolt(int sn, int level, CHAR_DATA *ch, SpellTarget /* vo */, C
 		return;
 	}
 
-	act("You briefly envelop yourself in pure plasma, streaking away!", ch, 0, 0, TO_CHAR);
-	act("$n flares with energy and streaks out of the area!", ch, 0, 0, TO_ROOM);
+	act("You briefly envelop yourself in pure plasma, streaking away!", ch, nullptr, nullptr, TO_CHAR);
+	act("$n flares with energy and streaks out of the area!", ch, nullptr, nullptr, TO_ROOM);
 
 	for (vch = ch->in_room->people; vch != nullptr; vch = vch_next)
 	{
@@ -7193,8 +7193,8 @@ void spell_plasma_bolt(int sn, int level, CHAR_DATA *ch, SpellTarget /* vo */, C
 	char_from_room(ch);
 	char_to_room(ch, pRoomIndex);
 
-	act("$n appears in a flash of plasma!", ch, 0, 0, TO_ROOM);
-	act("The plasma around you fades as quickly as it formed, and you are elsewhere.", ch, 0, 0, TO_CHAR);
+	act("$n appears in a flash of plasma!", ch, nullptr, nullptr, TO_ROOM);
+	act("The plasma around you fades as quickly as it formed, and you are elsewhere.", ch, nullptr, nullptr, TO_CHAR);
 
 	do_look(ch, "auto");
 	check_plasma_thread(ch, -1);
@@ -7247,8 +7247,8 @@ void sphere_of_plasma_pulse(CHAR_DATA *ch, AFFECT_DATA *af)
 	if (number_percent() > 60)
 		return;
 
-	act("A tendril of plasma from the sphere encircling you lashes out at $N!", ch, 0, Deref(ch->fighting), TO_CHAR);
-	act("A writhing, pulsating tendril of plasma lashes out from $n's body!", ch, 0, 0, TO_ROOM);
+	act("A tendril of plasma from the sphere encircling you lashes out at $N!", ch, nullptr, Deref(ch->fighting), TO_CHAR);
+	act("A writhing, pulsating tendril of plasma lashes out from $n's body!", ch, nullptr, nullptr, TO_ROOM);
 
 	damage_new(ch, Deref(ch->fighting), af->level, gsn_sphere_of_plasma, DAM_TRUESTRIKE, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, nullptr);
 
@@ -7296,8 +7296,8 @@ void spell_plasma_cube(int sn, int level, CHAR_DATA *ch, SpellTarget /* vo */, C
 		return;
 	}
 
-	act("You conjure a massive cube of interlaced plasma in the room.", ch, 0, 0, TO_CHAR);
-	act("$n conjures a massive cube of interlaced plasma in the room.", ch, 0, 0, TO_ROOM);
+	act("You conjure a massive cube of interlaced plasma in the room.", ch, nullptr, nullptr, TO_CHAR);
+	act("$n conjures a massive cube of interlaced plasma in the room.", ch, nullptr, nullptr, TO_ROOM);
 
 	init_affect_room(&raf);
 	raf.where = TO_ROOM_AFFECTS;
@@ -7331,9 +7331,9 @@ void spell_essence_of_plasma(int /* sn */, int level, CHAR_DATA *ch, SpellTarget
 		return;
 	}
 
-	act("As you gesture, an intensely bright point of radiance appears before you.", ch, 0, 0, TO_CHAR);
-	act("An intensely bright point of radiance appears before you.", ch, 0, 0, TO_ROOM);
-	act("The brilliant singularity flares into a pulsating ball of pure plasma!", ch, 0, 0, TO_ROOM);
+	act("As you gesture, an intensely bright point of radiance appears before you.", ch, nullptr, nullptr, TO_CHAR);
+	act("An intensely bright point of radiance appears before you.", ch, nullptr, nullptr, TO_ROOM);
+	act("The brilliant singularity flares into a pulsating ball of pure plasma!", ch, nullptr, nullptr, TO_ROOM);
 
 	init_affect_room(&raf);
 	raf.where = TO_ROOM_AFFECTS;
@@ -7401,8 +7401,8 @@ void essence_of_plasma_pulse(ROOM_INDEX_DATA *room, ROOM_AFFECT_DATA *af)
 
 	dam = dice(af->level, 10) / af->modifier;
 
-	act("The ball of plasma hurtles about wildly, discharging pure energy into you!", victim, 0, 0, TO_CHAR);
-	act("The ball of plasma hurtles about wildly, discharging pure energy into $n!", victim, 0, 0, TO_ROOM);
+	act("The ball of plasma hurtles about wildly, discharging pure energy into you!", victim, nullptr, nullptr, TO_CHAR);
+	act("The ball of plasma hurtles about wildly, discharging pure energy into $n!", victim, nullptr, nullptr, TO_ROOM);
 
 	damage_new(Deref(af->owner), victim, dam, gsn_essence_of_plasma, DAM_ENERGY, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "the essence of plasma*");
 
@@ -7420,7 +7420,7 @@ void essence_of_plasma_end(ROOM_INDEX_DATA *room, [[maybe_unused]] ROOM_AFFECT_D
 	if (!room->people)
 		return;
 
-	act("The writhing mass of plasma flickers one last time and then dissipates.", room->people, 0, 0, TO_ALL);
+	act("The writhing mass of plasma flickers one last time and then dissipates.", room->people, nullptr, nullptr, TO_ALL);
 }
 
 void plasma_thread_end(CHAR_DATA *ch, AFFECT_DATA *paf)
@@ -7457,25 +7457,25 @@ void spell_plasma_thread(int sn, int level, CHAR_DATA *ch, SpellTarget /* vo */,
 	if (!trusts(ch, victim) && is_safe(ch, victim))
 		return;
 
-	act("Concentrating intently, you conjure forth a plasma conduit at $N!", ch, 0, victim, TO_CHAR);
-	act("Reaching $s arms toward you, $n conjures forth a plasma conduit!", ch, 0, victim, TO_VICT);
-	act("Reaching $s arms toward $N, $n conjures forth a plasma conduit!", ch, 0, victim, TO_NOTVICT);
+	act("Concentrating intently, you conjure forth a plasma conduit at $N!", ch, nullptr, victim, TO_CHAR);
+	act("Reaching $s arms toward you, $n conjures forth a plasma conduit!", ch, nullptr, victim, TO_VICT);
+	act("Reaching $s arms toward $N, $n conjures forth a plasma conduit!", ch, nullptr, victim, TO_NOTVICT);
 
 	if (!trusts(ch, victim))
 	{
 		if (saves_spell(level, victim, DAM_ENERGY))
 		{
-			act("The thread of plasma dissipates before connecting you to $M.", ch, 0, victim, TO_CHAR);
-			act("The thread of plasma dissipates before connecting $m to you.", ch, 0, victim, TO_VICT);
-			act("The thread of plasma dissipates before connecting $n to $N.", ch, 0, victim, TO_NOTVICT);
+			act("The thread of plasma dissipates before connecting you to $M.", ch, nullptr, victim, TO_CHAR);
+			act("The thread of plasma dissipates before connecting $m to you.", ch, nullptr, victim, TO_VICT);
+			act("The thread of plasma dissipates before connecting $n to $N.", ch, nullptr, victim, TO_NOTVICT);
 			multi_hit(victim, ch, TYPE_UNDEFINED);
 			return;
 		}
 	}
 
-	act("The rippling thread of plasma connects, attaching you to $N!", ch, 0, victim, TO_CHAR);
-	act("The rippling thread of plasma connects, attaching $n to you!", ch, 0, victim, TO_VICT);
-	act("The rippling thread of plasma connects, attaching $n to $N!", ch, 0, victim, TO_NOTVICT);
+	act("The rippling thread of plasma connects, attaching you to $N!", ch, nullptr, victim, TO_CHAR);
+	act("The rippling thread of plasma connects, attaching $n to you!", ch, nullptr, victim, TO_VICT);
+	act("The rippling thread of plasma connects, attaching $n to $N!", ch, nullptr, victim, TO_NOTVICT);
 
 	init_affect(&af);
 	af.where = TO_AFFECTS;
@@ -7538,29 +7538,29 @@ void check_plasma_thread(CHAR_DATA *ch, int direction)
 
 	if (direction == -1)
 	{
-		act("The rippling thread of plasma pulls $N along with you.", ch, 0, victim, TO_CHAR);
-		act("A rippling thread of plasma pulls $N along with $n.", ch, 0, victim, TO_ROOM);
-		act("The rippling thread of plasma pulls you along with $N.", victim, 0, ch, TO_CHAR);
-		act("A rippling thread of plasma pulls $n along with $N.", victim, 0, ch, TO_ROOM);
+		act("The rippling thread of plasma pulls $N along with you.", ch, nullptr, victim, TO_CHAR);
+		act("A rippling thread of plasma pulls $N along with $n.", ch, nullptr, victim, TO_ROOM);
+		act("The rippling thread of plasma pulls you along with $N.", victim, nullptr, ch, TO_CHAR);
+		act("A rippling thread of plasma pulls $n along with $N.", victim, nullptr, ch, TO_ROOM);
 		char_from_room(victim);
 		char_to_room(victim, ch->in_room);
 		do_look(victim, "auto");
 	}
 	else
 	{
-		act("The thread of plasma pulls $N along with you.", ch, 0, victim, TO_CHAR);
-		act("A thread of plasma pulls $N along with $n.", ch, 0, victim, TO_ROOM);
-		act("The thread of plasma pulls you along with $N.", victim, 0, ch, TO_CHAR);
-		act("A thread of plasma pulls $n along with $N.", victim, 0, ch, TO_ROOM);
+		act("The thread of plasma pulls $N along with you.", ch, nullptr, victim, TO_CHAR);
+		act("A thread of plasma pulls $N along with $n.", ch, nullptr, victim, TO_ROOM);
+		act("The thread of plasma pulls you along with $N.", victim, nullptr, ch, TO_CHAR);
+		act("A thread of plasma pulls $n along with $N.", victim, nullptr, ch, TO_ROOM);
 		move_char(victim, direction, true, true);
 	}
 
 	if (ch->in_room != victim->in_room)
 	{
-		act("The writhing thread of plasma suddenly snaps you back to $N!", ch, 0, victim, TO_CHAR);
-		act("A writhing thread of plasma suddenly snaps $n back to $N!", ch, 0, victim, TO_ROOM);
-		act("The writhing thread of plasma suddenly snaps $N back to you!", victim, 0, ch, TO_CHAR);
-		act("The writhing thread of plasma suddenly snaps $N back to $n!", victim, 0, ch, TO_ROOM);
+		act("The writhing thread of plasma suddenly snaps you back to $N!", ch, nullptr, victim, TO_CHAR);
+		act("A writhing thread of plasma suddenly snaps $n back to $N!", ch, nullptr, victim, TO_ROOM);
+		act("The writhing thread of plasma suddenly snaps $N back to you!", victim, nullptr, ch, TO_CHAR);
+		act("The writhing thread of plasma suddenly snaps $N back to $n!", victim, nullptr, ch, TO_ROOM);
 		char_from_room(ch);
 		char_to_room(ch, victim->in_room);
 		do_look(ch, "auto");
@@ -7608,9 +7608,9 @@ void spell_melt_rock(int sn, [[maybe_unused]] int level, CHAR_DATA *ch, SpellTar
 	OBJ_DATA *obj;
 	int iWear, dam;
 
-	act("A wave of oppressive heat emanates from your fingertips as you gesture at $N.", ch, 0, victim, TO_CHAR);
-	act("As $n gestures, a wave of oppressive heat washes over you.", ch, 0, victim, TO_VICT);
-	act("$n gestures, sending a wave of oppressive heat washing over $N.", ch, 0, victim, TO_NOTVICT);
+	act("A wave of oppressive heat emanates from your fingertips as you gesture at $N.", ch, nullptr, victim, TO_CHAR);
+	act("As $n gestures, a wave of oppressive heat washes over you.", ch, nullptr, victim, TO_VICT);
+	act("$n gestures, sending a wave of oppressive heat washing over $N.", ch, nullptr, victim, TO_NOTVICT);
 
 	for (iWear = 0; iWear < MAX_WEAR; iWear++)
 	{
@@ -7708,16 +7708,16 @@ void spell_magma_tunnel(int /* sn */, int /* level */, CHAR_DATA *ch, SpellTarge
 		old_room = to_room;
 	}
 
-	act("As you gesture, the ground around your feet turns to magma and you are engulfed.", ch, 0, 0, TO_CHAR);
-	act("The ground around $n's feet turns into magma and $e is engulfed.", ch, 0, 0, TO_ROOM);
+	act("As you gesture, the ground around your feet turns to magma and you are engulfed.", ch, nullptr, nullptr, TO_CHAR);
+	act("The ground around $n's feet turns into magma and $e is engulfed.", ch, nullptr, nullptr, TO_ROOM);
 
 	char_from_room(ch);
 	char_to_room(ch, old_room);
 
 	do_look(ch, "auto");
 
-	act("You emerge from the ground.", ch, 0, 0, TO_CHAR);
-	act("$n emerges from the ground.", ch, 0, 0, TO_ROOM);
+	act("You emerge from the ground.", ch, nullptr, nullptr, TO_CHAR);
+	act("$n emerges from the ground.", ch, nullptr, nullptr, TO_ROOM);
 }
 
 void spell_fashion_crystal(int /* sn */, int level, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
@@ -7750,11 +7750,11 @@ void spell_fashion_crystal(int /* sn */, int level, CHAR_DATA *ch, SpellTarget /
 		ch->mana += 100;
 	}
 
-	act("You focus intently, channeling raw mana to form a pure energy crystal.", ch, 0, 0, TO_CHAR);
-	act("$n focuses intently and a flash of luminescence flickers in $s hands.", ch, 0, 0, TO_ROOM);
+	act("You focus intently, channeling raw mana to form a pure energy crystal.", ch, nullptr, nullptr, TO_CHAR);
+	act("$n focuses intently and a flash of luminescence flickers in $s hands.", ch, nullptr, nullptr, TO_ROOM);
 
 	if (mana > 100)
-		act("You channel additional mana into forming the crystal, infusing it with power.", ch, 0, 0, TO_CHAR);
+		act("You channel additional mana into forming the crystal, infusing it with power.", ch, nullptr, nullptr, TO_CHAR);
 
 	obj = create_object(get_obj_index(OBJ_VNUM_CRYSTAL), level);
 	obj_to_char(obj, ch);
@@ -7779,7 +7779,7 @@ void crystal_tick(OBJ_DATA *obj, OBJ_AFFECT_DATA *af)
 	if (af->modifier <= 0)
 	{
 		if (CHAR_DATA *carrier = Deref(obj->carried_by))
-			act("$p crumbles to dust as the energy contained within dissipates.", carrier, obj, 0, TO_CHAR);
+			act("$p crumbles to dust as the energy contained within dissipates.", carrier, obj, nullptr, TO_CHAR);
 
 		extract_obj(obj);
 	}
@@ -7795,7 +7795,7 @@ void spell_farsee(int /* sn */, int level, CHAR_DATA *ch, SpellTarget /* vo */, 
 		return;
 	}
 
-	act("Your vision sharpens as you attune yourself to magical crystals.", ch, 0, 0, TO_CHAR);
+	act("Your vision sharpens as you attune yourself to magical crystals.", ch, nullptr, nullptr, TO_CHAR);
 
 	init_affect(&af);
 	af.where = TO_AFFECTS;
@@ -7833,9 +7833,9 @@ void spell_mana_beam(int sn, [[maybe_unused]] int level, CHAR_DATA *ch, SpellTar
 		return;
 	}
 
-	act("You thrust forth your pulsing crystal, unleashing a beam of mana at $N!", ch, 0, victim, TO_CHAR);
-	act("$n thrusts forth a pulsing crystal, unleashing a beam of mana to sear you!", ch, 0, victim, TO_VICT);
-	act("$n thrusts forth a pulsing crystal, unleashing a beam of mana at $N!", ch, 0, victim, TO_NOTVICT);
+	act("You thrust forth your pulsing crystal, unleashing a beam of mana at $N!", ch, nullptr, victim, TO_CHAR);
+	act("$n thrusts forth a pulsing crystal, unleashing a beam of mana to sear you!", ch, nullptr, victim, TO_VICT);
+	act("$n thrusts forth a pulsing crystal, unleashing a beam of mana at $N!", ch, nullptr, victim, TO_NOTVICT);
 
 	dam = number_range(35, 45) * af->modifier;
 	dam /= 100;
@@ -7846,7 +7846,7 @@ void spell_mana_beam(int sn, [[maybe_unused]] int level, CHAR_DATA *ch, SpellTar
 
 	if (af->modifier == 0)
 	{
-		act("$p crumbles to dust in your hands.", ch, obj, 0, TO_CHAR);
+		act("$p crumbles to dust in your hands.", ch, obj, nullptr, TO_CHAR);
 		extract_obj(obj);
 	}
 }
@@ -7874,10 +7874,10 @@ void spell_detonation(int sn, int /* level */, CHAR_DATA *ch, SpellTarget /* vo 
 		return;
 	}
 
-	act("You hurl $p, sending it arcing through the air!", ch, obj, 0, TO_CHAR);
-	act("$n hurls $p, sending it arcing through the air!", ch, obj, 0, TO_ROOM);
-	act("You focus on the energy contained within $p and unleash a massive explosion!", ch, obj, 0, TO_CHAR);
-	act("$p suddenly explodes in mid-air, unleashing a torrent of raw energy!", ch, obj, 0, TO_ROOM);
+	act("You hurl $p, sending it arcing through the air!", ch, obj, nullptr, TO_CHAR);
+	act("$n hurls $p, sending it arcing through the air!", ch, obj, nullptr, TO_ROOM);
+	act("You focus on the energy contained within $p and unleash a massive explosion!", ch, obj, nullptr, TO_CHAR);
+	act("$p suddenly explodes in mid-air, unleashing a torrent of raw energy!", ch, obj, nullptr, TO_ROOM);
 
 	for (vch = ch->in_room->people; vch; vch = vch_next)
 	{
@@ -7946,11 +7946,11 @@ void spell_rotating_ward(int /* sn */, int level, CHAR_DATA *ch, SpellTarget /* 
 	}
 
 	if (affected)
-		act("You raise your hand and release another charged crystal to circle your body.", ch, 0, 0, TO_CHAR);
+		act("You raise your hand and release another charged crystal to circle your body.", ch, nullptr, nullptr, TO_CHAR);
 	else
-		act("You raise your hand, release your crystal, and it begins orbiting your body.", ch, 0, 0, TO_CHAR);
+		act("You raise your hand, release your crystal, and it begins orbiting your body.", ch, nullptr, nullptr, TO_CHAR);
 
-	act("$n holds out a multifaceted crystal and it begins orbiting $s body.", ch, 0, 0, TO_ROOM);
+	act("$n holds out a multifaceted crystal and it begins orbiting $s body.", ch, nullptr, nullptr, TO_ROOM);
 
 	init_affect(&af);
 	af.where = TO_AFFECTS;
@@ -7993,7 +7993,7 @@ void spell_fortify_crystal(int /* sn */, int /* level */, CHAR_DATA *ch, SpellTa
 		return;
 	}
 
-	act("$p hums briefly as you stabilize the energies within it.", ch, crystal, 0, TO_CHAR);
+	act("$p hums briefly as you stabilize the energies within it.", ch, crystal, nullptr, TO_CHAR);
 
 	af->tick_fun = nullptr;
 	af->modifier /= 2;
@@ -8003,9 +8003,9 @@ void mana_infusion_helper(CHAR_DATA *ch, CHAR_DATA *victim)
 {
 	AFFECT_DATA af;
 
-	act("Mana continues to flow out of $N, leaving $M glowing brightly.", ch, 0, victim, TO_CHAR);
-	act("Mana continues to flow out of $N, leaving $M glowing brightly.", ch, 0, victim, TO_NOTVICT);
-	act("Mana continues to flow out of you, leaving you glowing brightly.", ch, 0, victim, TO_VICT);
+	act("Mana continues to flow out of $N, leaving $M glowing brightly.", ch, nullptr, victim, TO_CHAR);
+	act("Mana continues to flow out of $N, leaving $M glowing brightly.", ch, nullptr, victim, TO_NOTVICT);
+	act("Mana continues to flow out of you, leaving you glowing brightly.", ch, nullptr, victim, TO_VICT);
 
 	init_affect(&af);
 	af.where = TO_AFFECTS;
@@ -8038,9 +8038,9 @@ void spell_mana_infusion(int /* sn */, int level, CHAR_DATA *ch, SpellTarget vo,
 	else
 		dammod = 120;
 
-	act("You infuse $N's body with pure mana, overwhelming it!", ch, 0, victim, TO_CHAR);
-	act("$n gestures at you and your body suddenly feels full!", ch, 0, victim, TO_VICT);
-	act("$n gestures at $N, who begins to glow.", ch, 0, victim, TO_NOTVICT);
+	act("You infuse $N's body with pure mana, overwhelming it!", ch, nullptr, victim, TO_CHAR);
+	act("$n gestures at you and your body suddenly feels full!", ch, nullptr, victim, TO_VICT);
+	act("$n gestures at $N, who begins to glow.", ch, nullptr, victim, TO_NOTVICT);
 
 	init_affect(&af1);
 	af1.where = TO_AFFECTS;
@@ -8061,8 +8061,8 @@ void spell_mana_infusion(int /* sn */, int level, CHAR_DATA *ch, SpellTarget vo,
 
 void infusion_tick(CHAR_DATA *ch, AFFECT_DATA *af)
 {
-	act("You writhe in pain as the mana continues to flow out of you.", ch, 0, 0, TO_CHAR);
-	act("$n writhes in pain as the mana continues to flow out of $m.", ch, 0, 0, TO_ROOM);
+	act("You writhe in pain as the mana continues to flow out of you.", ch, nullptr, nullptr, TO_CHAR);
+	act("$n writhes in pain as the mana continues to flow out of $m.", ch, nullptr, nullptr, TO_ROOM);
 
 	// One read: both uses are arguments to the same call, so nothing runs
 	// between them.

--- a/code/characterClasses/sorcerer.c
+++ b/code/characterClasses/sorcerer.c
@@ -1019,7 +1019,6 @@ void spell_vacuum(int sn, int level, CHAR_DATA *ch, [[maybe_unused]] SpellTarget
 {
 	ROOM_AFFECT_DATA raf;
 	CHAR_DATA *vch, *vch_next;
-	EXIT_DATA *pexit;
 	ROOM_INDEX_DATA *to_room;
 	char *direction;
 	char buf[MAX_STRING_LENGTH];
@@ -2534,7 +2533,7 @@ void spell_riptide(int sn, int level, CHAR_DATA *ch, [[maybe_unused]] SpellTarge
 {
 	ROOM_INDEX_DATA *room, *first_room = nullptr, *second_room = nullptr;
 	AFFECT_DATA af;
-	ROOM_AFFECT_DATA *raf, *fraf = nullptr, nraf;
+	ROOM_AFFECT_DATA *fraf = nullptr, nraf;
 
 	if (is_affected(ch, sn))
 	{
@@ -2852,7 +2851,7 @@ void spell_anchor(int /* sn */, int level, CHAR_DATA *ch, SpellTarget /* vo */, 
 
 void spell_aerial_transferrence(int sn, int /* level */, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
 {
-	CHAR_DATA *anchor = nullptr, *wch, *wch_next;
+	CHAR_DATA *anchor = nullptr;
 	ROOM_INDEX_DATA *pRoomIndex;
 
 	if (IS_SET(ch->in_room->room_flags, ROOM_NO_RECALL)
@@ -5482,7 +5481,6 @@ void spell_pure_air(int /* sn */, int /* level */, CHAR_DATA *ch, SpellTarget /*
 {
 	CHAR_DATA *vch;
 	bool cleansed;
-	ROOM_AFFECT_DATA *raf;
 
 	if (ch->in_room->sector_type && ch->in_room->sector_type == SECT_UNDERWATER)
 	{

--- a/code/characterClasses/thief.c
+++ b/code/characterClasses/thief.c
@@ -423,8 +423,8 @@ void do_blackjack(CHAR_DATA *ch, char *argument)
 
 	if (number_percent() < chance)
 	{
-		act("You whack $N over the head with a heavy looking sack. Ouch.", ch, 0, victim, TO_CHAR);
-		act("$n whacks $N over the head with a heavy looking sack. Ouch.", ch, 0, victim, TO_NOTVICT);
+		act("You whack $N over the head with a heavy looking sack. Ouch.", ch, nullptr, victim, TO_CHAR);
+		act("$n whacks $N over the head with a heavy looking sack. Ouch.", ch, nullptr, victim, TO_NOTVICT);
 		send_to_char("You feel a sudden pain erupt through the back of your skull.\n\r", victim);
 
 		af.duration = 2;
@@ -451,9 +451,9 @@ void do_blackjack(CHAR_DATA *ch, char *argument)
 	}
 	else
 	{
-		act("You attempt to blackjack $N but fail.", ch, 0, victim, TO_CHAR);
-		act("$n attempts to blackjack $N but misses.", ch, 0, victim, TO_NOTVICT);
-		act("$n hits you over the head with a heavy sack.", ch, 0, victim, TO_VICT);
+		act("You attempt to blackjack $N but fail.", ch, nullptr, victim, TO_CHAR);
+		act("$n attempts to blackjack $N but misses.", ch, nullptr, victim, TO_NOTVICT);
+		act("$n hits you over the head with a heavy sack.", ch, nullptr, victim, TO_VICT);
 
 		af.duration = 2;
 		affect_to_char(victim, &af);
@@ -548,9 +548,9 @@ void do_ghetto_bind(CHAR_DATA *ch, char *argument)
 		af.location = APPLY_DEX;
 		affect_to_char(victim, &af);
 
-		act("$n puts a sack over $N's head and ties a rope around $S legs tightly.", ch, 0, victim, TO_NOTVICT);
-		act("You feel someone putting something over your head and legs.", ch, 0, victim, TO_VICT);
-		act("You put a sack over $N's head and tie a rope around $S legs tightly.", ch, 0, victim, TO_CHAR);
+		act("$n puts a sack over $N's head and ties a rope around $S legs tightly.", ch, nullptr, victim, TO_NOTVICT);
+		act("You feel someone putting something over your head and legs.", ch, nullptr, victim, TO_VICT);
+		act("You put a sack over $N's head and tie a rope around $S legs tightly.", ch, nullptr, victim, TO_CHAR);
 
 		WAIT_STATE(ch, PULSE_VIOLENCE);
 		check_improve(ch, gsn_bind, true, 1);
@@ -567,10 +567,10 @@ void do_ghetto_bind(CHAR_DATA *ch, char *argument)
 		af.location = APPLY_NONE;
 		affect_to_char(victim, &af);
 
-		act("$n tries to put a sack over $N's head but it rips.", ch, 0, victim, TO_NOTVICT);
+		act("$n tries to put a sack over $N's head but it rips.", ch, nullptr, victim, TO_NOTVICT);
 		send_to_char("You feel someone trying to put something over your head and legs.\n\r", victim);
 
-		act("You try to put a sack over $N's head but it rips.", ch, 0, victim, TO_CHAR);
+		act("You try to put a sack over $N's head but it rips.", ch, nullptr, victim, TO_CHAR);
 
 		WAIT_STATE(ch, PULSE_VIOLENCE * 3);
 		check_improve(ch, gsn_bind, false, 3);
@@ -587,16 +587,16 @@ void do_ghetto_unbind(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 
 	if (number_percent() > 30)
 	{
-		act("You break free of the bindings on your head and legs.", ch, 0, 0, TO_CHAR);
-		act("$n breaks free of the bindings on $s head and legs.", ch, 0, 0, TO_ROOM);
+		act("You break free of the bindings on your head and legs.", ch, nullptr, nullptr, TO_CHAR);
+		act("$n breaks free of the bindings on $s head and legs.", ch, nullptr, nullptr, TO_ROOM);
 
 		affect_strip(ch, gsn_bind);
 		WAIT_STATE(ch, PULSE_VIOLENCE);
 	}
 	else
 	{
-		act("You fail to break free of the bindings on your head and legs.", ch, 0, 0, TO_CHAR);
-		act("$n fails to break free of the bindings on $s head and legs.", ch, 0, 0, TO_ROOM);
+		act("You fail to break free of the bindings on your head and legs.", ch, nullptr, nullptr, TO_CHAR);
+		act("$n fails to break free of the bindings on $s head and legs.", ch, nullptr, nullptr, TO_ROOM);
 
 		WAIT_STATE(ch, PULSE_VIOLENCE);
 	}
@@ -761,30 +761,30 @@ void do_ungag(CHAR_DATA *ch, char *argument)
 
 	if (check_bind(vch, "arms") != nullptr)
 	{
-		act("$T arms are bound too tightly for you to reach $T gag!\n\r", ch, 0, vch == ch ? "your" : "their", TO_CHAR);
+		act("$T arms are bound too tightly for you to reach $T gag!\n\r", ch, nullptr, vch == ch ? "your" : "their", TO_CHAR);
 		return;
 	}
 
 	if (number_percent() > 30)
 	{
-		act("You tear away the gag from $T mouth.", ch, 0, vch == ch ? "your" : "their", TO_CHAR);
+		act("You tear away the gag from $T mouth.", ch, nullptr, vch == ch ? "your" : "their", TO_CHAR);
 
 		if (vch == ch)
-			act("$n tears away the gag from $s mouth.", ch, 0, 0, TO_ROOM);
+			act("$n tears away the gag from $s mouth.", ch, nullptr, nullptr, TO_ROOM);
 		else
-			act("$n tears away the gag from $N's mouth.", ch, 0, vch, TO_ROOM);
+			act("$n tears away the gag from $N's mouth.", ch, nullptr, vch, TO_ROOM);
 
 		affect_strip(ch, gsn_gag);
 		WAIT_STATE(ch, PULSE_VIOLENCE);
 	}
 	else
 	{
-		act("The gag is tied too tightly and you fail to remove it.", ch, 0, 0, TO_CHAR);
+		act("The gag is tied too tightly and you fail to remove it.", ch, nullptr, nullptr, TO_CHAR);
 
 		if (vch == ch)
-			act("$n fails to remove $s gag.", ch, 0, 0, TO_ROOM);
+			act("$n fails to remove $s gag.", ch, nullptr, nullptr, TO_ROOM);
 		else
-			act("$n fails to remove $N's gag.", ch, 0, vch, TO_ROOM);
+			act("$n fails to remove $N's gag.", ch, nullptr, vch, TO_ROOM);
 
 		WAIT_STATE(ch, PULSE_VIOLENCE);
 	}
@@ -947,7 +947,7 @@ void do_drag(CHAR_DATA *ch, char *argument)
 
 	if (is_npc(victim) && IS_SET(victim->act, ACT_SENTINEL))
 	{
-		act("You can't seem to move $N from $S position!", ch, 0, victim, TO_CHAR);
+		act("You can't seem to move $N from $S position!", ch, nullptr, victim, TO_CHAR);
 		return;
 	}
 
@@ -1034,8 +1034,8 @@ void do_drag(CHAR_DATA *ch, char *argument)
 	}
 	else
 	{
-		act("You grapple $N, and try to drag $M but $E doesn't budge!", ch, 0, victim, TO_CHAR);
-		act("$n grapples $N, and tries to drag $M away but $N doesn't budge!", ch, 0, victim, TO_NOTVICT);
+		act("You grapple $N, and try to drag $M but $E doesn't budge!", ch, nullptr, victim, TO_CHAR);
+		act("$n grapples $N, and tries to drag $M away but $N doesn't budge!", ch, nullptr, victim, TO_NOTVICT);
 		check_improve(ch, gsn_drag, false, 1);
 	}
 
@@ -1086,7 +1086,7 @@ void do_tripwire(CHAR_DATA *ch, char *argument)
 	{
 		direction = flag_name_lookup(door, direction_table);
 
-		act("You lay a concealed tripwire across the exit $Tward and draw it taut.", ch, 0, direction, TO_CHAR);
+		act("You lay a concealed tripwire across the exit $Tward and draw it taut.", ch, nullptr, direction, TO_CHAR);
 
 		for (victim = ch->in_room->people; victim != nullptr; victim = victim->next_in_room)
 		{
@@ -1384,7 +1384,7 @@ void do_stash(CHAR_DATA *ch, char *argument)
 		return;
 	}
 
-	act("You attempt to stash $p away.", ch, obj, 0, TO_CHAR);
+	act("You attempt to stash $p away.", ch, obj, nullptr, TO_CHAR);
 
 	if (number_percent() < skill)
 	{
@@ -1467,8 +1467,8 @@ void do_disguise(CHAR_DATA *ch, char *argument)
 		return;
 	}
 
-	act("You strip $p of its garb and try to disguise yourself.", ch, corpse, 0, TO_CHAR);
-	act("$n strips $p of its garb and tries to disguise $mself.", ch, corpse, 0, TO_ROOM);
+	act("You strip $p of its garb and try to disguise yourself.", ch, corpse, nullptr, TO_CHAR);
+	act("$n strips $p of its garb and tries to disguise $mself.", ch, corpse, nullptr, TO_ROOM);
 
 	init_affect_obj(&oaf);
 	oaf.where = TO_OBJ_AFFECTS;
@@ -1531,15 +1531,15 @@ void disguise_pulse(CHAR_DATA *ch, AFFECT_DATA *af)
 {
 	if (Deref(ch->fighting) && number_percent() < 25)
 	{
-		act("Your shoddy disguise comes apart, the tatters falling away and revealing you!", ch, 0, 0, TO_CHAR);
-		act("$n's garb falls to tatters around $m...  revealing $t beneath the disguise!", ch, ch->pcdata->old->name, 0, TO_ROOM);
+		act("Your shoddy disguise comes apart, the tatters falling away and revealing you!", ch, nullptr, nullptr, TO_CHAR);
+		act("$n's garb falls to tatters around $m...  revealing $t beneath the disguise!", ch, ch->pcdata->old->name, nullptr, TO_ROOM);
 		affect_strip(ch, gsn_disguise);
 		return;
 	}
 
 	if (af->modifier < ch->in_room->area->min_vnum || af->modifier > ch->in_room->area->max_vnum)
 	{
-		act("Your disguise ceases to be effective as you leave the vicinity.", ch, 0, 0, TO_CHAR);
+		act("Your disguise ceases to be effective as you leave the vicinity.", ch, nullptr, nullptr, TO_CHAR);
 		affect_strip(ch, gsn_disguise);
 	}
 }
@@ -1577,8 +1577,8 @@ void do_undisguise(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 		}
 	}
 
-	act("$n suddenly slips out of $s garb... revealing $t beneath the disguise!", ch, ch->pcdata->old->name, 0, TO_ROOM);
-	act("You deftly slip out of your disguise and cast it aside.", ch, 0, 0, TO_CHAR);
+	act("$n suddenly slips out of $s garb... revealing $t beneath the disguise!", ch, ch->pcdata->old->name, nullptr, TO_ROOM);
+	act("You deftly slip out of your disguise and cast it aside.", ch, nullptr, nullptr, TO_CHAR);
 
 	affect_strip(ch, gsn_disguise);
 
@@ -1590,8 +1590,8 @@ void do_search(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 	OBJ_DATA *obj = nullptr;
 	int chance;
 
-	act("You intently scrutinize your surroundings...", ch, 0, 0, TO_CHAR);
-	act("$n intently scrutinizes $s surroundings...", ch, 0, 0, TO_ROOM);
+	act("You intently scrutinize your surroundings...", ch, nullptr, nullptr, TO_CHAR);
+	act("$n intently scrutinizes $s surroundings...", ch, nullptr, nullptr, TO_ROOM);
 
 	chance = number_percent();
 
@@ -1612,8 +1612,8 @@ void do_search(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 				if (Deref(oaf.owner) != ch && (number_percent() < chance))
 				{
 					affect_strip_obj(obj, gsn_stash);
-					act("You stumble across $p which seemed to be hidden from your eye.", ch, obj, 0, TO_CHAR);
-					act("$n stumbles across and reveals $p.", ch, obj, 0, TO_ROOM);
+					act("You stumble across $p which seemed to be hidden from your eye.", ch, obj, nullptr, TO_CHAR);
+					act("$n stumbles across and reveals $p.", ch, obj, nullptr, TO_ROOM);
 				}
 			}
 		}
@@ -1676,7 +1676,7 @@ void do_counterfeit(CHAR_DATA *ch, char *argument)
 
 	if (number_percent() < skill)
 	{
-		act("You successfully counterfeit $p.", ch, orig, 0, TO_CHAR);
+		act("You successfully counterfeit $p.", ch, orig, nullptr, TO_CHAR);
 
 		free_pstring(copy->short_descr);
 		copy->short_descr = palloc_string(orig->short_descr);
@@ -1691,7 +1691,7 @@ void do_counterfeit(CHAR_DATA *ch, char *argument)
 	}
 	else
 	{
-		act("You botch the counterfeit and ruin $p!", ch, copy, 0, TO_CHAR);
+		act("You botch the counterfeit and ruin $p!", ch, copy, nullptr, TO_CHAR);
 
 		free_pstring(copy->short_descr);
 		sprintf(hold, "a shoddy imitation of %s", orig->short_descr);
@@ -1779,7 +1779,7 @@ void do_shadow_cloak(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 
 	if (number_percent() < skill)
 	{
-		act("You sharpen your mind and attempt to shield yourself from scrying magic.", ch, 0, 0, TO_CHAR);
+		act("You sharpen your mind and attempt to shield yourself from scrying magic.", ch, nullptr, nullptr, TO_CHAR);
 
 		init_affect(&af);
 		af.where = TO_AFFECTS;
@@ -1792,7 +1792,7 @@ void do_shadow_cloak(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 	}
 	else
 	{
-		act("You sharpen your mind and attempt to shield yourself from scrying magic, but you fail.", ch, 0, 0, TO_CHAR);
+		act("You sharpen your mind and attempt to shield yourself from scrying magic, but you fail.", ch, nullptr, nullptr, TO_CHAR);
 		check_improve(ch, gsn_shadow_cloak, false, 1);
 	}
 
@@ -1826,7 +1826,7 @@ bool check_stealth(CHAR_DATA *ch, CHAR_DATA *mob)
 	}
 	else
 	{
-		act("You stumble slightly and $N notices you!", ch, 0, mob, TO_CHAR);
+		act("You stumble slightly and $N notices you!", ch, nullptr, mob, TO_CHAR);
 		check_improve(ch, gsn_stealth, false, 3);
 		return false;
 	}
@@ -1953,14 +1953,14 @@ void do_strip(CHAR_DATA *ch, char *argument)
 		}
 		else
 		{
-			act("Oops.", ch, 0, victim, TO_CHAR);
+			act("Oops.", ch, nullptr, victim, TO_CHAR);
 			thief_yell(ch, victim);
 			check_improve(ch, gsn_strip, false, 1);
 		}
 	}
 	else
 	{
-		act("Oops.", ch, 0, victim, TO_CHAR);
+		act("Oops.", ch, nullptr, victim, TO_CHAR);
 		thief_yell(ch, victim);
 		check_improve(ch, gsn_strip, false, 1);
 	}
@@ -2168,27 +2168,27 @@ void do_bind(CHAR_DATA *ch, char *argument)
 			af.location = APPLY_HITROLL;
 			af.modifier = -(ch->level / 5);
 
-			act("You lift up $N's head and slide a sack over it.", ch, 0, victim, TO_CHAR);
-			act_new("You feel someone putting something over your head.", ch, 0, victim, TO_VICT, POS_SLEEPING);
-			act("$n lifts up $N's head and slides a sack over it.", ch, 0, victim, TO_NOTVICT);
+			act("You lift up $N's head and slide a sack over it.", ch, nullptr, victim, TO_CHAR);
+			act_new("You feel someone putting something over your head.", ch, nullptr, victim, TO_VICT, POS_SLEEPING);
+			act("$n lifts up $N's head and slides a sack over it.", ch, nullptr, victim, TO_NOTVICT);
 		}
 		else if (!str_cmp(arg2, "arms"))
 		{
 			af.location = APPLY_STR;
 			af.modifier = -(ch->level / 8);
 
-			act("Pulling $N's arms together, you tie $S wrists with a rope.", ch, 0, victim, TO_CHAR);
-			act_new("You feel something painfully constrict your arms.", ch, 0, victim, TO_VICT, POS_SLEEPING);
-			act("Pulling $N's arms together, $n ties $S wrists with a rope.", ch, 0, victim, TO_NOTVICT);
+			act("Pulling $N's arms together, you tie $S wrists with a rope.", ch, nullptr, victim, TO_CHAR);
+			act_new("You feel something painfully constrict your arms.", ch, nullptr, victim, TO_VICT, POS_SLEEPING);
+			act("Pulling $N's arms together, $n ties $S wrists with a rope.", ch, nullptr, victim, TO_NOTVICT);
 		}
 		else if (!str_cmp(arg2, "legs"))
 		{
 			af.location = APPLY_DEX;
 			af.modifier = -(ch->level / 5);
 
-			act("You tie $N's legs together tightly with a rope.", ch, 0, victim, TO_CHAR);
-			act_new("You feel something being tied around your legs.", ch, 0, victim, TO_VICT, POS_SLEEPING);
-			act("$n ties $N's legs together tightly with a rope.", ch, 0, victim, TO_NOTVICT);
+			act("You tie $N's legs together tightly with a rope.", ch, nullptr, victim, TO_CHAR);
+			act_new("You feel something being tied around your legs.", ch, nullptr, victim, TO_VICT, POS_SLEEPING);
+			act("$n ties $N's legs together tightly with a rope.", ch, nullptr, victim, TO_NOTVICT);
 		}
 
 		affect_to_char(victim, &af);
@@ -2199,18 +2199,18 @@ void do_bind(CHAR_DATA *ch, char *argument)
 	{
 		if (!str_cmp(arg2, "head"))
 		{
-			act("You attempt to put a sack over $N's head, but it rips.", ch, 0, victim, TO_CHAR);
-			act("$n attempts to put a sack over $N's head, but it rips.", ch, 0, victim, TO_NOTVICT);
+			act("You attempt to put a sack over $N's head, but it rips.", ch, nullptr, victim, TO_CHAR);
+			act("$n attempts to put a sack over $N's head, but it rips.", ch, nullptr, victim, TO_NOTVICT);
 		}
 		else if (!str_cmp(arg2, "arms"))
 		{
-			act("You attempt to tie $N's wrists together, but the rope tears.", ch, 0, victim, TO_CHAR);
-			act("$n attempts to tie $N's wrists together, but the rope tears.", ch, 0, victim, TO_NOTVICT);
+			act("You attempt to tie $N's wrists together, but the rope tears.", ch, nullptr, victim, TO_CHAR);
+			act("$n attempts to tie $N's wrists together, but the rope tears.", ch, nullptr, victim, TO_NOTVICT);
 		}
 		else if (!str_cmp(arg2, "legs"))
 		{
-			act("You attempt to tie $N's legs together, but the rope tears.", ch, 0, victim, TO_CHAR);
-			act("$n attempts to tie $N's legs together, but the rope tears.", ch, 0, victim, TO_NOTVICT);
+			act("You attempt to tie $N's legs together, but the rope tears.", ch, nullptr, victim, TO_CHAR);
+			act("$n attempts to tie $N's legs together, but the rope tears.", ch, nullptr, victim, TO_NOTVICT);
 		}
 
 		WAIT_STATE(ch, PULSE_VIOLENCE * 2);
@@ -2244,14 +2244,14 @@ void do_unbind(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 	{
 		if (number_percent() < get_curr_stat(ch, STAT_STR) * 6)
 		{
-			act("Exerting all of your strength, you break the bindings on your arms!", ch, 0, 0, TO_CHAR);
-			act("Exerting all of $s strength, $n breaks the bindings on $s arms!", ch, 0, 0, TO_ROOM);
+			act("Exerting all of your strength, you break the bindings on your arms!", ch, nullptr, nullptr, TO_CHAR);
+			act("Exerting all of $s strength, $n breaks the bindings on $s arms!", ch, nullptr, nullptr, TO_ROOM);
 			affect_remove(ch, af);
 		}
 		else
 		{
-			act("You struggle with the bindings on your arms, but fail to break them.", ch, 0, 0, TO_CHAR);
-			act("$n struggles with the bindings on $s arms, but fails to break them.", ch, 0, 0, TO_ROOM);
+			act("You struggle with the bindings on your arms, but fail to break them.", ch, nullptr, nullptr, TO_CHAR);
+			act("$n struggles with the bindings on $s arms, but fails to break them.", ch, nullptr, nullptr, TO_ROOM);
 		}
 
 		WAIT_STATE(ch, PULSE_VIOLENCE);
@@ -2260,14 +2260,14 @@ void do_unbind(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 	{
 		if (number_percent() < get_curr_stat(ch, STAT_DEX) * 6)
 		{
-			act("Staggering blindly, you manage to rip the sack off your head!", ch, 0, 0, TO_CHAR);
-			act("Staggering blindly, $n manages to rip the sack off $s head!", ch, 0, 0, TO_ROOM);
+			act("Staggering blindly, you manage to rip the sack off your head!", ch, nullptr, nullptr, TO_CHAR);
+			act("Staggering blindly, $n manages to rip the sack off $s head!", ch, nullptr, nullptr, TO_ROOM);
 			affect_remove(ch, af);
 		}
 		else
 		{
-			act("You struggle with the sack on your head, but fail to remove it.", ch, 0, 0, TO_CHAR);
-			act("$n struggles with the sack on $s head, but fails to remove it.", ch, 0, 0, TO_ROOM);
+			act("You struggle with the sack on your head, but fail to remove it.", ch, nullptr, nullptr, TO_CHAR);
+			act("$n struggles with the sack on $s head, but fails to remove it.", ch, nullptr, nullptr, TO_ROOM);
 		}
 
 		WAIT_STATE(ch, PULSE_VIOLENCE);
@@ -2276,14 +2276,14 @@ void do_unbind(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 	{
 		if (number_percent() < (get_curr_stat(ch, STAT_DEX) * 3 + get_curr_stat(ch, STAT_STR) * 3))
 		{
-			act("You pull the bindings on your legs, ripping them apart!", ch, 0, 0, TO_CHAR);
-			act("$n pulls the bindings on $s legs, ripping them apart!", ch, 0, 0, TO_ROOM);
+			act("You pull the bindings on your legs, ripping them apart!", ch, nullptr, nullptr, TO_CHAR);
+			act("$n pulls the bindings on $s legs, ripping them apart!", ch, nullptr, nullptr, TO_ROOM);
 			affect_remove(ch, af);
 		}
 		else
 		{
-			act("You struggle with the bindings on your legs, but fail to break them.", ch, 0, 0, TO_CHAR);
-			act("$n struggles with the bindings on $s legs, but fails to break them.", ch, 0, 0, TO_ROOM);
+			act("You struggle with the bindings on your legs, but fail to break them.", ch, nullptr, nullptr, TO_CHAR);
+			act("$n struggles with the bindings on $s legs, but fails to break them.", ch, nullptr, nullptr, TO_ROOM);
 		}
 
 		WAIT_STATE(ch, PULSE_VIOLENCE);
@@ -2366,9 +2366,9 @@ void do_knife(CHAR_DATA *ch, char *argument)
 
 	if (number_percent() < get_skill(ch, gsn_knife))
 	{
-		act("You slam your dagger into $N's side!", ch, 0, victim, TO_CHAR);
-		act("$n slams $s dagger into your side!", ch, 0, victim, TO_VICT);
-		act("$n slams $s dagger into $N's side!", ch, 0, victim, TO_NOTVICT);
+		act("You slam your dagger into $N's side!", ch, nullptr, victim, TO_CHAR);
+		act("$n slams $s dagger into your side!", ch, nullptr, victim, TO_VICT);
+		act("$n slams $s dagger into $N's side!", ch, nullptr, victim, TO_NOTVICT);
 
 		bool killed = one_hit_new(ch, victim, gsn_knife, HIT_SPECIALS, HIT_UNBLOCKABLE, HIT_NOADD, 125, nullptr);
 
@@ -2379,7 +2379,7 @@ void do_knife(CHAR_DATA *ch, char *argument)
 
 		if (number_range(0, 5) == 3)
 		{
-			act("Bright red blood spurts out of $S wound!\n\r", ch, 0, victim, TO_CHAR);
+			act("Bright red blood spurts out of $S wound!\n\r", ch, nullptr, victim, TO_CHAR);
 
 			init_affect(&af);
 			af.where = TO_AFFECTS;

--- a/code/characterClasses/warrior.c
+++ b/code/characterClasses/warrior.c
@@ -3560,6 +3560,14 @@ void do_uncoil(CHAR_DATA *ch, char *argument)
 		}
 	}
 
+	// check_entwine above asks exactly what the search asks, so a miss means the
+	// two have drifted rather than that the character is loose.
+	if (af == nullptr)
+	{
+		send_to_char("You aren't entwined!\n\r", ch);
+		return;
+	}
+
 	guy = Deref(af->owner);
 
 	if (guy != nullptr)
@@ -3579,7 +3587,9 @@ void do_uncoil(CHAR_DATA *ch, char *argument)
 	{
 		if (type == 0)
 		{
-			if (str_cmp(argument, "automagic"))
+			// af2 is the coiler's half of the pair and stays null when the coiler
+			// is gone, so there is no limb to name and nobody to name it to.
+			if (af2 != nullptr && str_cmp(argument, "automagic"))
 			{
 				act("With a sudden jerk of your wrist, you uncoil your whip, freeing $N's $t!", ch, af2->modifier == 1 ? "arm" : af2->location == APPLY_DEX ? "leg" : "", guy, TO_CHAR);
 				act("With a sudden jerk of $n's wrist, $e uncoils $s whip, freeing your $t!", ch, af2->modifier == 1 ? "arm" : af2->location == APPLY_DEX ? "leg" : "", guy, TO_VICT);
@@ -3665,7 +3675,15 @@ void do_pull(CHAR_DATA *ch, char *argument)
 			}
 		}
 
-		guy = Deref(af->owner);
+		// The whip is still on, but the warrior holding the other end can have
+		// been extracted, and pulling needs both ends.
+		guy = af != nullptr ? Deref(af->owner) : nullptr;
+
+		if (guy == nullptr)
+		{
+			send_to_char("There is nobody on the other end of it.\n\r", ch);
+			return;
+		}
 
 		af2 = nullptr;
 		for (auto &af2_elem : guy->affected)
@@ -3675,6 +3693,12 @@ void do_pull(CHAR_DATA *ch, char *argument)
 				af2 = &af2_elem;
 				break;
 			}
+		}
+
+		if (af2 == nullptr)
+		{
+			send_to_char("There is nobody on the other end of it.\n\r", ch);
+			return;
 		}
 
 		WAIT_STATE(ch, PULSE_VIOLENCE * 2);

--- a/code/characterClasses/warrior.c
+++ b/code/characterClasses/warrior.c
@@ -3643,7 +3643,6 @@ void do_pull(CHAR_DATA *ch, char *argument)
 	AFFECT_DATA *af, *af2, taf;
 	int dir, skill;
 	char *direction;
-	ROOM_INDEX_DATA *to_room;
 	EXIT_DATA *pexit;
 
 	skill = get_skill(ch, gsn_entwine);
@@ -3732,7 +3731,6 @@ void do_pull(CHAR_DATA *ch, char *argument)
 				affect_to_char(ch, &taf);
 				affect_to_char(guy, &taf);
 
-				to_room = pexit->u1.to_room;
 
 				stop_fighting(ch, true);
 				move_char(ch, dir, true, false);
@@ -4287,7 +4285,6 @@ void do_offhand(CHAR_DATA *ch, [[maybe_unused]] char *arg)
 void do_drive(CHAR_DATA *ch, char *argument)
 {
 	int where, skill;
-	ROOM_INDEX_DATA *to_room;
 	EXIT_DATA *pexit;
 	CHAR_DATA *victim = nullptr;
 	char *direction;
@@ -4427,7 +4424,6 @@ void do_drive(CHAR_DATA *ch, char *argument)
 		act("$n surges at $N, pressing $M towards the $t!", ch, dir, victim, TO_NOTVICT);
 
 		/* Set the direction room */
-		to_room = pexit->u1.to_room;
 
 		/* stop and move driver */
 		stop_fighting(ch, true);

--- a/code/characterClasses/warrior.c
+++ b/code/characterClasses/warrior.c
@@ -137,7 +137,7 @@ void do_style(CHAR_DATA *ch, char *argument)
 		}
 
 		if (ch->pcdata->style)
-			act("You are fighting in the style of the $t.", ch, style_table[ch->pcdata->style].name, 0, TO_CHAR);
+			act("You are fighting in the style of the $t.", ch, style_table[ch->pcdata->style].name, nullptr, TO_CHAR);
 
 		return;
 	}
@@ -175,9 +175,9 @@ void do_style(CHAR_DATA *ch, char *argument)
 	}
 
 	if (style == ch->pcdata->style)
-		act("You are already fighting in the $t style.", ch, style_table[style].name, 0, TO_CHAR);
+		act("You are already fighting in the $t style.", ch, style_table[style].name, nullptr, TO_CHAR);
 	else
-		act("You fluidly shift your fighting methods into the $t style.", ch, style_table[style].name, 0, TO_CHAR);
+		act("You fluidly shift your fighting methods into the $t style.", ch, style_table[style].name, nullptr, TO_CHAR);
 
 	WAIT_STATE(ch, PULSE_VIOLENCE);
 	ch->pcdata->style = style;
@@ -256,18 +256,18 @@ void do_entrap(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 				sprintf(buf, "You entrap $N's %s beneath the haft of your %s but it won't budge!",
 					weapon_name_lookup(weapon->value[0]),
 					weapon_name_lookup(wield->value[0]));
-				act(buf, ch, 0, victim, TO_CHAR);
+				act(buf, ch, nullptr, victim, TO_CHAR);
 
 				sprintf(buf, "$n entraps your %s beneath the haft of $s %s but it won't budge!",
 					weapon_name_lookup(weapon->value[0]),
 					weapon_name_lookup(wield->value[0]));
-				act(buf, ch, 0, victim, TO_VICT);
+				act(buf, ch, nullptr, victim, TO_VICT);
 
 				sprintf(buf, "$n entraps $N's %s beneath the haft of $s %s but it won't budge!",
 					weapon_name_lookup(weapon->value[0]),
 					weapon_name_lookup(wield->value[0]));
 
-				act(buf, ch, 0, victim, TO_NOTVICT);
+				act(buf, ch, nullptr, victim, TO_NOTVICT);
 				WAIT_STATE(ch, PULSE_VIOLENCE * 2);
 				return;
 			}
@@ -276,21 +276,21 @@ void do_entrap(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 				sprintf(buf, "You entrap $N's %s beneath the haft of your %s and knock it to the ground!",
 					weapon_name_lookup(weapon->value[0]),
 					weapon_name_lookup(wield->value[0]));
-				act(buf, ch, 0, victim, TO_CHAR);
+				act(buf, ch, nullptr, victim, TO_CHAR);
 
 				sprintf(buf, "$n entraps your %s beneath the haft of $s %s and knocks it to the ground!",
 					weapon_name_lookup(weapon->value[0]),
 					weapon_name_lookup(wield->value[0]));
-				act(buf, ch, 0, victim, TO_VICT);
+				act(buf, ch, nullptr, victim, TO_VICT);
 
 				sprintf(buf, "$n entraps $N's %s beneath the haft of $s %s and knocks it to the ground!",
 					weapon_name_lookup(weapon->value[0]),
 					weapon_name_lookup(wield->value[0]));
-				act(buf, ch, 0, victim, TO_NOTVICT);
+				act(buf, ch, nullptr, victim, TO_NOTVICT);
 			}
 			else
 			{
-				act("You fail to entrap $N's weapon.", ch, 0, victim, TO_CHAR);
+				act("You fail to entrap $N's weapon.", ch, nullptr, victim, TO_CHAR);
 				act("$n attempts to entrap your weapon with $s $t, but fails.", ch, weapon_name_lookup(wield->value[0]), victim, TO_VICT);
 				act("$n attempts to entrap $N's weapon with $s $t, but fails.", ch, weapon_name_lookup(wield->value[0]), victim, TO_NOTVICT);
 				WAIT_STATE(ch, PULSE_VIOLENCE * 2);
@@ -363,9 +363,9 @@ void do_entrap(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 			}
 			else
 			{
-				act("You fail to entrap $N's weapon.", ch, 0, victim, TO_CHAR);
-				act("$n attempts to entrap your weapon with $s two weapons, but fails.", ch, 0, victim, TO_VICT);
-				act("$n attempts to entrap $N's weapon with $s two weapons, but fails.", ch, 0, victim, TO_NOTVICT);
+				act("You fail to entrap $N's weapon.", ch, nullptr, victim, TO_CHAR);
+				act("$n attempts to entrap your weapon with $s two weapons, but fails.", ch, nullptr, victim, TO_VICT);
+				act("$n attempts to entrap $N's weapon with $s two weapons, but fails.", ch, nullptr, victim, TO_NOTVICT);
 				WAIT_STATE(ch, PULSE_VIOLENCE * 2);
 				return;
 			}
@@ -401,8 +401,8 @@ void do_entrap(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 	if (dual != nullptr)
 	{
 		unequip_char(victim, dual, false);
-		act("You quickly swap $p into your primary hand.", victim, dual, 0, TO_CHAR);
-		act("$n quickly swaps $p into $s primary hand.", victim, dual, 0, TO_ROOM);
+		act("You quickly swap $p into your primary hand.", victim, dual, nullptr, TO_CHAR);
+		act("$n quickly swaps $p into $s primary hand.", victim, dual, nullptr, TO_ROOM);
 		equip_char(victim, dual, WEAR_WIELD, false);
 	}
 
@@ -460,39 +460,39 @@ void do_hobble(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 		switch (weapon->value[0])
 		{
 			case WEAPON_MACE:
-				act("You lower your mace near the ground and sweep at $N's legs!", ch, 0, victim, TO_CHAR);
-				act("$n lowers $s mace near the ground and sweeps at your legs!", ch, 0, victim, TO_VICT);
-				act("$n lowers $s mace near the ground and sweeps at $N's legs!", ch, 0, victim, TO_NOTVICT);
+				act("You lower your mace near the ground and sweep at $N's legs!", ch, nullptr, victim, TO_CHAR);
+				act("$n lowers $s mace near the ground and sweeps at your legs!", ch, nullptr, victim, TO_VICT);
+				act("$n lowers $s mace near the ground and sweeps at $N's legs!", ch, nullptr, victim, TO_NOTVICT);
 				break;
 			case WEAPON_AXE:
-				act("Pivoting suddenly, you bring your axe down in an arc towards $N's feet!", ch, 0, victim, TO_CHAR);
-				act("Pivoting suddenly, $n brings $s axe down in an arc towards your feet!", ch, 0, victim, TO_VICT);
-				act("Pivoting suddenly, $n brings $s axe down in an arc towards $N's feet!", ch, 0, victim, TO_NOTVICT);
+				act("Pivoting suddenly, you bring your axe down in an arc towards $N's feet!", ch, nullptr, victim, TO_CHAR);
+				act("Pivoting suddenly, $n brings $s axe down in an arc towards your feet!", ch, nullptr, victim, TO_VICT);
+				act("Pivoting suddenly, $n brings $s axe down in an arc towards $N's feet!", ch, nullptr, victim, TO_NOTVICT);
 				break;
 			case WEAPON_SWORD:
-				act("You drop your blade under $N's guard and strike at $S legs!", ch, 0, victim, TO_CHAR);
-				act("$n drops $s blade under your guard and strikes at your legs!", ch, 0, victim, TO_VICT);
-				act("$n drops $s blade under $N's guard and strikes at $S legs!", ch, 0, victim, TO_NOTVICT);
+				act("You drop your blade under $N's guard and strike at $S legs!", ch, nullptr, victim, TO_CHAR);
+				act("$n drops $s blade under your guard and strikes at your legs!", ch, nullptr, victim, TO_VICT);
+				act("$n drops $s blade under $N's guard and strikes at $S legs!", ch, nullptr, victim, TO_NOTVICT);
 				break;
 			case WEAPON_FLAIL:
-				act("Lashing out with your flail, you aim a sweeping blow at $N's legs!", ch, 0, victim, TO_CHAR);
-				act("Lashing out with $s flail, $n aims a sweeping blow at your legs!", ch, 0, victim, TO_VICT);
-				act("Lashing out with $s flail, $n aims a sweeping blow at $N's legs!", ch, 0, victim, TO_NOTVICT);
+				act("Lashing out with your flail, you aim a sweeping blow at $N's legs!", ch, nullptr, victim, TO_CHAR);
+				act("Lashing out with $s flail, $n aims a sweeping blow at your legs!", ch, nullptr, victim, TO_VICT);
+				act("Lashing out with $s flail, $n aims a sweeping blow at $N's legs!", ch, nullptr, victim, TO_NOTVICT);
 				break;
 			case WEAPON_STAFF:
-				act("Twirling your staff rapidly, you unleash a snapping strike at $N's feet!", ch, 0, victim, TO_CHAR);
-				act("Twirling $s staff rapidly, $n unleashes a snapping strike at your feet!", ch, 0, victim, TO_VICT);
-				act("Twirling $s staff rapidly, $n unleashes a snapping strike at $N's feet!", ch, 0, victim, TO_NOTVICT);
+				act("Twirling your staff rapidly, you unleash a snapping strike at $N's feet!", ch, nullptr, victim, TO_CHAR);
+				act("Twirling $s staff rapidly, $n unleashes a snapping strike at your feet!", ch, nullptr, victim, TO_VICT);
+				act("Twirling $s staff rapidly, $n unleashes a snapping strike at $N's feet!", ch, nullptr, victim, TO_NOTVICT);
 				break;
 			case WEAPON_SPEAR:
-				act("Stabbing suddenly, you aim a precise strike at $N's calf!", ch, 0, victim, TO_CHAR);
-				act("Stabbing suddenly, $n aims a precise strike at your calf!", ch, 0, victim, TO_VICT);
-				act("Stabbing suddenly, $n aims a precise strike at $N's calf!", ch, 0, victim, TO_NOTVICT);
+				act("Stabbing suddenly, you aim a precise strike at $N's calf!", ch, nullptr, victim, TO_CHAR);
+				act("Stabbing suddenly, $n aims a precise strike at your calf!", ch, nullptr, victim, TO_VICT);
+				act("Stabbing suddenly, $n aims a precise strike at $N's calf!", ch, nullptr, victim, TO_NOTVICT);
 				break;
 			case WEAPON_DAGGER:
-				act("You circle around $N and make a sweeping slash at $S calves!", ch, 0, victim, TO_CHAR);
-				act("$n circles around you and makes a sweeping slash at your calves!", ch, 0, victim, TO_VICT);
-				act("$n circles around $N and makes a sweeping slash at $S calves!", ch, 0, victim, TO_NOTVICT);
+				act("You circle around $N and make a sweeping slash at $S calves!", ch, nullptr, victim, TO_CHAR);
+				act("$n circles around you and makes a sweeping slash at your calves!", ch, nullptr, victim, TO_VICT);
+				act("$n circles around $N and makes a sweeping slash at $S calves!", ch, nullptr, victim, TO_NOTVICT);
 				break;
 			default:
 				send_to_char("You cannot properly strike your opponent's legs with that.\n\r", ch);
@@ -519,8 +519,8 @@ void do_hobble(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 			switch (weapon->value[0])
 			{
 				case WEAPON_MACE:
-					act("You hear the chilling sound of snapping bone as you land a solid blow.", ch, 0, victim, TO_CHAR);
-					act("You hear the chilling sound of snapping bone as $n lands a solid blow.", ch, 0, victim, TO_ROOM);
+					act("You hear the chilling sound of snapping bone as you land a solid blow.", ch, nullptr, victim, TO_CHAR);
+					act("You hear the chilling sound of snapping bone as $n lands a solid blow.", ch, nullptr, victim, TO_ROOM);
 
 					af.location = APPLY_DEX;
 					af.modifier = -(ch->level / 6);
@@ -530,9 +530,9 @@ void do_hobble(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 					victim->move = std::max(victim->move / 2, 0);
 					break;
 				case WEAPON_AXE:
-					act("$N's leg buckles beneath $m as your slash tears deep into muscle!", ch, 0, victim, TO_CHAR);
-					act("Your leg buckles beneath you as $n's slash tears deep into muscle.", ch, 0, victim, TO_VICT);
-					act("$N's leg buckles beneath $m as $n's slash tears deep into muscle.", ch, 0, victim, TO_NOTVICT);
+					act("$N's leg buckles beneath $m as your slash tears deep into muscle!", ch, nullptr, victim, TO_CHAR);
+					act("Your leg buckles beneath you as $n's slash tears deep into muscle.", ch, nullptr, victim, TO_VICT);
+					act("$N's leg buckles beneath $m as $n's slash tears deep into muscle.", ch, nullptr, victim, TO_NOTVICT);
 
 					af.location = APPLY_DEX;
 					af.modifier = -(ch->level / 8);
@@ -553,9 +553,9 @@ void do_hobble(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 					new_affect_to_char(victim, &af2);
 					break;
 				case WEAPON_SWORD:
-					act("$N's leg buckles beneath $m as your slash tears deep into muscle!", ch, 0, victim, TO_CHAR);
-					act("Your leg buckles beneath you as $n's slash tears deep into muscle.", ch, 0, victim, TO_VICT);
-					act("$N's leg buckles beneath $m as $n's slash tears deep into muscle.", ch, 0, victim, TO_NOTVICT);
+					act("$N's leg buckles beneath $m as your slash tears deep into muscle!", ch, nullptr, victim, TO_CHAR);
+					act("Your leg buckles beneath you as $n's slash tears deep into muscle.", ch, nullptr, victim, TO_VICT);
+					act("$N's leg buckles beneath $m as $n's slash tears deep into muscle.", ch, nullptr, victim, TO_NOTVICT);
 
 					af.location = APPLY_DEX;
 					af.modifier = -(ch->level / 8);
@@ -576,8 +576,8 @@ void do_hobble(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 					new_affect_to_char(victim, &af2);
 					break;
 				case WEAPON_FLAIL:
-					act("You hear the chilling sound of snapping bone as you land a solid blow.", ch, 0, victim, TO_CHAR);
-					act("You hear the chilling sound of snapping bone as $n lands a solid blow.", ch, 0, victim, TO_ROOM);
+					act("You hear the chilling sound of snapping bone as you land a solid blow.", ch, nullptr, victim, TO_CHAR);
+					act("You hear the chilling sound of snapping bone as $n lands a solid blow.", ch, nullptr, victim, TO_ROOM);
 
 					af.location = APPLY_DEX;
 					af.modifier = -(ch->level / 6);
@@ -587,8 +587,8 @@ void do_hobble(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 					victim->move = std::max(victim->move / 2, 0);
 					break;
 				case WEAPON_STAFF:
-					act("You hear the chilling sound of snapping bone as you land a solid blow.", ch, 0, victim, TO_CHAR);
-					act("You hear the chilling sound of snapping bone as $n lands a solid blow.", ch, 0, victim, TO_ROOM);
+					act("You hear the chilling sound of snapping bone as you land a solid blow.", ch, nullptr, victim, TO_CHAR);
+					act("You hear the chilling sound of snapping bone as $n lands a solid blow.", ch, nullptr, victim, TO_ROOM);
 
 					af.location = APPLY_DEX;
 					af.modifier = -(ch->level / 6);
@@ -598,9 +598,9 @@ void do_hobble(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 					victim->move = std::max(victim->move / 2, 0);
 					break;
 				case WEAPON_SPEAR:
-					act("$N falters, clutching $S leg in agony as your spear pierces $M clean through!", ch, 0, victim, TO_CHAR);
-					act("You falter, clutching your leg in agony as $n's spear pierces you clean through!", ch, 0, victim, TO_VICT);
-					act("$N falters, clutching $S leg in agony as $n's spear pierces $M clean through!", ch, 0, victim, TO_NOTVICT);
+					act("$N falters, clutching $S leg in agony as your spear pierces $M clean through!", ch, nullptr, victim, TO_CHAR);
+					act("You falter, clutching your leg in agony as $n's spear pierces you clean through!", ch, nullptr, victim, TO_VICT);
+					act("$N falters, clutching $S leg in agony as $n's spear pierces $M clean through!", ch, nullptr, victim, TO_NOTVICT);
 
 					af.location = APPLY_DEX;
 					af.modifier = -(ch->level / 7);
@@ -611,9 +611,9 @@ void do_hobble(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 					LAG_CHAR(victim, PULSE_VIOLENCE * 2);
 					break;
 				case WEAPON_DAGGER:
-					act("$N collapses to the ground in agony as you sever a tendon!", ch, 0, victim, TO_CHAR);
-					act("You collapse to the ground in agony as $n severs a tendon!", ch, 0, victim, TO_VICT);
-					act("$N collapses to the ground in agony as $n severs a tendon!", ch, 0, victim, TO_NOTVICT);
+					act("$N collapses to the ground in agony as you sever a tendon!", ch, nullptr, victim, TO_CHAR);
+					act("You collapse to the ground in agony as $n severs a tendon!", ch, nullptr, victim, TO_VICT);
+					act("$N collapses to the ground in agony as $n severs a tendon!", ch, nullptr, victim, TO_NOTVICT);
 
 					af.location = APPLY_DEX;
 					af.modifier = -(ch->level / 5);
@@ -746,29 +746,29 @@ void do_crippling_blow(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 		switch (weapon->value[0])
 		{
 			case WEAPON_MACE:
-				act("You take a measured swing at $N's exposed offhand arm with your mace!", ch, 0, victim, TO_CHAR);
-				act("$n takes a measured swing at your exposed offhand arm with $s mace!", ch, 0, victim, TO_VICT);
-				act("$n takes a measured swing at $N's exposed offhand arm with $s mace!", ch, 0, victim, TO_NOTVICT);
+				act("You take a measured swing at $N's exposed offhand arm with your mace!", ch, nullptr, victim, TO_CHAR);
+				act("$n takes a measured swing at your exposed offhand arm with $s mace!", ch, nullptr, victim, TO_VICT);
+				act("$n takes a measured swing at $N's exposed offhand arm with $s mace!", ch, nullptr, victim, TO_NOTVICT);
 				break;
 			case WEAPON_AXE:
-				act("Cleaving through $N's defenses, you strike at $N's vulnerable arm!", ch, 0, victim, TO_CHAR);
-				act("Cleaving through your defenses, $n strikes at your vulnerable arm!", ch, 0, victim, TO_VICT);
-				act("Cleaving through $N's defenses, $n strikes at $N's vulnerable arm!", ch, 0, victim, TO_NOTVICT);
+				act("Cleaving through $N's defenses, you strike at $N's vulnerable arm!", ch, nullptr, victim, TO_CHAR);
+				act("Cleaving through your defenses, $n strikes at your vulnerable arm!", ch, nullptr, victim, TO_VICT);
+				act("Cleaving through $N's defenses, $n strikes at $N's vulnerable arm!", ch, nullptr, victim, TO_NOTVICT);
 				break;
 			case WEAPON_SWORD:
-				act("With a compact horizontal slice, you strike at $N's exposed arm!", ch, 0, victim, TO_CHAR);
-				act("With a compact horizontal slice, $n strikes at your exposed arm!", ch, 0, victim, TO_VICT);
-				act("With a compact horizontal slice, $n strikes at $N's exposed arm!", ch, 0, victim, TO_NOTVICT);
+				act("With a compact horizontal slice, you strike at $N's exposed arm!", ch, nullptr, victim, TO_CHAR);
+				act("With a compact horizontal slice, $n strikes at your exposed arm!", ch, nullptr, victim, TO_VICT);
+				act("With a compact horizontal slice, $n strikes at $N's exposed arm!", ch, nullptr, victim, TO_NOTVICT);
 				break;
 			case WEAPON_FLAIL:
-				act("With a sidearm sweep, you bring the head of your flail about to strike $N's arm!", ch, 0, victim, TO_CHAR);
-				act("With a sidearm sweep, $n brings the head of $s flail about to strike your arm!", ch, 0, victim, TO_VICT);
-				act("With a sidearm sweep, $n brings the head of $s flail about to strike $N's arm!", ch, 0, victim, TO_NOTVICT);
+				act("With a sidearm sweep, you bring the head of your flail about to strike $N's arm!", ch, nullptr, victim, TO_CHAR);
+				act("With a sidearm sweep, $n brings the head of $s flail about to strike your arm!", ch, nullptr, victim, TO_VICT);
+				act("With a sidearm sweep, $n brings the head of $s flail about to strike $N's arm!", ch, nullptr, victim, TO_NOTVICT);
 				break;
 			case WEAPON_STAFF:
-				act("Using your right hand as a fulcrum, you swat suddenly at $N's exposed arm!", ch, 0, victim, TO_CHAR);
-				act("Using $s right hand as a fulcrum, $n swats suddenly at your exposed arm!", ch, 0, victim, TO_VICT);
-				act("Using $s right hand as a fulcrum, $n swats suddenly at $N's exposed arm!", ch, 0, victim, TO_NOTVICT);
+				act("Using your right hand as a fulcrum, you swat suddenly at $N's exposed arm!", ch, nullptr, victim, TO_CHAR);
+				act("Using $s right hand as a fulcrum, $n swats suddenly at your exposed arm!", ch, nullptr, victim, TO_VICT);
+				act("Using $s right hand as a fulcrum, $n swats suddenly at $N's exposed arm!", ch, nullptr, victim, TO_NOTVICT);
 				break;
 			default:
 				send_to_char("You cannot perform a crippling blow with that.\n\r", ch);
@@ -795,9 +795,9 @@ void do_crippling_blow(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 			switch (weapon->value[0])
 			{
 				case WEAPON_MACE:
-					act("You hear the sharp crack of splintering bone as $N's arm dangles loosely at $S side!", ch, 0, victim, TO_CHAR);
-					act("You hear the sharp crack of splintering bone as your arm dangles loosely at your side!", ch, 0, victim, TO_VICT);
-					act("You hear the sharp crack of splintering bone as $N's arm dangles loosely at $S side!", ch, 0, victim, TO_NOTVICT);
+					act("You hear the sharp crack of splintering bone as $N's arm dangles loosely at $S side!", ch, nullptr, victim, TO_CHAR);
+					act("You hear the sharp crack of splintering bone as your arm dangles loosely at your side!", ch, nullptr, victim, TO_VICT);
+					act("You hear the sharp crack of splintering bone as $N's arm dangles loosely at $S side!", ch, nullptr, victim, TO_NOTVICT);
 
 					af.location = APPLY_STR;
 					af.modifier = -(ch->level / 7);
@@ -815,9 +815,9 @@ void do_crippling_blow(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 					affect_to_char(victim, &af);
 					break;
 				case WEAPON_AXE:
-					act("Your axe rends through flesh and muscle, biting deep into $N's arm!", ch, 0, victim, TO_CHAR);
-					act("$n's axe rends through flesh and muscle, biting deep into your arm!", ch, 0, victim, TO_VICT);
-					act("$n's axe rends through flesh and muscle, biting deep into $N's arm!", ch, 0, victim, TO_NOTVICT);
+					act("Your axe rends through flesh and muscle, biting deep into $N's arm!", ch, nullptr, victim, TO_CHAR);
+					act("$n's axe rends through flesh and muscle, biting deep into your arm!", ch, nullptr, victim, TO_VICT);
+					act("$n's axe rends through flesh and muscle, biting deep into $N's arm!", ch, nullptr, victim, TO_NOTVICT);
 
 					af.location = APPLY_DEX;
 					af.modifier = -(ch->level / 8);
@@ -838,9 +838,9 @@ void do_crippling_blow(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 					new_affect_to_char(victim, &af2);
 					break;
 				case WEAPON_SWORD:
-					act("Your blade sinks deep into $N's flesh as blood runs down $S forearm!", ch, 0, victim, TO_CHAR);
-					act("$n's blade sinks deep into your flesh as blood runs down your forearm!", ch, 0, victim, TO_VICT);
-					act("$n's blade sinks deep into $N's flesh as blood runs down $S forearm!", ch, 0, victim, TO_NOTVICT);
+					act("Your blade sinks deep into $N's flesh as blood runs down $S forearm!", ch, nullptr, victim, TO_CHAR);
+					act("$n's blade sinks deep into your flesh as blood runs down your forearm!", ch, nullptr, victim, TO_VICT);
+					act("$n's blade sinks deep into $N's flesh as blood runs down $S forearm!", ch, nullptr, victim, TO_NOTVICT);
 
 					af.location = APPLY_DEX;
 					af.modifier = -(ch->level / 8);
@@ -861,9 +861,9 @@ void do_crippling_blow(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 					new_affect_to_char(victim, &af2);
 					break;
 				case WEAPON_FLAIL:
-					act("You hear the sharp crack of splintering bone as $N's arm dangles loosely at $S side!", ch, 0, victim, TO_CHAR);
-					act("You hear the sharp crack of splintering bone as your arm dangles loosely at your side!", ch, 0, victim, TO_VICT);
-					act("You hear the sharp crack of splintering bone as $N's arm dangles loosely at $S side!", ch, 0, victim, TO_NOTVICT);
+					act("You hear the sharp crack of splintering bone as $N's arm dangles loosely at $S side!", ch, nullptr, victim, TO_CHAR);
+					act("You hear the sharp crack of splintering bone as your arm dangles loosely at your side!", ch, nullptr, victim, TO_VICT);
+					act("You hear the sharp crack of splintering bone as $N's arm dangles loosely at $S side!", ch, nullptr, victim, TO_NOTVICT);
 
 					af.location = APPLY_STR;
 					af.modifier = -(ch->level / 7);
@@ -881,9 +881,9 @@ void do_crippling_blow(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 					affect_to_char(victim, &af);
 					break;
 				case WEAPON_STAFF:
-					act("You hear the sharp crack of splintering bone as $N's arm dangles loosely at $S side!", ch, 0, victim, TO_CHAR);
-					act("You hear the sharp crack of splintering bone as your arm dangles loosely at your side!", ch, 0, victim, TO_VICT);
-					act("You hear the sharp crack of splintering bone as $N's arm dangles loosely at $S side!", ch, 0, victim, TO_NOTVICT);
+					act("You hear the sharp crack of splintering bone as $N's arm dangles loosely at $S side!", ch, nullptr, victim, TO_CHAR);
+					act("You hear the sharp crack of splintering bone as your arm dangles loosely at your side!", ch, nullptr, victim, TO_VICT);
+					act("You hear the sharp crack of splintering bone as $N's arm dangles loosely at $S side!", ch, nullptr, victim, TO_NOTVICT);
 
 					af.location = APPLY_STR;
 					af.modifier = -(ch->level / 7);
@@ -1083,9 +1083,9 @@ void do_gouge(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 	if (number_percent() < skill)
 	{
 
-		act(hit1, ch, 0, victim, TO_CHAR);
-		act(hit2, ch, 0, victim, TO_VICT);
-		act(hit3, ch, 0, victim, TO_NOTVICT);
+		act(hit1, ch, nullptr, victim, TO_CHAR);
+		act(hit2, ch, nullptr, victim, TO_VICT);
+		act(hit3, ch, nullptr, victim, TO_NOTVICT);
 
 		if (!is_affected_by(victim, AFF_BLIND))
 		{
@@ -1109,9 +1109,9 @@ void do_gouge(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 	}
 	else
 	{
-		act(miss1, ch, 0, victim, TO_CHAR);
-		act(miss2, ch, 0, victim, TO_VICT);
-		act(miss3, ch, 0, victim, TO_NOTVICT);
+		act(miss1, ch, nullptr, victim, TO_CHAR);
+		act(miss2, ch, nullptr, victim, TO_VICT);
+		act(miss3, ch, nullptr, victim, TO_NOTVICT);
 
 		damage(ch, victim, 0, gsn_gouge, DAM_NONE, true);
 		check_improve(ch, gsn_gouge, false, 1);
@@ -1208,9 +1208,9 @@ void do_bleed(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 	if (number_percent() < .65 * skill)
 	{
 
-		act(hit1, ch, 0, victim, TO_CHAR);
-		act(hit2, ch, 0, victim, TO_VICT);
-		act(hit3, ch, 0, victim, TO_NOTVICT);
+		act(hit1, ch, nullptr, victim, TO_CHAR);
+		act(hit2, ch, nullptr, victim, TO_VICT);
+		act(hit3, ch, nullptr, victim, TO_NOTVICT);
 
 		if (!is_affected(victim, gsn_bleeding))
 		{
@@ -1233,9 +1233,9 @@ void do_bleed(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 	}
 	else
 	{
-		act(miss1, ch, 0, victim, TO_CHAR);
-		act(miss2, ch, 0, victim, TO_VICT);
-		act(miss3, ch, 0, victim, TO_NOTVICT);
+		act(miss1, ch, nullptr, victim, TO_CHAR);
+		act(miss2, ch, nullptr, victim, TO_VICT);
+		act(miss3, ch, nullptr, victim, TO_NOTVICT);
 
 		damage(ch, victim, 0, gsn_bleed, DAM_NONE, true);
 		check_improve(ch, gsn_bleed, false, 1);
@@ -1379,26 +1379,26 @@ void do_unbalance(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 
 	if (is_affected(victim, gsn_unbalance))
 	{
-		act("$N is already unbalanced.", ch, 0, victim, TO_CHAR);
+		act("$N is already unbalanced.", ch, nullptr, victim, TO_CHAR);
 		return;
 	}
 
 	if (number_percent() < .9 * skill)
 	{
-		act("You lunge at $N and suddenly withdraw, throwing $M off balance!", ch, 0, victim, TO_CHAR);
-		act("$n lunges at you and suddenly withdraws, throwing you off balance!", ch, 0, victim, TO_VICT);
-		act("$n lunges at $N and suddenly withdraws, throwing $M off balance!", ch, 0, victim, TO_NOTVICT);
+		act("You lunge at $N and suddenly withdraw, throwing $M off balance!", ch, nullptr, victim, TO_CHAR);
+		act("$n lunges at you and suddenly withdraws, throwing you off balance!", ch, nullptr, victim, TO_VICT);
+		act("$n lunges at $N and suddenly withdraws, throwing $M off balance!", ch, nullptr, victim, TO_NOTVICT);
 
 		if (victim->balance >= 40)
 		{
-			act("You stumble awkwardly and topple to the ground!", victim, 0, 0, TO_CHAR);
-			act("$n stumbles awkwardly and topples to the ground!", victim, 0, 0, TO_ROOM);
+			act("You stumble awkwardly and topple to the ground!", victim, nullptr, nullptr, TO_CHAR);
+			act("$n stumbles awkwardly and topples to the ground!", victim, nullptr, nullptr, TO_ROOM);
 			LAG_CHAR(victim, PULSE_VIOLENCE * 2);
 		}
 		else if (victim->balance >= 30)
 		{
-			act("You wobble unsteadily, struggling to stay on your feet.", victim, 0, 0, TO_CHAR);
-			act("$n wobbles unsteadily, struggling to stay on $s feet.", victim, 0, 0, TO_ROOM);
+			act("You wobble unsteadily, struggling to stay on your feet.", victim, nullptr, nullptr, TO_CHAR);
+			act("$n wobbles unsteadily, struggling to stay on $s feet.", victim, nullptr, nullptr, TO_ROOM);
 			LAG_CHAR(victim, PULSE_VIOLENCE);
 		}
 
@@ -1417,9 +1417,9 @@ void do_unbalance(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 	}
 	else
 	{
-		act("You lunge at $N and suddenly withdraw, but $E doesn't fall for your feint.", ch, 0, victim, TO_CHAR);
-		act("$n lunges at you and suddenly withdraws, but you don't fall for $s feint.", ch, 0, victim, TO_VICT);
-		act("$n lunges at $N and suddenly withdraws, but $E doesn't fall for $s feint.", ch, 0, victim, TO_NOTVICT);
+		act("You lunge at $N and suddenly withdraw, but $E doesn't fall for your feint.", ch, nullptr, victim, TO_CHAR);
+		act("$n lunges at you and suddenly withdraws, but you don't fall for $s feint.", ch, nullptr, victim, TO_VICT);
+		act("$n lunges at $N and suddenly withdraws, but $E doesn't fall for $s feint.", ch, nullptr, victim, TO_NOTVICT);
 		check_improve(ch, gsn_unbalance, false, 1);
 	}
 
@@ -1517,16 +1517,16 @@ void do_uppercut(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 	if (number_percent() < .8 * skill)
 	{
 		success = 1;
-		act(ch1, ch, 0, victim, TO_CHAR);
-		act(vict1, ch, 0, victim, TO_VICT);
-		act(nv1, ch, 0, victim, TO_NOTVICT);
+		act(ch1, ch, nullptr, victim, TO_CHAR);
+		act(vict1, ch, nullptr, victim, TO_VICT);
+		act(nv1, ch, nullptr, victim, TO_NOTVICT);
 
 		if (success == 1
 			&& number_percent() < (.4 * skill * (1 + weapon->weight / 200) * (1 + (get_curr_stat(ch, STAT_STR) - 20) / 10)))
 		{
-			act(chspecial, ch, 0, victim, TO_CHAR);
-			act(victspecial, ch, 0, victim, TO_VICT);
-			act(nvspecial, ch, 0, victim, TO_NOTVICT);
+			act(chspecial, ch, nullptr, victim, TO_CHAR);
+			act(victspecial, ch, nullptr, victim, TO_VICT);
+			act(nvspecial, ch, nullptr, victim, TO_NOTVICT);
 
 			if (!is_affected(victim, gsn_uppercut))
 			{
@@ -1547,9 +1547,9 @@ void do_uppercut(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 	}
 	else
 	{
-		act(ch1, ch, 0, victim, TO_CHAR);
-		act(vict1, ch, 0, victim, TO_VICT);
-		act(nv1, ch, 0, victim, TO_NOTVICT);
+		act(ch1, ch, nullptr, victim, TO_CHAR);
+		act(vict1, ch, nullptr, victim, TO_VICT);
+		act(nv1, ch, nullptr, victim, TO_NOTVICT);
 
 		damage(ch, victim, 0, gsn_uppercut, DAM_NONE, true);
 		check_improve(ch, gsn_uppercut, false, 1);
@@ -1662,11 +1662,11 @@ void do_dart(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 
 	if (number_percent() < (get_curr_stat(ch, STAT_DEX) + skill) * .80)
 	{
-		act("Moving nimbly, you dart in under $N's guard and strike!", ch, 0, victim, TO_CHAR);
-		act("$n nimbly darts under your guard and strikes!", ch, 0, victim, TO_VICT);
-		act(cha, ch, 0, victim, TO_CHAR);
-		act(vict, ch, 0, victim, TO_VICT);
-		act(nv, ch, 0, victim, TO_NOTVICT);
+		act("Moving nimbly, you dart in under $N's guard and strike!", ch, nullptr, victim, TO_CHAR);
+		act("$n nimbly darts under your guard and strikes!", ch, nullptr, victim, TO_VICT);
+		act(cha, ch, nullptr, victim, TO_CHAR);
+		act(vict, ch, nullptr, victim, TO_VICT);
+		act(nv, ch, nullptr, victim, TO_NOTVICT);
 
 		af.where = TO_AFFECTS;
 		af.level = ch->level;
@@ -1681,8 +1681,8 @@ void do_dart(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 	}
 	else
 	{
-		act("Moving nimbly, you dart in under $N's guard and strike!", ch, 0, victim, TO_CHAR);
-		act("$n nimbly darts under your guard and strikes!", ch, 0, victim, TO_VICT);
+		act("Moving nimbly, you dart in under $N's guard and strike!", ch, nullptr, victim, TO_CHAR);
+		act("$n nimbly darts under your guard and strikes!", ch, nullptr, victim, TO_VICT);
 		damage(ch, victim, 0, gsn_dart, DAM_NONE, true);
 		check_improve(ch, gsn_dart, false, 1);
 	}
@@ -1777,12 +1777,12 @@ void do_impale(CHAR_DATA *ch, char *argument)
 		if (!is_affected(victim, gsn_impale) &&
 			number_percent() < 20 - (material_table[weapon->pIndexData->material_index].mat_hardness * 5))
 		{
-			act(cha, ch, 0, victim, TO_CHAR);
-			act(vict, ch, 0, victim, TO_VICT);
-			act(nv, ch, 0, victim, TO_NOTVICT);
-			act(break1, ch, 0, victim, TO_NOTVICT);
-			act(break1, ch, 0, victim, TO_CHAR);
-			act(break2, ch, 0, victim, TO_VICT);
+			act(cha, ch, nullptr, victim, TO_CHAR);
+			act(vict, ch, nullptr, victim, TO_VICT);
+			act(nv, ch, nullptr, victim, TO_NOTVICT);
+			act(break1, ch, nullptr, victim, TO_NOTVICT);
+			act(break1, ch, nullptr, victim, TO_CHAR);
+			act(break2, ch, nullptr, victim, TO_VICT);
 			one_hit_new(ch, victim, TYPE_UNDEFINED, HIT_NOSPECIALS, HIT_UNBLOCKABLE, HIT_NOADD, 300, "impalement");
 
 			if (!is_affected(victim, gsn_bleeding))
@@ -1816,9 +1816,9 @@ void do_impale(CHAR_DATA *ch, char *argument)
 		}
 		else
 		{
-			act(cha, ch, 0, victim, TO_CHAR);
-			act(vict, ch, 0, victim, TO_VICT);
-			act(nv, ch, 0, victim, TO_NOTVICT);
+			act(cha, ch, nullptr, victim, TO_CHAR);
+			act(vict, ch, nullptr, victim, TO_VICT);
+			act(nv, ch, nullptr, victim, TO_NOTVICT);
 			one_hit_new(ch, victim, TYPE_UNDEFINED, HIT_NOSPECIALS, HIT_UNBLOCKABLE, HIT_NOADD, 200, "impalement");
 
 			if (!is_affected(victim, gsn_bleeding))
@@ -1844,9 +1844,9 @@ void do_impale(CHAR_DATA *ch, char *argument)
 	}
 	else
 	{
-		act("You make a ferocious lunge at $N with your weapon, but miss!", ch, 0, victim, TO_CHAR);
-		act("$n makes a ferocious lunge at you with $s weapon, but misses!", ch, 0, victim, TO_VICT);
-		act("$n makes a ferocious lunge at $N with $s weapon, but misses!", ch, 0, victim, TO_NOTVICT);
+		act("You make a ferocious lunge at $N with your weapon, but miss!", ch, nullptr, victim, TO_CHAR);
+		act("$n makes a ferocious lunge at you with $s weapon, but misses!", ch, nullptr, victim, TO_VICT);
+		act("$n makes a ferocious lunge at $N with $s weapon, but misses!", ch, nullptr, victim, TO_NOTVICT);
 
 		damage_new(ch, victim, 0, TYPE_UNDEFINED, DAM_NONE, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "impalement");
 		check_improve(ch, gsn_impale, false, 1);
@@ -1881,7 +1881,7 @@ void do_hurl(CHAR_DATA *ch, char *argument)
 
 	if (weapon->weight > skirmisher_max_weapweight(ch))
 	{
-		act("That $t is too heavy to be hurled properly.", ch, weapon_name_lookup(weapon->value[0]), 0, TO_CHAR);
+		act("That $t is too heavy to be hurled properly.", ch, weapon_name_lookup(weapon->value[0]), nullptr, TO_CHAR);
 		return;
 	}
 
@@ -1929,14 +1929,14 @@ void do_hurl(CHAR_DATA *ch, char *argument)
 		if (pexit == nullptr)
 		{
 			dirname = flag_name_lookup(direction, direction_table);
-			act("You can't hurl your weapon $t.", ch, dirname, 0, TO_CHAR);
+			act("You can't hurl your weapon $t.", ch, dirname, nullptr, TO_CHAR);
 			return;
 		}
 
 		if (IS_SET(pexit->exit_info, EX_CLOSED))
 		{
 			dirname = flag_name_lookup(direction, direction_table);
-			act("You can't hurl your weapon $t.", ch, dirname, 0, TO_CHAR);
+			act("You can't hurl your weapon $t.", ch, dirname, nullptr, TO_CHAR);
 			return;
 		}
 
@@ -1947,7 +1947,7 @@ void do_hurl(CHAR_DATA *ch, char *argument)
 		if (victim == nullptr)
 		{
 			dirname = flag_name_lookup(direction, direction_table);
-			act("You can't see them $t.", ch, dirname, 0, TO_CHAR);
+			act("You can't see them $t.", ch, dirname, nullptr, TO_CHAR);
 			return;
 		}
 	}
@@ -1959,7 +1959,7 @@ void do_hurl(CHAR_DATA *ch, char *argument)
 
 	if (is_affected(victim, gsn_hurl))
 	{
-		act("$N has taken cover and you can't get a clear shot at $M.", ch, 0, victim, TO_CHAR);
+		act("$N has taken cover and you can't get a clear shot at $M.", ch, nullptr, victim, TO_CHAR);
 		return;
 	}
 
@@ -1968,15 +1968,15 @@ void do_hurl(CHAR_DATA *ch, char *argument)
 		dirname = flag_name_lookup(direction, direction_table);
 
 		sprintf(buf, "Sighting $N in the distance %sward, you hurl your %s at $M!", dirname, weapon_name_lookup(weapon->value[0]));
-		act(buf, ch, 0, victim, TO_CHAR);
+		act(buf, ch, nullptr, victim, TO_CHAR);
 
 		sprintf(buf, "$n suddenly hurls $s %s %sward!", weapon_name_lookup(weapon->value[0]), dirname);
-		act(buf, ch, 0, victim, TO_ROOM);
+		act(buf, ch, nullptr, victim, TO_ROOM);
 
 		dirname = flag_name_lookup(reverse_d(direction), direction_table);
 
 		sprintf(buf, "A %s comes hurtling in from the %s, flipping end over end!", weapon_name_lookup(weapon->value[0]), dirname);
-		act(buf, victim, 0, 0, TO_ALL);
+		act(buf, victim, nullptr, nullptr, TO_ALL);
 
 		if (!is_npc(victim) && Deref(victim->fighting) == nullptr)
 		{
@@ -2050,8 +2050,8 @@ void do_hurl(CHAR_DATA *ch, char *argument)
 	if (dual != nullptr)
 	{
 		unequip_char(ch, dual, false);
-		act("You quickly swap $p into your primary hand.", ch, dual, 0, TO_CHAR);
-		act("$n quickly swaps $p into $s primary hand.", ch, dual, 0, TO_ROOM);
+		act("You quickly swap $p into your primary hand.", ch, dual, nullptr, TO_CHAR);
+		act("$n quickly swaps $p into $s primary hand.", ch, dual, nullptr, TO_ROOM);
 		equip_char(ch, dual, WEAR_WIELD, false);
 	}
 
@@ -2137,29 +2137,29 @@ void do_overhead(CHAR_DATA *ch, char *argument)
 	switch (weapon->value[0])
 	{
 		case WEAPON_MACE:
-			act("You swing your mace overhead and bring it down toward $N with terrible force!", ch, 0, victim, TO_CHAR);
-			act("$n swings $s mace overhead and brings it down toward you with terrible force!", ch, 0, victim, TO_VICT);
-			act("$n swings $s mace overhead and brings it down toward $N with terrible force!", ch, 0, victim, TO_NOTVICT);
+			act("You swing your mace overhead and bring it down toward $N with terrible force!", ch, nullptr, victim, TO_CHAR);
+			act("$n swings $s mace overhead and brings it down toward you with terrible force!", ch, nullptr, victim, TO_VICT);
+			act("$n swings $s mace overhead and brings it down toward $N with terrible force!", ch, nullptr, victim, TO_NOTVICT);
 			break;
 		case WEAPON_STAFF:
-			act("You let loose a vicious longarm strike, your staff arcing toward $N's head!", ch, 0, victim, TO_CHAR);
-			act("$n lets loose a vicious longarm strike, $s staff arcing toward your head!", ch, 0, victim, TO_VICT);
-			act("$n lets loose a vicious longarm strike, $s staff arcing towards $N's head!", ch, 0, victim, TO_NOTVICT);
+			act("You let loose a vicious longarm strike, your staff arcing toward $N's head!", ch, nullptr, victim, TO_CHAR);
+			act("$n lets loose a vicious longarm strike, $s staff arcing toward your head!", ch, nullptr, victim, TO_VICT);
+			act("$n lets loose a vicious longarm strike, $s staff arcing towards $N's head!", ch, nullptr, victim, TO_NOTVICT);
 			break;
 		case WEAPON_FLAIL:
-			act("The head of your flail whistles through the air, arcing towards $N's head!", ch, 0, victim, TO_CHAR);
-			act("The head of $n's flail whistles through the air, arcing towards your head!", ch, 0, victim, TO_VICT);
-			act("The head of $n's flail whistles through the air, arcing towards $N's head!", ch, 0, victim, TO_NOTVICT);
+			act("The head of your flail whistles through the air, arcing towards $N's head!", ch, nullptr, victim, TO_CHAR);
+			act("The head of $n's flail whistles through the air, arcing towards your head!", ch, nullptr, victim, TO_VICT);
+			act("The head of $n's flail whistles through the air, arcing towards $N's head!", ch, nullptr, victim, TO_NOTVICT);
 			break;
 		case WEAPON_AXE:
-			act("With a surge of brute force, you bring your axe arcing down towards $N's head!", ch, 0, victim, TO_CHAR);
-			act("With a surge of brute force, $n brings $s axe arcing down towards your head!", ch, 0, victim, TO_VICT);
-			act("With a surge of brute force, $n brings $s axe arcing down towards $N's head!", ch, 0, victim, TO_NOTVICT);
+			act("With a surge of brute force, you bring your axe arcing down towards $N's head!", ch, nullptr, victim, TO_CHAR);
+			act("With a surge of brute force, $n brings $s axe arcing down towards your head!", ch, nullptr, victim, TO_VICT);
+			act("With a surge of brute force, $n brings $s axe arcing down towards $N's head!", ch, nullptr, victim, TO_NOTVICT);
 			break;
 		case WEAPON_SWORD:
-			act("You raise your sword and attempt a vicious overhead slice at $N!", ch, 0, victim, TO_CHAR);
-			act("$n raises $s sword and attempts a vicious overhead slice at you!", ch, 0, victim, TO_VICT);
-			act("$n raises $s sword and attempts a vicious overhead slice at $N!", ch, 0, victim, TO_NOTVICT);
+			act("You raise your sword and attempt a vicious overhead slice at $N!", ch, nullptr, victim, TO_CHAR);
+			act("$n raises $s sword and attempts a vicious overhead slice at you!", ch, nullptr, victim, TO_VICT);
+			act("$n raises $s sword and attempts a vicious overhead slice at $N!", ch, nullptr, victim, TO_NOTVICT);
 			break;
 		default:
 			send_to_char("You cannot perform an overhead strike with that weapon.\n\r", ch);
@@ -2190,9 +2190,9 @@ void do_overhead(CHAR_DATA *ch, char *argument)
 				switch (weapon->value[0])
 				{
 					case WEAPON_MACE:
-						act("$N collapses in a heap as your mace comes down solidly on top of $S head!", ch, 0, victim, TO_CHAR);
-						act("The world goes black as $n's mace crashes into your head.", ch, 0, victim, TO_VICT);
-						act("$N collapses in a heap as the mace comes down solidly on top of $S head!", ch, 0, victim, TO_NOTVICT);
+						act("$N collapses in a heap as your mace comes down solidly on top of $S head!", ch, nullptr, victim, TO_CHAR);
+						act("The world goes black as $n's mace crashes into your head.", ch, nullptr, victim, TO_VICT);
+						act("$N collapses in a heap as the mace comes down solidly on top of $S head!", ch, nullptr, victim, TO_NOTVICT);
 
 						affect_to_char(victim, &af);
 						stop_fighting(victim, true);
@@ -2203,9 +2203,9 @@ void do_overhead(CHAR_DATA *ch, char *argument)
 						WAIT_STATE(ch, 2 * PULSE_VIOLENCE);
 						return;
 					case WEAPON_STAFF:
-						act("$N collapses in a heap as your staff comes down solidly on top of $S head!", ch, 0, victim, TO_CHAR);
-						act("The world goes black as $n's staff crashes into your head.", ch, 0, victim, TO_VICT);
-						act("$N collapses in a heap as the staff comes down solidly on top of $S head!", ch, 0, victim, TO_NOTVICT);
+						act("$N collapses in a heap as your staff comes down solidly on top of $S head!", ch, nullptr, victim, TO_CHAR);
+						act("The world goes black as $n's staff crashes into your head.", ch, nullptr, victim, TO_VICT);
+						act("$N collapses in a heap as the staff comes down solidly on top of $S head!", ch, nullptr, victim, TO_NOTVICT);
 
 						affect_to_char(victim, &af);
 						stop_fighting(victim, true);
@@ -2216,9 +2216,9 @@ void do_overhead(CHAR_DATA *ch, char *argument)
 						WAIT_STATE(ch, 2 * PULSE_VIOLENCE);
 						return;
 					case WEAPON_FLAIL:
-						act("$N collapses in a heap as your flail comes down solidly on top of $S head!", ch, 0, victim, TO_CHAR);
-						act("The world goes black as $n's flail crashes into your head.", ch, 0, victim, TO_VICT);
-						act("$N collapses in a heap as the flail comes down solidly on top of $S head!", ch, 0, victim, TO_NOTVICT);
+						act("$N collapses in a heap as your flail comes down solidly on top of $S head!", ch, nullptr, victim, TO_CHAR);
+						act("The world goes black as $n's flail crashes into your head.", ch, nullptr, victim, TO_VICT);
+						act("$N collapses in a heap as the flail comes down solidly on top of $S head!", ch, nullptr, victim, TO_NOTVICT);
 
 						affect_to_char(victim, &af);
 						stop_fighting(victim, true);
@@ -2248,33 +2248,33 @@ void do_overhead(CHAR_DATA *ch, char *argument)
 			switch (weapon->value[0])
 			{
 				case WEAPON_MACE:
-					act("$N staggers and looks stunned as your mace crashes into $S head!", ch, 0, victim, TO_CHAR);
-					act("You stagger in a daze as $n's mace crashes into your head!", ch, 0, victim, TO_VICT);
-					act("$N staggers and looks stunned as the mace crashes into $S head!", ch, 0, victim, TO_NOTVICT);
+					act("$N staggers and looks stunned as your mace crashes into $S head!", ch, nullptr, victim, TO_CHAR);
+					act("You stagger in a daze as $n's mace crashes into your head!", ch, nullptr, victim, TO_VICT);
+					act("$N staggers and looks stunned as the mace crashes into $S head!", ch, nullptr, victim, TO_NOTVICT);
 
 					LAG_CHAR(victim, 2 * PULSE_VIOLENCE);
 					dammod = 150;
 					break;
 				case WEAPON_STAFF:
-					act("$N staggers and looks stunned as your staff crashes into $S head!", ch, 0, victim, TO_CHAR);
-					act("You stagger in a daze as $n's staff crashes into your head!", ch, 0, victim, TO_VICT);
-					act("$N staggers and looks stunned as the staff crashes into $S head!", ch, 0, victim, TO_NOTVICT);
+					act("$N staggers and looks stunned as your staff crashes into $S head!", ch, nullptr, victim, TO_CHAR);
+					act("You stagger in a daze as $n's staff crashes into your head!", ch, nullptr, victim, TO_VICT);
+					act("$N staggers and looks stunned as the staff crashes into $S head!", ch, nullptr, victim, TO_NOTVICT);
 
 					LAG_CHAR(victim, 2 * PULSE_VIOLENCE);
 					dammod = 150;
 					break;
 				case WEAPON_FLAIL:
-					act("$N staggers and looks stunned as your flail crashes into $S head!", ch, 0, victim, TO_CHAR);
-					act("You stagger in a daze as $n's flail crashes into your head!", ch, 0, victim, TO_VICT);
-					act("$N staggers and looks stunned as the flail crashes into $S head!", ch, 0, victim, TO_NOTVICT);
+					act("$N staggers and looks stunned as your flail crashes into $S head!", ch, nullptr, victim, TO_CHAR);
+					act("You stagger in a daze as $n's flail crashes into your head!", ch, nullptr, victim, TO_VICT);
+					act("$N staggers and looks stunned as the flail crashes into $S head!", ch, nullptr, victim, TO_NOTVICT);
 
 					LAG_CHAR(victim, 2 * PULSE_VIOLENCE);
 					dammod = 150;
 					break;
 				case WEAPON_AXE:
-					act("$N is enshrouded in a fine mist of blood as your mighty blow strikes true!", ch, 0, victim, TO_CHAR);
-					act("You are enshrouded in a fine mist of blood as $n's axe strikes true!", ch, 0, victim, TO_VICT);
-					act("$N is enshrouded in a fine mist of blood as the mighty blow strikes true!", ch, 0, victim, TO_NOTVICT);
+					act("$N is enshrouded in a fine mist of blood as your mighty blow strikes true!", ch, nullptr, victim, TO_CHAR);
+					act("You are enshrouded in a fine mist of blood as $n's axe strikes true!", ch, nullptr, victim, TO_VICT);
+					act("$N is enshrouded in a fine mist of blood as the mighty blow strikes true!", ch, nullptr, victim, TO_NOTVICT);
 
 					af.duration = ch->level / 8;
 
@@ -2284,9 +2284,9 @@ void do_overhead(CHAR_DATA *ch, char *argument)
 
 					break;
 				case WEAPON_SWORD:
-					act("Your massive blade cleaves deeply into $N's flesh, striking bone!", ch, 0, victim, TO_CHAR);
-					act("$n's massive blade cleaves deeply into your flesh, striking bone!", ch, 0, victim, TO_VICT);
-					act("The massive blade cleaves deeply into $N's flesh, striking bone!", ch, 0, victim, TO_NOTVICT);
+					act("Your massive blade cleaves deeply into $N's flesh, striking bone!", ch, nullptr, victim, TO_CHAR);
+					act("$n's massive blade cleaves deeply into your flesh, striking bone!", ch, nullptr, victim, TO_VICT);
+					act("The massive blade cleaves deeply into $N's flesh, striking bone!", ch, nullptr, victim, TO_NOTVICT);
 
 					dammod = 200;
 					af.duration = ch->level / 12;
@@ -2338,7 +2338,7 @@ void do_extract(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 	dam = (int)((float)ch->max_hit * .2);
 
 	send_to_char("You rip the broken shaft out of your wound and blood gushes forth!\n\r", ch);
-	act("$n rips the broken shaft out of his wound!", ch, 0, 0, TO_ROOM);
+	act("$n rips the broken shaft out of his wound!", ch, nullptr, nullptr, TO_ROOM);
 
 	owner = ch;
 	af = affect_find(ch->affected, gsn_impale);
@@ -2398,9 +2398,9 @@ void do_exchange(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 
 	AC = 100 - AC;
 
-	act("Ignoring $N's onslaught, you close the ground between you and strike!", ch, 0, victim, TO_CHAR);
-	act("Ignoring your onslaught, $n closes the ground between you and strikes!", ch, 0, victim, TO_VICT);
-	act("Ignoring $N's onslaught, $n closes the ground between them and strikes!", ch, 0, victim, TO_NOTVICT);
+	act("Ignoring $N's onslaught, you close the ground between you and strike!", ch, nullptr, victim, TO_CHAR);
+	act("Ignoring your onslaught, $n closes the ground between you and strikes!", ch, nullptr, victim, TO_VICT);
+	act("Ignoring $N's onslaught, $n closes the ground between them and strikes!", ch, nullptr, victim, TO_NOTVICT);
 
 	one_hit_new(victim, ch, TYPE_UNDEFINED, HIT_NOSPECIALS, HIT_UNBLOCKABLE, HIT_NOADD, AC, nullptr);
 
@@ -2503,9 +2503,9 @@ void do_charge(CHAR_DATA *ch, char *argument)
 
 	if (number_percent() < avoid)
 	{
-		act("You deftly avoid $N's charge and $E topples to the ground.", victim, 0, ch, TO_CHAR);
-		act("$n deftly avoids $N's charge and $E topples to the ground.", victim, 0, ch, TO_NOTVICT);
-		act("Your charge is deftly avoided by $n, and you go crashing to the ground.", victim, 0, ch, TO_VICT);
+		act("You deftly avoid $N's charge and $E topples to the ground.", victim, nullptr, ch, TO_CHAR);
+		act("$n deftly avoids $N's charge and $E topples to the ground.", victim, nullptr, ch, TO_NOTVICT);
+		act("Your charge is deftly avoided by $n, and you go crashing to the ground.", victim, nullptr, ch, TO_VICT);
 		WAIT_STATE(ch, 3 * PULSE_VIOLENCE);
 		return;
 	}
@@ -2525,9 +2525,9 @@ void do_charge(CHAR_DATA *ch, char *argument)
 
 	if (number_percent() < 0.7 * skill)
 	{
-		act("You lower your shoulder and barrel into $N, sending $M flying!", ch, 0, victim, TO_CHAR);
-		act("$n lowers $s shoulder and barrels into you, sending you flying!", ch, 0, victim, TO_VICT);
-		act("$n lowers $s shoulder and barrels into $N, sending $M flying!", ch, 0, victim, TO_NOTVICT);
+		act("You lower your shoulder and barrel into $N, sending $M flying!", ch, nullptr, victim, TO_CHAR);
+		act("$n lowers $s shoulder and barrels into you, sending you flying!", ch, nullptr, victim, TO_VICT);
+		act("$n lowers $s shoulder and barrels into $N, sending $M flying!", ch, nullptr, victim, TO_NOTVICT);
 
 		lag = 1 + (armor_weight(ch) / 150);
 		dam = 10 + dice(armor_weight(ch) / 15, (int)(0.4 * (float)ch->level));
@@ -2540,9 +2540,9 @@ void do_charge(CHAR_DATA *ch, char *argument)
 	}
 	else
 	{
-		act("You charge toward $N but miss, crashing awkwardly to the ground!", ch, 0, victim, TO_CHAR);
-		act("$n charges toward you but misses, crashing awkwardly to the ground!", ch, 0, victim, TO_VICT);
-		act("$n charges toward $N but misses, crashing awkwardly to the ground!", ch, 0, victim, TO_NOTVICT);
+		act("You charge toward $N but miss, crashing awkwardly to the ground!", ch, nullptr, victim, TO_CHAR);
+		act("$n charges toward you but misses, crashing awkwardly to the ground!", ch, nullptr, victim, TO_VICT);
+		act("$n charges toward $N but misses, crashing awkwardly to the ground!", ch, nullptr, victim, TO_NOTVICT);
 
 		damage(ch, victim, 0, gsn_charge, DAM_NONE, true);
 		WAIT_STATE(ch, PULSE_VIOLENCE * 3);
@@ -2628,9 +2628,9 @@ void do_shieldbash(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 
 	if (number_percent() < chance)
 	{
-		act("You smash your shield into $N's chest, bearing down upon it with your weight!", ch, 0, victim, TO_CHAR);
-		act("$n smashes $s shield into your chest, bearing down upon you with $s weight!", ch, 0, victim, TO_VICT);
-		act("$n smashes $s shield into $N's chest, bearing down upon it with $s weight!", ch, 0, victim, TO_NOTVICT);
+		act("You smash your shield into $N's chest, bearing down upon it with your weight!", ch, nullptr, victim, TO_CHAR);
+		act("$n smashes $s shield into your chest, bearing down upon you with $s weight!", ch, nullptr, victim, TO_VICT);
+		act("$n smashes $s shield into $N's chest, bearing down upon it with $s weight!", ch, nullptr, victim, TO_NOTVICT);
 
 		dam = (int)((float)dice(ch->level / 4, 4) + ((float)weight / (float)20));
 
@@ -2645,9 +2645,9 @@ void do_shieldbash(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 	}
 	else
 	{
-		act("You thrust your shield towards $N, but $E avoids it.", ch, 0, victim, TO_CHAR);
-		act("$n thrusts $s shield towards you, but you avoid it.", ch, 0, victim, TO_VICT);
-		act("$n thrusts $s shield towards $N, but $E avoids it.", ch, 0, victim, TO_NOTVICT);
+		act("You thrust your shield towards $N, but $E avoids it.", ch, nullptr, victim, TO_CHAR);
+		act("$n thrusts $s shield towards you, but you avoid it.", ch, nullptr, victim, TO_VICT);
+		act("$n thrusts $s shield towards $N, but $E avoids it.", ch, nullptr, victim, TO_NOTVICT);
 
 		WAIT_STATE(ch, PULSE_VIOLENCE * 2);
 
@@ -2680,18 +2680,18 @@ void do_brace(CHAR_DATA *ch, [[maybe_unused]] char *arg)
 
 	if (number_percent() > .95 * skill)
 	{
-		act("You fail to position yourself properly to ward off incoming blows.", ch, 0, victim, TO_CHAR);
-		act("$n crouches awkwardly for a moment, and then straightens $mself out.", ch, 0, victim, TO_VICT);
-		act("$n crouches awkwardly for a moment, and then straightens $mself out.", ch, 0, victim, TO_NOTVICT);
+		act("You fail to position yourself properly to ward off incoming blows.", ch, nullptr, victim, TO_CHAR);
+		act("$n crouches awkwardly for a moment, and then straightens $mself out.", ch, nullptr, victim, TO_VICT);
+		act("$n crouches awkwardly for a moment, and then straightens $mself out.", ch, nullptr, victim, TO_NOTVICT);
 		WAIT_STATE(ch, PULSE_VIOLENCE * 2);
 		check_improve(ch, gsn_brace, false, 3);
 		return;
 	}
 	else
 	{
-		act("You brace yourself against incoming blows.", ch, 0, victim, TO_CHAR);
-		act("$n crouches slightly, steeling $mself against incoming blows.", ch, 0, victim, TO_VICT);
-		act("$n crouches slightly, steeling $mself against incoming blows.", ch, 0, victim, TO_NOTVICT);
+		act("You brace yourself against incoming blows.", ch, nullptr, victim, TO_CHAR);
+		act("$n crouches slightly, steeling $mself against incoming blows.", ch, nullptr, victim, TO_VICT);
+		act("$n crouches slightly, steeling $mself against incoming blows.", ch, nullptr, victim, TO_NOTVICT);
 		WAIT_STATE(ch, PULSE_VIOLENCE * 2);
 		ac = average_ac(ch);
 
@@ -3171,8 +3171,8 @@ void do_shatter(CHAR_DATA *ch, char *argument)
 	if (secondary != nullptr)
 	{
 		unequip_char(victim, secondary, false);
-		act("You quickly swap $p into your primary hand.", victim, secondary, 0, TO_CHAR);
-		act("$n quickly swaps $p into $s primary hand.", victim, secondary, 0, TO_ROOM);
+		act("You quickly swap $p into your primary hand.", victim, secondary, nullptr, TO_CHAR);
+		act("$n quickly swaps $p into $s primary hand.", victim, secondary, nullptr, TO_ROOM);
 		equip_char(victim, secondary, WEAR_WIELD, false);
 	}
 
@@ -3246,9 +3246,9 @@ void do_whirlwind(CHAR_DATA *ch, char *argument)
 		do_myell(victim, buf, ch);
 	}
 
-	act("You leap at $N, spinning and striking rapidly in all directions!", ch, 0, victim, TO_CHAR);
-	act("$n leaps at you, spinning and striking rapidly in all directions!", ch, 0, victim, TO_VICT);
-	act("$n leaps at $N, spinning and striking rapidly in all directions!", ch, 0, victim, TO_NOTVICT);
+	act("You leap at $N, spinning and striking rapidly in all directions!", ch, nullptr, victim, TO_CHAR);
+	act("$n leaps at you, spinning and striking rapidly in all directions!", ch, nullptr, victim, TO_VICT);
+	act("$n leaps at $N, spinning and striking rapidly in all directions!", ch, nullptr, victim, TO_NOTVICT);
 
 	chdex = get_curr_stat(ch, STAT_DEX);
 	chance -= 5 * (25 - chdex);
@@ -3620,8 +3620,8 @@ void do_uncoil(CHAR_DATA *ch, char *argument)
 				if (dual != nullptr)
 				{
 					unequip_char(guy, dual, false);
-					act("You quickly swap $p into your primary hand.", guy, dual, 0, TO_CHAR);
-					act("$n quickly swaps $p into $s primary hand.", guy, dual, 0, TO_ROOM);
+					act("You quickly swap $p into your primary hand.", guy, dual, nullptr, TO_CHAR);
+					act("$n quickly swaps $p into $s primary hand.", guy, dual, nullptr, TO_ROOM);
 					equip_char(guy, dual, WEAR_WIELD, false);
 				}
 			}
@@ -3629,9 +3629,9 @@ void do_uncoil(CHAR_DATA *ch, char *argument)
 	}
 	else
 	{
-		act("You struggle to free yourself from $N's grasp, but the whip holds firm!", ch, 0, guy, TO_CHAR);
-		act("$n struggles to free $mself from your grasp, but the whip holds firm!", ch, 0, guy, TO_VICT);
-		act("$n struggles to free $mself from $N's grasp, but the whip holds firm!", ch, 0, guy, TO_NOTVICT);
+		act("You struggle to free yourself from $N's grasp, but the whip holds firm!", ch, nullptr, guy, TO_CHAR);
+		act("$n struggles to free $mself from your grasp, but the whip holds firm!", ch, nullptr, guy, TO_VICT);
+		act("$n struggles to free $mself from $N's grasp, but the whip holds firm!", ch, nullptr, guy, TO_NOTVICT);
 	}
 
 	WAIT_STATE(ch, PULSE_VIOLENCE);
@@ -3684,17 +3684,17 @@ void do_pull(CHAR_DATA *ch, char *argument)
 		{
 			if (number_percent() < (skill * 0.8))
 			{
-				act("You draw your whip taut, pulling $N's legs out from under $M!", ch, 0, guy, TO_CHAR);
-				act("$n draws $s whip taut, pulling your legs out from under you!", ch, 0, guy, TO_VICT);
-				act("$n draws $s whip taut, pulling $N's legs out from under $M!", ch, 0, guy, TO_NOTVICT);
+				act("You draw your whip taut, pulling $N's legs out from under $M!", ch, nullptr, guy, TO_CHAR);
+				act("$n draws $s whip taut, pulling your legs out from under you!", ch, nullptr, guy, TO_VICT);
+				act("$n draws $s whip taut, pulling $N's legs out from under $M!", ch, nullptr, guy, TO_NOTVICT);
 				WAIT_STATE(guy, PULSE_VIOLENCE * 2);
 				check_improve(ch, gsn_pull, true, 1);
 			}
 			else
 			{
-				act("$N staggers slightly as you jerk your whip back, but remains standing.", ch, 0, guy, TO_CHAR);
-				act("You stagger slightly as $n jerks $s whip back, but remain standing.", ch, 0, guy, TO_VICT);
-				act("$N staggers slightly as $n jerks $s whip back, but remains standing.", ch, 0, guy, TO_NOTVICT);
+				act("$N staggers slightly as you jerk your whip back, but remains standing.", ch, nullptr, guy, TO_CHAR);
+				act("You stagger slightly as $n jerks $s whip back, but remain standing.", ch, nullptr, guy, TO_VICT);
+				act("$N staggers slightly as $n jerks $s whip back, but remains standing.", ch, nullptr, guy, TO_NOTVICT);
 				check_improve(ch, gsn_pull, false, 1);
 			}
 		}
@@ -3834,9 +3834,9 @@ void do_assess(CHAR_DATA *ch, char *argument)
 		return;
 	}
 
-	act("You examine $N closely, using your keen eye to assess $S weaknesses.", ch, 0, victim, TO_CHAR);
-	act("$n examines you closely, using $S keen eye to assess your weaknesses.", ch, 0, victim, TO_VICT);
-	act("$n examines $N closely, sizing $M up.", ch, 0, victim, TO_NOTVICT);
+	act("You examine $N closely, using your keen eye to assess $S weaknesses.", ch, nullptr, victim, TO_CHAR);
+	act("$n examines you closely, using $S keen eye to assess your weaknesses.", ch, nullptr, victim, TO_VICT);
+	act("$n examines $N closely, sizing $M up.", ch, nullptr, victim, TO_NOTVICT);
 
 	if (skill >= 60)
 	{
@@ -3876,19 +3876,19 @@ void do_assess(CHAR_DATA *ch, char *argument)
 			dammod *= 1.3;
 
 		if (victim->dam_mod < 20)
-			act("$N is virtually impervious to harm!", ch, 0, victim, TO_CHAR);
+			act("$N is virtually impervious to harm!", ch, nullptr, victim, TO_CHAR);
 		else if (victim->dam_mod <= 40)
-			act("$N has extensive protection from all sorts of harm.", ch, 0, victim, TO_CHAR);
+			act("$N has extensive protection from all sorts of harm.", ch, nullptr, victim, TO_CHAR);
 		else if (victim->dam_mod <= 60)
-			act("$N is well protected from all sorts of harm.", ch, 0, victim, TO_CHAR);
+			act("$N is well protected from all sorts of harm.", ch, nullptr, victim, TO_CHAR);
 		else if (victim->dam_mod <= 80)
-			act("$N is somewhat protected from all sorts of harm.", ch, 0, victim, TO_CHAR);
+			act("$N is somewhat protected from all sorts of harm.", ch, nullptr, victim, TO_CHAR);
 		else if (victim->dam_mod <= 99)
-			act("$N's susceptibility to damage is slightly reduced.", ch, 0, victim, TO_CHAR);
+			act("$N's susceptibility to damage is slightly reduced.", ch, nullptr, victim, TO_CHAR);
 		else if (victim->dam_mod <= 100)
-			act("$N does not appear to have any special protections.", ch, 0, victim, TO_CHAR);
+			act("$N does not appear to have any special protections.", ch, nullptr, victim, TO_CHAR);
 		else
-			act("$N is highly susceptible to all damage.", ch, 0, victim, TO_CHAR);
+			act("$N is highly susceptible to all damage.", ch, nullptr, victim, TO_CHAR);
 
 		found++;
 	}
@@ -3928,7 +3928,7 @@ bool check_exploit_armor_break(CHAR_DATA *ch, CHAR_DATA *victim, OBJ_DATA *expos
 
 	if (number_percent() < (int)chance) // destroy
 	{
-		act("You land a calculated blow upon $p, damaging it beyond repair!", ch, exposed, 0, TO_CHAR);
+		act("You land a calculated blow upon $p, damaging it beyond repair!", ch, exposed, nullptr, TO_CHAR);
 		act("$n lands a calculated blow upon $N's $p, damaging it beyond repair!", ch, exposed, victim, TO_NOTVICT);
 		act("$n lands a calculated blow upon your $p, damaging it beyond repair!", ch, exposed, victim, TO_VICT);
 
@@ -3947,7 +3947,7 @@ bool check_exploit_armor_break(CHAR_DATA *ch, CHAR_DATA *victim, OBJ_DATA *expos
 
 	if (number_percent() < (int)chance) // damage
 	{
-		act("You land a calculated blow upon $p, weakening it significantly.", ch, exposed, 0, TO_CHAR);
+		act("You land a calculated blow upon $p, weakening it significantly.", ch, exposed, nullptr, TO_CHAR);
 		act("$n lands a calculated blow upon $N's $p, weakening it.", ch, exposed, victim, TO_NOTVICT);
 		act("$n lands a calculated blow upon your $p, weakening it.", ch, exposed, victim, TO_VICT);
 
@@ -3959,7 +3959,7 @@ bool check_exploit_armor_break(CHAR_DATA *ch, CHAR_DATA *victim, OBJ_DATA *expos
 		return true;
 	}
 
-	act("Your blow fails to do any lasting damage to $p.", ch, exposed, 0, TO_CHAR);
+	act("Your blow fails to do any lasting damage to $p.", ch, exposed, nullptr, TO_CHAR);
 	return false;
 }
 
@@ -4167,12 +4167,12 @@ void do_exploit(CHAR_DATA *ch, char *argument)
 	}
 	else if (!anatomy)
 	{
-		act(anfail, ch, 0, victim, TO_CHAR);
+		act(anfail, ch, nullptr, victim, TO_CHAR);
 		check_improve(ch, gsn_exploit, false, 1);
 	}
 	else
 	{
-		act(chfail, ch, 0, victim, TO_CHAR);
+		act(chfail, ch, nullptr, victim, TO_CHAR);
 		check_improve(ch, gsn_exploit, false, 1);
 	}
 
@@ -4414,7 +4414,7 @@ void do_drive(CHAR_DATA *ch, char *argument)
 	{
 		if (pexit->u1.to_room->vnum < victim->pIndexData->restrict_low ||
 			pexit->u1.to_room->vnum > victim->pIndexData->restrict_high)
-			return act("$N will not budge that direction!", ch, 0, victim, TO_CHAR);
+			return act("$N will not budge that direction!", ch, nullptr, victim, TO_CHAR);
 	}
 
 	if (is_npc(victim) && IS_SET(victim->act, ACT_SENTINEL))
@@ -4445,9 +4445,9 @@ void do_drive(CHAR_DATA *ch, char *argument)
 	}
 	else
 	{
-		act("You surge at $N, but $E doesn't budge!", ch, 0, victim, TO_CHAR);
-		act("$n surges at you, but you don't budge!", ch, 0, victim, TO_VICT);
-		act("$n surges at $N, but $E doesn't budge!", ch, 0, victim, TO_NOTVICT);
+		act("You surge at $N, but $E doesn't budge!", ch, nullptr, victim, TO_CHAR);
+		act("$n surges at you, but you don't budge!", ch, nullptr, victim, TO_VICT);
+		act("$n surges at $N, but $E doesn't budge!", ch, nullptr, victim, TO_NOTVICT);
 		check_improve(ch, gsn_drive, false, 1);
 	}
 
@@ -4549,7 +4549,7 @@ void do_dash(CHAR_DATA *ch, char *argument)
 
 		ch->wait = 0;
 
-		act("$n dashes in from the $t!", ch, dir, 0, TO_ROOM);
+		act("$n dashes in from the $t!", ch, dir, nullptr, TO_ROOM);
 		interpret(ch, command);
 		WAIT_STATE(ch, PULSE_VIOLENCE);
 		check_improve(ch, gsn_dash, true, 5);
@@ -4560,7 +4560,7 @@ void do_dash(CHAR_DATA *ch, char *argument)
 
 		/* stop and move driver */
 		move_char(ch, where, true, false);
-		act("$n stumbles in from the $t!", ch, dir, 0, TO_ROOM);
+		act("$n stumbles in from the $t!", ch, dir, nullptr, TO_ROOM);
 		WAIT_STATE(ch, PULSE_VIOLENCE * 2);
 		check_improve(ch, gsn_dash, false, 5);
 	}
@@ -4677,9 +4677,9 @@ void do_concuss(CHAR_DATA *ch, char *argument)
 	}
 	else
 	{
-		act("You fail to connect with $N's temple.", ch, 0, victim, TO_CHAR);
-		act("$n fails to connect with $N's temple.", ch, 0, victim, TO_NOTVICT);
-		act("$n fails to hit you in the temple.", ch, 0, victim, TO_VICT);
+		act("You fail to connect with $N's temple.", ch, nullptr, victim, TO_CHAR);
+		act("$n fails to connect with $N's temple.", ch, nullptr, victim, TO_NOTVICT);
+		act("$n fails to hit you in the temple.", ch, nullptr, victim, TO_VICT);
 		damage(ch, victim, 0, gsn_concuss, DAM_NONE, true);
 		check_improve(ch, gsn_concuss, false, 1);
 	}
@@ -4725,7 +4725,7 @@ void do_retreat(CHAR_DATA *ch, char *arg)
 		return;
 	}
 
-	act("You begin plotting a retreat.", ch, 0, 0, TO_CHAR);
+	act("You begin plotting a retreat.", ch, nullptr, nullptr, TO_CHAR);
 
 	RS.Queue.AddToQueue(3, "do_retreat", "execute_retreat", execute_retreat, ch, direction);
 
@@ -4746,8 +4746,8 @@ void execute_retreat(CHAR_DATA *ch, int dir)
 	}
 
 	dirname = flag_name_lookup(dir, direction_table);
-	act("You make a hasty retreat $t.", ch, dirname, 0, TO_CHAR);
-	act("$n makes a hasty retreat $t.", ch, dirname, 0, TO_ROOM);
+	act("You make a hasty retreat $t.", ch, dirname, nullptr, TO_CHAR);
+	act("$n makes a hasty retreat $t.", ch, dirname, nullptr, TO_ROOM);
 
 	move_char(ch, dir, true, false);
 
@@ -4799,7 +4799,7 @@ void do_disrupt_formation(CHAR_DATA *ch, char *arg)
 
 	if (is_npc(victim))
 	{
-		act("$N does not have a group to disrupt!", ch, 0, victim, TO_CHAR);
+		act("$N does not have a group to disrupt!", ch, nullptr, victim, TO_CHAR);
 		return;
 	}
 
@@ -4821,9 +4821,9 @@ void do_disrupt_formation(CHAR_DATA *ch, char *arg)
 
 	if (number_percent() < skill)
 	{
-		act("You dart in to strike $N, weaving chaotically around $M!", ch, 0, victim, TO_CHAR);
-		act("$n darts in to strike you, weaving around chaotically!", ch, 0, victim, TO_VICT);
-		act("$n darts in to strike $N, weaving around chaotically!", ch, 0, victim, TO_NOTVICT);
+		act("You dart in to strike $N, weaving chaotically around $M!", ch, nullptr, victim, TO_CHAR);
+		act("$n darts in to strike you, weaving around chaotically!", ch, nullptr, victim, TO_VICT);
+		act("$n darts in to strike $N, weaving around chaotically!", ch, nullptr, victim, TO_NOTVICT);
 
 		for (vch = ch->in_room->people; vch != nullptr; vch = vch_next)
 		{
@@ -4851,24 +4851,24 @@ void do_disrupt_formation(CHAR_DATA *ch, char *arg)
 
 			if (number_percent() > percent)
 			{
-				act("$n's assault drives you out of formation and separates you from your group!", ch, 0, vch, TO_VICT);
-				act("Your assault drives $N out of formation and separates $M from the group.", ch, 0, vch, TO_CHAR);
-				act("$n's assault drives $N out of formation and separates $M from the group!", ch, 0, vch, TO_NOTVICT);
+				act("$n's assault drives you out of formation and separates you from your group!", ch, nullptr, vch, TO_VICT);
+				act("Your assault drives $N out of formation and separates $M from the group.", ch, nullptr, vch, TO_CHAR);
+				act("$n's assault drives $N out of formation and separates $M from the group!", ch, nullptr, vch, TO_NOTVICT);
 				vch->leader = nullptr;
 			}
 			else
 			{
-				act("$N retains $S composure amidst $n's onslaught, remaining with $S group.", ch, 0, vch, TO_NOTVICT);
-				act("$N retains $S composure amidst your onslaught, remaining with $S group.", ch, 0, vch, TO_CHAR);
-				act("You retain your composure amidst $n's onslaught, remaining with your group.", ch, 0, vch, TO_VICT);
+				act("$N retains $S composure amidst $n's onslaught, remaining with $S group.", ch, nullptr, vch, TO_NOTVICT);
+				act("$N retains $S composure amidst your onslaught, remaining with $S group.", ch, nullptr, vch, TO_CHAR);
+				act("You retain your composure amidst $n's onslaught, remaining with your group.", ch, nullptr, vch, TO_VICT);
 			}
 		}
 	}
 	else
 	{
-		act("Darting in to strike $N, you stumble into the midst of $S group.", ch, 0, victim, TO_CHAR);
-		act("Darting in to strike $N, $n stumbles and fails his ploy.", ch, 0, victim, TO_NOTVICT);
-		act("Darting in to strike you, $n stumbles into the midst of your group.", ch, 0, victim, TO_VICT);
+		act("Darting in to strike $N, you stumble into the midst of $S group.", ch, nullptr, victim, TO_CHAR);
+		act("Darting in to strike $N, $n stumbles and fails his ploy.", ch, nullptr, victim, TO_NOTVICT);
+		act("Darting in to strike you, $n stumbles into the midst of your group.", ch, nullptr, victim, TO_VICT);
 	}
 
 	one_hit(victim, ch, TYPE_UNDEFINED);
@@ -4914,17 +4914,17 @@ void do_leadership(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 
 	if (number_percent() > chance)
 	{
-		act("$n tries to explain combat tactics to you, but he just becomes frustrated at himself.", ch, 0, 0, TO_GROUP);
-		act("You try to explain combat tactics to your group, but they just do not understand.", ch, 0, 0, TO_CHAR);
+		act("$n tries to explain combat tactics to you, but he just becomes frustrated at himself.", ch, nullptr, nullptr, TO_GROUP);
+		act("You try to explain combat tactics to your group, but they just do not understand.", ch, nullptr, nullptr, TO_CHAR);
 		check_improve(ch, gsn_leadership, false, 2);
 		ch->mana -= 25;
 		WAIT_STATE(ch, PULSE_VIOLENCE * 2);
 	}
 	else
 	{
-		act("You organize your group into an efficient combat formation.", ch, 0, 0, TO_CHAR);
-		act("$n organizes the group into an efficient combat formation.", ch, 0, 0, TO_GROUP);
-		act("$n gives some instructions to $s group as they listen intently.", ch, 0, 0, TO_NOTGROUP);
+		act("You organize your group into an efficient combat formation.", ch, nullptr, nullptr, TO_CHAR);
+		act("$n organizes the group into an efficient combat formation.", ch, nullptr, nullptr, TO_GROUP);
+		act("$n gives some instructions to $s group as they listen intently.", ch, nullptr, nullptr, TO_NOTGROUP);
 		check_improve(ch, gsn_leadership, true, 2);
 
 		init_affect(&af);
@@ -5075,8 +5075,8 @@ void do_outflank(CHAR_DATA *ch, char *argument)
 	WAIT_STATE(ch, PULSE_VIOLENCE * 2);
 
 	direction = flag_name_lookup(type, direction_table);
-	act("You position yourself so as to obstruct the $t egress.", ch, direction, 0, TO_CHAR);
-	act("$n positions $mself so as to obstruct the $t egress.", ch, direction, 0, TO_ROOM);
+	act("You position yourself so as to obstruct the $t egress.", ch, direction, nullptr, TO_CHAR);
+	act("$n positions $mself so as to obstruct the $t egress.", ch, direction, nullptr, TO_ROOM);
 
 	affect_strip(ch, gsn_outflank);
 
@@ -5157,8 +5157,8 @@ bool outflank_me(CHAR_DATA *ch, int dir)
 				else
 				{
 					act("$N slips past you, escaping $t!", victim, direction, ch, TO_CHAR);
-					act("You slip past $n as $e attempts to block your path!", victim, 0, ch, TO_VICT);
-					act("$N slips past $n as $e attempts to block $S path!", victim, 0, ch, TO_NOTVICT);
+					act("You slip past $n as $e attempts to block your path!", victim, nullptr, ch, TO_VICT);
+					act("$N slips past $n as $e attempts to block $S path!", victim, nullptr, ch, TO_NOTVICT);
 					check_improve(victim, gsn_outflank, false, 2);
 				}
 			}

--- a/code/characterClasses/zealot.c
+++ b/code/characterClasses/zealot.c
@@ -45,9 +45,9 @@ void spell_infidels_weight(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[m
 	af.owner = ch->self;
 	new_affect_to_char(victim, &af);
 
-	act("You burden $N with the weight of a thousand infidels!", ch, 0, victim, TO_CHAR);
-	act("$n burdens you with the weight of a thousand infidels!", ch, 0, victim, TO_VICT);
-	act("$n burdens $N with the weight of a thousand infidels!", ch, 0, victim, TO_NOTVICT);
+	act("You burden $N with the weight of a thousand infidels!", ch, nullptr, victim, TO_CHAR);
+	act("$n burdens you with the weight of a thousand infidels!", ch, nullptr, victim, TO_VICT);
+	act("$n burdens $N with the weight of a thousand infidels!", ch, nullptr, victim, TO_NOTVICT);
 }
 
 int get_bv_stage(CHAR_DATA *ch)
@@ -100,9 +100,9 @@ void spell_burning_vision(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[ma
 		{
 			maf->modifier = mod;
 
-			act("$n further burns your vision!", ch, 0, victim, TO_VICT);
-			act("You further burn $N's vision!", ch, 0, victim, TO_CHAR);
-			act("$n further burns $N's vision!", ch, 0, victim, TO_NOTVICT);
+			act("$n further burns your vision!", ch, nullptr, victim, TO_VICT);
+			act("You further burn $N's vision!", ch, nullptr, victim, TO_CHAR);
+			act("$n further burns $N's vision!", ch, nullptr, victim, TO_NOTVICT);
 			return;
 		}
 	}
@@ -120,9 +120,9 @@ void spell_burning_vision(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[ma
 		af.mod_name = MOD_VISION;
 		new_affect_to_char(victim, &af);
 
-		act("You sear $N's vision!", ch, 0, victim, TO_CHAR);
-		act("$n sears your vision!", ch, 0, victim, TO_VICT);
-		act("$n sears $N's vision!", ch, 0, victim, TO_NOTVICT);
+		act("You sear $N's vision!", ch, nullptr, victim, TO_CHAR);
+		act("$n sears your vision!", ch, nullptr, victim, TO_VICT);
+		act("$n sears $N's vision!", ch, nullptr, victim, TO_NOTVICT);
 	}
 }
 
@@ -132,8 +132,8 @@ void burning_vision_tick(CHAR_DATA *ch, [[maybe_unused]] AFFECT_DATA *af)
 
 	if (get_bv_stage(ch) >= 4 && !is_affected_by(ch, AFF_BLIND))
 	{
-		act("You are blinded!", ch, 0, 0, TO_CHAR);
-		act("$n appears to be blinded.", ch, 0, 0, TO_ROOM);
+		act("You are blinded!", ch, nullptr, nullptr, TO_CHAR);
+		act("$n appears to be blinded.", ch, nullptr, nullptr, TO_ROOM);
 
 		caf = nullptr;
 		for (auto &caf_elem : ch->affected)
@@ -164,14 +164,14 @@ void spell_divine_malison(int /* sn */, int level, CHAR_DATA *ch, SpellTarget vo
 
 	if (victim && (paf = affect_find(victim->affected, gsn_divine_ward)) != nullptr && Deref(paf->owner) == ch)
 	{
-		act("Your deity already protects you from $N!", ch, 0, victim, TO_CHAR);
+		act("Your deity already protects you from $N!", ch, nullptr, victim, TO_CHAR);
 		return;
 	}
 
 	if (Deref(ch->fighting) && saves_spell(level + 9, victim, DAM_HOLY))
 	{
-		act("A nimbus flickers briefly around $n, but dissipates.", victim, 0, 0, TO_ROOM);
-		act("A haze surrounds you briefly, but dissipates.", victim, 0, 0, TO_CHAR);
+		act("A nimbus flickers briefly around $n, but dissipates.", victim, nullptr, nullptr, TO_ROOM);
+		act("A haze surrounds you briefly, but dissipates.", victim, nullptr, nullptr, TO_CHAR);
 		return;
 	}
 
@@ -179,15 +179,15 @@ void spell_divine_malison(int /* sn */, int level, CHAR_DATA *ch, SpellTarget vo
 	{
 		reduction = 1;
 
-		act("A hazy barrier forms between yourself and $n.", ch, 0, victim, TO_VICT);
-		act("A hazy barrier forms between yourself and $N.", ch, 0, victim, TO_CHAR);
-		act("A hazy barrier forms between $n and $N.", ch, 0, victim, TO_NOTVICT);
+		act("A hazy barrier forms between yourself and $n.", ch, nullptr, victim, TO_VICT);
+		act("A hazy barrier forms between yourself and $N.", ch, nullptr, victim, TO_CHAR);
+		act("A hazy barrier forms between $n and $N.", ch, nullptr, victim, TO_NOTVICT);
 	}
 	else
 	{
-		act("A luminous barrier forms between yourself and $n.", ch, 0, victim, TO_VICT);
-		act("A luminous barrier forms between yourself and $N.", ch, 0, victim, TO_CHAR);
-		act("A luminous barrier forms between $n and $N.", ch, 0, victim, TO_NOTVICT);
+		act("A luminous barrier forms between yourself and $n.", ch, nullptr, victim, TO_VICT);
+		act("A luminous barrier forms between yourself and $N.", ch, nullptr, victim, TO_CHAR);
+		act("A luminous barrier forms between $n and $N.", ch, nullptr, victim, TO_NOTVICT);
 
 		reduction = 2;
 	}

--- a/code/characterClasses/zealot.c
+++ b/code/characterClasses/zealot.c
@@ -52,20 +52,10 @@ void spell_infidels_weight(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[m
 
 int get_bv_stage(CHAR_DATA *ch)
 {
-	AFFECT_DATA *af;
+	AFFECT_DATA *af = affect_find(ch->affected, gsn_burning_vision);
 
-	if (!is_affected(ch, gsn_burning_vision) /*|| is_immortal(ch)*/)
+	if (af == nullptr /*|| is_immortal(ch)*/)
 		return -1;
-
-	af = nullptr;
-	for (auto &af_elem : ch->affected)
-	{
-		if (af_elem.type == gsn_burning_vision)
-		{
-			af = &af_elem;
-			break;
-		}
-	}
 
 	return ((20 - af->duration) / af->modifier);
 }
@@ -76,18 +66,10 @@ void spell_burning_vision(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[ma
 	AFFECT_DATA af, *maf;
 	int mod;
 
-	if (is_affected(victim, gsn_burning_vision))
-	{
-		maf = nullptr;
-		for (auto &maf_elem : victim->affected)
-		{
-			if (maf_elem.type == gsn_burning_vision)
-			{
-				maf = &maf_elem;
-				break;
-			}
-		}
+	maf = affect_find(victim->affected, gsn_burning_vision);
 
+	if (maf != nullptr)
+	{
 		mod = maf->modifier;
 		mod--;
 
@@ -135,18 +117,13 @@ void burning_vision_tick(CHAR_DATA *ch, [[maybe_unused]] AFFECT_DATA *af)
 		act("You are blinded!", ch, nullptr, nullptr, TO_CHAR);
 		act("$n appears to be blinded.", ch, nullptr, nullptr, TO_ROOM);
 
-		caf = nullptr;
-		for (auto &caf_elem : ch->affected)
-		{
-			if (caf_elem.type == gsn_burning_vision)
-			{
-				caf = &caf_elem;
-				break;
-			}
-		}
+		caf = affect_find(ch->affected, gsn_burning_vision);
 
-		SET_BIT(caf->bitvector, AFF_BLIND);
-		SET_BIT(ch->affected_by, AFF_BLIND);
+		if (caf != nullptr)
+		{
+			SET_BIT(caf->bitvector, AFF_BLIND);
+			SET_BIT(ch->affected_by, AFF_BLIND);
+		}
 	}
 }
 

--- a/code/comm.c
+++ b/code/comm.c
@@ -916,6 +916,14 @@ void bust_a_prompt(CHAR_DATA *ch)
 					sprintf(buf2, " (%s - %s)", olc_ed_name(ch), olc_ed_vnum(ch));
 					i = buf2;
 				}
+				else
+				{
+					// Every other code assigns i on every path. Leaving it alone here
+					// meant %o substituted whatever the previous code had produced, or
+					// dereferenced null when it was the first code in the prompt.
+					i = "";
+				}
+
 				break;
 			case 't':
 				sprintf(buf2, "%d%s %s",

--- a/code/comm.c
+++ b/code/comm.c
@@ -497,21 +497,10 @@ void read_from_buffer(DESCRIPTOR_DATA *d)
 const char *get_battle_condition(CHAR_DATA *victim, int percent)
 {
 
-	if (is_affected(victim, gsn_bluff))
-	{
-		AFFECT_DATA *b_af = nullptr;
+	AFFECT_DATA *b_af = affect_find(victim->affected, gsn_bluff);
 
-		for (auto &b_af_elem : victim->affected)
-		{
-			if (b_af_elem.type == gsn_bluff)
-			{
-				b_af = &b_af_elem;
-				break;
-			}
-		}
-
+	if (b_af != nullptr)
 		percent *= (b_af->modifier * 3);
-	}
 
 	if (percent >= 100)
 		return "is in perfect condition.";

--- a/code/comm.c
+++ b/code/comm.c
@@ -2983,14 +2983,14 @@ void fix_sex(CHAR_DATA *ch)
 /// Exists for compatibility only with older code that may use it.
 /// @deprecated Please use act_new instead.
 ///
-void act(const char *format, CHAR_DATA *ch, const void *arg1, const void *arg2, int type)
+void act(const char *format, CHAR_DATA *ch, ActArg arg1, ActArg arg2, int type)
 {
 	act_new(format, ch, arg1, arg2, type, POS_RESTING);
 }
 
 void act_queue(std::string format, CHAR_DATA *ch, OBJ_DATA *arg1, CHAR_DATA *arg2, int type)
 {
-	act_new(format.c_str(), ch, (void*)arg1, (void*)arg2, type, POS_RESTING);
+	act_new(format.c_str(), ch, arg1, arg2, type, POS_RESTING);
 }
 
 void act_area(const char *format, CHAR_DATA *ch, CHAR_DATA *victim)
@@ -3131,7 +3131,7 @@ void act_area(const char *format, CHAR_DATA *ch, CHAR_DATA *victim)
 /// @param arg2: (optional) The second subject mentioned
 /// @param type: The scope of the message, e.g. TO_ROOM, TO_GROUP, etc.
 /// @param min_pos: The minimum position for the act (lowest default is POS_RESTING)
-void act_new(const char *format, CHAR_DATA *ch, const void *arg1, const void *arg2, int type, int min_pos)
+void act_new(const char *format, CHAR_DATA *ch, ActArg arg1, ActArg arg2, int type, int min_pos)
 {
 	static char *const he_she[] = {"it", "he", "she"};
 	static char *const him_her[] = {"it", "him", "her"};
@@ -3140,11 +3140,13 @@ void act_new(const char *format, CHAR_DATA *ch, const void *arg1, const void *ar
 	char buf[MAX_STRING_LENGTH], buf2[100];
 	char fname[MAX_INPUT_LENGTH];
 	CHAR_DATA *to;
-	CHAR_DATA *vch = (CHAR_DATA *)arg2;
-	OBJ_DATA *obj1 = (OBJ_DATA *)arg1;
-	OBJ_DATA *obj2 = (OBJ_DATA *)arg2;
+	CHAR_DATA *vch = arg2.AsCharacter();
+	OBJ_DATA *obj1 = arg1.AsObject();
+	OBJ_DATA *obj2 = arg2.AsObject();
 	const char *str;
 	const char *i;
+	const int *number;
+	const char *door_name;
 	char *point;
 
 	// Neither the format nor the substituted text is bounded by anything. Object
@@ -3170,7 +3172,15 @@ void act_new(const char *format, CHAR_DATA *ch, const void *arg1, const void *ar
 	{
 		if (vch == nullptr)
 		{
-			RS.Logger.Warn("Act: null vch with TO_VICT. -- {}", format);
+			// Worth telling apart. The first is a caller that forgot an argument.
+			// The second used to be a char pointer or an object read as a
+			// character and dereferenced a few lines below this, with nothing
+			// anywhere in the function able to notice.
+			if (arg2.IsEmpty())
+				RS.Logger.Warn("Act: null vch with TO_VICT. -- {}", format);
+			else
+				RS.Logger.Warn("Act: arg2 with TO_VICT is not a character. -- {}", format);
+
 			return;
 		}
 
@@ -3229,7 +3239,7 @@ void act_new(const char *format, CHAR_DATA *ch, const void *arg1, const void *ar
 
 			++str;
 
-			if (arg2 == nullptr && *str >= 'A' && *str <= 'Z' && *str != 'I')
+			if (arg2.IsEmpty() && *str >= 'A' && *str <= 'Z')
 			{
 				RS.Logger.Warn("Act: missing arg2 for code {}.", *str);
 				i = " <@@@> ";
@@ -3240,53 +3250,73 @@ void act_new(const char *format, CHAR_DATA *ch, const void *arg1, const void *ar
 				{
 					/* Thx alex for 't' idea */
 					case 't':
-						i = (char *)arg1;
+						i = arg1.AsText();
 						break;
 					case 'T':
-						i = (char *)arg2;
+						i = arg2.AsText();
 						break;
 					case 'n':
 						i = get_descr_form(ch, to, false);
 						break;
 					case 'N':
-						i = get_descr_form(vch, to, false);
+						i = vch != nullptr ? get_descr_form(vch, to, false) : nullptr;
 						break;
 					case 'f':
 						i = (ch->true_name ? ch->true_name : ch->name);
 						break;
 					case 'F':
-						i = (vch->true_name ? vch->true_name : vch->name);
+						i = vch != nullptr ? (vch->true_name ? vch->true_name : vch->name) : nullptr;
 						break;
 					case 'i':
-						sprintf(buf2, "%d", *((int *)arg1));
-						i = (const char *)&buf2;
+						number = arg1.AsNumber();
+
+						if (number != nullptr)
+						{
+							sprintf(buf2, "%d", *number);
+							i = buf2;
+						}
+						else
+						{
+							i = nullptr;
+						}
+
 						break;
 					case 'I':
-						sprintf(buf2, "%d", *((int *)arg2));
-						i = (const char *)&buf2;
+						number = arg2.AsNumber();
+
+						if (number != nullptr)
+						{
+							sprintf(buf2, "%d", *number);
+							i = buf2;
+						}
+						else
+						{
+							i = nullptr;
+						}
+
 						break;
 					case 'e':
 						i = he_she[URANGE(0, ch->sex, 2)];
 						break;
 					case 'E':
-						i = he_she[URANGE(0, vch->sex, 2)];
+						i = vch != nullptr ? he_she[URANGE(0, vch->sex, 2)] : nullptr;
 						break;
 					case 'm':
 						i = him_her[URANGE(0, ch->sex, 2)];
 						break;
 					case 'M':
-						i = him_her[URANGE(0, vch->sex, 2)];
+						i = vch != nullptr ? him_her[URANGE(0, vch->sex, 2)] : nullptr;
 						break;
 					case 's':
 						i = his_her[URANGE(0, ch->sex, 2)];
 						break;
 					case 'S':
-						i = his_her[URANGE(0, vch->sex, 2)];
+						i = vch != nullptr ? his_her[URANGE(0, vch->sex, 2)] : nullptr;
 						break;
 					case 'p':
 						if (obj1 == nullptr)
 						{
-							i = "something";
+							i = arg1.IsEmpty() ? "something" : nullptr;
 							break;
 						}
 
@@ -3306,24 +3336,48 @@ void act_new(const char *format, CHAR_DATA *ch, const void *arg1, const void *ar
 
 						break;
 					case 'P':
+						if (obj2 == nullptr)
+						{
+							i = arg2.IsEmpty() ? "something" : nullptr;
+							break;
+						}
+
 						i = can_see_obj(to, obj2) ? obj2->short_descr : "something";
 						break;
 					case 'd':
-						if (arg2 == nullptr || ((char *)arg2)[0] == '\0')
+						door_name = arg2.AsText();
+
+						if (arg2.IsEmpty() || (door_name != nullptr && door_name[0] == '\0'))
 						{
 							i = "door";
 						}
+						else if (door_name == nullptr)
+						{
+							// arg2 holds something, and it is not the door name this code wants.
+							i = nullptr;
+						}
 						else
 						{
-							one_argument((char *)arg2, fname);
+							one_argument(const_cast<char *>(door_name), fname);
 							i = fname;
 						}
+
 						break;
 					default:
 						RS.Logger.Warn("Act: bad code {}.", *str);
 						i = " <@@@> ";
 						break;
 				}
+			}
+
+			// A code asked its argument for something the argument does not hold.
+			// This is the case that used to reinterpret the pointer and read whatever
+			// was behind it. The message names the code and the format so the call
+			// site can be found.
+			if (i == nullptr)
+			{
+				RS.Logger.Warn("Act: code {} cannot read its argument. -- {}", *str, format);
+				i = " <@@@> ";
 			}
 
 			++str;

--- a/code/comm.c
+++ b/code/comm.c
@@ -657,6 +657,12 @@ void bust_a_prompt(CHAR_DATA *ch)
 	const char *dir_name[] = {"N", "E", "S", "W", "U", "D"};
 	int door;
 	point = buf;
+	bool truncated = false;
+
+	// Nothing below bounds a write into buf. The prompt is player authored and the
+	// substitutions splice in room names, exit lists and cabal names, so a long
+	// enough prompt runs off the end. Stop one byte short so the terminator fits.
+	char *const limit = buf + sizeof(buf) - 1;
 
 	if (is_npc(ch)
 		|| !str_cmp(ch->prompt, "")
@@ -676,10 +682,16 @@ void bust_a_prompt(CHAR_DATA *ch)
 	orig = &buf3[0];
 	str = orig;
 
-	while (*str != '\0')
+	while (*str != '\0' && !truncated)
 	{
 		if (*str != '%')
 		{
+			if (point >= limit)
+			{
+				truncated = true;
+				break;
+			}
+
 			*point++ = *str++;
 			continue;
 		}
@@ -924,11 +936,20 @@ void bust_a_prompt(CHAR_DATA *ch)
 
 		++str;
 
-		while ((*point = *i) != '\0')
+		while (*i != '\0')
 		{
-			++point, ++i;
+			if (point >= limit)
+			{
+				truncated = true;
+				break;
+			}
+
+			*point++ = *i++;
 		}
 	}
+
+	if (truncated)
+		RS.Logger.Warn("Bust_a_prompt: prompt truncated to {} bytes for {}.", (int)(point - buf), ch->name);
 
 	// The literal-character branch above advances point without terminating, so a
 	// prompt that does not end in a % substitution leaves buf unterminated. We
@@ -2983,6 +3004,11 @@ void act_area(const char *format, CHAR_DATA *ch, CHAR_DATA *victim)
 	const char *i;
 	char *point;
 
+	// Same unbounded write as act_new below. get_descr_form output and the format
+	// itself are both arbitrary length, so stop one byte short of the end and
+	// leave room for the terminator.
+	char *const limit = buf + sizeof(buf) - 1;
+
 	/*
 	 * Discard null and zero-length messages.
 	 */
@@ -3015,11 +3041,18 @@ void act_area(const char *format, CHAR_DATA *ch, CHAR_DATA *victim)
 
 			point = buf;
 			str = format;
+			bool truncated = false;
 
-			while (*str != '\0')
+			while (*str != '\0' && !truncated)
 			{
 				if (*str != '$')
 				{
+					if (point >= limit)
+					{
+						truncated = true;
+						break;
+					}
+
 					*point++ = *str++;
 					continue;
 				}
@@ -3057,11 +3090,20 @@ void act_area(const char *format, CHAR_DATA *ch, CHAR_DATA *victim)
 
 				++str;
 
-				while ((*point = *i) != '\0')
+				while (*i != '\0')
 				{
-					++point, ++i;
+					if (point >= limit)
+					{
+						truncated = true;
+						break;
+					}
+
+					*point++ = *i++;
 				}
 			}
+
+			if (truncated)
+				RS.Logger.Warn("Act_area: message truncated to {} bytes for {}. -- {}", (int)(point - buf), to->name, format);
 
 			*point = '\0';
 
@@ -3104,6 +3146,12 @@ void act_new(const char *format, CHAR_DATA *ch, const void *arg1, const void *ar
 	const char *str;
 	const char *i;
 	char *point;
+
+	// Neither the format nor the substituted text is bounded by anything. Object
+	// short descriptions, get_descr_form output and the caller strings spliced in
+	// by $t and $T are all arbitrary length, so a long enough one runs off the end
+	// of buf. Stop three bytes short so the "\n\r\0" tail below always fits.
+	char *const limit = buf + sizeof(buf) - 3;
 
 	/*
 	 * Discard null and zero-length messages.
@@ -3163,11 +3211,18 @@ void act_new(const char *format, CHAR_DATA *ch, const void *arg1, const void *ar
 
 		point = buf;
 		str = format;
+		bool truncated = false;
 
-		while (*str != '\0')
+		while (*str != '\0' && !truncated)
 		{
 			if (*str != '$')
 			{
+				if (point >= limit)
+				{
+					truncated = true;
+					break;
+				}
+
 				*point++ = *str++;
 				continue;
 			}
@@ -3273,11 +3328,20 @@ void act_new(const char *format, CHAR_DATA *ch, const void *arg1, const void *ar
 
 			++str;
 
-			while ((*point = *i) != '\0')
+			while (*i != '\0')
 			{
-				++point, ++i;
+				if (point >= limit)
+				{
+					truncated = true;
+					break;
+				}
+
+				*point++ = *i++;
 			}
 		}
+
+		if (truncated)
+			RS.Logger.Warn("Act: message truncated to {} bytes for {}. -- {}", (int)(point - buf), to->name, format);
 
 		*point++ = '\n';
 		*point++ = '\r';

--- a/code/comm.h
+++ b/code/comm.h
@@ -20,6 +20,7 @@
 #endif
 
 #include <string>
+#include <variant>
 
 #include "entity/fwd.h"
 #include "entity/limits.h"
@@ -178,10 +179,68 @@ void page_to_char (const char *txt, CHAR_DATA *ch);
 void show_string (struct descriptor_data *d, char *input);
 /* quick sex fixer */
 void fix_sex (CHAR_DATA *ch);
-void act (const char *format, CHAR_DATA *ch, const void *arg1, const void *arg2, int type);
+///
+/// One of act()'s two substitution arguments.
+///
+/// These were const void * and were reinterpreted by format code at runtime, so
+/// arg1 was read as three unrelated types and arg2 as four, with the choice made
+/// by a character in the format string and checked by nothing. Carrying the type
+/// with the value lets the format switch ask what it was handed. A mismatch is
+/// then a logged, attributable message instead of a wild read.
+///
+/// The constructors are implicit so call sites pass what they always passed. The
+/// types that are absent are absent on purpose. A std::string has no conversion to
+/// any alternative, so passing one is a compile error rather than the address of a
+/// string object arriving where a char pointer was expected. A bare void * and a
+/// literal 0 are both rejected as ambiguous for the same reason.
+///
+struct ActArg
+{
+	std::variant<std::monostate, const char *, const int *, OBJ_DATA *, CHAR_DATA *> value;
+
+	ActArg() : value(std::monostate()) {}
+	ActArg(std::nullptr_t) : value(std::monostate()) {}
+	ActArg(const char *text) : value(text) {}
+	ActArg(char *text) : value(static_cast<const char *>(text)) {}
+	ActArg(const int *number) : value(number) {}
+	ActArg(int *number) : value(static_cast<const int *>(number)) {}
+	ActArg(OBJ_DATA *obj) : value(obj) {}
+	ActArg(CHAR_DATA *ch) : value(ch) {}
+
+	/// True when the caller passed no argument at all.
+	bool IsEmpty() const { return std::holds_alternative<std::monostate>(value); }
+
+	/// Each of these returns nullptr when the argument holds something else, which
+	/// is what turns a type confusion into a message the caller can be found by.
+	const char *AsText() const
+	{
+		const char *const *held = std::get_if<const char *>(&value);
+		return held != nullptr ? *held : nullptr;
+	}
+
+	const int *AsNumber() const
+	{
+		const int *const *held = std::get_if<const int *>(&value);
+		return held != nullptr ? *held : nullptr;
+	}
+
+	OBJ_DATA *AsObject() const
+	{
+		OBJ_DATA *const *held = std::get_if<OBJ_DATA *>(&value);
+		return held != nullptr ? *held : nullptr;
+	}
+
+	CHAR_DATA *AsCharacter() const
+	{
+		CHAR_DATA *const *held = std::get_if<CHAR_DATA *>(&value);
+		return held != nullptr ? *held : nullptr;
+	}
+};
+
+void act (const char *format, CHAR_DATA *ch, ActArg arg1, ActArg arg2, int type);
 void act_queue (std::string format, CHAR_DATA *ch, OBJ_DATA *arg1, CHAR_DATA *arg2, int type);
 void act_area (const char *format, CHAR_DATA *ch, CHAR_DATA *victim);
-void act_new (const char *format, CHAR_DATA *ch, const void *arg1, const void *arg2, int type, int min_pos);
+void act_new (const char *format, CHAR_DATA *ch, ActArg arg1, ActArg arg2, int type, int min_pos);
 void announce_login (CHAR_DATA *ch);
 void announce_logout (CHAR_DATA *ch);
 void do_rename (CHAR_DATA* ch, char* argument);

--- a/code/db.c
+++ b/code/db.c
@@ -2778,7 +2778,6 @@ void do_dump([[maybe_unused]] CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	int count, count2, num_pcs, aff_count;
 	MOB_INDEX_DATA *pMobIndex;
-	OBJ_DATA *obj;
 	OBJ_INDEX_DATA *pObjIndex;
 	ROOM_INDEX_DATA *room;
 	EXIT_DATA *exit;
@@ -3728,7 +3727,6 @@ void load_newresets(FILE *fp)
 {
 	RESET_DATA *pReset;
 	int iLastRoom = 0;
-	int iLastObj = 0;
 
 	if (area_last == nullptr)
 	{
@@ -3815,7 +3813,6 @@ void load_newresets(FILE *fp)
 				if (pRoomIndex)
 				{
 					new_reset(pRoomIndex, pReset);
-					iLastObj = pReset->arg3;
 				}
 
 				if (area_last->area_type == ARE_UNOPENED)
@@ -3854,7 +3851,6 @@ void load_newresets(FILE *fp)
 				if (pRoomIndex)
 				{
 					new_reset(pRoomIndex, pReset);
-					iLastObj = iLastRoom;
 				}
 
 				break;
@@ -3874,7 +3870,6 @@ void load_newresets(FILE *fp)
 				if (pRoomIndex)
 				{
 					new_reset(pRoomIndex, pReset);
-					iLastObj = iLastRoom;
 				}
 
 				break;

--- a/code/db.c
+++ b/code/db.c
@@ -499,6 +499,15 @@ void new_load_area(FILE *fp)
 				SKEY("Credits", pArea->credits)
 				break;
 		}
+
+		// Every KEY/SKEY above ends by setting fMatch, and nothing used to read
+		// it: an unrecognized key was skipped silently and its value stayed in
+		// the stream to be read as the next key.
+		if (!fMatch)
+		{
+			RS.Logger.Warn("New_load_area: unknown key [{}] in {}.", word, strArea);
+			fread_to_eol(fp);
+		}
 	}
 }
 
@@ -1290,15 +1299,10 @@ void reset_room(ROOM_INDEX_DATA *pRoom)
 				}
 				else /* ROM OLC else version */
 				{
-					int limit;
-
-					if (pReset->arg2 > 50) /* old format */
-						limit = 6;
-					else if (pReset->arg2 == -1 || pReset->arg2 == 0) /* no limit */
-						limit = 999;
-					else
-						limit = pReset->arg2;
-
+					// This branch used to derive a per-reset cap from arg2. Both
+					// 'G' and 'E' set arg2 to 0 when they load and save_resets
+					// never writes it, so the cap could only ever come out as
+					// the "no limit" value. Only limtotal actually bounds these.
 					if (pObjIndex->limcount >= pObjIndex->limtotal && pObjIndex->limtotal > 0)
 					{
 						break;

--- a/code/db2.c
+++ b/code/db2.c
@@ -410,7 +410,6 @@ void load_mobs(FILE *fp)
 	int i = 0, pos = 0;
 	std::string aword, bword;
 	char *temp_wealth;
-	char bugtext[250];
 	short wealth;
 
 	for (;;)
@@ -766,13 +765,13 @@ void load_mobs(FILE *fp)
 			}
 			else if (letter == 'C')
 			{
-				char *word, letter, *discard;
+				char *word, letter;
 				int i;
 
 				/* Mob casts - dev */
 				if ((letter = fread_letter(fp)) == 'A')
 				{
-					discard = fread_word(fp);
+					fread_word(fp);
 					pMobIndex->cabal = cabal_lookup(fread_word(fp));
 					continue;
 				}
@@ -849,19 +848,19 @@ void load_mobs(FILE *fp)
 			}
 			else if (letter == 'N')
 			{
-				char *discard = fread_word(fp);
+				fread_word(fp);
 				pMobIndex->notes = fread_string(fp);
 			}
 			else if (letter == 'L')
 			{
-				char *discard = fread_word(fp);
+				fread_word(fp);
 				pMobIndex->restrict_low = fread_number(fp);
 				pMobIndex->restrict_high = fread_number(fp);
 			}
 			else if (letter == 'S')
 			{
 				SHOP_DATA *pShop;
-				char *discard = fread_word(fp);
+				fread_word(fp);
 				pShop = new SHOP_DATA;
 				fread_word(fp); // open
 				pShop->open_hour = fread_number(fp);
@@ -897,7 +896,7 @@ void load_mobs(FILE *fp)
 			}
 			else if (letter == 'T')
 			{
-				char *discard = fread_word(fp);
+				fread_word(fp);
 				int opennum;
 
 				for (opennum = 0; opennum < MAX_PROFS_TAUGHT_BY_MOB; opennum++)
@@ -915,7 +914,7 @@ void load_mobs(FILE *fp)
 			}
 			else if (letter == 'Y')
 			{
-				char *discard = fread_word(fp);
+				fread_word(fp);
 				pMobIndex->attack_yell = fread_string(fp);
 			}
 			else
@@ -1201,8 +1200,8 @@ void load_objs(FILE *fp)
 			}
 			else if (letter == 'F')
 			{
-				char *discard, *word;
-				discard = fread_word(fp);
+				char *word;
+				fread_word(fp);
 				word = fread_word(fp);
 
 				if (!str_cmp(word, "AFF"))

--- a/code/devextra.c
+++ b/code/devextra.c
@@ -3014,7 +3014,7 @@ void do_forceremove(CHAR_DATA *ch, char *argument)
 
 void do_createcosmetic(CHAR_DATA *ch, char *argument)
 {
-	char arg1[MSL], arg2[MSL], wlname[MSL], *wearname;
+	char arg1[MSL], arg2[MSL], wlname[MSL];
 	OBJ_DATA *obj;
 	int value = 0;
 	bool under= false, wear= false;

--- a/code/devextra.c
+++ b/code/devextra.c
@@ -130,12 +130,12 @@ void do_gold(CHAR_DATA *ch, char *argument)
 	{
 		gold_constant = atoi(argument);
 		total_gold = num_pfiles * gold_constant;
-		act("Global gold constant rate is now set to $t.", ch, argument, 0, TO_CHAR);
+		act("Global gold constant rate is now set to $t.", ch, argument, nullptr, TO_CHAR);
 		return;
 	}
 
-	act("Riftshadow Gold System", ch, 0, 0, TO_CHAR);
-	act("----------------------", ch, 0, 0, TO_CHAR);
+	act("Riftshadow Gold System", ch, nullptr, nullptr, TO_CHAR);
+	act("----------------------", ch, nullptr, nullptr, TO_CHAR);
 
 	sprintf(buf, "Total gold in world  : %ld (%d players)\n\r", total_gold, num_pfiles);
 	send_to_char(buf, ch);
@@ -1926,7 +1926,7 @@ void do_assess_old(CHAR_DATA *ch, char *argument)
 		return;
 	}
 
-	act("You study $N intently, searching for signs of affliction.", ch, 0, victim, TO_CHAR);
+	act("You study $N intently, searching for signs of affliction.", ch, nullptr, victim, TO_CHAR);
 
 	if (number_percent() > skill)
 	{
@@ -2471,7 +2471,7 @@ void do_commune(CHAR_DATA *ch, char *argument)
 		/*
 		if (IS_SET(ch->in_room->room_flags,ROOM_NO_MAGIC) && !(ch->level > LEVEL_HERO))
 		{
-			act("$n's spell fizzles.",ch,0,0,TO_ROOM);
+			act("$n's spell fizzles.",ch,nullptr,nullptr,TO_ROOM);
 			send_to_char("Your prayer fizzles and dies.\n\r",ch);
 			return;
 		}
@@ -2501,15 +2501,15 @@ void do_commune(CHAR_DATA *ch, char *argument)
 
 		if (offensive_at_char && victim != ch)
 		{
-			act("You narrow your eyes and glare in $N's direction.", ch, 0, victim, TO_CHAR);
-			act("$n narrows $s eyes and glares in $N's direction.", ch, 0, victim, TO_NOTVICT);
-			act("$n narrows $s eyes and glares in your direction.", ch, 0, victim, TO_VICT);
+			act("You narrow your eyes and glare in $N's direction.", ch, nullptr, victim, TO_CHAR);
+			act("$n narrows $s eyes and glares in $N's direction.", ch, nullptr, victim, TO_NOTVICT);
+			act("$n narrows $s eyes and glares in your direction.", ch, nullptr, victim, TO_VICT);
 
 			if (check_volley(ch, victim))
 			{
-				act("$N reflects your spell right back at you!", ch, 0, victim, TO_CHAR);
-				act("You reflect $n's spell right back at $m!", ch, 0, victim, TO_VICT);
-				act("$N reflects $n's spell right back at $m!", ch, 0, victim, TO_NOTVICT);
+				act("$N reflects your spell right back at you!", ch, nullptr, victim, TO_CHAR);
+				act("You reflect $n's spell right back at $m!", ch, nullptr, victim, TO_VICT);
+				act("$N reflects $n's spell right back at $m!", ch, nullptr, victim, TO_NOTVICT);
 
 				(*skill_table[sn].spell_fun)(sn, ch->level * 2, victim, ch, CastMode::Spell);
 				return;
@@ -2522,21 +2522,21 @@ void do_commune(CHAR_DATA *ch, char *argument)
 			|| skill_table[sn].target == TAR_OBJ_CHAR_OFF
 			|| (skill_table[sn].target == TAR_CHAR_DEFENSIVE && victim == ch))
 		{
-			act("You close your eyes and concentrate for a moment.", ch, 0, 0, TO_CHAR);
-			act("$n closes $s eyes with a look of concentration for a moment.", ch, 0, 0, TO_ROOM);
+			act("You close your eyes and concentrate for a moment.", ch, nullptr, nullptr, TO_CHAR);
+			act("$n closes $s eyes with a look of concentration for a moment.", ch, nullptr, nullptr, TO_ROOM);
 		}
 
 		if (skill_table[sn].target == TAR_CHAR_DEFENSIVE && victim != ch)
 		{
-			act("You close your eyes for a moment and nod at $N.", ch, 0, victim, TO_CHAR);
-			act("$n closes $s eyes for a moment and nods at $N.", ch, 0, victim, TO_NOTVICT);
-			act("$n closes $s eyes for a moment and nods at you.", ch, 0, victim, TO_VICT);
+			act("You close your eyes for a moment and nod at $N.", ch, nullptr, victim, TO_CHAR);
+			act("$n closes $s eyes for a moment and nods at $N.", ch, nullptr, victim, TO_NOTVICT);
+			act("$n closes $s eyes for a moment and nods at you.", ch, nullptr, victim, TO_VICT);
 		}
 
 		if (skill_table[sn].target == TAR_OBJ_INV)
 		{
-			act("You furrow your brow as you look through your possessions.", ch, 0, 0, TO_CHAR);
-			act("$n furrows $s brow as $e looks through $s possessions.", ch, 0, 0, TO_ROOM);
+			act("You furrow your brow as you look through your possessions.", ch, nullptr, nullptr, TO_CHAR);
+			act("$n furrows $s brow as $e looks through $s possessions.", ch, nullptr, nullptr, TO_ROOM);
 		}
 
 		(*skill_table[sn].spell_fun)(sn, ch->level, ch, vo, CastMode::Spell);
@@ -2854,9 +2854,9 @@ void do_call(CHAR_DATA *ch, char *argument)
 
 			if (check_volley(ch, victim))
 			{
-				act("$N reflects your spell right back at you!", ch, 0, victim, TO_CHAR);
-				act("You reflect $n's spell right back at $m!", ch, 0, victim, TO_VICT);
-				act("$N reflects $n's spell right back at $m!", ch, 0, victim, TO_NOTVICT);
+				act("$N reflects your spell right back at you!", ch, nullptr, victim, TO_CHAR);
+				act("You reflect $n's spell right back at $m!", ch, nullptr, victim, TO_VICT);
+				act("$N reflects $n's spell right back at $m!", ch, nullptr, victim, TO_NOTVICT);
 				(*skill_table[sn].spell_fun)(sn, ch->level * 2, victim, ch, CastMode::Spell);
 				return;
 			}
@@ -2946,7 +2946,7 @@ void do_snare(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 	affect_to_char(ch, &snaretimer);
 
 	send_to_char("You lay down vines and plants in a cunningly concealed snare to trap the unwary.\n\r", ch);
-	act("$n lays down vines and plants in a cunningly concealed snare to trap the unwary.\n\r", ch, 0, 0, TO_ROOM);
+	act("$n lays down vines and plants in a cunningly concealed snare to trap the unwary.\n\r", ch, nullptr, nullptr, TO_ROOM);
 
 	WAIT_STATE(ch, PULSE_VIOLENCE * 4);
 }
@@ -3106,7 +3106,7 @@ void do_createcosmetic(CHAR_DATA *ch, char *argument)
 		obj->wear_loc_name = palloc_string(wlname);
 	}
 
-	act("You create $p.", ch, obj, 0, TO_CHAR);
+	act("You create $p.", ch, obj, nullptr, TO_CHAR);
 }
 
 OBJ_DATA *make_cosmetic(char *name, char *wearloc, char *underloc, char *cosmeticloc)

--- a/code/dioextra.c
+++ b/code/dioextra.c
@@ -1361,7 +1361,7 @@ void do_finger(CHAR_DATA *ch, char *argument)
 		sprintf(buf2, "  Align: %-16s Ethos: %-20s Sex:  %s\n\r",
 			align < 0 ? "evil" : align == 0 ? "neutral" : align > 0 ? "good" : "(none)",
 			ethos < 0 ? "chaotic" : ethos == 0 ? "neutral" : ethos > 0 ? "lawful" : "(none)",
-			pc_race_table[race].name);
+			sex);
 		send_to_char(buf2, ch);
 
 		sprintf(buf3, "%d (b%d)", time_info.year - born, born);

--- a/code/dioextra.c
+++ b/code/dioextra.c
@@ -353,7 +353,7 @@ void do_affrem(CHAR_DATA *ch, char *argument)
 	}
 
 	if (skill_table[sn].room_msg_off && remove)
-		act(skill_table[sn].room_msg_off, victim, 0, 0, TO_ROOM);
+		act(skill_table[sn].room_msg_off, victim, nullptr, nullptr, TO_ROOM);
 
 	sprintf(buf, "The %s affect is removed from %s.\n\r", skill_table[sn].name, victim->name);
 
@@ -705,9 +705,9 @@ bool check_shroud_of_light(CHAR_DATA *ch, CHAR_DATA *victim)
 
 	if (number_percent() <= 35 && is_affected(ch, gsn_shroud_of_light))
 	{
-		act("As you approach $M, $N's shroud of light sears you!", ch, 0, victim, TO_CHAR);
-		act("As $n approaches you, your shroud of light sears $m!", ch, 0, victim, TO_VICT);
-		act("$n is seared by $N's shroud of light!", ch, 0, victim, TO_NOTVICT);
+		act("As you approach $M, $N's shroud of light sears you!", ch, nullptr, victim, TO_CHAR);
+		act("As $n approaches you, your shroud of light sears $m!", ch, nullptr, victim, TO_VICT);
+		act("$n is seared by $N's shroud of light!", ch, nullptr, victim, TO_NOTVICT);
 
 		init_affect(&af);
 		af.where = TO_AFFECTS;

--- a/code/fight.c
+++ b/code/fight.c
@@ -86,7 +86,6 @@ void violence_update(void)
 {
 	CHAR_DATA *victim;
 	CHAR_DATA *opponent;
-	int regen = 0;
 	OBJ_DATA *obj;
 	AFFECT_DATA *af;
 
@@ -356,7 +355,7 @@ void multi_hit(CHAR_DATA *ch, CHAR_DATA *victim, int dt)
 {
 	float chance;
 	float dual_chance;
-	int i, attacks;
+	int i;
 	char buf[500];
 	bool noprimary = false;
 
@@ -828,9 +827,9 @@ int one_hit(CHAR_DATA *ch, CHAR_DATA *victim, int dt)
  * return of -1 = Death			*/
 int one_hit_new(CHAR_DATA *ch, CHAR_DATA *victim, int dt, bool specials, bool blockable, int addition, int multiplier, char *dnoun)
 {
-	OBJ_DATA *wield = nullptr, *dualw = nullptr;
+	OBJ_DATA *wield = nullptr;
 	AFFECT_DATA *af;
-	int mdam, diceroll, diceroll2 = 0, sn, skill, dam_type, tmp_dt, result, rdt;
+	int mdam, sn, skill, dam_type, result, rdt;
 	float dam;
 	bool truestrike = false;
 
@@ -2882,7 +2881,6 @@ void check_analyze(CHAR_DATA *ch, CHAR_DATA *victim)
  */
 void update_pos(CHAR_DATA *victim)
 {
-	int diff = 0;
 
 	if (victim->hit > 0)
 	{
@@ -3181,7 +3179,6 @@ void death_cry(CHAR_DATA *ch, bool infidels)
 {
 	ROOM_INDEX_DATA *was_in_room;
 	char *msg;
-	int door;
 	int vnum;
 
 	vnum = 0;
@@ -3308,7 +3305,7 @@ void raw_kill(CHAR_DATA *ch, CHAR_DATA *victim)
 	AFFECT_DATA af;
 	ROOM_AFFECT_DATA raf;
 	AREA_AFFECT_DATA aaf;
-	OBJ_DATA *obj, *obj2, *corpse;
+	OBJ_DATA *obj, *obj2;
 	char wizbuf[MSL], *cname, buf[MSL], buf2[MSL];
 	bool infidels = false;
 
@@ -3934,7 +3931,6 @@ int xp_compute(CHAR_DATA *gch, CHAR_DATA *victim, int group_amount, int glevel)
 	float xp, base_exp;
 	int level_range;
 	float mult, peer_factor = BASE_PEER_FACTOR, gavg = glevel / group_amount;
-	CHAR_DATA *cPeers = nullptr;
 	mult = (100 - (gavg > gch->level ? gavg - gch->level : gch->level - gavg) * 6) / 100;
 	level_range = victim->level - gch->level;
 
@@ -8483,7 +8479,6 @@ void do_pugil(CHAR_DATA *ch, char *argument)
 	CHAR_DATA *victim;
 	OBJ_DATA *obj;
 	int chance;
-	int dam;
 
 	one_argument(argument, arg);
 

--- a/code/fight.c
+++ b/code/fight.c
@@ -1204,18 +1204,10 @@ int damage_new(CHAR_DATA *ch, CHAR_DATA *victim, int idam, int dt, int dam_type,
 	}
 
 	/* empathy */
-	if (is_affected(victim, gsn_empathy))
-	{
-		laf = nullptr;
-		for (auto &laf_elem : victim->affected)
-		{
-			if (laf_elem.type == gsn_empathy)
-			{
-				laf = &laf_elem;
-				break;
-			}
-		}
+	laf = affect_find(victim->affected, gsn_empathy);
 
+	if (laf != nullptr)
+	{
 		if (ch != victim)
 			damage_new(ch, Deref(laf->owner), (int)(dam * 0.25f), gsn_empathy, DAM_INTERNAL, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "spiritual link");
 

--- a/code/fight.c
+++ b/code/fight.c
@@ -238,9 +238,9 @@ void check_assist(CHAR_DATA *ch, CHAR_DATA *victim)
 						&& number_percent() > 40
 						&& number_percent() < get_skill(rch, gsn_rescue))
 					{
-						act("$n leaps to $N's rescue!", rch, 0, ch, TO_NOTVICT);
-						act("$n leaps to your rescue!", rch, 0, ch, TO_VICT);
-						act("You leap to $N's rescue!", rch, 0, ch, TO_CHAR);
+						act("$n leaps to $N's rescue!", rch, nullptr, ch, TO_NOTVICT);
+						act("$n leaps to your rescue!", rch, nullptr, ch, TO_VICT);
+						act("You leap to $N's rescue!", rch, nullptr, ch, TO_CHAR);
 
 						if (is_safe(rch, fch))
 							return;
@@ -954,7 +954,7 @@ int one_hit_new(CHAR_DATA *ch, CHAR_DATA *victim, int dt, bool specials, bool bl
 	if (!is_npc(ch) && is_affected(ch, gsn_rage) && ch->pcdata->tribe == TRIBE_BOAR && number_percent() < 10)
 	{
 		send_to_char("The fury of the Boar enrages you as you deliver a mighty blow!\n\r", ch);
-		act("$n gets an enraged look in $s eyes and delivers a mighty blow!", ch, 0, 0, TO_ROOM);
+		act("$n gets an enraged look in $s eyes and delivers a mighty blow!", ch, nullptr, nullptr, TO_ROOM);
 		dam *= ch->level / 20;
 	}
 
@@ -1252,8 +1252,8 @@ int damage_new(CHAR_DATA *ch, CHAR_DATA *victim, int idam, int dt, int dam_type,
 				if (diamondskin <= 0)
 				{
 					diamondskin = 0;
-					act("$n howls in agony as the diamond shell that was once $s skin shatters!", victim, 0, 0, TO_ROOM);
-					act("Unspeakable agony wracks your entire frame as your very skin shatters!", victim, 0, 0, TO_CHAR);
+					act("$n howls in agony as the diamond shell that was once $s skin shatters!", victim, nullptr, nullptr, TO_ROOM);
+					act("Unspeakable agony wracks your entire frame as your very skin shatters!", victim, nullptr, nullptr, TO_CHAR);
 					damage_new(victim, victim, victim->max_hit / 2, gsn_diamondskin, DAM_TRUESTRIKE, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, nullptr);
 					affect_strip(victim, gsn_diamondskin);
 
@@ -1466,7 +1466,7 @@ int damage_new(CHAR_DATA *ch, CHAR_DATA *victim, int idam, int dt, int dam_type,
 			send_to_char("You are stunned, but will probably recover.\n\r", victim);
 			break;
 		case POS_DEAD:
-			act("$n is DEAD!!", victim, 0, 0, TO_ROOM);
+			act("$n is DEAD!!", victim, nullptr, nullptr, TO_ROOM);
 			send_to_char("You have been KILLED!!\n\r\n\r", victim);
 			break;
 		default:
@@ -1681,8 +1681,8 @@ bool is_safe_new(CHAR_DATA *ch, CHAR_DATA *victim, bool show)
 	{
 		if (show)
 		{
-			act("The gods protect $N from $n.", ch, 0, victim, TO_NOTVICT);
-			act("The gods protect $N from you.", ch, 0, victim, TO_CHAR);
+			act("The gods protect $N from $n.", ch, nullptr, victim, TO_NOTVICT);
+			act("The gods protect $N from you.", ch, nullptr, victim, TO_CHAR);
 		}
 
 		return true;
@@ -1694,7 +1694,7 @@ bool is_safe_new(CHAR_DATA *ch, CHAR_DATA *victim, bool show)
 	if (is_affected(ch, gsn_calm))
 	{
 		if (show)
-			act("You're feeling too relaxed to hurt $N.", ch, 0, victim, TO_CHAR);
+			act("You're feeling too relaxed to hurt $N.", ch, nullptr, victim, TO_CHAR);
 
 		return true;
 	}
@@ -1709,9 +1709,9 @@ bool is_safe_new(CHAR_DATA *ch, CHAR_DATA *victim, bool show)
 	{
 		if (show)
 		{
-			act("The gods protect $N from $n.", ch, 0, victim, TO_NOTVICT);
-			act("The gods protect you from $n.", ch, 0, victim, TO_VICT);
-			act("The gods protect $N from you.", ch, 0, victim, TO_CHAR);
+			act("The gods protect $N from $n.", ch, nullptr, victim, TO_NOTVICT);
+			act("The gods protect you from $n.", ch, nullptr, victim, TO_VICT);
+			act("The gods protect $N from you.", ch, nullptr, victim, TO_CHAR);
 		}
 
 		return true;
@@ -1723,9 +1723,9 @@ bool is_safe_new(CHAR_DATA *ch, CHAR_DATA *victim, bool show)
 		{
 			if (show)
 			{
-				act("The gods protect $N from $n.", ch, 0, victim, TO_NOTVICT);
-				act("The gods protect you from $n.", ch, 0, victim, TO_VICT);
-				act("The gods protect $N from you.", ch, 0, victim, TO_CHAR);
+				act("The gods protect $N from $n.", ch, nullptr, victim, TO_NOTVICT);
+				act("The gods protect you from $n.", ch, nullptr, victim, TO_VICT);
+				act("The gods protect $N from you.", ch, nullptr, victim, TO_CHAR);
 			}
 
 			return true;
@@ -1735,9 +1735,9 @@ bool is_safe_new(CHAR_DATA *ch, CHAR_DATA *victim, bool show)
 		{
 			if (show)
 			{
-				act("The gods protect $N from $n.", ch, 0, victim, TO_NOTVICT);
-				act("The gods protect you from $n.", ch, 0, victim, TO_VICT);
-				act("The gods protect $N from you.", ch, 0, victim, TO_CHAR);
+				act("The gods protect $N from $n.", ch, nullptr, victim, TO_NOTVICT);
+				act("The gods protect you from $n.", ch, nullptr, victim, TO_VICT);
+				act("The gods protect $N from you.", ch, nullptr, victim, TO_CHAR);
 			}
 
 			return true;
@@ -1754,9 +1754,9 @@ bool is_safe_new(CHAR_DATA *ch, CHAR_DATA *victim, bool show)
 			{
 				if (show)
 				{
-					act("The gods protect $N from $n.", ch, 0, victim, TO_NOTVICT);
-					act("The gods protect you from $n.", ch, 0, victim, TO_VICT);
-					act("The gods protect $N from you.", ch, 0, victim, TO_CHAR);
+					act("The gods protect $N from $n.", ch, nullptr, victim, TO_NOTVICT);
+					act("The gods protect you from $n.", ch, nullptr, victim, TO_VICT);
+					act("The gods protect $N from you.", ch, nullptr, victim, TO_CHAR);
 				}
 
 				return true;
@@ -1787,9 +1787,9 @@ bool is_safe_new(CHAR_DATA *ch, CHAR_DATA *victim, bool show)
 			{
 				if (show)
 				{
-					act("The gods protect $N from $n.", ch, 0, victim, TO_NOTVICT);
-					act("The gods protect you from $n.", ch, 0, victim, TO_VICT);
-					act("The gods protect $N from you.", ch, 0, victim, TO_CHAR);
+					act("The gods protect $N from $n.", ch, nullptr, victim, TO_NOTVICT);
+					act("The gods protect you from $n.", ch, nullptr, victim, TO_VICT);
+					act("The gods protect $N from you.", ch, nullptr, victim, TO_CHAR);
 				}
 
 				return true;
@@ -2169,8 +2169,8 @@ bool check_parry(CHAR_DATA *ch, CHAR_DATA *victim, int dt)
 	if (IS_SET(ch->wiznet, WIZ_PERCENT))
 		sprintf(buf2, "$N parries your %s. (%d%%)", attack, (int)chance);
 
-	act(buf1, ch, 0, victim, TO_VICT);
-	act(buf2, ch, 0, victim, TO_CHAR);
+	act(buf1, ch, nullptr, victim, TO_VICT);
+	act(buf2, ch, nullptr, victim, TO_CHAR);
 	check_improve(victim, gsn_parry, true, 2);
 
 	/* Barbarian batter check */
@@ -2277,8 +2277,8 @@ bool check_shield_block(CHAR_DATA *ch, CHAR_DATA *victim, int dt)
 	if (IS_SET(ch->wiznet, WIZ_PERCENT))
 		sprintf(buf2, "$N blocks your %s with $S shield. (%d%%)", attack, (int)chance);
 
-	act(buf1, ch, 0, victim, TO_VICT);
-	act(buf2, ch, 0, victim, TO_CHAR);
+	act(buf1, ch, nullptr, victim, TO_VICT);
+	act(buf2, ch, nullptr, victim, TO_CHAR);
 	check_improve(victim, gsn_shield_block, true, 4);
 
 	/* Barbarian batter check */
@@ -2314,9 +2314,9 @@ bool check_piety(CHAR_DATA *ch, CHAR_DATA *victim, int dt)
 
 		if (number_percent() <= 50)
 		{
-			act("While you recover from your deflected attack, $N quickly strikes you!", ch, 0, victim, TO_CHAR);
-			act("While $n recovers from your deflection, you quickly strike $m!", ch, 0, victim, TO_VICT);
-			act("While $n recovers from $s deflected blow, $N quickly strikes $m!", ch, 0, victim, TO_NOTVICT);
+			act("While you recover from your deflected attack, $N quickly strikes you!", ch, nullptr, victim, TO_CHAR);
+			act("While $n recovers from your deflection, you quickly strike $m!", ch, nullptr, victim, TO_VICT);
+			act("While $n recovers from $s deflected blow, $N quickly strikes $m!", ch, nullptr, victim, TO_NOTVICT);
 			one_hit_new(victim, ch, TYPE_UNDEFINED, HIT_SPECIALS, HIT_BLOCKABLE, HIT_NOADD, 100, nullptr);
 		}
 
@@ -2444,8 +2444,8 @@ bool check_dodge(CHAR_DATA *ch, CHAR_DATA *victim, int dt)
 	if (IS_SET(ch->wiznet, WIZ_PERCENT))
 		sprintf(buf2, "$N dodges your %s. (%d%% -- %d%% needed)", attack, roll, (int)chance);
 
-	act(buf1, ch, 0, victim, TO_VICT);
-	act(buf2, ch, 0, victim, TO_CHAR);
+	act(buf1, ch, nullptr, victim, TO_VICT);
+	act(buf2, ch, nullptr, victim, TO_CHAR);
 
 	check_improve(victim, gsn_dodge, true, 5);
 
@@ -2567,8 +2567,8 @@ bool check_avoid(CHAR_DATA *ch, CHAR_DATA *victim, int dt)
 	sprintf(buf1, "You %savoid $n's %s%s.", (diff < 15) ? "barely " : "", attack, (diff > 50) ? " with ease" : "");
 	sprintf(buf2, "$N %savoids your %s%s.", (diff < 15) ? "barely " : "", attack, (diff > 50) ? " with ease" : "");
 
-	act(buf1, ch, 0, victim, TO_VICT);
-	act(buf2, ch, 0, victim, TO_CHAR);
+	act(buf1, ch, nullptr, victim, TO_VICT);
+	act(buf2, ch, nullptr, victim, TO_CHAR);
 
 	check_improve(victim, gsn_avoid, true, 5);
 
@@ -2792,8 +2792,8 @@ bool check_deflect(CHAR_DATA *ch, CHAR_DATA *victim, int dt)
 	sprintf(buf1, "You deflect $n's %s with your armored forearm.", attack);
 	sprintf(buf2, "$N deflects your %s with $S armored forearm.", attack);
 
-	act(buf1, ch, 0, victim, TO_VICT);
-	act(buf2, ch, 0, victim, TO_CHAR);
+	act(buf1, ch, nullptr, victim, TO_VICT);
+	act(buf2, ch, nullptr, victim, TO_CHAR);
 
 	check_improve(victim, gsn_deflect, true, 4);
 	return true;
@@ -2818,8 +2818,8 @@ bool check_mist(CHAR_DATA *ch, CHAR_DATA *victim, int dt)
 	sprintf(buf1, "$n's %s passes harmlessly through your cloak of mist.", attack);
 	sprintf(buf2, "Your %s passes harmlessly through $N's cloak of mist.", attack);
 
-	act(buf1, ch, 0, victim, TO_VICT);
-	act(buf2, ch, 0, victim, TO_CHAR);
+	act(buf1, ch, nullptr, victim, TO_VICT);
+	act(buf2, ch, nullptr, victim, TO_CHAR);
 	return true;
 }
 
@@ -3338,7 +3338,7 @@ void raw_kill(CHAR_DATA *ch, CHAR_DATA *victim)
 		}
 		else
 		{
-			act("$n's skull glows brightly and $n rises from $s ashes!", victim, 0, 0, TO_ROOM);
+			act("$n's skull glows brightly and $n rises from $s ashes!", victim, nullptr, nullptr, TO_ROOM);
 			send_to_char("Your skull glows brightly and you rise from your ashes!\n\r", victim);
 		}
 
@@ -3577,8 +3577,8 @@ void raw_kill(CHAR_DATA *ch, CHAR_DATA *victim)
 
 	if (infidels == true)
 	{
-		act("You impale $N's head on a ceremonial spear, making an example of $M.", ch, 0, victim, TO_CHAR);
-		act("$n impales $N's head on a ceremonial spear!", ch, 0, victim, TO_ROOM);
+		act("You impale $N's head on a ceremonial spear, making an example of $M.", ch, nullptr, victim, TO_CHAR);
+		act("$n impales $N's head on a ceremonial spear!", ch, nullptr, victim, TO_ROOM);
 		obj2 = create_object(get_obj_index(2999), ch->level);
 		obj2->timer = ch->level;
 		obj_to_room(obj2, ch->in_room);
@@ -3620,7 +3620,7 @@ void raw_kill(CHAR_DATA *ch, CHAR_DATA *victim)
 		}
 	}
 
-	act("$n appears in the room.", victim, 0, 0, TO_ROOM);
+	act("$n appears in the room.", victim, nullptr, nullptr, TO_ROOM);
 	do_look(victim, "auto");
 }
 
@@ -5027,8 +5027,8 @@ void disarm(CHAR_DATA *ch, CHAR_DATA *victim)
 	if (secondary != nullptr)
 	{
 		unequip_char(victim, secondary, false);
-		act("You quickly swap $p into your primary hand.", victim, secondary, 0, TO_CHAR);
-		act("$n quickly swaps $p into $s primary hand.", victim, secondary, 0, TO_ROOM);
+		act("You quickly swap $p into your primary hand.", victim, secondary, nullptr, TO_CHAR);
+		act("$n quickly swaps $p into $s primary hand.", victim, secondary, nullptr, TO_ROOM);
 		equip_char(victim, secondary, WEAR_WIELD, false);
 	}
 }
@@ -5211,9 +5211,9 @@ void do_bash(CHAR_DATA *ch, char *argument)
 
 		if (number_percent() < avoid)
 		{
-			act("You deftly avoid $N's bash and $E topples to the ground.", victim, 0, ch, TO_CHAR);
-			act("$n deftly avoids $N's bash and $E topples to the ground.", victim, 0, ch, TO_NOTVICT);
-			act("Your bash is deftly avoided by $n, and you go crashing to the ground.", victim, 0, ch, TO_VICT);
+			act("You deftly avoid $N's bash and $E topples to the ground.", victim, nullptr, ch, TO_CHAR);
+			act("$n deftly avoids $N's bash and $E topples to the ground.", victim, nullptr, ch, TO_NOTVICT);
+			act("Your bash is deftly avoided by $n, and you go crashing to the ground.", victim, nullptr, ch, TO_VICT);
 
 			WAIT_STATE(ch, 3 * PULSE_VIOLENCE);
 			return;
@@ -5222,9 +5222,9 @@ void do_bash(CHAR_DATA *ch, char *argument)
 
 	if (is_affected(victim, gsn_protective_shield))
 	{
-		act("$N's bash seems to slide around you.", victim, 0, ch, TO_CHAR);
-		act("$N's bash seems to slide around $n.", victim, 0, ch, TO_NOTVICT);
-		act("Your bash seems to slide around $n.", victim, 0, ch, TO_VICT);
+		act("$N's bash seems to slide around you.", victim, nullptr, ch, TO_CHAR);
+		act("$N's bash seems to slide around $n.", victim, nullptr, ch, TO_NOTVICT);
+		act("Your bash seems to slide around $n.", victim, nullptr, ch, TO_VICT);
 
 		WAIT_STATE(ch, (int)(PULSE_VIOLENCE * .5));
 		return;
@@ -5232,9 +5232,9 @@ void do_bash(CHAR_DATA *ch, char *argument)
 
 	if (is_affected(victim, gsn_sanguine_ward))
 	{
-		act("$N tries to bash you but your sanguine ward keeps $M at bay.", victim, 0, ch, TO_CHAR);
-		act("$n's ward flares brightly as $N tries to bash $m, deflecting the attack!", victim, 0, ch, TO_NOTVICT);
-		act("$n's ward flares brightly as you try to bash $m, sending you flying back!", victim, 0, ch, TO_VICT);
+		act("$N tries to bash you but your sanguine ward keeps $M at bay.", victim, nullptr, ch, TO_CHAR);
+		act("$n's ward flares brightly as $N tries to bash $m, deflecting the attack!", victim, nullptr, ch, TO_NOTVICT);
+		act("$n's ward flares brightly as you try to bash $m, sending you flying back!", victim, nullptr, ch, TO_VICT);
 
 		WAIT_STATE(ch, PULSE_VIOLENCE * 1);
 		return;
@@ -5242,9 +5242,9 @@ void do_bash(CHAR_DATA *ch, char *argument)
 
 	if (is_affected(victim, gsn_heatshield))
 	{
-		act("$N tries to bash you but is stopped by a wave of searing heat.", victim, 0, ch, TO_CHAR);
-		act("$N tries to bash $n but a wave of searing heat stops him.", victim, 0, ch, TO_NOTVICT);
-		act("You try to bash $n but a wave of searing heat stops you!", victim, 0, ch, TO_VICT);
+		act("$N tries to bash you but is stopped by a wave of searing heat.", victim, nullptr, ch, TO_CHAR);
+		act("$N tries to bash $n but a wave of searing heat stops him.", victim, nullptr, ch, TO_NOTVICT);
+		act("You try to bash $n but a wave of searing heat stops you!", victim, nullptr, ch, TO_VICT);
 
 		WAIT_STATE(ch, PULSE_VIOLENCE * 1);
 
@@ -5254,9 +5254,9 @@ void do_bash(CHAR_DATA *ch, char *argument)
 
 	if (is_affected(victim, gsn_elecshield))
 	{
-		act("$N attempts to bash you, but collides with your electric shield.", victim, 0, ch, TO_CHAR);
-		act("$N attempts to bash $n, but collides with $s electric shield.", victim, 0, ch, TO_NOTVICT);
-		act("You are stopped by an electric field, shocking you and sapping your energy!", victim, 0, ch, TO_VICT);
+		act("$N attempts to bash you, but collides with your electric shield.", victim, nullptr, ch, TO_CHAR);
+		act("$N attempts to bash $n, but collides with $s electric shield.", victim, nullptr, ch, TO_NOTVICT);
+		act("You are stopped by an electric field, shocking you and sapping your energy!", victim, nullptr, ch, TO_VICT);
 
 		WAIT_STATE(ch, PULSE_VIOLENCE * 1);
 
@@ -5267,9 +5267,9 @@ void do_bash(CHAR_DATA *ch, char *argument)
 
 	if (is_affected(victim, gsn_airshield))
 	{
-		act("$N attempts to bash you, but a curtain of swirling winds throws $M back!", victim, 0, ch, TO_CHAR);
-		act("$N attempts to bash $n, but a curtain of swirling winds throws $M back!", victim, 0, ch, TO_NOTVICT);
-		act("You try to bash $n but a curtain of swirling winds throw you back!", victim, 0, ch, TO_VICT);
+		act("$N attempts to bash you, but a curtain of swirling winds throws $M back!", victim, nullptr, ch, TO_CHAR);
+		act("$N attempts to bash $n, but a curtain of swirling winds throws $M back!", victim, nullptr, ch, TO_NOTVICT);
+		act("You try to bash $n but a curtain of swirling winds throw you back!", victim, nullptr, ch, TO_VICT);
 
 		dam = dice(2, 10);
 		damage_old(victim, ch, dam, gsn_airshield, DAM_BASH, true);
@@ -5280,9 +5280,9 @@ void do_bash(CHAR_DATA *ch, char *argument)
 
 	if (is_affected(victim, gsn_earthshield))
 	{
-		act("$N attempts to bash you, but collides with your earthshield.", victim, 0, ch, TO_CHAR);
-		act("$N attempts to bash $n, but instead collides with a solid barrier.", victim, 0, ch, TO_NOTVICT);
-		act("Your hear your bones crack as you slam into a rock-hard shield around $n.", victim, 0, ch, TO_VICT);
+		act("$N attempts to bash you, but collides with your earthshield.", victim, nullptr, ch, TO_CHAR);
+		act("$N attempts to bash $n, but instead collides with a solid barrier.", victim, nullptr, ch, TO_NOTVICT);
+		act("Your hear your bones crack as you slam into a rock-hard shield around $n.", victim, nullptr, ch, TO_VICT);
 
 		damage_old(victim, ch, dice(2, 10), gsn_earthshield, DAM_BASH, true);
 
@@ -5307,9 +5307,9 @@ void do_bash(CHAR_DATA *ch, char *argument)
 
 	if (is_affected(victim, gsn_watershield))
 	{
-		act("$N attempts to bash you, and you feel slightly invigorated as $E crashes into your watershield.", victim, 0, ch, TO_CHAR);
-		act("$n looks slightly invigorated as $N crashes into $s watershield.", victim, 0, ch, TO_NOTVICT);
-		act("You feel drained as your mass collides with $n's shield of swirling water.", victim, 0, ch, TO_VICT);
+		act("$N attempts to bash you, and you feel slightly invigorated as $E crashes into your watershield.", victim, nullptr, ch, TO_CHAR);
+		act("$n looks slightly invigorated as $N crashes into $s watershield.", victim, nullptr, ch, TO_NOTVICT);
+		act("You feel drained as your mass collides with $n's shield of swirling water.", victim, nullptr, ch, TO_VICT);
 
 		dam = dice(3, 10);
 		damage_old(victim, ch, dam, gsn_watershield, DAM_DROWNING, true);
@@ -5330,9 +5330,9 @@ void do_bash(CHAR_DATA *ch, char *argument)
 
 	if (is_affected(victim, gsn_coldshield))
 	{
-		act("$N attempts to bash you, but is stopped by a wave of freezing air.", victim, 0, ch, TO_CHAR);
-		act("$N attempts to bash $n, but is stopped by a wave of freezing air.", victim, 0, ch, TO_NOTVICT);
-		act("You attempt to bash $n, but are seared by a wave of freezing air.", victim, 0, ch, TO_VICT);
+		act("$N attempts to bash you, but is stopped by a wave of freezing air.", victim, nullptr, ch, TO_CHAR);
+		act("$N attempts to bash $n, but is stopped by a wave of freezing air.", victim, nullptr, ch, TO_NOTVICT);
+		act("You attempt to bash $n, but are seared by a wave of freezing air.", victim, nullptr, ch, TO_VICT);
 		(*skill_table[gsn_chill].spell_fun)(gsn_chill, ch->level, victim, ch, CastMode::Spell);
 
 		WAIT_STATE(ch, PULSE_VIOLENCE * 2);
@@ -5917,13 +5917,13 @@ void do_murder(CHAR_DATA *ch, char *argument)
 
 	if (is_affected(ch, gsn_rage) && !is_npc(ch) && ch->pcdata->tribe == TRIBE_FOX)
 	{
-		act("Charging towards $N, with the cunning of the Fox, you circle around and strike at $S exposed flank!", ch, 0, victim, TO_CHAR);
-		act("Charging towards you, $n abruptly circles around and strikes at your exposed flank!", ch, 0, victim, TO_VICT);
-		act("Charging towards $N, $n abruptly circles around and strikes at $S exposed flank!", ch, 0, victim, TO_NOTVICT);
+		act("Charging towards $N, with the cunning of the Fox, you circle around and strike at $S exposed flank!", ch, nullptr, victim, TO_CHAR);
+		act("Charging towards you, $n abruptly circles around and strikes at your exposed flank!", ch, nullptr, victim, TO_VICT);
+		act("Charging towards $N, $n abruptly circles around and strikes at $S exposed flank!", ch, nullptr, victim, TO_NOTVICT);
 
 		if (number_percent() > 25 && get_curr_stat(victim, STAT_STR) > 13 && get_curr_stat(victim, STAT_DEX) > 9)
 		{
-			act("A chilling tearing sound heralds the destruction of flesh and bone.", ch, 0, 0, TO_ALL);
+			act("A chilling tearing sound heralds the destruction of flesh and bone.", ch, nullptr, nullptr, TO_ALL);
 
 			init_affect(&af);
 			af.where = TO_AFFECTS;
@@ -6437,21 +6437,21 @@ void do_herb(CHAR_DATA *ch, char *argument)
 	if (number_percent() > get_skill(ch, gsn_herb))
 	{
 		send_to_char("You search for herbs but fail to find any.\n\r", ch);
-		act("$n looks about in the bushes but finds nothing.", ch, 0, 0, TO_ROOM);
+		act("$n looks about in the bushes but finds nothing.", ch, nullptr, nullptr, TO_ROOM);
 		check_improve(ch, gsn_herb, false, 4);
 		return;
 	}
 
 	if (victim != ch)
 	{
-		act("$n applies herbs to $N.", ch, 0, victim, TO_NOTVICT);
-		act("You apply herbs to $N.", ch, 0, victim, TO_CHAR);
-		act("$n applies herbs to you.", ch, 0, victim, TO_VICT);
+		act("$n applies herbs to $N.", ch, nullptr, victim, TO_NOTVICT);
+		act("You apply herbs to $N.", ch, nullptr, victim, TO_CHAR);
+		act("$n applies herbs to you.", ch, nullptr, victim, TO_VICT);
 	}
 
 	if (victim == ch)
 	{
-		act("$n applies herbs to $mself.", ch, 0, 0, TO_ROOM);
+		act("$n applies herbs to $mself.", ch, nullptr, nullptr, TO_ROOM);
 		send_to_char("You find herbs and apply them to yourself.\n\r", ch);
 	}
 
@@ -6460,7 +6460,7 @@ void do_herb(CHAR_DATA *ch, char *argument)
 	if (is_affected_by(victim, AFF_PLAGUE) && number_percent() > 30)
 	{
 		affect_strip(victim, gsn_plague);
-		act("The sores on $n's body vanish.\n\r", victim, 0, 0, TO_ROOM);
+		act("The sores on $n's body vanish.\n\r", victim, nullptr, nullptr, TO_ROOM);
 		send_to_char("The sores on your body vanish.\n\r", victim);
 	}
 
@@ -6579,9 +6579,9 @@ void do_cleave(CHAR_DATA *ch, char *argument)
 	if (IS_IMP(ch))
 		chance += 100;
 
-	act("You make a brutal swing at $N in an attempt to cleave them in half.", ch, 0, victim, TO_CHAR);
-	act("$n attempts to cleave you in half with a brutal slice.", ch, 0, victim, TO_VICT);
-	act("$n makes an attempt to cleave $N in half.", ch, 0, victim, TO_NOTVICT);
+	act("You make a brutal swing at $N in an attempt to cleave them in half.", ch, nullptr, victim, TO_CHAR);
+	act("$n attempts to cleave you in half with a brutal slice.", ch, nullptr, victim, TO_VICT);
+	act("$n makes an attempt to cleave $N in half.", ch, nullptr, victim, TO_NOTVICT);
 
 	if (is_npc(victim))
 		victim->last_fought = ch->self;
@@ -6607,9 +6607,9 @@ void do_cleave(CHAR_DATA *ch, char *argument)
 		return;
 	}
 
-	act("Your cleave slices $S body in half with a clean cut!", ch, 0, victim, TO_CHAR);
-	act("$n cleaves you in half, tearing your body into two bloody bits!", ch, 0, victim, TO_VICT);
-	act("$n cleaves $N into bits of bloody flesh!", ch, 0, victim, TO_NOTVICT);
+	act("Your cleave slices $S body in half with a clean cut!", ch, nullptr, victim, TO_CHAR);
+	act("$n cleaves you in half, tearing your body into two bloody bits!", ch, nullptr, victim, TO_VICT);
+	act("$n cleaves $N into bits of bloody flesh!", ch, nullptr, victim, TO_NOTVICT);
 	check_improve(ch, gsn_cleave, true, 5);
 	raw_kill(ch, victim);
 }
@@ -6637,9 +6637,9 @@ void check_ground_control(CHAR_DATA *ch, CHAR_DATA *victim, float chance, int da
 		return;
 	}
 
-	act("With brutal skill you grind $N against the ground with your weight.", ch, 0, victim, TO_CHAR);
-	act("$n takes hold of $N and grinds $M against the ground.", ch, 0, victim, TO_NOTVICT);
-	act("$n grinds you against the ground with brutal skill.", ch, 0, victim, TO_VICT);
+	act("With brutal skill you grind $N against the ground with your weight.", ch, nullptr, victim, TO_CHAR);
+	act("$n takes hold of $N and grinds $M against the ground.", ch, nullptr, victim, TO_NOTVICT);
+	act("$n grinds you against the ground with brutal skill.", ch, nullptr, victim, TO_VICT);
 
 	dam -= 10;
 
@@ -6695,7 +6695,7 @@ void do_tail(CHAR_DATA *ch, char *argument)
 	chance += get_curr_stat(ch, STAT_DEX) / 3;
 	chance += get_curr_stat(ch, STAT_STR) / 3;
 
-	act("$n violently lashes out with $s tail.", ch, 0, 0, TO_ROOM);
+	act("$n violently lashes out with $s tail.", ch, nullptr, nullptr, TO_ROOM);
 	send_to_char("You violently lash out with your tail!\n\r", ch);
 
 	if (number_percent() > chance)
@@ -6711,7 +6711,7 @@ void do_tail(CHAR_DATA *ch, char *argument)
 
 	if (number_percent() < knock)
 	{
-		act("$n is sent crashing to the ground by the force of the blow!", victim, 0, 0, TO_ROOM);
+		act("$n is sent crashing to the ground by the force of the blow!", victim, nullptr, nullptr, TO_ROOM);
 		send_to_char("The tail strike sends you crashing to the ground!\n\r", victim);
 		LAG_CHAR(victim, (3 * PULSE_VIOLENCE / 2));
 	}
@@ -6764,9 +6764,9 @@ void do_throw(CHAR_DATA *ch, char *argument)
 
 	if (is_affected(victim, gsn_protective_shield))
 	{
-		act("$N's throw seems to slide around you.", victim, 0, ch, TO_CHAR);
-		act("$N's throw seems to slide around $n.", victim, 0, ch, TO_NOTVICT);
-		act("Your throw seems to slide around $n.", victim, 0, ch, TO_VICT);
+		act("$N's throw seems to slide around you.", victim, nullptr, ch, TO_CHAR);
+		act("$N's throw seems to slide around $n.", victim, nullptr, ch, TO_NOTVICT);
+		act("Your throw seems to slide around $n.", victim, nullptr, ch, TO_VICT);
 
 		WAIT_STATE(ch, PULSE_VIOLENCE * 2);
 		return;
@@ -6774,9 +6774,9 @@ void do_throw(CHAR_DATA *ch, char *argument)
 
 	if (is_affected(victim, gsn_sanguine_ward))
 	{
-		act("$N tries to throw you but your sanguine ward keeps $M at bay.", victim, 0, ch, TO_CHAR);
-		act("$n's ward flares brightly as $N tries to throw $m, deflecting the attack!", victim, 0, ch, TO_NOTVICT);
-		act("$n's ward flares brightly as you try to throw $m, sending you flying back!", victim, 0, ch, TO_VICT);
+		act("$N tries to throw you but your sanguine ward keeps $M at bay.", victim, nullptr, ch, TO_CHAR);
+		act("$n's ward flares brightly as $N tries to throw $m, deflecting the attack!", victim, nullptr, ch, TO_NOTVICT);
+		act("$n's ward flares brightly as you try to throw $m, sending you flying back!", victim, nullptr, ch, TO_VICT);
 
 		WAIT_STATE(ch, PULSE_VIOLENCE * 1);
 		return;
@@ -6784,9 +6784,9 @@ void do_throw(CHAR_DATA *ch, char *argument)
 
 	if (is_affected(victim, gsn_heatshield))
 	{
-		act("$N tries to throw you but is stopped by a wave of searing heat.", victim, 0, ch, TO_CHAR);
-		act("$N tries to throw $n but a wave of searing heat stops him.", victim, 0, ch, TO_NOTVICT);
-		act("You try to throw $n but a wave of searing heat stops you!", victim, 0, ch, TO_VICT);
+		act("$N tries to throw you but is stopped by a wave of searing heat.", victim, nullptr, ch, TO_CHAR);
+		act("$N tries to throw $n but a wave of searing heat stops him.", victim, nullptr, ch, TO_NOTVICT);
+		act("You try to throw $n but a wave of searing heat stops you!", victim, nullptr, ch, TO_VICT);
 
 		WAIT_STATE(ch, PULSE_VIOLENCE * 1);
 		damage_old(victim, ch, dice(8, 10), gsn_heatshield, DAM_FIRE, true);
@@ -6795,9 +6795,9 @@ void do_throw(CHAR_DATA *ch, char *argument)
 
 	if (is_affected(victim, gsn_elecshield))
 	{
-		act("$N attempts to throw you, but collides with your electric shield.", victim, 0, ch, TO_CHAR);
-		act("$N attempts to throw $n, but collides with $s electric shield.", victim, 0, ch, TO_NOTVICT);
-		act("You are stopped by an electric field, shocking you and sapping your energy!", victim, 0, ch, TO_VICT);
+		act("$N attempts to throw you, but collides with your electric shield.", victim, nullptr, ch, TO_CHAR);
+		act("$N attempts to throw $n, but collides with $s electric shield.", victim, nullptr, ch, TO_NOTVICT);
+		act("You are stopped by an electric field, shocking you and sapping your energy!", victim, nullptr, ch, TO_VICT);
 
 		WAIT_STATE(ch, PULSE_VIOLENCE * 1);
 
@@ -6808,9 +6808,9 @@ void do_throw(CHAR_DATA *ch, char *argument)
 
 	if (is_affected(victim, gsn_airshield))
 	{
-		act("$N attempts to throw you, but a curtain of swirling winds throws $M back!", victim, 0, ch, TO_CHAR);
-		act("$N attempts to throw $n, but a curtain of swirling winds throws $M back!", victim, 0, ch, TO_NOTVICT);
-		act("You try to throw $n but a curtain of swirling winds throw you back!", victim, 0, ch, TO_VICT);
+		act("$N attempts to throw you, but a curtain of swirling winds throws $M back!", victim, nullptr, ch, TO_CHAR);
+		act("$N attempts to throw $n, but a curtain of swirling winds throws $M back!", victim, nullptr, ch, TO_NOTVICT);
+		act("You try to throw $n but a curtain of swirling winds throw you back!", victim, nullptr, ch, TO_VICT);
 
 		dam = dice(2, 10);
 		damage_old(victim, ch, dam, gsn_airshield, DAM_DROWNING, true);
@@ -6821,9 +6821,9 @@ void do_throw(CHAR_DATA *ch, char *argument)
 
 	if (is_affected(victim, gsn_earthshield))
 	{
-		act("$N attempts to throw you, but collides with your earthshield.", victim, 0, ch, TO_CHAR);
-		act("$N attempts to throw $n, but instead collides with a solid barrier.", victim, 0, ch, TO_NOTVICT);
-		act("Your hear your bones crack as you slam into a rock-hard shield around $n.", victim, 0, ch, TO_VICT);
+		act("$N attempts to throw you, but collides with your earthshield.", victim, nullptr, ch, TO_CHAR);
+		act("$N attempts to throw $n, but instead collides with a solid barrier.", victim, nullptr, ch, TO_NOTVICT);
+		act("Your hear your bones crack as you slam into a rock-hard shield around $n.", victim, nullptr, ch, TO_VICT);
 		damage_old(victim, ch, dice(2, 10), gsn_earthshield, DAM_BASH, true);
 
 		init_affect(&af);
@@ -6847,9 +6847,9 @@ void do_throw(CHAR_DATA *ch, char *argument)
 
 	if (is_affected(victim, gsn_watershield))
 	{
-		act("$N attempts to throw you, and you feel slightly invigorated as $E crashes into your watershield.", victim, 0, ch, TO_CHAR);
-		act("$n looks slightly invigorated as $N crashes into $s watershield.", victim, 0, ch, TO_NOTVICT);
-		act("You feel drained as your mass collides with $n's shield of swirling water.", victim, 0, ch, TO_VICT);
+		act("$N attempts to throw you, and you feel slightly invigorated as $E crashes into your watershield.", victim, nullptr, ch, TO_CHAR);
+		act("$n looks slightly invigorated as $N crashes into $s watershield.", victim, nullptr, ch, TO_NOTVICT);
+		act("You feel drained as your mass collides with $n's shield of swirling water.", victim, nullptr, ch, TO_VICT);
 
 		dam = dice(3, 10);
 		damage_old(victim, ch, dam, gsn_watershield, DAM_DROWNING, true);
@@ -6869,9 +6869,9 @@ void do_throw(CHAR_DATA *ch, char *argument)
 
 	if (is_affected(victim, gsn_coldshield))
 	{
-		act("$N attempts to throw you, but is stopped by a wave of freezing air.", victim, 0, ch, TO_CHAR);
-		act("$N attempts to throw $n, but is stopped by a wave of freezing air.", victim, 0, ch, TO_NOTVICT);
-		act("You attempt to throw $n, but are seared by a wave of freezing air.", victim, 0, ch, TO_VICT);
+		act("$N attempts to throw you, but is stopped by a wave of freezing air.", victim, nullptr, ch, TO_CHAR);
+		act("$N attempts to throw $n, but is stopped by a wave of freezing air.", victim, nullptr, ch, TO_NOTVICT);
+		act("You attempt to throw $n, but are seared by a wave of freezing air.", victim, nullptr, ch, TO_VICT);
 		(*skill_table[gsn_chill].spell_fun)(gsn_chill, ch->level, victim, ch, CastMode::Spell);
 
 		WAIT_STATE(ch, PULSE_VIOLENCE * 2);
@@ -6917,9 +6917,9 @@ void do_throw(CHAR_DATA *ch, char *argument)
 		else
 			dam = 72;
 
-		act("$n grabs $N and throws $M to the ground with stunning force!", ch, 0, victim, TO_NOTVICT);
-		act("You grab $N and throw $M to the ground with stunning force!", ch, 0, victim, TO_CHAR);
-		act("$n grabs you and throws you to the ground with stunning force!", ch, 0, victim, TO_VICT);
+		act("$n grabs $N and throws $M to the ground with stunning force!", ch, nullptr, victim, TO_NOTVICT);
+		act("You grab $N and throw $M to the ground with stunning force!", ch, nullptr, victim, TO_CHAR);
+		act("$n grabs you and throws you to the ground with stunning force!", ch, nullptr, victim, TO_VICT);
 
 		dam += str_app[get_curr_stat(ch, STAT_STR)].todam;
 		check_improve(ch, gsn_throw, true, 3);
@@ -6985,9 +6985,9 @@ void do_nerve(CHAR_DATA *ch, char *argument)
 
 	if (number_percent() > chance)
 	{
-		act("$n grasps $N's arm but fails to apply the right pressure point.", ch, 0, victim, TO_NOTVICT);
-		act("You grasp $N's arm but fail to apply the right pressure point.", ch, 0, victim, TO_CHAR);
-		act("$n grasps your arm but fails to apply the right pressure point.", ch, 0, victim, TO_VICT);
+		act("$n grasps $N's arm but fails to apply the right pressure point.", ch, nullptr, victim, TO_NOTVICT);
+		act("You grasp $N's arm but fail to apply the right pressure point.", ch, nullptr, victim, TO_CHAR);
+		act("$n grasps your arm but fails to apply the right pressure point.", ch, nullptr, victim, TO_VICT);
 
 		check_improve(ch, gsn_nerve, false, 3);
 		WAIT_STATE(ch, PULSE_VIOLENCE);
@@ -6995,9 +6995,9 @@ void do_nerve(CHAR_DATA *ch, char *argument)
 	}
 	else
 	{
-		act("$n grasps $N's arm and weakens $m with pressure points.", ch, 0, victim, TO_NOTVICT);
-		act("You grasp $N's arm and weaken $m with pressure points.", ch, 0, victim, TO_CHAR);
-		act("$n grasps your arm and weakens you with pressure point.", ch, 0, victim, TO_VICT);
+		act("$n grasps $N's arm and weakens $m with pressure points.", ch, nullptr, victim, TO_NOTVICT);
+		act("You grasp $N's arm and weaken $m with pressure points.", ch, nullptr, victim, TO_CHAR);
+		act("$n grasps your arm and weakens you with pressure point.", ch, nullptr, victim, TO_VICT);
 		check_improve(ch, gsn_nerve, true, 3);
 
 		init_affect(&af);
@@ -7097,7 +7097,7 @@ void do_blindness_dust(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 
 	if (number_percent() > chance)
 	{
-		act("$n hurls some dust into the air but it is blown away.", ch, 0, 0, TO_ROOM);
+		act("$n hurls some dust into the air but it is blown away.", ch, nullptr, nullptr, TO_ROOM);
 		send_to_char("You throw out some dust but it is blown away.\n\r", ch);
 		ch->mana -= 9;
 		check_improve(ch, gsn_blindness_dust, false, 2);
@@ -7106,7 +7106,7 @@ void do_blindness_dust(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 		return;
 	}
 
-	act("$n hurls a handful of dust into the room!", ch, 0, 0, TO_ROOM);
+	act("$n hurls a handful of dust into the room!", ch, nullptr, nullptr, TO_ROOM);
 	send_to_char("You throw a handful of blindness dust into the room!\n\r", ch);
 	check_improve(ch, gsn_blindness_dust, true, 2);
 
@@ -7141,7 +7141,7 @@ void do_blindness_dust(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 
 		if (!is_affected_by(vch, AFF_BLIND) && !saves_spell(ch->level, vch, DAM_OTHER))
 		{
-			act("$n appears blinded.", vch, 0, 0, TO_ROOM);
+			act("$n appears blinded.", vch, nullptr, nullptr, TO_ROOM);
 			send_to_char("You get dust in your eyes.\n\r", vch);
 			affect_to_char(vch, &af);
 		}
@@ -7183,7 +7183,7 @@ void do_poison_dust(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 
 	if (number_percent() > chance)
 	{
-		act("$n hurls some dust into the air but it is blown away.", ch, 0, 0, TO_ROOM);
+		act("$n hurls some dust into the air but it is blown away.", ch, nullptr, nullptr, TO_ROOM);
 		send_to_char("You throw out some dust but it is blown away.\n\r", ch);
 		ch->mana -= 10;
 
@@ -7192,7 +7192,7 @@ void do_poison_dust(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 		return;
 	}
 
-	act("$n hurls a handful of dust into the room!", ch, 0, 0, TO_ROOM);
+	act("$n hurls a handful of dust into the room!", ch, nullptr, nullptr, TO_ROOM);
 	send_to_char("You throw a handful of poison dust into the room!\n\r", ch);
 	check_improve(ch, gsn_poison_dust, true, 2);
 
@@ -7229,7 +7229,7 @@ void do_poison_dust(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 
 		if (!is_affected_by(vch, AFF_POISON) && !saves_spell(ch->level, vch, DAM_POISON))
 		{
-			act("$n turns green and looks sick.", vch, 0, 0, TO_ROOM);
+			act("$n turns green and looks sick.", vch, nullptr, nullptr, TO_ROOM);
 			send_to_char("You suddenly feel very sick.\n\r", vch);
 			affect_to_char(vch, &af);
 		}
@@ -7272,7 +7272,7 @@ void do_warcry(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 	}
 	if (number_percent() > chance)
 	{
-		act("$n makes some soft grunting noises.", ch, 0, 0, TO_ROOM);
+		act("$n makes some soft grunting noises.", ch, nullptr, nullptr, TO_ROOM);
 		send_to_char("You make soft grunting sounds but nothing happens.\n\r", ch);
 		check_improve(ch, gsn_warcry, false, 2);
 		ch->mana -= 10;
@@ -7281,7 +7281,7 @@ void do_warcry(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 		return;
 	}
 
-	act("$n lets out a blood freezing warcry!", ch, 0, 0, TO_ROOM);
+	act("$n lets out a blood freezing warcry!", ch, nullptr, nullptr, TO_ROOM);
 	send_to_char("You let out a fierce warcry!\n\r", ch);
 	check_improve(ch, gsn_warcry, true, 2);
 
@@ -7414,8 +7414,8 @@ void do_strangle(CHAR_DATA *ch, char *argument)
 		return;
 	}
 
-	act("$n grabs hold of $N's neck and puts them to sleep.", ch, 0, victim, TO_NOTVICT);
-	act("You grab hold of $N's neck and put them to sleep.", ch, 0, victim, TO_CHAR);
+	act("$n grabs hold of $N's neck and puts them to sleep.", ch, nullptr, victim, TO_NOTVICT);
+	act("You grab hold of $N's neck and put them to sleep.", ch, nullptr, victim, TO_CHAR);
 	send_to_char("Someone grabs hold of your neck and puts you to sleep.\n\r", victim);
 	affect_to_char(victim, &af);
 
@@ -7532,8 +7532,8 @@ void do_enlist(CHAR_DATA *ch, char *argument)
 	af.duration = 15;
 	affect_to_char(ch, &af);
 
-	act("$N salutes you and prepares to follow into combat.", ch, 0, victim, TO_CHAR);
-	act("$N salutes $n and falls into line with $s.", ch, 0, victim, TO_NOTVICT);
+	act("$N salutes you and prepares to follow into combat.", ch, nullptr, victim, TO_CHAR);
+	act("$N salutes $n and falls into line with $s.", ch, nullptr, victim, TO_NOTVICT);
 }
 
 void do_tame(CHAR_DATA *ch, char *argument)
@@ -7576,16 +7576,16 @@ void do_tame(CHAR_DATA *ch, char *argument)
 
 	if (number_percent() > chance)
 	{
-		act("$n tries to calm down $N but fails.", ch, 0, victim, TO_NOTVICT);
-		act("$n tries to calm you down but fails.", ch, 0, victim, TO_VICT);
-		act("You try to calm $N down but fail.", ch, 0, victim, TO_CHAR);
+		act("$n tries to calm down $N but fails.", ch, nullptr, victim, TO_NOTVICT);
+		act("$n tries to calm you down but fails.", ch, nullptr, victim, TO_VICT);
+		act("You try to calm $N down but fail.", ch, nullptr, victim, TO_CHAR);
 		check_improve(ch, gsn_tame, false, 2);
 		return;
 	}
 
-	act("$n calms $N down.", ch, 0, victim, TO_NOTVICT);
-	act("You calm $N down.", ch, 0, victim, TO_CHAR);
-	act("$n calms you down.", ch, 0, victim, TO_VICT);
+	act("$n calms $N down.", ch, nullptr, victim, TO_NOTVICT);
+	act("You calm $N down.", ch, nullptr, victim, TO_CHAR);
+	act("$n calms you down.", ch, nullptr, victim, TO_VICT);
 
 	check_improve(ch, gsn_tame, true, 2);
 	stop_fighting(victim, true);
@@ -7624,7 +7624,7 @@ void do_find_water(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 
 	if (number_percent() > chance)
 	{
-		act("$n pokes the ground with a stick then scratches $s head.", ch, 0, 0, TO_ROOM);
+		act("$n pokes the ground with a stick then scratches $s head.", ch, nullptr, nullptr, TO_ROOM);
 		send_to_char("You poke about on the ground but fail to find any water.\n\r", ch);
 		check_improve(ch, gsn_find_water, false, 1);
 		ch->mana -= 7;
@@ -7633,7 +7633,7 @@ void do_find_water(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 		return;
 	}
 
-	act("$n pokes at the ground and digs up a spring of natural water!", ch, 0, 0, TO_ROOM);
+	act("$n pokes at the ground and digs up a spring of natural water!", ch, nullptr, nullptr, TO_ROOM);
 	send_to_char("You poke about for a bit and eventually dig up a spring of water.\n\r", ch);
 
 	WAIT_STATE(ch, 18);
@@ -7728,9 +7728,9 @@ void do_shield_cleave(CHAR_DATA *ch, char *argument)
 
 	if (number_percent() > chance)
 	{
-		act("$n makes a might blow at $N's shield but fails to cleave it.", ch, 0, victim, TO_NOTVICT);
-		act("$n lands a mighty blow to your shield but fails to cleave it.", ch, 0, victim, TO_VICT);
-		act("You strike a mighty blow to $N's shield but fail to cleave it.", ch, 0, victim, TO_CHAR);
+		act("$n makes a might blow at $N's shield but fails to cleave it.", ch, nullptr, victim, TO_NOTVICT);
+		act("$n lands a mighty blow to your shield but fails to cleave it.", ch, nullptr, victim, TO_VICT);
+		act("You strike a mighty blow to $N's shield but fail to cleave it.", ch, nullptr, victim, TO_CHAR);
 		check_improve(ch, gsn_shield_cleave, false, 1);
 
 		WAIT_STATE(ch, 12);
@@ -7738,9 +7738,9 @@ void do_shield_cleave(CHAR_DATA *ch, char *argument)
 		return;
 	}
 
-	act("$n's mighty blow cleaves $N's shield in half!", ch, 0, victim, TO_NOTVICT);
-	act("Your mighty blow cleaves $N's shield in half!", ch, 0, victim, TO_CHAR);
-	act("$n strikes your shield with powerful force, cleaving it in two!", ch, 0, victim, TO_VICT);
+	act("$n's mighty blow cleaves $N's shield in half!", ch, nullptr, victim, TO_NOTVICT);
+	act("Your mighty blow cleaves $N's shield in half!", ch, nullptr, victim, TO_CHAR);
+	act("$n strikes your shield with powerful force, cleaving it in two!", ch, nullptr, victim, TO_VICT);
 	extract_obj(shield);
 
 	WAIT_STATE(ch, 12);
@@ -7755,12 +7755,12 @@ void bag_explode(CHAR_DATA *ch, OBJ_DATA *obj, int everyone)
 	CHAR_DATA *vch;
 	CHAR_DATA *vch_next;
 
-	act("\x01B[1;31mA small bag of explosives detonates in a blinding flash of light!\x01B[0;37m", ch, obj, 0, TO_ROOM);
-	act("\x01B[1;31mA small bag of explosives detonates in a blinding flash of light!\x01B[0;37m", ch, obj, 0, TO_CHAR);
+	act("\x01B[1;31mA small bag of explosives detonates in a blinding flash of light!\x01B[0;37m", ch, obj, nullptr, TO_ROOM);
+	act("\x01B[1;31mA small bag of explosives detonates in a blinding flash of light!\x01B[0;37m", ch, obj, nullptr, TO_CHAR);
 
 	if (everyone == 3)
 	{
-		act("$n EXPLODES in an eruption of blood and fluids!", ch, 0, 0, TO_ROOM);
+		act("$n EXPLODES in an eruption of blood and fluids!", ch, nullptr, nullptr, TO_ROOM);
 		send_to_char("You have EXPLODED!!\n\r", ch);
 		unequip_char(ch, obj, true);
 		extract_obj(obj);
@@ -7774,7 +7774,7 @@ void bag_explode(CHAR_DATA *ch, OBJ_DATA *obj, int everyone)
 			if (vch == ch)
 				continue;
 
-			act("$n EXPLODES in an eruption of blood and fluids!", vch, 0, 0, TO_ROOM);
+			act("$n EXPLODES in an eruption of blood and fluids!", vch, nullptr, nullptr, TO_ROOM);
 			send_to_char("You have EXPLODED!!\n\r", vch);
 			raw_kill(ch, vch);
 		}
@@ -7784,7 +7784,7 @@ void bag_explode(CHAR_DATA *ch, OBJ_DATA *obj, int everyone)
 
 		unequip_char(ch, obj, true);
 		extract_obj(obj);
-		act("$n EXPLODES in an eruption of blood and fluids!", ch, 0, 0, TO_ROOM);
+		act("$n EXPLODES in an eruption of blood and fluids!", ch, nullptr, nullptr, TO_ROOM);
 		send_to_char("You have EXPLODED!!\n\r", ch);
 		raw_kill(ch, ch);
 	}
@@ -7854,14 +7854,14 @@ void do_forage(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 
 	if (number_percent() > chance)
 	{
-		act("$n messes about in the undergrowth but comes up looking perplexed.", ch, 0, 0, TO_ROOM);
+		act("$n messes about in the undergrowth but comes up looking perplexed.", ch, nullptr, nullptr, TO_ROOM);
 		send_to_char("You search around but find nothing you can recognise as edible.\n\r", ch);
 		check_improve(ch, gsn_forage, false, 2);
 		WAIT_STATE(ch, 12);
 		return;
 	}
 
-	act("$n messes about in the nearby bushes and comes out with some berries.", ch, 0, 0, TO_ROOM);
+	act("$n messes about in the nearby bushes and comes out with some berries.", ch, nullptr, nullptr, TO_ROOM);
 	send_to_char("You search around and find some edible berries in the bushes.\n\r", ch);
 	check_improve(ch, gsn_forage, true, 2);
 
@@ -7943,13 +7943,13 @@ void do_defend(CHAR_DATA *ch, char *argument)
 
 	if (ward != nullptr)
 	{
-		act("You stop defending $N.", ch, 0, ward, TO_CHAR);
-		act("$n stops defending you.", ch, 0, ward, TO_VICT);
+		act("You stop defending $N.", ch, nullptr, ward, TO_CHAR);
+		act("$n stops defending you.", ch, nullptr, ward, TO_VICT);
 	}
 
-	act("You start defending $N.\n\r", ch, 0, victim, TO_CHAR);
+	act("You start defending $N.\n\r", ch, nullptr, victim, TO_CHAR);
 	ch->defending = victim->self;
-	act("$n is now defending you.", ch, 0, victim, TO_VICT);
+	act("$n is now defending you.", ch, nullptr, victim, TO_VICT);
 }
 
 void do_intimidate(CHAR_DATA *ch, char *argument)
@@ -8003,14 +8003,14 @@ void do_intimidate(CHAR_DATA *ch, char *argument)
 
 	if (number_percent() > chance)
 	{
-		act("$n tries to intimidate $N into submission but just makes a fool of $mself.", ch, 0, victim, TO_NOTVICT);
-		act("You try to intimidate $N into submission but just make a fool of yourself.", ch, 0, victim, TO_CHAR);
+		act("$n tries to intimidate $N into submission but just makes a fool of $mself.", ch, nullptr, victim, TO_NOTVICT);
+		act("You try to intimidate $N into submission but just make a fool of yourself.", ch, nullptr, victim, TO_CHAR);
 		check_improve(ch, gsn_intimidate, false, 1);
 		return;
 	}
 
-	act("$n stares down $N with $s overwhelming presence.", ch, 0, victim, TO_NOTVICT);
-	act("You stare down $N with your overwhelming presence.", ch, 0, victim, TO_CHAR);
+	act("$n stares down $N with $s overwhelming presence.", ch, nullptr, victim, TO_NOTVICT);
+	act("You stare down $N with your overwhelming presence.", ch, nullptr, victim, TO_CHAR);
 
 	check_improve(ch, gsn_intimidate, true, 1);
 	stop_fighting(victim, true);
@@ -8042,8 +8042,8 @@ void do_flee(CHAR_DATA *ch, char *argument)
 
 	if (check_bind(ch, "legs"))
 	{
-		act("$n attempts to flee but $s bindings cause $m to trip up and fall!", ch, 0, 0, TO_ROOM);
-		act("You attempt to flee but your bindings cause you to trip up and fall!", ch, 0, 0, TO_CHAR);
+		act("$n attempts to flee but $s bindings cause $m to trip up and fall!", ch, nullptr, nullptr, TO_ROOM);
+		act("You attempt to flee but your bindings cause you to trip up and fall!", ch, nullptr, nullptr, TO_CHAR);
 		WAIT_STATE(ch, PULSE_VIOLENCE);
 		check_parting_blow(ch, victim);
 		return;
@@ -8060,8 +8060,8 @@ void do_flee(CHAR_DATA *ch, char *argument)
 
 	if (is_affected(ch, gsn_web) && number_percent() > 60)
 	{
-		act("$n tries to flee, but the webs $e's entangled in cause $m to trip up and fall!", ch, 0, 0, TO_ROOM);
-		act("You try to flee, but the webs you are entangled in cause you to trip up and fall!", ch, 0, 0, TO_CHAR);
+		act("$n tries to flee, but the webs $e's entangled in cause $m to trip up and fall!", ch, nullptr, nullptr, TO_ROOM);
+		act("You try to flee, but the webs you are entangled in cause you to trip up and fall!", ch, nullptr, nullptr, TO_CHAR);
 		check_parting_blow(ch, victim);
 		WAIT_STATE(ch, PULSE_VIOLENCE);
 		return;
@@ -8173,14 +8173,14 @@ void do_flee(CHAR_DATA *ch, char *argument)
 
 		if (panther && pounced && !is_npc(panther))
 		{
-			act("$n unleashes a loud roar and leaps after $N!", panther, 0, ch, TO_NOTVICT);
-			act("Sensing $n's fear as $e turns to flee, you roar and leap after $m!", ch, 0, panther, TO_VICT);
+			act("$n unleashes a loud roar and leaps after $N!", panther, nullptr, ch, TO_NOTVICT);
+			act("Sensing $n's fear as $e turns to flee, you roar and leap after $m!", ch, nullptr, panther, TO_VICT);
 		}
 
 		/*
 		if(panther && is_npc(panther))
 		{
-			act("$n flees the room, $N still stuck to $s face!",ch,0,panther,TO_NOTVICT);
+			act("$n flees the room, $N still stuck to $s face!",ch,nullptr,panther,TO_NOTVICT);
 		}
 		*/
 
@@ -8194,9 +8194,9 @@ void do_flee(CHAR_DATA *ch, char *argument)
 				return;
 
 			if (!is_npc(panther))
-				act("$n chases $N into the room, leaping upon $M!", panther, 0, ch, TO_NOTVICT);
+				act("$n chases $N into the room, leaping upon $M!", panther, nullptr, ch, TO_NOTVICT);
 			else
-				act("$n runs into the room screaming, $N latched to $s face!", ch, 0, panther, TO_NOTVICT);
+				act("$n runs into the room screaming, $N latched to $s face!", ch, nullptr, panther, TO_NOTVICT);
 
 			send_to_char("You flee, but the worm is still attached to your face!\n\r", ch);
 			WAIT_STATE(ch, PULSE_VIOLENCE);
@@ -8303,10 +8303,10 @@ void do_assassinate(CHAR_DATA *ch, char *argument)
 	if (chance > 6)
 		chance = 5;
 
-	act("$n tries to strike at $N's critical nerves!", ch, 0, victim, TO_NOTVICT);
-	act("You try to strike $N's critical nerves!", ch, 0, victim, TO_CHAR);
+	act("$n tries to strike at $N's critical nerves!", ch, nullptr, victim, TO_NOTVICT);
+	act("You try to strike $N's critical nerves!", ch, nullptr, victim, TO_CHAR);
 
-	/*        act("$n strikes at your critical nerves!",ch,0,victim,TO_VICT); */
+	/*        act("$n strikes at your critical nerves!",ch,nullptr,victim,TO_VICT); */
 
 	if (ch->level == MAX_LEVEL)
 	{
@@ -8315,9 +8315,9 @@ void do_assassinate(CHAR_DATA *ch, char *argument)
 
 	if (number_percent() < chance)
 	{
-		act("$n +++ ASSASSINATES +++ $N!", ch, 0, victim, TO_NOTVICT);
-		act("You +++ ASSASSINATE +++ $N!", ch, 0, victim, TO_CHAR);
-		act_new("$n +++ ASSASSINATES +++ you!", ch, 0, victim, TO_VICT, POS_DEAD);
+		act("$n +++ ASSASSINATES +++ $N!", ch, nullptr, victim, TO_NOTVICT);
+		act("You +++ ASSASSINATE +++ $N!", ch, nullptr, victim, TO_CHAR);
+		act_new("$n +++ ASSASSINATES +++ you!", ch, nullptr, victim, TO_VICT, POS_DEAD);
 		raw_kill(ch, victim);
 		check_improve(ch, gsn_assassinate, true, 3);
 		return;
@@ -8449,9 +8449,9 @@ void do_lash(CHAR_DATA *ch, char *argument)
 
 	if (number_percent() > chance)
 	{
-		act("$n lashes at $N's legs but misses.", ch, 0, victim, TO_NOTVICT);
-		act("$n lashes at your legs but misses.", ch, 0, victim, TO_VICT);
-		act("You lash at $N's legs but miss.", ch, 0, victim, TO_CHAR);
+		act("$n lashes at $N's legs but misses.", ch, nullptr, victim, TO_NOTVICT);
+		act("$n lashes at your legs but misses.", ch, nullptr, victim, TO_VICT);
+		act("You lash at $N's legs but miss.", ch, nullptr, victim, TO_CHAR);
 		check_improve(ch, gsn_lash, false, 1);
 
 		if (Deref(ch->fighting) == nullptr)
@@ -8461,9 +8461,9 @@ void do_lash(CHAR_DATA *ch, char *argument)
 		return;
 	}
 
-	act("$n lashes $N's legs, sending $M crashing down.", ch, 0, victim, TO_NOTVICT);
-	act("$n lashes your legs, sending you crashing to the ground.", ch, 0, victim, TO_VICT);
-	act("You lash $N's legs, sending $M crashing to the ground.", ch, 0, victim, TO_CHAR);
+	act("$n lashes $N's legs, sending $M crashing down.", ch, nullptr, victim, TO_NOTVICT);
+	act("$n lashes your legs, sending you crashing to the ground.", ch, nullptr, victim, TO_VICT);
+	act("You lash $N's legs, sending $M crashing to the ground.", ch, nullptr, victim, TO_CHAR);
 	check_improve(ch, gsn_lash, true, 1);
 
 	LAG_CHAR(victim, (int)(PULSE_VIOLENCE * 1.5));
@@ -8799,9 +8799,9 @@ bool check_parting_blow(CHAR_DATA *ch, CHAR_DATA *victim)
 
 	if (number_percent() < get_skill(victim, gsn_parting_blow))
 	{
-		act("You get in one more shot as $N flees.", victim, 0, ch, TO_CHAR);
-		act("$n gets in one more shot as $N flees.", victim, 0, ch, TO_NOTVICT);
-		act("$n gets in one more shot as you flee.", victim, 0, ch, TO_VICT);
+		act("You get in one more shot as $N flees.", victim, nullptr, ch, TO_CHAR);
+		act("$n gets in one more shot as $N flees.", victim, nullptr, ch, TO_NOTVICT);
+		act("$n gets in one more shot as you flee.", victim, nullptr, ch, TO_VICT);
 
 		check_improve(victim, gsn_parting_blow, true, 1);
 
@@ -8836,9 +8836,9 @@ bool check_blade_barrier(CHAR_DATA *ch, CHAR_DATA *victim)
 
 	if (is_affected(victim, gsn_blade_barrier))
 	{
-		act("Your blade barrier tears into $N's flesh before fading away into nothingness.", victim, 0, ch, TO_CHAR);
-		act("$n's blade barrier tears into $N's flesh before fading away into nothingness.", victim, 0, ch, TO_NOTVICT);
-		act("$n's blade barrier tears into your flesh before fading away into nothingness.", victim, 0, ch, TO_VICT);
+		act("Your blade barrier tears into $N's flesh before fading away into nothingness.", victim, nullptr, ch, TO_CHAR);
+		act("$n's blade barrier tears into $N's flesh before fading away into nothingness.", victim, nullptr, ch, TO_NOTVICT);
+		act("$n's blade barrier tears into your flesh before fading away into nothingness.", victim, nullptr, ch, TO_VICT);
 		damage_old(victim, ch, dice(victim->level, 5), gsn_blade_barrier, DAM_SLASH, true);
 		affect_strip(victim, gsn_blade_barrier);
 		return true;
@@ -8948,9 +8948,9 @@ bool check_catch(CHAR_DATA *ch, CHAR_DATA *victim, OBJ_DATA *obj)
 
 	if (number_percent() > (chance * .9))
 	{
-		act("You attempt to grab $N's disarmed weapon, but fail to catch it.", ch, 0, victim, TO_CHAR);
-		act("$n tries to catch your weapon as it falls to the ground.", ch, 0, victim, TO_VICT);
-		act("$n attempts to grab for $N's disarmed weapon, but fails to catch it!", ch, 0, victim, TO_NOTVICT);
+		act("You attempt to grab $N's disarmed weapon, but fail to catch it.", ch, nullptr, victim, TO_CHAR);
+		act("$n tries to catch your weapon as it falls to the ground.", ch, nullptr, victim, TO_VICT);
+		act("$n attempts to grab for $N's disarmed weapon, but fails to catch it!", ch, nullptr, victim, TO_NOTVICT);
 		return false;
 	}
 	else
@@ -9050,14 +9050,14 @@ void trophy_corpse(CHAR_DATA *ch, CHAR_DATA *victim)
 
 	if (number_percent() > get_skill(ch, gsn_trophy) + 8)
 	{
-		act("You mangle $N's scalp beyond repair in your attempt to trophy it, and throw it away in disgust.", ch, 0, victim, TO_CHAR);
-		act("$n mangles $N's scalp beyond repair in $s attempt to trophy it, and throws it away in disgust.", ch, 0, victim, TO_NOTVICT);
+		act("You mangle $N's scalp beyond repair in your attempt to trophy it, and throw it away in disgust.", ch, nullptr, victim, TO_CHAR);
+		act("$n mangles $N's scalp beyond repair in $s attempt to trophy it, and throws it away in disgust.", ch, nullptr, victim, TO_NOTVICT);
 		check_improve(ch, gsn_trophy, false, 1);
 		return;
 	}
 
-	act("With a smooth stroke, you slice $N's scalp cleanly from $S head, attaching it to your belt!", ch, 0, victim, TO_CHAR);
-	act("$n smoothly slices $N's scalp from $S head and attaches it to $s belt!", ch, 0, victim, TO_NOTVICT);
+	act("With a smooth stroke, you slice $N's scalp cleanly from $S head, attaching it to your belt!", ch, nullptr, victim, TO_CHAR);
+	act("$n smoothly slices $N's scalp from $S head and attaches it to $s belt!", ch, nullptr, victim, TO_NOTVICT);
 	check_improve(ch, gsn_trophy, true, 1);
 
 	if (ch->pcdata->trophy.empty())
@@ -9302,9 +9302,9 @@ void do_gore(CHAR_DATA *ch, char *argument)
 
 	if (number_percent() < 0.7 * skill)
 	{
-		act("Charging furiously, you ram into $N, goring $M with your horns!", ch, 0, victim, TO_CHAR);
-		act("Charging furiously, $n rams into you, goring you with $s horns!", ch, 0, victim, TO_VICT);
-		act("Charging furiously, $n rams into $N, goring $M with $s horns!", ch, 0, victim, TO_NOTVICT);
+		act("Charging furiously, you ram into $N, goring $M with your horns!", ch, nullptr, victim, TO_CHAR);
+		act("Charging furiously, $n rams into you, goring you with $s horns!", ch, nullptr, victim, TO_VICT);
+		act("Charging furiously, $n rams into $N, goring $M with $s horns!", ch, nullptr, victim, TO_NOTVICT);
 
 		dam = dice(ch->level, 5);
 
@@ -9312,9 +9312,9 @@ void do_gore(CHAR_DATA *ch, char *argument)
 
 		if (number_percent() < 0.5 * skill && !is_affected(victim, gsn_bleeding))
 		{
-			act("Blood pours from two deep wounds as $n's horns pierce your flesh!", ch, 0, victim, TO_VICT);
-			act("Blood pours from two deep wounds as your horns pierce $N's flesh!", ch, 0, victim, TO_CHAR);
-			act("Blood pours from two deep wounds as $n's horns pierce $N's flesh!", ch, 0, victim, TO_NOTVICT);
+			act("Blood pours from two deep wounds as $n's horns pierce your flesh!", ch, nullptr, victim, TO_VICT);
+			act("Blood pours from two deep wounds as your horns pierce $N's flesh!", ch, nullptr, victim, TO_CHAR);
+			act("Blood pours from two deep wounds as $n's horns pierce $N's flesh!", ch, nullptr, victim, TO_NOTVICT);
 
 			init_affect(&af);
 			af.where = TO_AFFECTS;
@@ -9336,9 +9336,9 @@ void do_gore(CHAR_DATA *ch, char *argument)
 	}
 	else
 	{
-		act("$N avoids your attempt to gore $M, and you go sprawling to the ground!", ch, 0, victim, TO_CHAR);
-		act("You avoid $n's attempt to gore you, and $e goes sprawling to the ground!", ch, 0, victim, TO_VICT);
-		act("$N avoids $n's attempt to gore $M, and $n goes sprawling to the ground!", ch, 0, victim, TO_NOTVICT);
+		act("$N avoids your attempt to gore $M, and you go sprawling to the ground!", ch, nullptr, victim, TO_CHAR);
+		act("You avoid $n's attempt to gore you, and $e goes sprawling to the ground!", ch, nullptr, victim, TO_VICT);
+		act("$N avoids $n's attempt to gore $M, and $n goes sprawling to the ground!", ch, nullptr, victim, TO_NOTVICT);
 
 		damage_new(ch, victim, 0, gsn_gore, DAM_PIERCE, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "goring");
 
@@ -9384,9 +9384,9 @@ void do_headbutt(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 
 	if (skill > (number_percent() + 5))
 	{
-		act("You slam your forehead into $N with bone-jarring force!", ch, 0, victim, TO_CHAR);
-		act("$n brings $s head crashing into yours with a ferocious headbutt!", ch, 0, victim, TO_VICT);
-		act("$n slams $s forehead into $N with bone-jarring force!", ch, 0, victim, TO_NOTVICT);
+		act("You slam your forehead into $N with bone-jarring force!", ch, nullptr, victim, TO_CHAR);
+		act("$n brings $s head crashing into yours with a ferocious headbutt!", ch, nullptr, victim, TO_VICT);
+		act("$n slams $s forehead into $N with bone-jarring force!", ch, nullptr, victim, TO_NOTVICT);
 
 		dam = dice(ch->level / 2, 3);
 
@@ -9394,8 +9394,8 @@ void do_headbutt(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 
 		if (number_percent() < 3 && !IS_SET(victim->imm_flags, IMM_BASH) && !IS_SET(victim->imm_flags, IMM_SLEEP))
 		{
-			act("With the impact, everything suddenly goes black....", victim, 0, 0, TO_CHAR);
-			act("$n staggers back from the collision and then collapses in a heap!", victim, 0, 0, TO_ROOM);
+			act("With the impact, everything suddenly goes black....", victim, nullptr, nullptr, TO_CHAR);
+			act("$n staggers back from the collision and then collapses in a heap!", victim, nullptr, nullptr, TO_ROOM);
 
 			init_affect(&af);
 			af.where = TO_AFFECTS;
@@ -9417,8 +9417,8 @@ void do_headbutt(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 
 		if (number_percent() < 2)
 		{
-			act("With the impact, everything suddenly goes black....", ch, 0, 0, TO_CHAR);
-			act("$n staggers back from the collision and then collapses in a heap!", ch, 0, 0, TO_ROOM);
+			act("With the impact, everything suddenly goes black....", ch, nullptr, nullptr, TO_CHAR);
+			act("$n staggers back from the collision and then collapses in a heap!", ch, nullptr, nullptr, TO_ROOM);
 
 			init_affect(&af);
 			af.where = TO_AFFECTS;
@@ -9441,9 +9441,9 @@ void do_headbutt(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 	}
 	else
 	{
-		act("You look rather foolish as you attempt to headbutt $N, but miss.", ch, 0, victim, TO_CHAR);
-		act("$n brings $s head forward in an attempt to headbutt you, but misses.", ch, 0, victim, TO_VICT);
-		act("$n brings $s head forward in an attempt to headbutt $N, but misses.", ch, 0, victim, TO_NOTVICT);
+		act("You look rather foolish as you attempt to headbutt $N, but miss.", ch, nullptr, victim, TO_CHAR);
+		act("$n brings $s head forward in an attempt to headbutt you, but misses.", ch, nullptr, victim, TO_VICT);
+		act("$n brings $s head forward in an attempt to headbutt $N, but misses.", ch, nullptr, victim, TO_NOTVICT);
 		damage_new(ch, victim, 0, gsn_headbutt, DAM_BASH, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "headbutt");
 		check_improve(ch, gsn_headbutt, false, 3);
 	}
@@ -9469,9 +9469,9 @@ void do_disengage(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 		return;
 	}
 
-	act("You cease attacking $N.", ch, 0, opponent, TO_CHAR);
-	act("$n ceases attacking you.", ch, 0, opponent, TO_VICT);
-	act("$n ceases attacking $N.", ch, 0, opponent, TO_NOTVICT);
+	act("You cease attacking $N.", ch, nullptr, opponent, TO_CHAR);
+	act("$n ceases attacking you.", ch, nullptr, opponent, TO_VICT);
+	act("$n ceases attacking $N.", ch, nullptr, opponent, TO_NOTVICT);
 
 	stop_fighting(ch, false);
 

--- a/code/handler.c
+++ b/code/handler.c
@@ -1318,8 +1318,8 @@ void affect_modify(CHAR_DATA *ch, AFFECT_DATA *paf, bool fAdd)
 		if (disarmed && get_eq_char(ch, WEAR_WIELD) == nullptr)
 		{
 			unequip_char(ch, wield, false);
-			act("You swap $p into your primary hand.", ch, wield, 0, TO_CHAR);
-			act("$n swaps $p into $s primary hand.", ch, wield, 0, TO_ROOM);
+			act("You swap $p into your primary hand.", ch, wield, nullptr, TO_CHAR);
+			act("$n swaps $p into $s primary hand.", ch, wield, nullptr, TO_ROOM);
 			equip_char(ch, wield, WEAR_WIELD, false);
 		}
 	}
@@ -1414,7 +1414,7 @@ void new_affect_to_char(CHAR_DATA *ch, AFFECT_DATA *paf)
 	if (IS_SET(ch->imm_flags, IMM_SLEEP) && IS_SET(paf->bitvector, AFF_SLEEP) && paf->where == TO_AFFECTS)
 	{
 		send_to_char("You are unaffected.\n\r", ch);
-		act("$n is unaffected.", ch, 0, 0, TO_ROOM);
+		act("$n is unaffected.", ch, nullptr, nullptr, TO_ROOM);
 		return;
 	}
 
@@ -1941,10 +1941,10 @@ void equip_char(CHAR_DATA *ch, OBJ_DATA *obj, int iWear, bool show)
 		ch->in_room->light += 3;
 
 	if (show && obj->pIndexData->wear_echo[0] != nullptr)
-		act(palloc_string(obj->pIndexData->wear_echo[0]), ch, obj, 0, TO_CHAR);
+		act(palloc_string(obj->pIndexData->wear_echo[0]), ch, obj, nullptr, TO_CHAR);
 
 	if (show && obj->pIndexData->wear_echo[1] != nullptr)
-		act(palloc_string(obj->pIndexData->wear_echo[1]), ch, obj, 0, TO_ROOM);
+		act(palloc_string(obj->pIndexData->wear_echo[1]), ch, obj, nullptr, TO_ROOM);
 }
 
 /*
@@ -2001,10 +2001,10 @@ void unequip_char(CHAR_DATA *ch, OBJ_DATA *obj, bool show)
 		ch->in_room->light = std::max(0, ch->in_room->light - 3);
 
 	if (show && obj->pIndexData->remove_echo[0] != nullptr)
-		act(palloc_string(obj->pIndexData->remove_echo[0]), ch, obj, 0, TO_CHAR);
+		act(palloc_string(obj->pIndexData->remove_echo[0]), ch, obj, nullptr, TO_CHAR);
 
 	if (show && obj->pIndexData->remove_echo[1] != nullptr)
-		act(palloc_string(obj->pIndexData->remove_echo[1]), ch, obj, 0, TO_ROOM);
+		act(palloc_string(obj->pIndexData->remove_echo[1]), ch, obj, nullptr, TO_ROOM);
 }
 
 /*

--- a/code/handler.c
+++ b/code/handler.c
@@ -942,9 +942,7 @@ int get_curr_stat(CHAR_DATA *ch, int stat)
 int get_max_train(CHAR_DATA *ch, int stat)
 {
 	int max;
-	int iClass;
 
-	iClass = (ch->Class()->GetIndex() + 1);
 
 	if (is_npc(ch) || ch->level > LEVEL_IMMORTAL)
 		return 25;
@@ -1168,10 +1166,8 @@ void init_affect(AFFECT_DATA *paf)
 void affect_modify(CHAR_DATA *ch, AFFECT_DATA *paf, bool fAdd)
 {
 	OBJ_DATA *wield;
-	int mod;
 	bool disarmed= false;
 
-	mod = paf->modifier;
 
 	if (fAdd)
 	{
@@ -1862,9 +1858,7 @@ bool is_worn(OBJ_DATA *obj)
 void equip_char(CHAR_DATA *ch, OBJ_DATA *obj, int iWear, bool show)
 {
 	int i;
-	bool status;
 
-	status= false;
 	if (iWear != WEAR_COSMETIC && get_eq_char(ch, iWear) != nullptr)
 	{
 		RS.Logger.Warn("Equip_char: already equipped ({}) -- {} -- {}.", iWear, ch->name, ch->in_room->area->file_name);

--- a/code/handler.c
+++ b/code/handler.c
@@ -1616,15 +1616,16 @@ void char_from_room(CHAR_DATA *ch)
 	ch->next_in_room = nullptr;
 	ch->on = nullptr; /* sanity check! */
 
-	if (is_affected_room(prev_room, gsn_gravity_well))
-	{
-		af = affect_find_room(prev_room->affected, gsn_gravity_well);
+	af = affect_find_room(prev_room->affected, gsn_gravity_well);
 
-		if (ch == Deref(af->owner))
-			gravity_well_explode(prev_room, af);
-	}
+	if (af != nullptr && ch == Deref(af->owner))
+		gravity_well_explode(prev_room, af);
+
 	if (!is_affected(ch, gsn_pull) && (check_entwine(ch, 1) || check_entwine(ch, 2)))
 	{
+		// check_entwine(1) and check_entwine(2) together ask exactly what this
+		// search asks, so a miss means the two have drifted apart rather than
+		// that the character is not entwined.
 		aaf = nullptr;
 		for (auto &aaf_elem : ch->affected)
 		{
@@ -1635,7 +1636,12 @@ void char_from_room(CHAR_DATA *ch)
 			}
 		}
 
-		do_uncoil(Deref(aaf->owner), "automagic");
+		// The coiler can be gone while the wire is still on. do_uncoil reads the
+		// character it is handed, so there is nothing to hand it.
+		CHAR_DATA *coiler = aaf != nullptr ? Deref(aaf->owner) : nullptr;
+
+		if (coiler != nullptr)
+			do_uncoil(coiler, "automagic");
 	}
 	else if (!is_affected(ch, gsn_pull) && check_entwine(ch, 0))
 	{

--- a/code/interp.c
+++ b/code/interp.c
@@ -105,7 +105,7 @@ bool fLogAll= false;
 /*
  * Command table.
  */
-const struct cmd_type cmd_table[] = {
+constexpr struct cmd_type cmd_table[] = {
 	/*
 	 * Common movement commands.
 	 */
@@ -728,10 +728,10 @@ void interpret(CHAR_DATA *ch, char *argument)
 	found= false;
 	trust = get_trust(ch);
 
-	for (cmd = 0; cmd_table[cmd].name[0] != '\0'; cmd++)
+	for (cmd = 0; !cmd_table[cmd].name.empty(); cmd++)
 	{
 		if (command[0] == cmd_table[cmd].name[0]
-			&& !str_prefix(command, cmd_table[cmd].name)
+			&& !str_prefix(command, cmd_table[cmd].name.data())
 			&& cmd_table[cmd].level <= trust
 			&& knows_command(ch, cmd))
 		{
@@ -781,8 +781,8 @@ void interpret(CHAR_DATA *ch, char *argument)
 	if (!is_npc(ch)
 		&& (is_affected(ch, gsn_hold_person) || ch->pcdata->energy_state < -4)
 		&& get_trust(ch) < MAX_LEVEL
-		&& str_cmp(cmd_table[cmd].name, "immtalk")
-		&& str_cmp(cmd_table[cmd].name, "astrip"))
+		&& cmd_table[cmd].name != "immtalk"
+		&& cmd_table[cmd].name != "astrip")
 	{
 		send_to_char("You are totally frozen!\n\r", ch);
 		return;
@@ -792,7 +792,7 @@ void interpret(CHAR_DATA *ch, char *argument)
 	{
 		paf = affect_find(ch->affected, gsn_creeping_tomb);
 		
-		if (paf->duration <= 2 && (str_cmp(cmd_table[cmd].name, "astrip")) && (str_cmp(cmd_table[cmd].name, "immtalk")))
+		if (paf->duration <= 2 && (cmd_table[cmd].name != "astrip") && (cmd_table[cmd].name != "immtalk"))
 		{
 			send_to_char("You are entombed in ooze and cannot move.\n\r", ch);
 			return;
@@ -808,29 +808,29 @@ void interpret(CHAR_DATA *ch, char *argument)
 	}
 
 	if (is_affected(ch, gsn_ultradiffusion)
-		&& str_cmp(cmd_table[cmd].name, "visible")
-		&& str_cmp(cmd_table[cmd].name, "score")
-		&& str_cmp(cmd_table[cmd].name, "look")
-		&& str_cmp(cmd_table[cmd].name, "who")
-		&& str_cmp(cmd_table[cmd].name, "where")
-		&& str_cmp(cmd_table[cmd].name, "affects")
-		&& str_cmp(cmd_table[cmd].name, "group")
-		&& str_cmp(cmd_table[cmd].name, "gt")
-		&& str_cmp(cmd_table[cmd].name, "gtell")
-		&& str_cmp(cmd_table[cmd].name, "tell")
-		&& str_cmp(cmd_table[cmd].name, "reply")
-		&& str_cmp(cmd_table[cmd].name, "north")
-		&& str_cmp(cmd_table[cmd].name, "east")
-		&& str_cmp(cmd_table[cmd].name, "south")
-		&& str_cmp(cmd_table[cmd].name, "west")
-		&& str_cmp(cmd_table[cmd].name, "up")
-		&& str_cmp(cmd_table[cmd].name, "down")
-		&& str_cmp(cmd_table[cmd].name, "equipment")
-		&& str_cmp(cmd_table[cmd].name, "skills")
-		&& str_cmp(cmd_table[cmd].name, "save")
-		&& str_cmp(cmd_table[cmd].name, "skills")
-		&& str_cmp(cmd_table[cmd].name, "spells")
-		&& str_cmp(cmd_table[cmd].name, "pray")
+		&& cmd_table[cmd].name != "visible"
+		&& cmd_table[cmd].name != "score"
+		&& cmd_table[cmd].name != "look"
+		&& cmd_table[cmd].name != "who"
+		&& cmd_table[cmd].name != "where"
+		&& cmd_table[cmd].name != "affects"
+		&& cmd_table[cmd].name != "group"
+		&& cmd_table[cmd].name != "gt"
+		&& cmd_table[cmd].name != "gtell"
+		&& cmd_table[cmd].name != "tell"
+		&& cmd_table[cmd].name != "reply"
+		&& cmd_table[cmd].name != "north"
+		&& cmd_table[cmd].name != "east"
+		&& cmd_table[cmd].name != "south"
+		&& cmd_table[cmd].name != "west"
+		&& cmd_table[cmd].name != "up"
+		&& cmd_table[cmd].name != "down"
+		&& cmd_table[cmd].name != "equipment"
+		&& cmd_table[cmd].name != "skills"
+		&& cmd_table[cmd].name != "save"
+		&& cmd_table[cmd].name != "skills"
+		&& cmd_table[cmd].name != "spells"
+		&& cmd_table[cmd].name != "pray"
 		&& !(cmd_table[cmd].level > LEVEL_HERO))
 	{
 		send_to_char("You cannot do that while your molecules are diffused from your body.\n\r", ch);
@@ -847,53 +847,53 @@ void interpret(CHAR_DATA *ch, char *argument)
 	}
 
 	if (is_affected(ch, gsn_bind_feet)
-		&& str_cmp(cmd_table[cmd].name, "score")
-		&& str_cmp(cmd_table[cmd].name, "look")
-		&& str_cmp(cmd_table[cmd].name, "glance")
-		&& str_cmp(cmd_table[cmd].name, "examine")
-		&& str_cmp(cmd_table[cmd].name, "get")
-		&& str_cmp(cmd_table[cmd].name, "wear")
-		&& str_cmp(cmd_table[cmd].name, "remove")
-		&& str_cmp(cmd_table[cmd].name, "wield")
-		&& str_cmp(cmd_table[cmd].name, "zap")
-		&& str_cmp(cmd_table[cmd].name, "recite")
-		&& str_cmp(cmd_table[cmd].name, "brandish")
-		&& str_cmp(cmd_table[cmd].name, "invoke")
-		&& str_cmp(cmd_table[cmd].name, "quaff")
-		&& str_cmp(cmd_table[cmd].name, "eat")
-		&& str_cmp(cmd_table[cmd].name, "drink")
-		&& str_cmp(cmd_table[cmd].name, "say")
-		&& str_cmp(cmd_table[cmd].name, "'")
-		&& str_cmp(cmd_table[cmd].name, "tell")
-		&& str_cmp(cmd_table[cmd].name, "whisper")
-		&& str_cmp(cmd_table[cmd].name, "[")
-		&& str_cmp(cmd_table[cmd].name, ";")
-		&& str_cmp(cmd_table[cmd].name, ",")
-		&& str_cmp(cmd_table[cmd].name, "yell")
-		&& str_cmp(cmd_table[cmd].name, "who")
-		&& str_cmp(cmd_table[cmd].name, "where")
-		&& str_cmp(cmd_table[cmd].name, "chess")
-		&& str_cmp(cmd_table[cmd].name, "affects")
-		&& str_cmp(cmd_table[cmd].name, "group")
-		&& str_cmp(cmd_table[cmd].name, "gt")
-		&& str_cmp(cmd_table[cmd].name, "gtell")
-		&& str_cmp(cmd_table[cmd].name, "reply")
-		&& str_cmp(cmd_table[cmd].name, "immtalk")
-		&& str_cmp(cmd_table[cmd].name, "equipment")
-		&& str_cmp(cmd_table[cmd].name, "save")
-		&& str_cmp(cmd_table[cmd].name, "trustgroup")
-		&& str_cmp(cmd_table[cmd].name, "trustall")
-		&& str_cmp(cmd_table[cmd].name, "trustcabal")
-		&& str_cmp(cmd_table[cmd].name, "skills")
-		&& str_cmp(cmd_table[cmd].name, "spells")
-		&& str_cmp(cmd_table[cmd].name, "supplications")
-		&& str_cmp(cmd_table[cmd].name, "powers")
-		&& str_cmp(cmd_table[cmd].name, "pray")
-		&& str_cmp(cmd_table[cmd].name, "cast")
-		&& str_cmp(cmd_table[cmd].name, "commune")
-		&& str_cmp(cmd_table[cmd].name, "cast")
-		&& str_cmp(cmd_table[cmd].name, "astrip")
-		&& str_cmp(cmd_table[cmd].name, "force")
+		&& cmd_table[cmd].name != "score"
+		&& cmd_table[cmd].name != "look"
+		&& cmd_table[cmd].name != "glance"
+		&& cmd_table[cmd].name != "examine"
+		&& cmd_table[cmd].name != "get"
+		&& cmd_table[cmd].name != "wear"
+		&& cmd_table[cmd].name != "remove"
+		&& cmd_table[cmd].name != "wield"
+		&& cmd_table[cmd].name != "zap"
+		&& cmd_table[cmd].name != "recite"
+		&& cmd_table[cmd].name != "brandish"
+		&& cmd_table[cmd].name != "invoke"
+		&& cmd_table[cmd].name != "quaff"
+		&& cmd_table[cmd].name != "eat"
+		&& cmd_table[cmd].name != "drink"
+		&& cmd_table[cmd].name != "say"
+		&& cmd_table[cmd].name != "'"
+		&& cmd_table[cmd].name != "tell"
+		&& cmd_table[cmd].name != "whisper"
+		&& cmd_table[cmd].name != "["
+		&& cmd_table[cmd].name != ";"
+		&& cmd_table[cmd].name != ","
+		&& cmd_table[cmd].name != "yell"
+		&& cmd_table[cmd].name != "who"
+		&& cmd_table[cmd].name != "where"
+		&& cmd_table[cmd].name != "chess"
+		&& cmd_table[cmd].name != "affects"
+		&& cmd_table[cmd].name != "group"
+		&& cmd_table[cmd].name != "gt"
+		&& cmd_table[cmd].name != "gtell"
+		&& cmd_table[cmd].name != "reply"
+		&& cmd_table[cmd].name != "immtalk"
+		&& cmd_table[cmd].name != "equipment"
+		&& cmd_table[cmd].name != "save"
+		&& cmd_table[cmd].name != "trustgroup"
+		&& cmd_table[cmd].name != "trustall"
+		&& cmd_table[cmd].name != "trustcabal"
+		&& cmd_table[cmd].name != "skills"
+		&& cmd_table[cmd].name != "spells"
+		&& cmd_table[cmd].name != "supplications"
+		&& cmd_table[cmd].name != "powers"
+		&& cmd_table[cmd].name != "pray"
+		&& cmd_table[cmd].name != "cast"
+		&& cmd_table[cmd].name != "commune"
+		&& cmd_table[cmd].name != "cast"
+		&& cmd_table[cmd].name != "astrip"
+		&& cmd_table[cmd].name != "force"
 		&& !is_social)
 	{
 		send_to_char("Your feet are rooted to the ground and you cannot move!\n\r", ch);
@@ -984,16 +984,16 @@ void interpret(CHAR_DATA *ch, char *argument)
 		un_hide(ch, nullptr);
 
 	/* Style checks */
-	if (!is_npc(ch) && get_trust(ch) < 60 && ch->pcdata->style && str_cmp(cmd_table[cmd].skill_name, "none"))
+	if (!is_npc(ch) && get_trust(ch) < 60 && ch->pcdata->style && cmd_table[cmd].skill_name != "none")
 	{
-		if (!str_cmp(cmd_table[cmd].skill_name, "none"))
-			sprintf(skill_name, "%s", cmd_table[cmd].name);
+		if (cmd_table[cmd].skill_name == "none")
+			sprintf(skill_name, "%s", cmd_table[cmd].name.data());
 		else
-			sprintf(skill_name, "%s", cmd_table[cmd].skill_name);
+			sprintf(skill_name, "%s", cmd_table[cmd].skill_name.data());
 
 		if ((skill_num = skill_lookup(skill_name)) > 0)
 		{
-			if (!str_cmp(cmd_table[cmd].skill_name, skill_table[skill_num].name))
+			if (cmd_table[cmd].skill_name == skill_table[skill_num].name)
 			{
 				if ((gn = gn_skill_lookup(skill_num)) > 1)
 				{
@@ -1010,7 +1010,7 @@ void interpret(CHAR_DATA *ch, char *argument)
 	/*
 	 * Dispatch the command.
 	 */
-	if (str_cmp(cmd_table[cmd].skill_name, "none") && (sn = skill_lookup(cmd_table[cmd].skill_name)) > 1)
+	if (cmd_table[cmd].skill_name != "none" && (sn = skill_lookup(cmd_table[cmd].skill_name.data())) > 1)
 	{
 		switch (skill_table[sn].target)
 		{
@@ -1140,10 +1140,10 @@ void interpret_queue(CHAR_DATA *ch, std::string argument)
 
 bool knows_command(CHAR_DATA *ch, int cmd)
 {
-	if (!cmd_table[cmd].skill_name || cmd_table[cmd].skill_name == "none")
+	if (cmd_table[cmd].skill_name.empty() || cmd_table[cmd].skill_name == "none")
 		return true;
 
-	if (get_skill(ch, skill_lookup(cmd_table[cmd].skill_name)) < 2)
+	if (get_skill(ch, skill_lookup(cmd_table[cmd].skill_name.data())) < 2)
 		return false;
 
 	return true;
@@ -1390,11 +1390,11 @@ void do_commands(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 
 	col = 0;
 
-	for (cmd = 0; cmd_table[cmd].name[0] != '\0'; cmd++)
+	for (cmd = 0; !cmd_table[cmd].name.empty(); cmd++)
 	{
 		if (cmd_table[cmd].level < LEVEL_HERO && cmd_table[cmd].level <= get_trust(ch) && cmd_table[cmd].show)
 		{
-			sprintf(buf, "%-12s", cmd_table[cmd].name);
+			sprintf(buf, "%-12s", cmd_table[cmd].name.data());
 			send_to_char(buf, ch);
 
 			if (++col % 6 == 0)
@@ -1423,22 +1423,22 @@ void do_wizhelp(CHAR_DATA *ch, char *argument)
 	if (showlevel && showval > get_trust(ch))
 		return;
 
-	for (cmd = 0; cmd_table[cmd].name[0] != '\0'; cmd++)
+	for (cmd = 0; !cmd_table[cmd].name.empty(); cmd++)
 	{
 		if (((!showlevel && cmd_table[cmd].level >= LEVEL_HERO && cmd_table[cmd].level <= get_trust(ch))
 				|| (showlevel && cmd_table[cmd].level == showval))
 			&& cmd_table[cmd].level == arrangeListLooper)
 		{
-			if (!showlevel && argument[0] != '\0' && str_prefix(argument, cmd_table[cmd].name))
+			if (!showlevel && argument[0] != '\0' && str_prefix(argument, cmd_table[cmd].name.data()))
 				continue;
 
-			sprintf(buf, "(%i)%-18s  ", cmd_table[cmd].level, cmd_table[cmd].name);
+			sprintf(buf, "(%i)%-18s  ", cmd_table[cmd].level, cmd_table[cmd].name.data());
 			send_to_char(buf, ch);
 
 			if (++col % 5 == 0)
 				send_to_char("\n\r", ch);
 
-			if (cmd_table[cmd + 1].name[0] == '\0' && arrangeListLooper < MAX_LEVEL)
+			if (cmd_table[cmd + 1].name.empty() && arrangeListLooper < MAX_LEVEL)
 			{
 				arrangeListLooper++;
 				cmd = 0;

--- a/code/interp.c
+++ b/code/interp.c
@@ -645,7 +645,6 @@ void interpret(CHAR_DATA *ch, char *argument)
 	char command[MAX_INPUT_LENGTH], arg_dup[MSL], object[MSL];
 	char logline[MAX_INPUT_LENGTH];
 	char skill_name[MSL];
-	char buf[MSL];
 	int cmd, gn, skill_num, cmd2;
 	int trust, sn = 0, where, mana = 0;
 	bool found, is_social= false, vprog= false;

--- a/code/interp.h
+++ b/code/interp.h
@@ -37,6 +37,7 @@
 #define INTERP_H
 
 #include <string>
+#include <string_view>
 
 #include "entity/fwd.h"
 
@@ -58,14 +59,14 @@
  */
 struct cmd_type
 {
-	char * const name;
+	std::string_view name;
 	DO_FUN *do_fun;
 	short position;
 	short level;
 	short log;
 	short show;
 	short hide;
-	char * const skill_name;
+	std::string_view skill_name;
 };
 
 /* the command table itself */

--- a/code/iprog.c
+++ b/code/iprog.c
@@ -3058,7 +3058,11 @@ void communion_handler(CHAR_DATA *ch)
 
 			cabal_members[CABAL_HORDE]++;
 
-			if (is_immortal(Deref(af->owner)) && is_immortal(ch))
+			// is_immortal only tests level, and plenty of mobs are levelled past
+			// LEVEL_IMMORTAL, so it does not establish either side is a player.
+			// The record reads pcdata from both, and that is null for an NPC.
+			if (is_immortal(Deref(af->owner)) && is_immortal(ch)
+				&& !is_npc(Deref(af->owner)) && !is_npc(ch))
 			{
 				Induction record;
 				record.ch = Deref(af->owner)->true_name;

--- a/code/iprog.c
+++ b/code/iprog.c
@@ -604,7 +604,7 @@ void fight_prog_drow_talisman(OBJ_DATA *obj, CHAR_DATA *ch)
 	if (!is_worn(obj) || number_percent() > 7 || !Deref(ch->fighting))
 		return;
 
-	act("$p pulses and glows a sickly shade of green!", ch, obj, 0, TO_ALL);
+	act("$p pulses and glows a sickly shade of green!", ch, obj, nullptr, TO_ALL);
 
 	if (number_percent() > 50)
 		obj_cast_spell(skill_lookup("frost breath"), ch->level, ch, Deref(ch->fighting), obj);
@@ -619,8 +619,8 @@ void fight_prog_devils_eye(OBJ_DATA *obj, CHAR_DATA *ch)
 
 	if (number_percent() < 5)
 	{
-		act("The Devil's Eye suddenly pivots and stares directly into $n's face!", ch, 0, Deref(ch->fighting), TO_NOTVICT);
-		act("The Devil's Eye suddenly pivots and stares directly into your face!", ch, 0, Deref(ch->fighting), TO_VICT);
+		act("The Devil's Eye suddenly pivots and stares directly into $n's face!", ch, nullptr, Deref(ch->fighting), TO_NOTVICT);
+		act("The Devil's Eye suddenly pivots and stares directly into your face!", ch, nullptr, Deref(ch->fighting), TO_VICT);
 		damage_new(ch, Deref(ch->fighting), dice(12, 12), TYPE_UNDEFINED, DAM_SLASH, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "heartquake");
 	}
 }
@@ -638,8 +638,8 @@ void fight_prog_skean(OBJ_DATA *obj, CHAR_DATA *ch)
 		percent = number_percent();
 		if (Deref(ch->fighting)->Class()->ctype == CLASS_COMMUNER && !is_affected(Deref(ch->fighting), gsn_severed))
 		{
-			act("An enchanted obsidian skean blazes through the air, leaving a trail of fire!", ch, 0, Deref(ch->fighting), TO_ROOM);
-			act("Your vital ties to the gods' empowerment have been severed!", ch, 0, Deref(ch->fighting), TO_VICT);
+			act("An enchanted obsidian skean blazes through the air, leaving a trail of fire!", ch, nullptr, Deref(ch->fighting), TO_ROOM);
+			act("Your vital ties to the gods' empowerment have been severed!", ch, nullptr, Deref(ch->fighting), TO_VICT);
 
 			init_affect(&af);
 			af.where = TO_AFFECTS;
@@ -655,8 +655,8 @@ void fight_prog_skean(OBJ_DATA *obj, CHAR_DATA *ch)
 
 		if (!IS_SET(ch->affected_by, AFF_BLIND))
 		{
-			act("An enchanted obsidian skean darts toward your eyes, gouging you painfully!", ch, 0, Deref(ch->fighting), TO_VICT);
-			act("An enchanted obsidian skean darts toward $N's eyes, gouging $M painfully!", ch, 0, Deref(ch->fighting), TO_NOTVICT);
+			act("An enchanted obsidian skean darts toward your eyes, gouging you painfully!", ch, nullptr, Deref(ch->fighting), TO_VICT);
+			act("An enchanted obsidian skean darts toward $N's eyes, gouging $M painfully!", ch, nullptr, Deref(ch->fighting), TO_NOTVICT);
 
 			init_affect(&af);
 			af.where = TO_AFFECTS;
@@ -673,7 +673,7 @@ void fight_prog_skean(OBJ_DATA *obj, CHAR_DATA *ch)
 
 		if (is_good(Deref(ch->fighting)))
 		{
-			act("You swoon for a moment, and the world goes slightly hazy...", Deref(ch->fighting), 0, 0, TO_CHAR);
+			act("You swoon for a moment, and the world goes slightly hazy...", Deref(ch->fighting), nullptr, nullptr, TO_CHAR);
 			WAIT_STATE(Deref(ch->fighting), PULSE_VIOLENCE * 2);
 			return;
 		}
@@ -690,8 +690,8 @@ void fight_prog_cankerworm(OBJ_DATA *obj, CHAR_DATA *ch)
 	if (number_percent() < 10)
 	{
 		dam = dice((ch->level), 3);
-		act("The Cankerworm leaps from your hands momentarily!", ch, 0, 0, TO_CHAR);
-		act("The Cankerworm seems to leap from $n's hands momentarily!", ch, 0, 0, TO_ROOM);
+		act("The Cankerworm leaps from your hands momentarily!", ch, nullptr, nullptr, TO_CHAR);
+		act("The Cankerworm seems to leap from $n's hands momentarily!", ch, nullptr, nullptr, TO_ROOM);
 		damage_new(ch, Deref(ch->fighting), dam, TYPE_UNDEFINED, DAM_SLASH, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "burrowing axe");
 	}
 }
@@ -705,8 +705,8 @@ void fight_prog_axe_trelaran(OBJ_DATA *obj, CHAR_DATA *ch)
 
 	if (str_cmp(race_table[ch->race].name, "duergar"))
 	{
-		act("Your hand twists in agony as $p glows midnight black!", ch, obj, 0, TO_CHAR);
-		act("$n's hand twists in agony as $p tries to writhe free!", ch, obj, 0, TO_ROOM);
+		act("Your hand twists in agony as $p glows midnight black!", ch, obj, nullptr, TO_CHAR);
+		act("$n's hand twists in agony as $p tries to writhe free!", ch, obj, nullptr, TO_ROOM);
 
 		obj_cast_spell(skill_lookup("curse"), 60, ch, ch, obj);
 		obj_cast_spell(skill_lookup("plague"), 60, ch, ch, obj);
@@ -716,7 +716,7 @@ void fight_prog_axe_trelaran(OBJ_DATA *obj, CHAR_DATA *ch)
 	{
 		if (number_percent() < 6 && (crown->pIndexData->vnum == 21825))
 		{
-			act("$p suddenly shifts to the likeness of a gaping dragon head, as it spits out a blast of acid!", ch, obj, 0, TO_ALL);
+			act("$p suddenly shifts to the likeness of a gaping dragon head, as it spits out a blast of acid!", ch, obj, nullptr, TO_ALL);
 			obj_cast_spell(skill_lookup("acid blast"), ch->level, ch, Deref(ch->fighting), obj);
 		}
 	}
@@ -726,8 +726,8 @@ void fight_prog_cure_critical(OBJ_DATA *obj, CHAR_DATA *ch)
 {
 	if (number_percent() < 8 && is_worn(obj))
 	{
-		act("$n's $p glows bright blue!", ch, obj, 0, TO_ROOM);
-		act("$p glows bright blue!", ch, obj, 0, TO_CHAR);
+		act("$n's $p glows bright blue!", ch, obj, nullptr, TO_ROOM);
+		act("$p glows bright blue!", ch, obj, nullptr, TO_CHAR);
 		obj_cast_spell(skill_lookup("cure critical"), obj->level, ch, ch, obj);
 	}
 }
@@ -787,8 +787,8 @@ void invoke_prog_tattoo_dioxide(OBJ_DATA *obj, CHAR_DATA *ch, [[maybe_unused]] c
 	return;
 
 	obj = get_eq_char(ch, WEAR_BRAND);
-	act("$n's $p glows blue.", ch, obj, 0, TO_ROOM);
-	act("Your $p glows blue.", ch, obj, 0, TO_CHAR);
+	act("$n's $p glows blue.", ch, obj, nullptr, TO_ROOM);
+	act("Your $p glows blue.", ch, obj, nullptr, TO_CHAR);
 
 	ch->hit += (ch->level * 2) * 8;
 	ch->hit = std::min(ch->hit, (int)ch->max_hit);
@@ -841,8 +841,8 @@ void invoke_prog_tattoo_dioxide(OBJ_DATA *obj, CHAR_DATA *ch, [[maybe_unused]] c
 void invoke_prog_tattoo_jackass(OBJ_DATA *obj, CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
 	obj = get_eq_char(ch, WEAR_BRAND);
-	act("$n's $p doesn't glow much due to $s stupidity.", ch, obj, 0, TO_ROOM);
-	act("Your $p doesn't glow much, probably because you're a jackass.", ch, obj, 0, TO_CHAR);
+	act("$n's $p doesn't glow much due to $s stupidity.", ch, obj, nullptr, TO_ROOM);
+	act("Your $p doesn't glow much, probably because you're a jackass.", ch, obj, nullptr, TO_CHAR);
 
 	send_to_char("You smite yourself! What a jackass!\n\r", ch);
 
@@ -918,7 +918,7 @@ void invoke_prog_tattoo_sceptre(OBJ_DATA *obj, CHAR_DATA *ch, char *argument)
 	}
 
 	send_to_char("Your body heals at great cost to your abilities.\n\r", ch);
-	act("$n looks better, but weakened.", ch, 0, 0, TO_ROOM);
+	act("$n looks better, but weakened.", ch, nullptr, nullptr, TO_ROOM);
 
 	ch->hit = ch->hit + 500;
 
@@ -961,14 +961,14 @@ void invoke_prog_tattoo_zethus(OBJ_DATA *obj, CHAR_DATA *ch, [[maybe_unused]] ch
 		return;
 	}
 
-	act("$n concentrates intently for a moment.", ch, 0, 0, TO_ROOM);
+	act("$n concentrates intently for a moment.", ch, nullptr, nullptr, TO_ROOM);
 	obj->value[0] -= 1;
 
 	if (!saves_spell(ch->level + dice(1, 5), Deref(ch->fighting), DAM_NEGATIVE))
 	{
-		act("A flash of darkness arcs between $n and $N, leaving $N looking hopeless!", ch, 0, Deref(ch->fighting), TO_NOTVICT);
-		act("A flash of darkness arcs between you and $N as you sever $N's link with $S god.", ch, 0, Deref(ch->fighting), TO_CHAR);
-		act("Negative energy crackles in the air around you, temporarily severing your link with your god!", ch, 0, Deref(ch->fighting), TO_VICT);
+		act("A flash of darkness arcs between $n and $N, leaving $N looking hopeless!", ch, nullptr, Deref(ch->fighting), TO_NOTVICT);
+		act("A flash of darkness arcs between you and $N as you sever $N's link with $S god.", ch, nullptr, Deref(ch->fighting), TO_CHAR);
+		act("Negative energy crackles in the air around you, temporarily severing your link with your god!", ch, nullptr, Deref(ch->fighting), TO_VICT);
 		damage_new(ch, Deref(ch->fighting), ch->level + 15, TYPE_UNDEFINED, DAM_NEGATIVE, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "energy wave");
 		damage_new(ch, ch, ch->level - 15, TYPE_UNDEFINED, DAM_INTERNAL, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "exertion");
 
@@ -1028,21 +1028,21 @@ void invoke_prog_explosives(OBJ_DATA *obj, CHAR_DATA *ch, char *argument)
 		{
 			if (fuse == 0)
 			{
-				act("$n sets $p and stuffs it in $s mouth!", ch, obj, 0, TO_ROOM);
-				act("You set $p and stuff it in your mouth!", ch, obj, 0, TO_CHAR);
+				act("$n sets $p and stuffs it in $s mouth!", ch, obj, nullptr, TO_ROOM);
+				act("You set $p and stuff it in your mouth!", ch, obj, nullptr, TO_CHAR);
 
 				unequip_char(ch, obj, true);
 				bag_explode(ch, obj, 3);
 				return;
 			}
 
-			act("$n fumbles awkwardly with $p, and it begins to tick.", ch, obj, 0, TO_ROOM);
-			act("You fumble awkwardly with $p, and it begins to tick.", ch, obj, 0, TO_CHAR);
+			act("$n fumbles awkwardly with $p, and it begins to tick.", ch, obj, nullptr, TO_ROOM);
+			act("You fumble awkwardly with $p, and it begins to tick.", ch, obj, nullptr, TO_CHAR);
 		}
 		else
 		{
-			act("$n sets the fuse of $p, and it begins to tick.", ch, obj, 0, TO_ROOM);
-			act("You set the fuse of $p, and it begins to tick.", ch, obj, 0, TO_CHAR);
+			act("$n sets the fuse of $p, and it begins to tick.", ch, obj, nullptr, TO_ROOM);
+			act("You set the fuse of $p, and it begins to tick.", ch, obj, nullptr, TO_CHAR);
 
 			obj->timer = fuse;
 			return;
@@ -1050,8 +1050,8 @@ void invoke_prog_explosives(OBJ_DATA *obj, CHAR_DATA *ch, char *argument)
 	}
 	else
 	{
-		act("$n fumbles awkwardly with $p, and it begins to tick.", ch, obj, 0, TO_ROOM);
-		act("You fumble awkwardly with $p, and it begins to tick.", ch, obj, 0, TO_CHAR);
+		act("$n fumbles awkwardly with $p, and it begins to tick.", ch, obj, nullptr, TO_ROOM);
+		act("You fumble awkwardly with $p, and it begins to tick.", ch, obj, nullptr, TO_CHAR);
 	}
 
 	fuse = number_range(2, 48);
@@ -1080,7 +1080,7 @@ void speech_prog_ice_dragon_statue(OBJ_DATA *obj, CHAR_DATA *ch, char *speech)
 		return;
 	}
 
-	act("$p shatters violently in a cloud of ice. As it clears, a dragon of pure ice hovers over you.", dragon, obj, 0, TO_ROOM);
+	act("$p shatters violently in a cloud of ice. As it clears, a dragon of pure ice hovers over you.", dragon, obj, nullptr, TO_ROOM);
 	add_follower(dragon, ch);
 
 	dragon->leader = ch->self;
@@ -1121,8 +1121,8 @@ void fight_prog_scales(OBJ_DATA *obj, CHAR_DATA *ch)
 		case 2:
 			if (number_percent() > 85)
 			{
-				act("$p throbs momentarily, and you feel invigorated!", ch, obj, 0, TO_CHAR);
-				act("$n looks a bit more refreshed.", ch, obj, 0, TO_ROOM);
+				act("$p throbs momentarily, and you feel invigorated!", ch, obj, nullptr, TO_CHAR);
+				act("$n looks a bit more refreshed.", ch, obj, nullptr, TO_ROOM);
 
 				if (number_percent() > 50)
 					ch->hit += ch->level;
@@ -1142,8 +1142,8 @@ void fight_prog_amber_medallion(OBJ_DATA *obj, CHAR_DATA *ch)
 
 	intel = get_curr_stat(ch, STAT_INT);
 
-	act("$p glows softly and you feel refreshed.", ch, obj, 0, TO_CHAR);
-	act("$p glows softly.", ch, obj, 0, TO_ROOM);
+	act("$p glows softly and you feel refreshed.", ch, obj, nullptr, TO_CHAR);
+	act("$p glows softly.", ch, obj, nullptr, TO_ROOM);
 
 	ch->mana = std::min(ch->mana + number_range(intel, intel * 2), (int)ch->max_mana);
 }
@@ -1178,12 +1178,12 @@ void get_prog_bad_idea(OBJ_DATA *obj, CHAR_DATA *ch)
 	EXIT_DATA *pexit = ch->in_room->exit[Directions::Up];
 	CHAR_DATA *vch;
 
-	act("As you pick up $p, a booming voice can be heard.", ch, obj, 0, TO_CHAR);
-	act("As $n picks up $p, a booming voice can be heard.", ch, obj, 0, TO_ROOM);
-	act("'Stealing from the Gods, are we?  Ah, yes.  I like that.  Very daring.  Good taste.  Pity I like $p.'\n\r", ch, obj, 0, TO_CHAR);
-	act("'Stealing from the Gods, are we?  Ah, yes.  I like that.  Very daring.  Good taste.  Pity I like $p.'", ch, obj, 0, TO_ROOM);
-	act("$p grows searing hot and you are forced to drop it!", ch, obj, 0, TO_CHAR);
-	act("$p glows searing white and $n is forced to drop it!", ch, obj, 0, TO_ROOM);
+	act("As you pick up $p, a booming voice can be heard.", ch, obj, nullptr, TO_CHAR);
+	act("As $n picks up $p, a booming voice can be heard.", ch, obj, nullptr, TO_ROOM);
+	act("'Stealing from the Gods, are we?  Ah, yes.  I like that.  Very daring.  Good taste.  Pity I like $p.'\n\r", ch, obj, nullptr, TO_CHAR);
+	act("'Stealing from the Gods, are we?  Ah, yes.  I like that.  Very daring.  Good taste.  Pity I like $p.'", ch, obj, nullptr, TO_ROOM);
+	act("$p grows searing hot and you are forced to drop it!", ch, obj, nullptr, TO_CHAR);
+	act("$p glows searing white and $n is forced to drop it!", ch, obj, nullptr, TO_ROOM);
 
 	obj_from_char(obj);
 	obj_to_room(obj, ch->in_room);
@@ -1207,11 +1207,11 @@ void get_prog_bad_idea(OBJ_DATA *obj, CHAR_DATA *ch)
 		affect_to_char(ch, &af);
 
 		send_to_char("You feel very sick.  Clearly you've made someone angry.\n\r", ch);
-		act("$n looks extremely ill.", ch, 0, 0, TO_ROOM);
+		act("$n looks extremely ill.", ch, nullptr, nullptr, TO_ROOM);
 	}
 	else
 	{
-		act("'I believe you've earned a rest from your hard exertions, and a chance to enjoy the spoils of your victory.'", ch, 0, 0, TO_ALL);
+		act("'I believe you've earned a rest from your hard exertions, and a chance to enjoy the spoils of your victory.'", ch, nullptr, nullptr, TO_ALL);
 		pexit->u1.to_room = nullptr;
 
 		init_affect(&af);
@@ -1258,8 +1258,8 @@ void greet_prog_corpse_explode(OBJ_DATA *obj, CHAR_DATA *ch)
 	if (is_safe_new(ch, owner, false))
 		return;
 
-	act("As $n enters, $p starts to shudder violently, then explodes!", ch, obj, 0, TO_NOTVICT);
-	act("As you enter, $p starts to shudder violently, then explodes!", ch, obj, 0, TO_CHAR);
+	act("As $n enters, $p starts to shudder violently, then explodes!", ch, obj, nullptr, TO_NOTVICT);
+	act("As you enter, $p starts to shudder violently, then explodes!", ch, obj, nullptr, TO_CHAR);
 
 	damage_new(owner, ch, dice(obj->level, 2), TYPE_UNDEFINED, DAM_ENERGY, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "the exploding corpse*");
 	extract_obj(obj);
@@ -1274,7 +1274,7 @@ void fight_prog_horde_bull([[maybe_unused]] OBJ_DATA *obj, CHAR_DATA *ch)
 		return;
 
 	send_to_char("The fortitude of the Bull fills you, inspiring you to ignore your pain and fight on.\n\r", ch);
-	act("$n's muscles ripple with fresh vigor as $s eyes harden with new resolve.", ch, 0, 0, TO_ROOM);
+	act("$n's muscles ripple with fresh vigor as $s eyes harden with new resolve.", ch, nullptr, nullptr, TO_ROOM);
 
 	ch->hit = std::min((int)ch->max_hit, ch->hit + number_range(ch->level * (short)1.2, ch->level * (short)2.2));
 }
@@ -1284,9 +1284,9 @@ void fight_prog_horde_bear([[maybe_unused]] OBJ_DATA *obj, CHAR_DATA *ch)
 	if (!is_affected(ch, gsn_rage) || !Deref(ch->fighting) || number_percent() > (.15 * get_skill(ch, gsn_rage)))
 		return;
 
-	act("The rage of the Bear roars through you as you charge into $N, sending $m sprawling!", ch, 0, Deref(ch->fighting), TO_CHAR);
-	act("$n gets a wild look in $s eyes, charging into you and sending you sprawling!", ch, 0, Deref(ch->fighting), TO_VICT);
-	act("$n gets a wild look in $s eyes, charging into $N and sending $m sprawling!", ch, 0, Deref(ch->fighting), TO_NOTVICT);
+	act("The rage of the Bear roars through you as you charge into $N, sending $m sprawling!", ch, nullptr, Deref(ch->fighting), TO_CHAR);
+	act("$n gets a wild look in $s eyes, charging into you and sending you sprawling!", ch, nullptr, Deref(ch->fighting), TO_VICT);
+	act("$n gets a wild look in $s eyes, charging into $N and sending $m sprawling!", ch, nullptr, Deref(ch->fighting), TO_NOTVICT);
 
 	WAIT_STATE(Deref(ch->fighting), (int)(PULSE_VIOLENCE * 1.9));
 
@@ -1300,9 +1300,9 @@ void fight_prog_horde_lion([[maybe_unused]] OBJ_DATA *obj, CHAR_DATA *ch)
 	if (!is_affected(ch, gsn_rage) || !Deref(ch->fighting) || number_percent() > (.18 * get_skill(ch, gsn_rage)))
 		return;
 
-	act("The spirit of the Lion surges through you as you claw at $N's flesh!", ch, 0, Deref(ch->fighting), TO_CHAR);
-	act("$n gets a wild look in $s eyes, clawing viciously at $N!", ch, 0, Deref(ch->fighting), TO_NOTVICT);
-	act("$n gets a wild look in $s eyes, clawing viciously at you!", ch, 0, Deref(ch->fighting), TO_VICT);
+	act("The spirit of the Lion surges through you as you claw at $N's flesh!", ch, nullptr, Deref(ch->fighting), TO_CHAR);
+	act("$n gets a wild look in $s eyes, clawing viciously at $N!", ch, nullptr, Deref(ch->fighting), TO_NOTVICT);
+	act("$n gets a wild look in $s eyes, clawing viciously at you!", ch, nullptr, Deref(ch->fighting), TO_VICT);
 
 	damage_new(ch, Deref(ch->fighting), dice(ch->level - 2, 4), TYPE_UNDEFINED, DAM_BASH, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "raking claws$");
 
@@ -1323,7 +1323,7 @@ void fight_prog_horde_lion([[maybe_unused]] OBJ_DATA *obj, CHAR_DATA *ch)
 	new_affect_to_char(Deref(ch->fighting), &af);
 
 	send_to_char("Blood begins to gush from your vicious wounds.\n\r", Deref(ch->fighting));
-	act("Bright red blood begins to gush from $n's wounds.", Deref(ch->fighting), 0, 0, TO_ROOM);
+	act("Bright red blood begins to gush from $n's wounds.", Deref(ch->fighting), nullptr, nullptr, TO_ROOM);
 }
 
 void fight_prog_horde_wolf([[maybe_unused]] OBJ_DATA *obj, CHAR_DATA *ch)
@@ -1333,9 +1333,9 @@ void fight_prog_horde_wolf([[maybe_unused]] OBJ_DATA *obj, CHAR_DATA *ch)
 	if (!is_affected(ch, gsn_rage) || !Deref(ch->fighting) || number_percent() > (.18 * get_skill(ch, gsn_rage)))
 		return;
 
-	act("The spirit of the Wolf enrages you as you leap at $N and sink your fangs into $S throat!", ch, 0, Deref(ch->fighting), TO_CHAR);
-	act("$n gets a wild look in $s eyes and leaps at $N, sinking $s teeth into $S throat!", ch, 0, Deref(ch->fighting), TO_NOTVICT);
-	act("$n gets a wild look in $s eyes and leaps at you, sinking $s teeth into your throat!", ch, 0, Deref(ch->fighting), TO_VICT);
+	act("The spirit of the Wolf enrages you as you leap at $N and sink your fangs into $S throat!", ch, nullptr, Deref(ch->fighting), TO_CHAR);
+	act("$n gets a wild look in $s eyes and leaps at $N, sinking $s teeth into $S throat!", ch, nullptr, Deref(ch->fighting), TO_NOTVICT);
+	act("$n gets a wild look in $s eyes and leaps at you, sinking $s teeth into your throat!", ch, nullptr, Deref(ch->fighting), TO_VICT);
 	damage_new(ch, Deref(ch->fighting), dice(ch->level, 2), TYPE_UNDEFINED, DAM_BASH, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "bite");
 
 	if (!Deref(ch->fighting))
@@ -1370,9 +1370,9 @@ void fight_prog_horde_wolf([[maybe_unused]] OBJ_DATA *obj, CHAR_DATA *ch)
 		af.end_fun = nullptr;
 		new_affect_to_char(Deref(ch->fighting), &af);
 
-		act("You hear the satisfying crunch of bone as you tear deeply into $N's throat.", ch, 0, Deref(ch->fighting), TO_CHAR);
-		act("You hear the crunch of bone as $n tears deeply into your throat.", ch, 0, Deref(ch->fighting), TO_VICT);
-		act("You hear the crunch of bone as $n tears deeply into $N's throat.", ch, 0, Deref(ch->fighting), TO_NOTVICT);
+		act("You hear the satisfying crunch of bone as you tear deeply into $N's throat.", ch, nullptr, Deref(ch->fighting), TO_CHAR);
+		act("You hear the crunch of bone as $n tears deeply into your throat.", ch, nullptr, Deref(ch->fighting), TO_VICT);
+		act("You hear the crunch of bone as $n tears deeply into $N's throat.", ch, nullptr, Deref(ch->fighting), TO_NOTVICT);
 	}
 }
 
@@ -1381,9 +1381,9 @@ void fight_prog_horde_hawk([[maybe_unused]] OBJ_DATA *obj, CHAR_DATA *ch)
 	if (!is_affected(ch, gsn_rage) || !Deref(ch->fighting) || number_percent() > (.2 * get_skill(ch, gsn_rage)))
 		return;
 
-	act("The spirit of the Hawk flows through you as you sense a weakness in $N's defenses and strike!", ch, 0, Deref(ch->fighting), TO_CHAR);
-	act("$n pauses for a moment before unleashing a well aimed blow at you.", ch, 0, Deref(ch->fighting), TO_VICT);
-	act("$n pauses for a moment before unleashing a well aimed blow at $N.", ch, 0, Deref(ch->fighting), TO_NOTVICT);
+	act("The spirit of the Hawk flows through you as you sense a weakness in $N's defenses and strike!", ch, nullptr, Deref(ch->fighting), TO_CHAR);
+	act("$n pauses for a moment before unleashing a well aimed blow at you.", ch, nullptr, Deref(ch->fighting), TO_VICT);
+	act("$n pauses for a moment before unleashing a well aimed blow at $N.", ch, nullptr, Deref(ch->fighting), TO_NOTVICT);
 
 	one_hit_new(ch, Deref(ch->fighting), TYPE_TRUESTRIKE, HIT_NOSPECIALS, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, nullptr);
 }
@@ -1487,8 +1487,8 @@ void verb_prog_check_bounties([[maybe_unused]] OBJ_DATA *obj, CHAR_DATA *ch, [[m
 
 	ch->gold -= 50;
 
-	act("You hand $N 50 gold pieces.", ch, 0, mob, TO_CHAR);
-	act("$n hands $N some gold.", ch, 0, mob, TO_ROOM);
+	act("You hand $N 50 gold pieces.", ch, nullptr, mob, TO_CHAR);
+	act("$n hands $N some gold.", ch, nullptr, mob, TO_ROOM);
 	do_emote(mob, "slips the gold into his pouch.");
 	do_say(mob, "Now then..");
 	do_emote(mob, "studies his list of bounties.");
@@ -1599,7 +1599,7 @@ void verb_prog_ilopheth_bush([[maybe_unused]] OBJ_DATA *obj, CHAR_DATA *ch, [[ma
 	}
 
 	send_to_char("With a mighty effort, you duck your head and push through the bushes to the west.\n\r", ch);
-	act("With a mighty effort, $n ducks $s head and pushes through the bushes to the west.", ch, 0, 0, TO_ROOM);
+	act("With a mighty effort, $n ducks $s head and pushes through the bushes to the west.", ch, nullptr, nullptr, TO_ROOM);
 
 	room = get_room_index(9096);
 
@@ -1626,8 +1626,8 @@ void verb_prog_ilopheth_climb_tree([[maybe_unused]] OBJ_DATA *obj, CHAR_DATA *ch
 		return;
 	}
 
-	act("You pull yourself up into the branches of the massive tree and ascend.", ch, 0, 0, TO_CHAR);
-	act("$n carefully climbs the massive tree, disappearing into the canopy.", ch, 0, 0, TO_ROOM);
+	act("You pull yourself up into the branches of the massive tree and ascend.", ch, nullptr, nullptr, TO_CHAR);
+	act("$n carefully climbs the massive tree, disappearing into the canopy.", ch, nullptr, nullptr, TO_ROOM);
 
 	char_from_room(ch);
 	char_to_room(ch, to_room);
@@ -1653,9 +1653,9 @@ void verb_prog_antava_touch_hand([[maybe_unused]] OBJ_DATA *obj, CHAR_DATA *ch, 
 		return;
 	}
 
-	act("You touch the hand of the decaying statue.", ch, 0, 0, TO_CHAR);
-	act("$n reaches up and touches the hand of the decaying statue.", ch, 0, 0, TO_ROOM);
-	act("A rusty clicking noise begins to sound from within the statue.", 0, 0, 0, TO_ROOM);
+	act("You touch the hand of the decaying statue.", ch, nullptr, nullptr, TO_CHAR);
+	act("$n reaches up and touches the hand of the decaying statue.", ch, nullptr, nullptr, TO_ROOM);
+	act("A rusty clicking noise begins to sound from within the statue.", 0, nullptr, nullptr, TO_ROOM);
 
 	if (ch->in_room->vnum != 462)
 		return;
@@ -1702,8 +1702,8 @@ void verb_prog_sidhe_climb_vine([[maybe_unused]] OBJ_DATA *obj, CHAR_DATA *ch, c
 
 	if (ch->in_room->vnum == 4101)
 	{
-		act("You slowly lower yourself down the vines, descending halfway down the tree.", ch, 0, 0, TO_CHAR);
-		act("$n carefully climbs up the vines hanging here, disappearing into the foliage.", ch, 0, 0, TO_ROOM);
+		act("You slowly lower yourself down the vines, descending halfway down the tree.", ch, nullptr, nullptr, TO_CHAR);
+		act("$n carefully climbs up the vines hanging here, disappearing into the foliage.", ch, nullptr, nullptr, TO_ROOM);
 		char_from_room(ch);
 		char_to_room(ch, down_room);
 		do_look(ch, "auto");
@@ -1712,16 +1712,16 @@ void verb_prog_sidhe_climb_vine([[maybe_unused]] OBJ_DATA *obj, CHAR_DATA *ch, c
 
 	if (!str_cmp(argument, "up"))
 	{
-		act("You test the vines, and then climb carefully upward into the tree.", ch, 0, 0, TO_CHAR);
-		act("$n carefully climbs up the vines hanging here, disappearing into the foliage.", ch, 0, 0, TO_ROOM);
+		act("You test the vines, and then climb carefully upward into the tree.", ch, nullptr, nullptr, TO_CHAR);
+		act("$n carefully climbs up the vines hanging here, disappearing into the foliage.", ch, nullptr, nullptr, TO_ROOM);
 		char_from_room(ch);
 		char_to_room(ch, up_room);
 		do_look(ch, "auto");
 	}
 	else if (!str_cmp(argument, "down"))
 	{
-		act("You slowly lower yourself down the vines, descending to the floor below.", ch, 0, 0, TO_CHAR);
-		act("$n slowly lowers $mself down the vines, descending to the floor below.", ch, 0, 0, TO_ROOM);
+		act("You slowly lower yourself down the vines, descending to the floor below.", ch, nullptr, nullptr, TO_CHAR);
+		act("$n slowly lowers $mself down the vines, descending to the floor below.", ch, nullptr, nullptr, TO_ROOM);
 		char_from_room(ch);
 		char_to_room(ch, down_room);
 		do_look(ch, "auto");
@@ -1870,8 +1870,8 @@ void verb_prog_listen_conversation([[maybe_unused]] OBJ_DATA *obj, CHAR_DATA *ch
 
 void verb_prog_rub_ball(OBJ_DATA *obj, CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
-	act("You rub the BALL OF DEATH.", ch, obj, 0, TO_CHAR);
-	act("$n rubs the BALL OF DEATH.", ch, obj, 0, TO_ROOM);
+	act("You rub the BALL OF DEATH.", ch, obj, nullptr, TO_CHAR);
+	act("$n rubs the BALL OF DEATH.", ch, obj, nullptr, TO_ROOM);
 
 	raw_kill(ch, ch);
 }
@@ -1884,8 +1884,8 @@ void verb_prog_twist_ring(OBJ_DATA *obj, CHAR_DATA *ch, [[maybe_unused]] char *a
 		return;
 	}
 
-	act("As you twist a tarnished gold ring on your finger, you feel lighter on your feet.", ch, 0, 0, TO_CHAR);
-	act("$n twists $p on his finger.", ch, obj, 0, TO_ROOM);
+	act("As you twist a tarnished gold ring on your finger, you feel lighter on your feet.", ch, nullptr, nullptr, TO_CHAR);
+	act("$n twists $p on his finger.", ch, obj, nullptr, TO_ROOM);
 	obj_cast_spell(skill_lookup("refresh"), obj->level, ch, ch, nullptr);
 
 	WAIT_STATE(ch, PULSE_VIOLENCE);
@@ -1904,28 +1904,28 @@ void verb_prog_twist_two_faced([[maybe_unused]] OBJ_DATA *obj, CHAR_DATA *ch, ch
 	if (!strcmp(argument, "clockwise"))
 	{
 		send_to_char("You twist the sundial clockwise.\n\r", ch);
-		act("$n twists the sundial clockwise.", ch, 0, 0, TO_ROOM);
+		act("$n twists the sundial clockwise.", ch, nullptr, nullptr, TO_ROOM);
 		nChance = 35;
 	}
 	else
 	{
 		send_to_char("You twist the sundial counterclockwise.\n\r", ch);
-		act("$n twists the sundial counterclockwise.", ch, 0, 0, TO_ROOM);
+		act("$n twists the sundial counterclockwise.", ch, nullptr, nullptr, TO_ROOM);
 		nChance = 65;
 	}
 
 	if (number_percent() > nChance)
 	{
-		act("The faces of the statue seem to grin maniacally.", ch, 0, 0, TO_ALL);
+		act("The faces of the statue seem to grin maniacally.", ch, nullptr, nullptr, TO_ALL);
 		send_to_char("A stream of acid shoots out of the mouth of the statue at you!\n\r", ch);
-		act("A stream of acid shoots out of the mouth of the statue at $n!", ch, 0, 0, TO_ROOM);
+		act("A stream of acid shoots out of the mouth of the statue at $n!", ch, nullptr, nullptr, TO_ROOM);
 		spell_acid_stream(gsn_acid_stream, ch->level + 1, ch, ch, CastMode::Spell);
 
 		if (ch->ghost)
 			return;
 
 		send_to_char("A small dart flies out of the eye of the statue, barely piercing your skin.\n\r", ch);
-		act("A small dart flies out of the eye of the statue, barely piercing $n's skin.", ch, 0, 0, TO_ROOM);
+		act("A small dart flies out of the eye of the statue, barely piercing $n's skin.", ch, nullptr, nullptr, TO_ROOM);
 		spell_plague(gsn_plague, ch->level + 5, ch, ch, CastMode::Spell);
 	}
 	else
@@ -1965,8 +1965,8 @@ void verb_prog_energize_tattoo(OBJ_DATA *obj, CHAR_DATA *ch, [[maybe_unused]] ch
 		return;
 	}
 
-	act("You attempt to siphon some energy from $N to power your tattoo.", ch, 0, Deref(ch->fighting), TO_CHAR);
-	act("You feel a cold sensation run through your body.", ch, 0, Deref(ch->fighting), TO_VICT);
+	act("You attempt to siphon some energy from $N to power your tattoo.", ch, nullptr, Deref(ch->fighting), TO_CHAR);
+	act("You feel a cold sensation run through your body.", ch, nullptr, Deref(ch->fighting), TO_VICT);
 
 	if (!saves_spell(ch->level, Deref(ch->fighting), DAM_NEGATIVE))
 	{
@@ -2059,8 +2059,8 @@ void verb_prog_harness_crystal(OBJ_DATA *obj, CHAR_DATA *ch, [[maybe_unused]] ch
 		efficiency = number_range(5, 20);
 	}
 
-	act("Focusing intently on the charged crystal, you harness the energy stored within.", ch, 0, 0, TO_CHAR);
-	act("$n focuses intently on a glowing crystal in $s hands.", ch, 0, 0, TO_ROOM);
+	act("Focusing intently on the charged crystal, you harness the energy stored within.", ch, nullptr, nullptr, TO_CHAR);
+	act("$n focuses intently on a glowing crystal in $s hands.", ch, nullptr, nullptr, TO_ROOM);
 
 	mana = oaf->modifier;
 
@@ -2068,11 +2068,11 @@ void verb_prog_harness_crystal(OBJ_DATA *obj, CHAR_DATA *ch, [[maybe_unused]] ch
 
 	if (efficiency <= 20 && number_percent() > 50)
 	{
-		act("The crystal crumbles into dust and the energy dissipates as your focus falters.", ch, 0, 0, TO_CHAR);
+		act("The crystal crumbles into dust and the energy dissipates as your focus falters.", ch, nullptr, nullptr, TO_CHAR);
 		return;
 	}
 
-	act("The crystal crumbles to dust as you harness the mana stored within.", ch, 0, 0, TO_CHAR);
+	act("The crystal crumbles to dust as you harness the mana stored within.", ch, nullptr, nullptr, TO_CHAR);
 
 	mana *= efficiency;
 	mana /= 100;
@@ -2184,13 +2184,13 @@ void verb_prog_fire_pistol(OBJ_DATA *obj, CHAR_DATA *ch, char *argument)
 
 	if (ch == victim)
 	{
-		act("Oh no!  $n puts $p in $s mouth and pulls the trigger!", ch, obj, 0, TO_ROOM);
+		act("Oh no!  $n puts $p in $s mouth and pulls the trigger!", ch, obj, nullptr, TO_ROOM);
 		send_to_char("Don't do it, man!\n\r", ch);
-		act("You put $p in your mouth and pull the trigger!", ch, obj, 0, TO_CHAR);
+		act("You put $p in your mouth and pull the trigger!", ch, obj, nullptr, TO_CHAR);
 	}
 	else
 	{
-		act("You pull the trigger and bust a cap in $N's ass!", ch, 0, victim, TO_CHAR);
+		act("You pull the trigger and bust a cap in $N's ass!", ch, nullptr, victim, TO_CHAR);
 		act("$n turns $p sideways and busts a cap in yo ass!", ch, obj, victim, TO_VICT);
 		act("$n turns $p sideways and busts a cap in $N's ass!", ch, obj, victim, TO_NOTVICT);
 	}
@@ -2204,11 +2204,11 @@ void verb_prog_kneel_guillotine([[maybe_unused]] OBJ_DATA *obj, CHAR_DATA *ch, [
 {
 	ROOM_INDEX_DATA *old_room = ch->in_room;
 
-	act("You place your neck across the wooden bar of the guillotine.", ch, 0, 0, TO_CHAR);
-	act("$n places $s neck across the wooden bar of the guillotine.", ch, 0, 0, TO_ROOM);
+	act("You place your neck across the wooden bar of the guillotine.", ch, nullptr, nullptr, TO_CHAR);
+	act("$n places $s neck across the wooden bar of the guillotine.", ch, nullptr, nullptr, TO_ROOM);
 
-	act("The whistle of metal slicing through the air is the last thing you hear.", ch, 0, 0, TO_CHAR);
-	act("The razor-sharp blade drops rapidly, slicing $n's head clean from $s body!", ch, 0, 0, TO_ROOM);
+	act("The whistle of metal slicing through the air is the last thing you hear.", ch, nullptr, nullptr, TO_CHAR);
+	act("The razor-sharp blade drops rapidly, slicing $n's head clean from $s body!", ch, nullptr, nullptr, TO_ROOM);
 
 	raw_kill(ch, ch);
 
@@ -2229,7 +2229,7 @@ void hit_prog_blade_truth(OBJ_DATA *obj, CHAR_DATA *ch, CHAR_DATA *victim, [[may
 	if ((get_eq_char(ch, WEAR_DUAL_WIELD)) == obj)
 		dual = true;
 
-	act("$p blurs into motion as it whistles through the air.", ch, obj, 0, TO_ALL);
+	act("$p blurs into motion as it whistles through the air.", ch, obj, nullptr, TO_ALL);
 
 	if (dual)
 		one_hit(ch, victim, gsn_dual_wield);
@@ -2276,8 +2276,8 @@ void hit_prog_essence_light(OBJ_DATA *obj, CHAR_DATA *ch, CHAR_DATA *victim, int
 				{
 					case 1:
 					case 2:
-						act("You reel in agony as the raw energy engulfs you!", victim, 0, ch, TO_CHAR);
-						act("$n staggers as the raw energy engulfs $m!", victim, 0, ch, TO_ROOM);
+						act("You reel in agony as the raw energy engulfs you!", victim, nullptr, ch, TO_CHAR);
+						act("$n staggers as the raw energy engulfs $m!", victim, nullptr, ch, TO_ROOM);
 						LAG_CHAR(victim, PULSE_VIOLENCE);
 						break;
 				}
@@ -2311,8 +2311,8 @@ void hit_prog_essence_darkness(OBJ_DATA *obj, CHAR_DATA *ch, CHAR_DATA *victim, 
 
 	if (!is_affected(victim, gsn_curse) && number_percent() <= 25)
 	{
-		act("A black aura briefly envelops $n as the darkness touches $s flesh.", victim, 0, ch, TO_ROOM);
-		act("You feel a taint wash over you as the darkness touches your flesh.", victim, 0, ch, TO_CHAR);
+		act("A black aura briefly envelops $n as the darkness touches $s flesh.", victim, nullptr, ch, TO_ROOM);
+		act("You feel a taint wash over you as the darkness touches your flesh.", victim, nullptr, ch, TO_CHAR);
 
 		init_affect(&af);
 		af.where = TO_AFFECTS;
@@ -2340,8 +2340,8 @@ void hit_prog_essence_darkness(OBJ_DATA *obj, CHAR_DATA *ch, CHAR_DATA *victim, 
 			dual = true;
 
 		act("$p writhes in your hands and strikes anew, thirsty for blood!", ch, obj, victim, TO_CHAR);
-		act("A mournful wail is audible as $n's black hands lash out at $N!", ch, 0, victim, TO_NOTVICT);
-		act("A mournful wail is audible as $n's black hands lash out at you!", ch, 0, victim, TO_VICT);
+		act("A mournful wail is audible as $n's black hands lash out at $N!", ch, nullptr, victim, TO_NOTVICT);
+		act("A mournful wail is audible as $n's black hands lash out at you!", ch, nullptr, victim, TO_VICT);
 
 		if (dual)
 			one_hit(ch, victim, gsn_dual_wield);
@@ -2368,19 +2368,19 @@ void fight_prog_essence_darkness(OBJ_DATA *obj, CHAR_DATA *ch)
 	switch (number_range(1, 3))
 	{
 		case 1:
-			act("A cloud of putrefaction issues forth from your hands!", ch, 0, victim, TO_CHAR);
-			act("A cloud of putrefaction issues forth from $n's hands!", ch, 0, victim, TO_ROOM);
+			act("A cloud of putrefaction issues forth from your hands!", ch, nullptr, victim, TO_CHAR);
+			act("A cloud of putrefaction issues forth from $n's hands!", ch, nullptr, victim, TO_ROOM);
 			obj_cast_spell(skill_lookup("plague"), ch->level, ch, victim, obj);
 			break;
 		case 2:
-			act("Your eyes cloud suddenly with a black haze!", victim, 0, ch, TO_CHAR);
-			act("A swirling black cloud encircles $n's face!", victim, 0, ch, TO_ROOM);
+			act("Your eyes cloud suddenly with a black haze!", victim, nullptr, ch, TO_CHAR);
+			act("A swirling black cloud encircles $n's face!", victim, nullptr, ch, TO_ROOM);
 			obj_cast_spell(skill_lookup("blindness"), ch->level, ch, victim, obj);
 			break;
 		case 3:
-			act("Darkness lashes out from $N's hands to engulf you!", victim, 0, ch, TO_CHAR);
-			act("Darkness lashes out from $N's hands to engulf $n!", victim, 0, ch, TO_NOTVICT);
-			act("Darkness lashes out from your hands to engulf $n!", victim, 0, ch, TO_VICT);
+			act("Darkness lashes out from $N's hands to engulf you!", victim, nullptr, ch, TO_CHAR);
+			act("Darkness lashes out from $N's hands to engulf $n!", victim, nullptr, ch, TO_NOTVICT);
+			act("Darkness lashes out from your hands to engulf $n!", victim, nullptr, ch, TO_VICT);
 			obj_cast_spell(skill_lookup("energy drain"), ch->level, ch, victim, obj);
 			break;
 	}
@@ -2391,8 +2391,8 @@ void verb_prog_rub_talisman(OBJ_DATA *obj, CHAR_DATA *ch, [[maybe_unused]] char 
 	int sn = skill_lookup("word of recall");
 	SpellTarget vo = ch;
 
-	act("You rub a worn patch of the wooden talisman.", ch, 0, 0, TO_CHAR);
-	act("$n vigorously rubs $p.", ch, obj, 0, TO_ROOM);
+	act("You rub a worn patch of the wooden talisman.", ch, nullptr, nullptr, TO_CHAR);
+	act("$n vigorously rubs $p.", ch, obj, nullptr, TO_ROOM);
 
 	WAIT_STATE(ch, PULSE_VIOLENCE);
 
@@ -2407,7 +2407,7 @@ void verb_prog_rub_talisman(OBJ_DATA *obj, CHAR_DATA *ch, [[maybe_unused]] char 
 
 	(*skill_table[sn].spell_fun)(sn, ch->level, ch, vo, CastMode::Spell);
 
-	act("$p crumbles into dust as the magic drains from it.", ch, obj, 0, TO_CHAR);
+	act("$p crumbles into dust as the magic drains from it.", ch, obj, nullptr, TO_CHAR);
 
 	extract_obj(obj);
 }
@@ -2433,7 +2433,7 @@ void verb_prog_gate_talisman([[maybe_unused]] OBJ_DATA *obj, CHAR_DATA *ch, char
 
 	send_to_char("The talisman flickers and feels warm for a moment, and you are elsewhere.\n\r", ch);
 
-	act("A rift opens in midair beside $n and $e steps in and vanishes.", ch, 0, 0, TO_ROOM);
+	act("A rift opens in midair beside $n and $e steps in and vanishes.", ch, nullptr, nullptr, TO_ROOM);
 
 	char_from_room(ch);
 	char_to_room(ch, to_room);
@@ -2479,7 +2479,7 @@ void pulse_prog_pillar_zap(OBJ_DATA *obj, [[maybe_unused]] bool isTick)
 
 	sprintf(buf, "\x01B[1;34mThe pillars crackle suddenly with raw energy and emit a beam of blinding light!\x01B[0m");
 
-	act(buf, room->people, 0, 0, TO_ALL);
+	act(buf, room->people, nullptr, nullptr, TO_ALL);
 
 	for (mob = room->people; mob; mob = mob_next)
 	{
@@ -2487,7 +2487,7 @@ void pulse_prog_pillar_zap(OBJ_DATA *obj, [[maybe_unused]] bool isTick)
 
 		if (is_npc(mob) && (IS_SET(mob->act, ACT_UNDEAD) || IS_SET(mob->form, FORM_UNDEAD)))
 		{
-			act("$n dissolves into dust as the shining blue light sweeps over it!", mob, 0, 0, TO_ROOM);
+			act("$n dissolves into dust as the shining blue light sweeps over it!", mob, nullptr, nullptr, TO_ROOM);
 			extract_char(mob, true);
 		}
 	}
@@ -2555,14 +2555,14 @@ bool open_prog_sewer_casket(OBJ_DATA *obj, CHAR_DATA *ch)
 	REMOVE_BIT_OLD(obj->value[1], CONT_CLOSED);
 
 	send_to_char("You slide the heavy lid off the stone burial casket.\n\r", ch);
-	act("$n slides the heavy lid off the stone burial casket.", ch, 0, 0, TO_ROOM);
+	act("$n slides the heavy lid off the stone burial casket.", ch, nullptr, nullptr, TO_ROOM);
 
 	skeleton = create_mobile(get_mob_index(2200));
 
 	char_to_room(skeleton, ch->in_room);
-	act("Dust fills the burial chamber, and as it clears....", ch, 0, 0, TO_ALL);
-	act("$N rises out of the casket and lunges at you!", ch, 0, skeleton, TO_CHAR);
-	act("$N rises out of the casket and lunges at $n!", ch, 0, skeleton, TO_ROOM);
+	act("Dust fills the burial chamber, and as it clears....", ch, nullptr, nullptr, TO_ALL);
+	act("$N rises out of the casket and lunges at you!", ch, nullptr, skeleton, TO_CHAR);
+	act("$N rises out of the casket and lunges at $n!", ch, nullptr, skeleton, TO_ROOM);
 
 	do_murder(skeleton, ch->name);
 
@@ -2579,8 +2579,8 @@ void verb_prog_pull_hook([[maybe_unused]] OBJ_DATA *obj, CHAR_DATA *ch, [[maybe_
 
 	if (!IS_SET(pexit->exit_info, EX_CLOSED) || !IS_SET(pexit->exit_info, EX_LOCKED))
 	{
-		act("You tug on a metal hook inside a notch in the marble and nothing happens.", ch, 0, 0, TO_CHAR);
-		act("$n tugs on a metal hook inside a notch in the marble.", ch, 0, 0, TO_ROOM);
+		act("You tug on a metal hook inside a notch in the marble and nothing happens.", ch, nullptr, nullptr, TO_CHAR);
+		act("$n tugs on a metal hook inside a notch in the marble.", ch, nullptr, nullptr, TO_ROOM);
 		return;
 	}
 
@@ -2589,7 +2589,7 @@ void verb_prog_pull_hook([[maybe_unused]] OBJ_DATA *obj, CHAR_DATA *ch, [[maybe_
 
 	send_to_char("You tug on a hook of metal inside this notch.\n\r", ch);
 	act("$n tugs on a small metal hook inside a notch in the marble.", ch, nullptr, pexit->keyword, TO_ROOM);
-	act("A soft click is audible and then the southern wall slides noisily open!", ch, 0, 0, TO_ALL);
+	act("A soft click is audible and then the southern wall slides noisily open!", ch, nullptr, nullptr, TO_ALL);
 
 	if ((to_room = pexit->u1.to_room) != nullptr
 		&& (pexit_rev = to_room->exit[0]) != nullptr
@@ -2624,21 +2624,21 @@ void verb_prog_turn_spindle(OBJ_DATA *obj, CHAR_DATA *ch, [[maybe_unused]] char 
 			dir = Directions::Up;
 			break;
 		default:
-			act("You turn the wheel and it spins rapidly, seemingly unattached to anything.", ch, 0, 0, TO_CHAR);
-			act("$n turns the wheel and it spins rapidly, seemingly unattached to anything.", ch, 0, 0, TO_ROOM);
+			act("You turn the wheel and it spins rapidly, seemingly unattached to anything.", ch, nullptr, nullptr, TO_CHAR);
+			act("$n turns the wheel and it spins rapidly, seemingly unattached to anything.", ch, nullptr, nullptr, TO_ROOM);
 			return;
 	}
 
 	pexit = room->exit[dir];
 
-	act("The spindle wheel creaks loudly as you turn it....", ch, 0, 0, TO_CHAR);
-	act("The spindle wheel creaks loudly as $n turns it....", ch, 0, 0, TO_ROOM);
+	act("The spindle wheel creaks loudly as you turn it....", ch, nullptr, nullptr, TO_CHAR);
+	act("The spindle wheel creaks loudly as $n turns it....", ch, nullptr, nullptr, TO_ROOM);
 
 	direction = flag_name_lookup(dir, direction_table);
 
 	if (IS_SET(pexit->exit_info, EX_CLOSED))
 	{
-		act("A massive rusted grate slides noisily open, revealing a tunnel $tward!", ch, direction, 0, TO_ALL);
+		act("A massive rusted grate slides noisily open, revealing a tunnel $tward!", ch, direction, nullptr, TO_ALL);
 
 		REMOVE_BIT(pexit->exit_info, EX_CLOSED);
 		REMOVE_BIT(pexit->exit_info, EX_LOCKED);
@@ -2648,12 +2648,12 @@ void verb_prog_turn_spindle(OBJ_DATA *obj, CHAR_DATA *ch, [[maybe_unused]] char 
 		if (pexit->u1.to_room->people)
 		{
 			revdir = flag_name_lookup(reverse_d(dir), direction_table);
-			act("A massive rusted grate slides noisily open, revealing a tunnel $tward!", ch, revdir, 0, TO_ALL);
+			act("A massive rusted grate slides noisily open, revealing a tunnel $tward!", ch, revdir, nullptr, TO_ALL);
 		}
 	}
 	else
 	{
-		act("A massive rusted grates slides noisily shut, barring the tunnel $tward!", ch, direction, 0, TO_ALL);
+		act("A massive rusted grates slides noisily shut, barring the tunnel $tward!", ch, direction, nullptr, TO_ALL);
 
 		SET_BIT(pexit->exit_info, EX_CLOSED);
 		SET_BIT(pexit->exit_info, EX_LOCKED);
@@ -2663,7 +2663,7 @@ void verb_prog_turn_spindle(OBJ_DATA *obj, CHAR_DATA *ch, [[maybe_unused]] char 
 		if (pexit->u1.to_room->people)
 		{
 			revdir = flag_name_lookup(reverse_d(dir), direction_table);
-			act("A massive rusted grate slides noisily shut, revealing a tunnel $tward!", ch, revdir, 0, TO_ALL);
+			act("A massive rusted grate slides noisily shut, revealing a tunnel $tward!", ch, revdir, nullptr, TO_ALL);
 		}
 	}
 }
@@ -3161,8 +3161,8 @@ void pulse_prog_cimar_babies(OBJ_DATA *obj, [[maybe_unused]] bool isTick)
 	if (number_percent() <= 98 || is_affected_obj(obj, gsn_bash))
 		return;
 
-	act("$p begins wailing, its squalling face turning bright red.", ch, obj, 0, TO_CHAR);
-	act("$n's baby begins wailing...", ch, obj, 0, TO_ROOM);
+	act("$p begins wailing, its squalling face turning bright red.", ch, obj, nullptr, TO_CHAR);
+	act("$n's baby begins wailing...", ch, obj, nullptr, TO_ROOM);
 }
 
 void verb_prog_feed_baby(OBJ_DATA *obj, CHAR_DATA *ch, [[maybe_unused]] char *argument)
@@ -3192,8 +3192,8 @@ void verb_prog_feed_baby(OBJ_DATA *obj, CHAR_DATA *ch, [[maybe_unused]] char *ar
 		return;
 	}
 
-	act("$p greedily begins to feed from a bladder of milk.", ch, obj, 0, TO_CHAR);
-	act("$n's baby greedily begins to feed.", ch, 0, 0, TO_ROOM);
+	act("$p greedily begins to feed from a bladder of milk.", ch, obj, nullptr, TO_CHAR);
+	act("$n's baby greedily begins to feed.", ch, nullptr, nullptr, TO_ROOM);
 	milk->value[1] = 0;
 
 	RS.Queue.AddToQueue(12, "verb_prog_feed_baby", "act_queue", act_queue, "$p drifts off to sleep.", ch, obj, nullptr, TO_CHAR);
@@ -3224,8 +3224,8 @@ void baby_end(OBJ_DATA *obj, [[maybe_unused]] OBJ_AFFECT_DATA *af)
 	if (ch == nullptr)
 		return;
 
-	act("$p suddenly wakens and looks around curiously.", ch, obj, 0, TO_CHAR);
-	act("$n's baby wakes up.", ch, 0, 0, TO_ROOM);
+	act("$p suddenly wakens and looks around curiously.", ch, obj, nullptr, TO_CHAR);
+	act("$n's baby wakes up.", ch, nullptr, nullptr, TO_ROOM);
 }
 
 void baby_burp(OBJ_DATA *obj, [[maybe_unused]] OBJ_AFFECT_DATA *af)
@@ -3235,8 +3235,8 @@ void baby_burp(OBJ_DATA *obj, [[maybe_unused]] OBJ_AFFECT_DATA *af)
 	if (ch == nullptr)
 		return;
 
-	act("$p burps loudly.", ch, obj, 0, TO_CHAR);
-	act("$n's baby burps loudly.", ch, 0, 0, TO_ROOM);
+	act("$p burps loudly.", ch, obj, nullptr, TO_CHAR);
+	act("$n's baby burps loudly.", ch, nullptr, nullptr, TO_ROOM);
 }
 
 void verb_prog_pull_book([[maybe_unused]] OBJ_DATA *obj, CHAR_DATA *ch, [[maybe_unused]] char *argument)
@@ -3246,7 +3246,7 @@ void verb_prog_pull_book([[maybe_unused]] OBJ_DATA *obj, CHAR_DATA *ch, [[maybe_
 
 	if (!IS_SET(pexit->exit_info, EX_CLOSED))
 	{
-		act("The book snaps back into the shelf.", ch, 0, 0, TO_ALL);
+		act("The book snaps back into the shelf.", ch, nullptr, nullptr, TO_ALL);
 		return;
 	}
 
@@ -3254,10 +3254,10 @@ void verb_prog_pull_book([[maybe_unused]] OBJ_DATA *obj, CHAR_DATA *ch, [[maybe_
 	REMOVE_BIT(pexit->exit_info, EX_CLOSED);
 	REMOVE_BIT(pexit->exit_info, EX_NONOBVIOUS);
 
-	act("You pull The Tome of the Caverns from the shelf.", ch, 0, 0, TO_CHAR);
-	act("$n pulls a book from the shelf.", ch, 0, 0, TO_ROOM);
-	act("The book snaps back into the shelf, and a creaking sound fills the air!", ch, 0, 0, TO_ALL);
-	act("A trap door in the floor swings open.", ch, 0, 0, TO_ALL);
+	act("You pull The Tome of the Caverns from the shelf.", ch, nullptr, nullptr, TO_CHAR);
+	act("$n pulls a book from the shelf.", ch, nullptr, nullptr, TO_ROOM);
+	act("The book snaps back into the shelf, and a creaking sound fills the air!", ch, nullptr, nullptr, TO_ALL);
+	act("A trap door in the floor swings open.", ch, nullptr, nullptr, TO_ALL);
 
 	init_affect_room(&raf);
 	raf.where = TO_ROOM_AFFECTS;
@@ -3284,7 +3284,7 @@ void trapdoor_end(ROOM_INDEX_DATA *room, [[maybe_unused]] ROOM_AFFECT_DATA *af)
 		CHAR_DATA *ch = walk.Current();
 
 		if (ch->in_room == room)
-			act("A creaking sound fills the air, and a trap door in the floor swings shut.", ch, 0, 0, TO_CHAR);
+			act("A creaking sound fills the air, and a trap door in the floor swings shut.", ch, nullptr, nullptr, TO_CHAR);
 	}
 }
 
@@ -3307,11 +3307,11 @@ bool open_prog_beef_balls([[maybe_unused]] OBJ_DATA *obj, CHAR_DATA *ch)
 		}
 	}
 
-	act("The trapped aroma of the beef balls wafts through the air like a brick.", ch, 0, 0, TO_CHAR);
+	act("The trapped aroma of the beef balls wafts through the air like a brick.", ch, nullptr, nullptr, TO_CHAR);
 
 	if (found && ch->pcdata->quests[PETE_QUEST] == 1)
 	{
-		act("$N's eyes go wild at the odor, and he leaps to his feet!", ch, 0, mob, TO_ALL);
+		act("$N's eyes go wild at the odor, and he leaps to his feet!", ch, nullptr, mob, TO_ALL);
 		mprog_say(2, "Please!  Please, please, please, Pete must have that bag, please!  Will please give you information you like!", mob, ch);
 		ch->pcdata->quests[PETE_QUEST] = 2;
 	}
@@ -3408,7 +3408,7 @@ void verb_prog_attach_weapon(OBJ_DATA *obj, CHAR_DATA *ch, [[maybe_unused]] char
 		return;
 	}
 
-	act("You attach $p to a long wooden pole.", ch, obj, 0, TO_CHAR);
+	act("You attach $p to a long wooden pole.", ch, obj, nullptr, TO_CHAR);
 
 	switch (obj->pIndexData->vnum)
 	{
@@ -3520,8 +3520,8 @@ void verb_prog_pull_lever(OBJ_DATA *obj, CHAR_DATA *ch, [[maybe_unused]] char *a
 
 	mob = create_mobile(get_mob_index(vnum));
 	char_to_room(mob, ch->in_room);
-	act(buf2, ch, 0, 0, TO_ROOM);
-	act(buf, ch, 0, 0, TO_CHAR);
+	act(buf2, ch, nullptr, nullptr, TO_ROOM);
+	act(buf, ch, nullptr, nullptr, TO_CHAR);
 	one_hit(ch, mob, TYPE_UNDEFINED);
 
 	WAIT_STATE(ch, PULSE_VIOLENCE);
@@ -3550,8 +3550,8 @@ void verb_prog_tie_rope(OBJ_DATA *obj, CHAR_DATA *ch, [[maybe_unused]] char *arg
 		return;
 	}
 
-	act("You tie a length of rope between the wheel and the metal plate.", ch, 0, 0, TO_CHAR);
-	act("$n ties a length of rope between the wheel and the metal plate.", ch, 0, 0, TO_ROOM);
+	act("You tie a length of rope between the wheel and the metal plate.", ch, nullptr, nullptr, TO_CHAR);
+	act("$n ties a length of rope between the wheel and the metal plate.", ch, nullptr, nullptr, TO_ROOM);
 
 	init_affect_obj(&oaf);
 	oaf.where = TO_OBJ_AFFECTS;
@@ -3579,8 +3579,8 @@ void verb_prog_turn_wheel(OBJ_DATA *obj, CHAR_DATA *ch, [[maybe_unused]] char *a
 	REMOVE_BIT(exit->exit_info, EX_NOPASS);
 	REMOVE_BIT(exit->exit_info, EX_CLOSED);
 
-	act("You spin the wheel like a crank, and the rope hauls the metal plate up easily!", ch, 0, 0, TO_CHAR);
-	act("$n spins the wheel and a metal plate in the floor opens!", ch, 0, 0, TO_ROOM);
+	act("You spin the wheel like a crank, and the rope hauls the metal plate up easily!", ch, nullptr, nullptr, TO_CHAR);
+	act("$n spins the wheel and a metal plate in the floor opens!", ch, nullptr, nullptr, TO_ROOM);
 }
 
 void rope_end(OBJ_DATA *obj, [[maybe_unused]] OBJ_AFFECT_DATA *af)
@@ -3596,7 +3596,7 @@ void rope_end(OBJ_DATA *obj, [[maybe_unused]] OBJ_AFFECT_DATA *af)
 	if (!room->people)
 		return;
 
-	act("As the rope breaks, the metal plate slams back into the floor.", room->people, 0, 0, TO_ALL);
+	act("As the rope breaks, the metal plate slams back into the floor.", room->people, nullptr, nullptr, TO_ALL);
 }
 
 void verb_prog_tilt_bust([[maybe_unused]] OBJ_DATA *obj, CHAR_DATA *ch, [[maybe_unused]] char *argument)
@@ -3605,14 +3605,14 @@ void verb_prog_tilt_bust([[maybe_unused]] OBJ_DATA *obj, CHAR_DATA *ch, [[maybe_
 
 	if (!IS_SET(exit->exit_info, EX_CLOSED))
 	{
-		act("$n tilts the bust backwards.", ch, 0, 0, TO_ROOM);
-		act("You tilt the bust backwards.", ch, 0, 0, TO_CHAR);
+		act("$n tilts the bust backwards.", ch, nullptr, nullptr, TO_ROOM);
+		act("You tilt the bust backwards.", ch, nullptr, nullptr, TO_CHAR);
 		return;
 	}
 
-	act("You tilt the bust backwards.", ch, 0, 0, TO_CHAR);
-	act("$n tilts the bust backwards.", ch, 0, 0, TO_ROOM);
-	act("The south wall slides back silently, revealing a doorway!", ch, 0, 0, TO_ALL);
+	act("You tilt the bust backwards.", ch, nullptr, nullptr, TO_CHAR);
+	act("$n tilts the bust backwards.", ch, nullptr, nullptr, TO_ROOM);
+	act("The south wall slides back silently, revealing a doorway!", ch, nullptr, nullptr, TO_ALL);
 
 	REMOVE_BIT(exit->exit_info, EX_LOCKED);
 	REMOVE_BIT(exit->exit_info, EX_CLOSED);
@@ -3639,7 +3639,7 @@ void verb_prog_roll_tablet([[maybe_unused]] OBJ_DATA *obj, CHAR_DATA *ch, [[mayb
 	REMOVE_BIT(exit->exit_info, EX_CLOSED);
 	REMOVE_BIT(exit->exit_info, EX_LOCKED);
 
-	act("Grunting with the effort, you slowly roll the huge stone tablet to the side of the tunnel.", ch, 0, 0, TO_CHAR);
+	act("Grunting with the effort, you slowly roll the huge stone tablet to the side of the tunnel.", ch, nullptr, nullptr, TO_CHAR);
 }
 
 void close_elevator(ROOM_INDEX_DATA *pRoom)
@@ -3652,8 +3652,8 @@ void close_elevator(ROOM_INDEX_DATA *pRoom)
 	{
 		if (pRoom->exit[i] && pRoom->exit[i]->u1.to_room)
 		{
-			act(mmsg, pRoom->exit[i]->u1.to_room->people, 0, 0, TO_ALL);
-			act(mmsg, pRoom->people, 0, 0, TO_ALL);
+			act(mmsg, pRoom->exit[i]->u1.to_room->people, nullptr, nullptr, TO_ALL);
+			act(mmsg, pRoom->people, nullptr, nullptr, TO_ALL);
 
 			toRoom = pRoom->exit[i]->u1.to_room;
 
@@ -3670,8 +3670,8 @@ void open_elevator(ROOM_INDEX_DATA *eleRoom, ROOM_INDEX_DATA *toRoom)
 	int i;
 	const char omsg[] = "The doors to the lift slide open with a loud clang.";
 
-	act(omsg, eleRoom->people, 0, 0, TO_ALL);
-	act(omsg, toRoom->people, 0, 0, TO_ALL);
+	act(omsg, eleRoom->people, nullptr, nullptr, TO_ALL);
+	act(omsg, toRoom->people, nullptr, nullptr, TO_ALL);
 
 	eleRoom->mana_rate = 100;
 
@@ -3698,7 +3698,7 @@ void act_to_room(void *vo1, void *vo2)
 	if (!pRoom->people)
 		return;
 
-	act((char *)vo1, pRoom->people, 0, 0, TO_ALL);
+	act((char *)vo1, pRoom->people, nullptr, nullptr, TO_ALL);
 }
 
 void act_to_room_queue(std::string format, ROOM_INDEX_DATA *room)
@@ -3733,7 +3733,7 @@ void verb_prog_iseldheim_lever_pull(OBJ_DATA *obj, CHAR_DATA *ch, [[maybe_unused
 	if (elInTransit || eleRoom->mana_rate == 101)
 	{
 		send_to_char("You pull the lever, but nothing seems to happen.\n\r", ch);
-		act("$n pulls the lever, but nothing seems to happen.", ch, 0, 0, TO_ROOM);
+		act("$n pulls the lever, but nothing seems to happen.", ch, nullptr, nullptr, TO_ROOM);
 		return;
 	}
 
@@ -3756,8 +3756,8 @@ void verb_prog_iseldheim_lever_pull(OBJ_DATA *obj, CHAR_DATA *ch, [[maybe_unused
 		RS.Queue.AddToQueue(9, "verb_prog_iseldheim_lever_pull", "act_to_room_queue", act_to_room_queue, "The lift shudders as it slowly comes to a halt.", eleRoom);
 		RS.Queue.AddToQueue(10, "verb_prog_iseldheim_lever_pull", "open_elevator", open_elevator, eleRoom, lRoom);
 
-		act("You pull the lever into the down position.", ch, 0, 0, TO_CHAR);
-		act("$n pulls the lever into the down position.", ch, 0, 0, TO_ROOM);
+		act("You pull the lever into the down position.", ch, nullptr, nullptr, TO_CHAR);
+		act("$n pulls the lever into the down position.", ch, nullptr, nullptr, TO_ROOM);
 	}
 	else if (lRoom->exit[eDir]->u1.to_room)
 	{ // elevator is here, we can send it back up
@@ -3770,8 +3770,8 @@ void verb_prog_iseldheim_lever_pull(OBJ_DATA *obj, CHAR_DATA *ch, [[maybe_unused
 		RS.Queue.AddToQueue(9, "verb_prog_iseldheim_lever_pull", "act_to_room_queue", act_to_room_queue, "The lift shudders as it slowly comes to a halt.", eleRoom);
 		RS.Queue.AddToQueue(10, "verb_prog_iseldheim_lever_pull", "open_elevator", open_elevator, eleRoom, tRoom);
 
-		act("You pull the lever into the up position.", ch, 0, 0, TO_CHAR);
-		act("$n pulls the lever into the up position.", ch, 0, 0, TO_ROOM);
+		act("You pull the lever into the up position.", ch, nullptr, nullptr, TO_CHAR);
+		act("$n pulls the lever into the up position.", ch, nullptr, nullptr, TO_ROOM);
 	}
 }
 
@@ -3782,9 +3782,9 @@ void fight_prog_bugzapper(OBJ_DATA *obj, CHAR_DATA *ch)
 	if (!victim || !is_npc(victim) || victim->pIndexData->vnum < 3000 || victim->pIndexData->vnum > 3010 || !is_worn(obj))
 		return;
 
-	act("$n shrinks back suddenly at the sight of $p.", victim, obj, 0, TO_ROOM);
-	act("Imbued with newfound vigor, you hack mercilessly at $n.", victim, 0, ch, TO_VICT);
-	act("$N suddenly strikes $n with a brutal blow.", victim, 0, ch, TO_NOTVICT);
+	act("$n shrinks back suddenly at the sight of $p.", victim, obj, nullptr, TO_ROOM);
+	act("Imbued with newfound vigor, you hack mercilessly at $n.", victim, nullptr, ch, TO_VICT);
+	act("$N suddenly strikes $n with a brutal blow.", victim, nullptr, ch, TO_NOTVICT);
 	one_hit_new(ch, victim, TYPE_UNDEFINED, HIT_NOSPECIALS, HIT_UNBLOCKABLE, HIT_NOADD, 700, nullptr);
 }
 
@@ -3801,12 +3801,12 @@ void fight_prog_arms_light(OBJ_DATA *obj, CHAR_DATA *ch)
 
 	if (number_percent() > 90)
 	{
-		act("$p suddenly flares brightly!", victim, obj, 0, TO_ROOM);
+		act("$p suddenly flares brightly!", victim, obj, nullptr, TO_ROOM);
 
 		if (!saves_spell(ch->level, victim, DAM_LIGHT))
 		{
-			act("$n appears to be blinded.", victim, obj, 0, TO_ROOM);
-			act("You are blinded!", ch, 0, victim, TO_VICT);
+			act("$n appears to be blinded.", victim, obj, nullptr, TO_ROOM);
+			act("You are blinded!", ch, nullptr, victim, TO_VICT);
 
 			init_affect(&af);
 			af.where = TO_AFFECTS;
@@ -3829,7 +3829,7 @@ void drop_prog_elven_gem(OBJ_DATA *obj, CHAR_DATA *ch)
 	{
 		if (obj->pIndexData->vnum == obj2->pIndexData->vnum)
 		{
-			act("As $p falls to the floor, it disintegrates and becomes a cloud of dust.", ch, obj, 0, TO_ROOM);
+			act("As $p falls to the floor, it disintegrates and becomes a cloud of dust.", ch, obj, nullptr, TO_ROOM);
 			extract_obj(obj);
 			break;
 		}
@@ -3953,7 +3953,7 @@ void speech_prog_elven_mirror(OBJ_DATA *obj, CHAR_DATA *ch, char *speech)
 	{
 		act("$p forms into a hazy image of $N.", ch, obj, victim, TO_CHAR);
 		sprintf(buf, "Peering into the mirror, you see $N %s.", sect);
-		act(buf, ch, 0, victim, TO_CHAR);
+		act(buf, ch, nullptr, victim, TO_CHAR);
 
 		free_pstring(obj->description);
 		sprintf(buf, "A curious mirror lies here, humming softly.  Peering into the glass, you see %s %s.", victim->name, sect);
@@ -3962,7 +3962,7 @@ void speech_prog_elven_mirror(OBJ_DATA *obj, CHAR_DATA *ch, char *speech)
 	}
 
 	if (rand > 89)
-		act("$p fails to form into a coherent image.", ch, obj, 0, TO_CHAR);
+		act("$p fails to form into a coherent image.", ch, obj, nullptr, TO_CHAR);
 }
 
 void verb_prog_turn_wyntran([[maybe_unused]] OBJ_DATA *obj, CHAR_DATA *ch, [[maybe_unused]] char *argument)
@@ -3978,8 +3978,8 @@ void verb_prog_turn_wyntran([[maybe_unused]] OBJ_DATA *obj, CHAR_DATA *ch, [[may
 
 	victim = create_mobile(pMobIndex);
 
-	act("The temperature in the room drops rapidly as a darkened portal opens overhead.", ch, 0, 0, TO_ROOM);
-	act("The temperature in the room drops rapidly as a darkened portal opens overhead.", ch, 0, 0, TO_CHAR);
+	act("The temperature in the room drops rapidly as a darkened portal opens overhead.", ch, nullptr, nullptr, TO_ROOM);
+	act("The temperature in the room drops rapidly as a darkened portal opens overhead.", ch, nullptr, nullptr, TO_CHAR);
 
 	RS.Queue.AddToQueue(3, "verb_prog_turn_wyntran", "act_queue", act_queue, "Accompanied by peals of thunder a shrouded being descends from the portal.", ch, nullptr, nullptr, TO_CHAR);
 	RS.Queue.AddToQueue(3, "verb_prog_turn_wyntran", "act_queue", act_queue, "Accompanied by peals of thunder a shrouded being descends from the portal.", ch, nullptr, nullptr, TO_ROOM);
@@ -4025,15 +4025,15 @@ void verb_prog_place_star(OBJ_DATA *obj, CHAR_DATA *ch, [[maybe_unused]] char *a
 		}
 	}
 
-	act("You set $p on the surface of the symbol.", ch, obj, 0, TO_CHAR);
-	act("$n sets $p on the surface of the symbol.", ch, obj, 0, TO_ROOM);
+	act("You set $p on the surface of the symbol.", ch, obj, nullptr, TO_CHAR);
+	act("$n sets $p on the surface of the symbol.", ch, obj, nullptr, TO_ROOM);
 
 	sprintf(buf, "%s$p rotates rapidly before flying into %s in the symbol with an audible click!%s",
 		get_char_color(ch, "yellow"),
 		iStars >= 4 ? "the last indentation" : "one of the indentations",
 		END_COLOR(ch));
 
-	act(buf, ch, obj, 0, TO_ALL);
+	act(buf, ch, obj, nullptr, TO_ALL);
 	obj_from_char(obj);
 	obj_to_obj(obj, pContainer);
 
@@ -4050,7 +4050,7 @@ void verb_prog_place_star(OBJ_DATA *obj, CHAR_DATA *ch, [[maybe_unused]] char *a
 		get_char_color(ch, "white"),
 		END_COLOR(ch));
 
-	act(buf, ch, 0, 0, TO_ALL);
+	act(buf, ch, nullptr, nullptr, TO_ALL);
 
 	if (!(nroom = get_room_index(4649)))
 		return;
@@ -4102,8 +4102,8 @@ void verb_prog_fallendesert_climb_ladder([[maybe_unused]] OBJ_DATA *obj, CHAR_DA
 		return;
 	}
 
-	act("The ladder gives slightly from your weight as you climb into the tent.", ch, 0, 0, TO_CHAR);
-	act("The ladder gives slightly from $n's weight as $e climbs into the tent.", ch, 0, 0, TO_ROOM);
+	act("The ladder gives slightly from your weight as you climb into the tent.", ch, nullptr, nullptr, TO_CHAR);
+	act("The ladder gives slightly from $n's weight as $e climbs into the tent.", ch, nullptr, nullptr, TO_ROOM);
 
 	char_from_room(ch);
 	char_to_room(ch, to_room);
@@ -4147,8 +4147,8 @@ void verb_prog_fallendesert_(OBJ_DATA *obj, CHAR_DATA *ch, char *argument)
 		return;
 	}
 
-	act("The ladder gives slightly from your weight as you climb into the tent.", ch, 0, 0, TO_CHAR);
-	act("The ladder gives slightly from $n's weight as $e climbs into the tent.", ch, 0, 0, TO_ROOM);
+	act("The ladder gives slightly from your weight as you climb into the tent.", ch, nullptr, nullptr, TO_CHAR);
+	act("The ladder gives slightly from $n's weight as $e climbs into the tent.", ch, nullptr, nullptr, TO_ROOM);
 
 	char_from_room(ch);
 	char_to_room(ch, to_room);

--- a/code/iprog.c
+++ b/code/iprog.c
@@ -1971,7 +1971,14 @@ void verb_prog_energize_tattoo(OBJ_DATA *obj, CHAR_DATA *ch, [[maybe_unused]] ch
 	if (!saves_spell(ch->level, Deref(ch->fighting), DAM_NEGATIVE))
 	{
 		damage_new(ch, Deref(ch->fighting), dice(1, 10), TYPE_UNDEFINED, DAM_NEGATIVE, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "energy sapping");
-		Deref(ch->fighting)->mana -= (int)(2.8 * ch->level);
+
+		// Re-read rather than hoist: damage_new can kill the target, which clears
+		// this handle. It yields null then instead of a freed character.
+		CHAR_DATA *victim = Deref(ch->fighting);
+
+		if (victim != nullptr)
+			victim->mana -= (int)(2.8 * ch->level);
+
 		obj->value[0]++;
 
 		init_affect_obj(&oaf);

--- a/code/ispec.c
+++ b/code/ispec.c
@@ -28,10 +28,10 @@ static int torture_flail_fight(CHAR_DATA *ch, OBJ_DATA *)
 	AFFECT_DATA af;
 	init_affect(&af);
 
-	act("A scream escapes your flail as a shadow tears at $N's eyes!", ch, 0, Deref(ch->fighting), TO_CHAR);
-	act("A scream escapes $n's flail as a shadow tears at $N's eyes!", ch, 0, Deref(ch->fighting), TO_NOTVICT);
-	act("A scream escapes $n's flail as a shadow tears at your eyes!", ch, 0, Deref(ch->fighting), TO_VICT);
-	act("$n appears to be blinded.", Deref(ch->fighting), 0, 0, TO_ROOM);
+	act("A scream escapes your flail as a shadow tears at $N's eyes!", ch, nullptr, Deref(ch->fighting), TO_CHAR);
+	act("A scream escapes $n's flail as a shadow tears at $N's eyes!", ch, nullptr, Deref(ch->fighting), TO_NOTVICT);
+	act("A scream escapes $n's flail as a shadow tears at your eyes!", ch, nullptr, Deref(ch->fighting), TO_VICT);
+	act("$n appears to be blinded.", Deref(ch->fighting), nullptr, nullptr, TO_ROOM);
 
 	af.type = gsn_blindness;
 	af.aftype = AFT_MALADY;
@@ -50,7 +50,7 @@ static int torture_flail_fight(CHAR_DATA *ch, OBJ_DATA *)
 /// @note Body taken from the EVENT_IWEAR block of ispec_g_money.
 static int g_money_wear(CHAR_DATA *ch, OBJ_DATA *)
 {
-	act("J00 gonna wear me!? J00 GONNA WEAR ME?!?!?", ch, 0, 0, TO_CHAR);
+	act("J00 gonna wear me!? J00 GONNA WEAR ME?!?!?", ch, nullptr, nullptr, TO_CHAR);
 	return 0;
 }
 
@@ -61,7 +61,7 @@ static int g_money_wear(CHAR_DATA *ch, OBJ_DATA *)
 /// @note Body taken from the EVENT_IREMOVE block of ispec_g_money.
 static int g_money_remove(CHAR_DATA *ch, OBJ_DATA *obj)
 {
-	act("You feel vary vary stoopid as you remove $p.", ch, obj, 0, TO_CHAR);
+	act("You feel vary vary stoopid as you remove $p.", ch, obj, nullptr, TO_CHAR);
 	do_say(ch, "Duuuuuuuuh.");
 
 	return 0;
@@ -77,7 +77,7 @@ static int qwhip_one_hit(CHAR_DATA *ch, CHAR_DATA *, OBJ_DATA *, float &, int &,
 {
 	if (number_percent() > 96 && Deref(ch->fighting))
 	{
-		act("Sadistic urges compel you to lash out viciously at $N!", ch, 0, Deref(ch->fighting), TO_CHAR);
+		act("Sadistic urges compel you to lash out viciously at $N!", ch, nullptr, Deref(ch->fighting), TO_CHAR);
 		//dam = dam * 1.3;
 		//dt = 42;
 		//ch->hit = std::min(ch->max_hit, ch->hit + ((int)dam / 4));
@@ -97,9 +97,9 @@ static int qwhip_fight(CHAR_DATA *ch, OBJ_DATA *)
 
 	CHAR_DATA *victim = Deref(ch->fighting);
 
-	act("$n wraps $s whip around $N's legs, sending $M staggering!", ch, 0, victim, TO_NOTVICT);
-	act("You wrap your whip around $N's legs, sending $M staggering.", ch, 0, victim, TO_CHAR);
-	act("$n wraps $s whip around your legs, sending you staggering!", ch, 0, victim, TO_VICT);
+	act("$n wraps $s whip around $N's legs, sending $M staggering!", ch, nullptr, victim, TO_NOTVICT);
+	act("You wrap your whip around $N's legs, sending $M staggering.", ch, nullptr, victim, TO_CHAR);
+	act("$n wraps $s whip around your legs, sending you staggering!", ch, nullptr, victim, TO_VICT);
 
 	WAIT_STATE(victim, PULSE_VIOLENCE + 2);
 

--- a/code/magic.c
+++ b/code/magic.c
@@ -494,7 +494,6 @@ void do_laying_hands(CHAR_DATA *ch, char *argument)
 	CHAR_DATA *victim; /* Well not really victim, but keeping it standard varibale anmes */
 	AFFECT_DATA af;
 	int heal;
-	int chance;
 
 	if ((get_skill(ch, gsn_laying_hands) == 0) ||
 		(ch->level < skill_table[gsn_laying_hands].skill_level[ch->Class()->GetIndex()]))
@@ -2181,7 +2180,6 @@ void spell_cure_serious(int /* sn */, int level, CHAR_DATA *ch, SpellTarget vo, 
 void spell_curse(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
 {
 	CHAR_DATA *victim;
-	OBJ_DATA *obj;
 	AFFECT_DATA af;
 
 	/* deal with the object case first
@@ -4501,9 +4499,8 @@ void spell_turn_undead(int sn, int level, CHAR_DATA *ch, SpellTarget /* vo */, C
 	CHAR_DATA *v_next;
 	int dam = 0;
 	int value, count, num;
-	CHAR_DATA *follower;
 
-	follower = nullptr; /* follower, count and num used for evil clerics */
+	/* count and num are used for evil clerics */
 	count = 0;
 	num = 0;
 

--- a/code/magic.c
+++ b/code/magic.c
@@ -342,7 +342,7 @@ bool check_dispel(int dis_level, CHAR_DATA *victim, int sn)
 					}
 
 					if (str_cmp(skill_table[sn].room_msg_off, ""))
-						act(skill_table[sn].room_msg_off, victim, 0, 0, TO_ROOM);
+						act(skill_table[sn].room_msg_off, victim, nullptr, nullptr, TO_ROOM);
 
 					return true;
 				}
@@ -382,13 +382,13 @@ bool check_dispel_cancellation(int dis_level, CHAR_DATA *victim, CHAR_DATA *ch, 
 						if (ch != victim)
 						{
 							sprintf(buf, "The magic of $N's %s spell unravels.", skill_table[sn].name);
-							act(buf, ch, 0, victim, TO_CHAR);
+							act(buf, ch, nullptr, victim, TO_CHAR);
 						}
 
 						if (sn == gsn_diamondskin)
 						{
-							act("Unspeakable agony wracks your entire frame as your very skin shatters!", victim, 0, 0, TO_CHAR);
-							act("$n howls in agony as the diamond shell that was once $s skin shatters!", victim, 0, 0, TO_ROOM);
+							act("Unspeakable agony wracks your entire frame as your very skin shatters!", victim, nullptr, nullptr, TO_CHAR);
+							act("$n howls in agony as the diamond shell that was once $s skin shatters!", victim, nullptr, nullptr, TO_ROOM);
 							damage_new(victim, victim, victim->max_hit / 2, gsn_diamondskin, DAM_TRUESTRIKE, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, nullptr);
 						}
 
@@ -402,7 +402,7 @@ bool check_dispel_cancellation(int dis_level, CHAR_DATA *victim, CHAR_DATA *ch, 
 						if (ch != victim)
 						{
 							sprintf(buf, "The magic of $N's %s spell is unaffected.", skill_table[sn].name);
-							act(buf, ch, 0, victim, TO_CHAR);
+							act(buf, ch, nullptr, victim, TO_CHAR);
 						}
 					}
 				}
@@ -417,7 +417,7 @@ bool check_dispel_cancellation(int dis_level, CHAR_DATA *victim, CHAR_DATA *ch, 
 						if (ch != victim)
 						{
 							sprintf(buf, "The power of $N's %s supplication unravels.", skill_table[sn].name);
-							act(buf, ch, 0, victim, TO_CHAR);
+							act(buf, ch, nullptr, victim, TO_CHAR);
 						}
 
 						return true;
@@ -430,7 +430,7 @@ bool check_dispel_cancellation(int dis_level, CHAR_DATA *victim, CHAR_DATA *ch, 
 						if (ch != victim)
 						{
 							sprintf(buf, "The power of $N's %s supplication is unaffected.", skill_table[sn].name);
-							act(buf, ch, 0, victim, TO_CHAR);
+							act(buf, ch, nullptr, victim, TO_CHAR);
 						}
 					}
 				}
@@ -1027,7 +1027,7 @@ void do_cast(CHAR_DATA *ch, char *argument)
 
 		if (IS_SET(ch->in_room->room_flags, ROOM_NO_MAGIC) && !(ch->level > LEVEL_HERO))
 		{
-			act("$n's spell fizzles.", ch, 0, 0, TO_ROOM);
+			act("$n's spell fizzles.", ch, nullptr, nullptr, TO_ROOM);
 			send_to_char("Your spell fizzles and dies.\n\r", ch);
 			return;
 		}
@@ -1055,9 +1055,9 @@ void do_cast(CHAR_DATA *ch, char *argument)
 
 		if (offensive_at_char && is_affected(victim, gsn_cloak_of_mist) && number_percent() > 60)
 		{
-			act("Your spell dissipates in the mist swirling around $N.", ch, 0, victim, TO_CHAR);
-			act("$n's spell dissipates in the mist swirling around you.", ch, 0, victim, TO_VICT);
-			act("$n's spell dissipates in the mist swirling around $N.", ch, 0, victim, TO_NOTVICT);
+			act("Your spell dissipates in the mist swirling around $N.", ch, nullptr, victim, TO_CHAR);
+			act("$n's spell dissipates in the mist swirling around you.", ch, nullptr, victim, TO_VICT);
+			act("$n's spell dissipates in the mist swirling around $N.", ch, nullptr, victim, TO_NOTVICT);
 			return;
 		}
 
@@ -1066,14 +1066,14 @@ void do_cast(CHAR_DATA *ch, char *argument)
 			paf = affect_find(victim->affected, gsn_rotating_ward);
 			paf->modifier--;
 
-			act("A crystal rotating around $N's body absorbs your spell!", ch, 0, victim, TO_CHAR);
-			act("A crystal rotating around your body absorbs $n's spell!", ch, 0, victim, TO_VICT);
-			act("$n's spell is absorbed by a crystal rotating around $N's body!", ch, 0, victim, TO_NOTVICT);
+			act("A crystal rotating around $N's body absorbs your spell!", ch, nullptr, victim, TO_CHAR);
+			act("A crystal rotating around your body absorbs $n's spell!", ch, nullptr, victim, TO_VICT);
+			act("$n's spell is absorbed by a crystal rotating around $N's body!", ch, nullptr, victim, TO_NOTVICT);
 
 			if (paf->modifier <= 0)
 			{
 				affect_remove(victim, paf);
-				act("The crystal crumbles under the stress!", ch, 0, 0, TO_ROOM);
+				act("The crystal crumbles under the stress!", ch, nullptr, nullptr, TO_ROOM);
 			}
 
 			return;
@@ -1089,9 +1089,9 @@ void do_cast(CHAR_DATA *ch, char *argument)
 			{
 				if (number_percent() < (get_skill(victim, gsn_nullify) - 10))
 				{
-					act("Your magic fizzles out before it reaches $N!", ch, 0, victim, TO_CHAR);
-					act("$n's magic fizzles out before it reaches you!", ch, 0, victim, TO_VICT);
-					act("$n's magic fizzles out before it reaches $N!", ch, 0, victim, TO_NOTVICT);
+					act("Your magic fizzles out before it reaches $N!", ch, nullptr, victim, TO_CHAR);
+					act("$n's magic fizzles out before it reaches you!", ch, nullptr, victim, TO_VICT);
+					act("$n's magic fizzles out before it reaches $N!", ch, nullptr, victim, TO_NOTVICT);
 					check_improve(victim, gsn_nullify, true, 5);
 					return;
 				}
@@ -1148,7 +1148,7 @@ void obj_cast_spell(int sn, int level, CHAR_DATA *ch, CHAR_DATA *victim, OBJ_DAT
 
 	if (IS_SET(ch->in_room->room_flags, ROOM_NO_MAGIC))
 	{
-		act("$n's spell fizzles.", ch, 0, 0, TO_ROOM);
+		act("$n's spell fizzles.", ch, nullptr, nullptr, TO_ROOM);
 		send_to_char("Your spell fizzles and dies.\n\r", ch);
 		return;
 	}
@@ -1409,7 +1409,7 @@ void spell_blindness(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_u
 
 	if (is_affected_by(victim, AFF_BLIND))
 	{
-		act("$N is already blind!", ch, 0, victim, TO_CHAR);
+		act("$N is already blind!", ch, nullptr, victim, TO_CHAR);
 		return;
 	}
 
@@ -1417,7 +1417,7 @@ void spell_blindness(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_u
 		|| (is_npc(victim) && IS_SET(victim->act, ACT_UNDEAD))
 		|| IS_SET(victim->form, FORM_UNDEAD))
 	{
-		act("You failed to blind $N.", ch, 0, victim, TO_CHAR);
+		act("You failed to blind $N.", ch, nullptr, victim, TO_CHAR);
 		return;
 	}
 
@@ -1586,7 +1586,7 @@ void spell_chain_lightning(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[m
 	if (is_affected(ch, gsn_grounding))
 	{
 		send_to_char("The electricity fizzles at your feet.\n\r", ch);
-		act("A lightning bolt leaps from $n's hand but fizzles into the ground.", ch, 0, 0, TO_ROOM);
+		act("A lightning bolt leaps from $n's hand but fizzles into the ground.", ch, nullptr, nullptr, TO_ROOM);
 		return;
 	}
 
@@ -1868,9 +1868,9 @@ void spell_wrath(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unuse
 	if (saves_spell(level, victim, DAM_HOLY) || saves_spell(level, victim, DAM_HOLY))
 		dam /= 2;
 
-	act("You call down the wrath of god upon $N.", ch, 0, victim, TO_CHAR);
-	act("$n calls down the wrath of god upon $N.", ch, 0, victim, TO_NOTVICT);
-	act("$n calls down the wrath of god upon you.", ch, 0, victim, TO_VICT);
+	act("You call down the wrath of god upon $N.", ch, nullptr, victim, TO_CHAR);
+	act("$n calls down the wrath of god upon $N.", ch, nullptr, victim, TO_NOTVICT);
+	act("$n calls down the wrath of god upon you.", ch, nullptr, victim, TO_VICT);
 
 	damage_old(ch, victim, dam, sn, DAM_HOLY, true);
 
@@ -2023,7 +2023,7 @@ void spell_cure_blindness(int /* sn */, int level, CHAR_DATA *ch, SpellTarget vo
 	{
 		if (check_dispel(level, victim, gsn_blindness_dust))
 		{
-			act("The dust in $n's eyes fades away.", victim, 0, 0, TO_ROOM);
+			act("The dust in $n's eyes fades away.", victim, nullptr, nullptr, TO_ROOM);
 
 			if (!is_affected(victim, gsn_blindness))
 				return;
@@ -2146,7 +2146,7 @@ void spell_cure_poison(int /* sn */, int level, CHAR_DATA *ch, SpellTarget vo, C
 		if (check_dispel(level, victim, gsn_poison_dust))
 			send_to_char("A warm feelings runs through you as the poison dust vanishes.\n\r", victim);
 
-		act("$n looks much better.", victim, 0, 0, TO_ROOM);
+		act("$n looks much better.", victim, nullptr, nullptr, TO_ROOM);
 
 		if (!is_affected(victim, gsn_poison))
 			return;
@@ -2246,7 +2246,7 @@ void spell_curse(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unuse
 
 	if (saves_spell(level, victim, DAM_NEGATIVE))
 	{
-		act("You failed to curse $N.", ch, 0, victim, TO_CHAR);
+		act("You failed to curse $N.", ch, nullptr, victim, TO_CHAR);
 		return;
 	}
 
@@ -2823,14 +2823,14 @@ void spell_faerie_fire(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe
 
 	if (is_affected(victim, sn))
 	{
-		act("$N is already glowing with faerie fire.", ch, 0, victim, TO_CHAR);
+		act("$N is already glowing with faerie fire.", ch, nullptr, victim, TO_CHAR);
 		return;
 	}
 
 	if (saves_spell(level + 15, victim, DAM_OTHER))
 	{
-		act("$N resists your magical faerie fire.", ch, 0, victim, TO_CHAR);
-		act("You resist $n's magical faerie fire.", ch, 0, victim, TO_VICT);
+		act("$N resists your magical faerie fire.", ch, nullptr, victim, TO_CHAR);
+		act("You resist $n's magical faerie fire.", ch, nullptr, victim, TO_VICT);
 		return;
 	}
 
@@ -3602,9 +3602,9 @@ void spell_magic_missile(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[may
 	if (saves_spell(level, victim, DAM_ENERGY))
 		dam /= 2;
 
-	act("Missiles of pure mana streak from $n's hands to strike $N!", ch, 0, victim, TO_NOTVICT);
-	act("Missiles of pure mana streak from $n's hands to strike you!", ch, 0, victim, TO_VICT);
-	act("Missiles of pure mana streak from your hands to strike $N!", ch, 0, victim, TO_CHAR);
+	act("Missiles of pure mana streak from $n's hands to strike $N!", ch, nullptr, victim, TO_NOTVICT);
+	act("Missiles of pure mana streak from $n's hands to strike you!", ch, nullptr, victim, TO_VICT);
+	act("Missiles of pure mana streak from your hands to strike $N!", ch, nullptr, victim, TO_CHAR);
 
 	damage_new(ch, victim, dam, sn, DAM_ENERGY, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "magic missiles$");
 }
@@ -3722,14 +3722,14 @@ void spell_plague([[maybe_unused]] int sn, int level, CHAR_DATA *ch, SpellTarget
 	{
 		if (ch == victim)
 		{
-			act("A sudden fever washes over you, but it passes.", ch, 0, 0, TO_CHAR);
-			act("$n looks flushed for a moment, but it passes.", ch, 0, 0, TO_ROOM);
+			act("A sudden fever washes over you, but it passes.", ch, nullptr, nullptr, TO_CHAR);
+			act("$n looks flushed for a moment, but it passes.", ch, nullptr, nullptr, TO_ROOM);
 		}
 		else
 		{
 			act("$N resists the disease.", ch, nullptr, victim, TO_CHAR);
-			act("A sudden fever washes over you, but it passes.", ch, 0, victim, TO_VICT);
-			act("$N looks flushed for a moment, but it passes.", ch, 0, victim, TO_NOTVICT);
+			act("A sudden fever washes over you, but it passes.", ch, nullptr, victim, TO_VICT);
+			act("$N looks flushed for a moment, but it passes.", ch, nullptr, victim, TO_NOTVICT);
 		}
 
 		return;
@@ -3764,8 +3764,8 @@ void plague_tick(CHAR_DATA *ch, AFFECT_DATA *af)
 	if (!ch->in_room)
 		return;
 
-	act("$n writhes in agony, consumed by a debilitating plague.", ch, 0, 0, TO_ROOM);
-	act("You writhe in agony from the plague.", ch, 0, 0, TO_CHAR);
+	act("$n writhes in agony, consumed by a debilitating plague.", ch, nullptr, nullptr, TO_ROOM);
+	act("You writhe in agony from the plague.", ch, nullptr, nullptr, TO_CHAR);
 
 	if (af->level == 1)
 		return;
@@ -3792,8 +3792,8 @@ void plague_tick(CHAR_DATA *ch, AFFECT_DATA *af)
 			&& (!is_npc(vch) || !IS_SET(vch->act, ACT_UNDEAD))
 			&& !is_affected_by(vch, AFF_PLAGUE) && number_bits(4) == 0)
 		{
-			act("You feel hot and feverish.", vch, 0, 0, TO_CHAR);
-			act("$n shivers and looks very ill.", vch, 0, 0, TO_ROOM);
+			act("You feel hot and feverish.", vch, nullptr, nullptr, TO_CHAR);
+			act("$n shivers and looks very ill.", vch, nullptr, nullptr, TO_ROOM);
 			new_affect_join(vch, &plague);
 		}
 	}
@@ -4147,8 +4147,8 @@ void spell_sanctuary(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_u
 	}
 	else
 	{
-		act("$n is surrounded by a dark aura.", victim, 0, 0, TO_ROOM);
-		act("You are surrounded by a dark aura.", victim, 0, 0, TO_CHAR);
+		act("$n is surrounded by a dark aura.", victim, nullptr, nullptr, TO_ROOM);
+		act("You are surrounded by a dark aura.", victim, nullptr, nullptr, TO_CHAR);
 	}
 
 	affect_to_char(victim, &af);
@@ -4217,7 +4217,7 @@ void spell_sleep(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unuse
 		|| saves_spell(level - 1, victim, DAM_CHARM)
 		|| IS_SET(victim->imm_flags, IMM_SLEEP))
 	{
-		act("$N resisted your sleep spell.", ch, 0, victim, TO_CHAR);
+		act("$N resisted your sleep spell.", ch, nullptr, victim, TO_CHAR);
 		return;
 	}
 
@@ -4373,7 +4373,7 @@ void spell_summon(int /* sn */, int level, CHAR_DATA *ch, SpellTarget /* vo */, 
 
 	if (saves_spell(level + 1, victim, DAM_OTHER))
 	{
-		act("$N resisted your summoning.", ch, 0, victim, TO_CHAR);
+		act("$N resisted your summoning.", ch, nullptr, victim, TO_CHAR);
 
 		if (saves_spell(level - 1, victim, DAM_OTHER))
 			send_to_char("You feel a strange wrenching sensation, but it passes.\n\r", victim);
@@ -4383,7 +4383,7 @@ void spell_summon(int /* sn */, int level, CHAR_DATA *ch, SpellTarget /* vo */, 
 
 	RS.Queue.AddToQueue(3, "spell_summon", "summon_char", summon_char, ch, victim);
 
-	act("You begin the summoning of $N.", ch, 0, victim, TO_CHAR);
+	act("You begin the summoning of $N.", ch, nullptr, victim, TO_CHAR);
 
 	if (saves_spell(level, victim, DAM_OTHER))
 		send_to_char("You feel a strange wrenching sensation at the very core of your being.\n\r", victim);
@@ -4417,7 +4417,7 @@ void summon_char(CHAR_DATA *ch, CHAR_DATA *victim)
 		return;
 	}
 
-	act("The summoning of $N fails as $E escapes your grasp.", ch, 0, victim, TO_CHAR);
+	act("The summoning of $N fails as $E escapes your grasp.", ch, nullptr, victim, TO_CHAR);
 }
 
 /* Modified teleport -- only within radius of one area now. */
@@ -4517,7 +4517,7 @@ void spell_turn_undead(int sn, int level, CHAR_DATA *ch, SpellTarget /* vo */, C
 	}
 	else
 	{
-		act("$n turns $s unholy influence upon the room.", ch, 0, 0, TO_ROOM);
+		act("$n turns $s unholy influence upon the room.", ch, nullptr, nullptr, TO_ROOM);
 		send_to_char("You turn your unholy influence upon those in the room.\n\r", ch);
 	}
 
@@ -4589,12 +4589,12 @@ void spell_turn_undead(int sn, int level, CHAR_DATA *ch, SpellTarget /* vo */, C
 				|| saves_spell(ch->level, victim, DAM_OTHER)
 				|| !is_npc(victim))
 			{
-				act("You attempt to control $N but do not have the influence.", ch, 0, victim, TO_CHAR);
+				act("You attempt to control $N but do not have the influence.", ch, nullptr, victim, TO_CHAR);
 				continue;
 			}
 			else
 			{
-				act("$n stares in hatred for a moment then suddenly becomes very subdued.", victim, 0, 0, TO_NOTVICT);
+				act("$n stares in hatred for a moment then suddenly becomes very subdued.", victim, nullptr, nullptr, TO_NOTVICT);
 				stop_fighting(victim, true);
 
 				victim->master = ch->self;
@@ -4603,7 +4603,7 @@ void spell_turn_undead(int sn, int level, CHAR_DATA *ch, SpellTarget /* vo */, C
 				SET_BIT(victim->affected_by, AFF_CHARM);
 				REMOVE_BIT(victim->act, ACT_AGGRESSIVE);
 
-				act("$N now follows you.", ch, 0, victim, TO_CHAR);
+				act("$N now follows you.", ch, nullptr, victim, TO_CHAR);
 
 				num++;
 				count += victim->level;
@@ -4643,7 +4643,7 @@ void spell_weaken(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unus
 
 	if (is_affected(victim, sn) || saves_spell(level, victim, DAM_OTHER))
 	{
-		act("$N's muscles wither slightly then regain their vigor.", ch, 0, victim, TO_CHAR);
+		act("$N's muscles wither slightly then regain their vigor.", ch, nullptr, victim, TO_CHAR);
 		return;
 	}
 
@@ -4702,7 +4702,7 @@ void spell_word_of_recall(int /* sn */, int /* level */, CHAR_DATA *ch, SpellTar
 	}
 
 	if (ch != victim)
-		act("You prepare to send $N home.", ch, 0, victim, TO_CHAR);
+		act("You prepare to send $N home.", ch, nullptr, victim, TO_CHAR);
 
 	RS.Queue.AddToQueue(6, "spell_word_of_recall", "recall_execute", recall_execute, victim, location);
 
@@ -4730,13 +4730,13 @@ void recall_execute(CHAR_DATA *ch, ROOM_INDEX_DATA *location)
 	if (is_affected(ch, gsn_camouflage))
 	{
 		affect_strip(ch, gsn_camouflage);
-		act("$n steps out from $s cover.", ch, 0, 0, TO_ROOM);
+		act("$n steps out from $s cover.", ch, nullptr, nullptr, TO_ROOM);
 		send_to_char("You step out from your cover.\n\r", ch);
 	}
 
 	un_watermeld(ch, nullptr);
 
-	act("As the magic takes effect, a black haze clouds your mind.\n\rWhen it passes, you find yourself elsewhere.", ch, 0, 0, TO_CHAR);
+	act("As the magic takes effect, a black haze clouds your mind.\n\rWhen it passes, you find yourself elsewhere.", ch, nullptr, nullptr, TO_CHAR);
 	act("$n suddenly disappears.", ch, nullptr, nullptr, TO_ROOM);
 
 	char_from_room(ch);
@@ -4981,8 +4981,8 @@ void spell_nether_breath(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[may
 	int dam;
 	bool saved = true;
 
-	act("$n opens $s mouth and unleashes a blast of pure darkness at you!", ch, 0, victim, TO_VICT);
-	act("$n opens $s mouth and unleashes a blast of pure darkness at $N!", ch, 0, victim, TO_NOTVICT);
+	act("$n opens $s mouth and unleashes a blast of pure darkness at you!", ch, nullptr, victim, TO_VICT);
+	act("$n opens $s mouth and unleashes a blast of pure darkness at $N!", ch, nullptr, victim, TO_NOTVICT);
 
 	dam = std::max(100, ch->hit / 10);
 
@@ -5010,7 +5010,7 @@ void spell_nether_breath(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[may
 		affect_to_char(victim, &af);
 
 		send_to_char("You feel unclean.\n\r", victim);
-		act("$n looks very uncomfortable.", victim, 0, 0, TO_ROOM);
+		act("$n looks very uncomfortable.", victim, nullptr, nullptr, TO_ROOM);
 	}
 }
 
@@ -5120,7 +5120,7 @@ void spell_protective_shield(int sn, int level, CHAR_DATA *ch, SpellTarget /* vo
 	af.mod_name = MOD_PROTECTION;
 	affect_to_char(ch, &af);
 
-	act("$n is surrounded by a protective shield.", ch, 0, 0, TO_ROOM);
+	act("$n is surrounded by a protective shield.", ch, nullptr, nullptr, TO_ROOM);
 	send_to_char("You are surrounded by a protective shield.\n\r", ch);
 }
 
@@ -5142,9 +5142,9 @@ void sanguine_blind(CHAR_DATA *ch, CHAR_DATA *victim)
 	if (is_affected(victim, gsn_blindness))
 		return;
 
-	act("You force your way through $n's undulating ward of blood to strike at $m.", ch, 0, victim, TO_VICT);
-	act("$N struggles through $n's ward to strike at $m before stumbling away clawing at his eyes!", ch, 0, victim, TO_NOTVICT);
-	act("$N struggles through your ward to strike at you before stumbling away clawing at his eyes!", ch, 0, victim, TO_CHAR);
+	act("You force your way through $n's undulating ward of blood to strike at $m.", ch, nullptr, victim, TO_VICT);
+	act("$N struggles through $n's ward to strike at $m before stumbling away clawing at his eyes!", ch, nullptr, victim, TO_NOTVICT);
+	act("$N struggles through your ward to strike at you before stumbling away clawing at his eyes!", ch, nullptr, victim, TO_CHAR);
 	send_to_char("Your vision fades to blackness as the coagulated blood flows hungrily over your eyes!\n\r", victim);
 
 	af.where = TO_AFFECTS;
@@ -5197,19 +5197,19 @@ void spell_sanguine_ward(int sn, int level, CHAR_DATA *ch, SpellTarget /* vo */,
 	send_to_char("Using the blood from your urn, you trace a symbol upon your forehead.\n\r", ch);
 	send_to_char("A translucent red shield flickers into existence around you.\n\r", ch);
 
-	act("$n dips a finger into $s urn and traces a symbol onto $s forehead.", ch, 0, 0, TO_ROOM);
-	act("A translucent red shield flickers into existence around $n.", ch, 0, 0, TO_ROOM);
+	act("$n dips a finger into $s urn and traces a symbol onto $s forehead.", ch, nullptr, nullptr, TO_ROOM);
+	act("A translucent red shield flickers into existence around $n.", ch, nullptr, nullptr, TO_ROOM);
 
 	if (charges > 2 && charges != 5)
 	{
 		send_to_char("The strong ward seems nearly solid for a moment before fading back to translucence.\n\r", ch);
-		act("The ward around $n seems nearly solid for a moment before fading back to translucence.", ch, 0, 0, TO_ROOM);
+		act("The ward around $n seems nearly solid for a moment before fading back to translucence.", ch, nullptr, nullptr, TO_ROOM);
 	}
 
 	if (charges == 5)
 	{
 		send_to_char("Your surroundings seem to blur momentarily as the powerful ward coalesces around you.\n\r", ch);
-		act("$n seems to flicker out of existence momentarily as the powerful ward coalesces around $m.", ch, 0, 0, TO_ROOM);
+		act("$n seems to flicker out of existence momentarily as the powerful ward coalesces around $m.", ch, nullptr, nullptr, TO_ROOM);
 	}
 
 	send_to_char("\n\r", ch);
@@ -5270,17 +5270,17 @@ void spell_consecrate(int sn, int level, CHAR_DATA *ch, [[maybe_unused]] SpellTa
 
 	chance -= count * 10;
 
-	act("$n gestures around the room and utters a blessing of holy rights.", ch, 0, 0, TO_ROOM);
+	act("$n gestures around the room and utters a blessing of holy rights.", ch, nullptr, nullptr, TO_ROOM);
 	send_to_char("You chant a blessing and give the divine somatic motions of consecration.\n\r", ch);
 
 	if (number_percent() > chance)
 	{
-		act("You feel the atmosphere lighten for a moment but it passes.", ch, 0, 0, TO_ROOM);
+		act("You feel the atmosphere lighten for a moment but it passes.", ch, nullptr, nullptr, TO_ROOM);
 		send_to_char("Your holy rights are invoked but fail to affect the room's evil.\n\r", ch);
 		return;
 	}
 
-	act("The atmosphere in the room lightens.", ch, 0, 0, TO_ROOM);
+	act("The atmosphere in the room lightens.", ch, nullptr, nullptr, TO_ROOM);
 	send_to_char("You succeed in consecrating the ground for a brief period!\n\r", ch);
 
 	init_affect_room(&raf);
@@ -5336,7 +5336,7 @@ void spell_safety(int /* sn */, int /* level */, CHAR_DATA *ch, SpellTarget /* v
 		}
 		else
 		{
-			act("$n suddenly vanishes!", gch, 0, 0, TO_ROOM);
+			act("$n suddenly vanishes!", gch, nullptr, nullptr, TO_ROOM);
 		}
 	}
 
@@ -5355,7 +5355,7 @@ void spell_safety(int /* sn */, int /* level */, CHAR_DATA *ch, SpellTarget /* v
 
 		char_from_room(gch);
 		char_to_room(gch, pRoomIndex);
-		act("$n suddenly appears in the room.", gch, 0, 0, TO_ROOM);
+		act("$n suddenly appears in the room.", gch, nullptr, nullptr, TO_ROOM);
 		do_look(gch, "auto");
 	}
 
@@ -5384,7 +5384,7 @@ void spell_blade_barrier(int /* sn */, int /* level */, CHAR_DATA *ch, SpellTarg
 	affect_to_char(ch, &af);
 
 	send_to_char("A barrier of deadly whirling blades comes into existence around you.\n\r", ch);
-	act("A barrier of deadly whirling blades comes into existence around $n.", ch, 0, 0, TO_ROOM);
+	act("A barrier of deadly whirling blades comes into existence around $n.", ch, nullptr, nullptr, TO_ROOM);
 
 	WAIT_STATE(ch, PULSE_VIOLENCE * 2);
 }
@@ -5404,8 +5404,8 @@ void spell_old_blade_barrier(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [
 
 	if (number_percent() > chance || victim == ch)
 	{
-		act("$n creates a whirlwind of spinning blades which turn and strike $m down!", ch, 0, 0, TO_ROOM);
-		act("Your blade barrier turns and strikes you down!", ch, 0, 0, TO_CHAR);
+		act("$n creates a whirlwind of spinning blades which turn and strike $m down!", ch, nullptr, nullptr, TO_ROOM);
+		act("Your blade barrier turns and strikes you down!", ch, nullptr, nullptr, TO_CHAR);
 
 		dam /= 2;
 
@@ -5422,16 +5422,16 @@ void spell_old_blade_barrier(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [
 			dam *= 3;
 			dam /= 2;
 
-			act("The blades spin and slice away at $n.", ch, 0, 0, TO_ROOM);
-			act("The blades spin and slice away at you.", ch, 0, 0, TO_CHAR);
+			act("The blades spin and slice away at $n.", ch, nullptr, nullptr, TO_ROOM);
+			act("The blades spin and slice away at you.", ch, nullptr, nullptr, TO_CHAR);
 			damage_old(ch, ch, dam, sn, DAM_SLASH, true);
 		}
 	}
 	else
 	{
-		act("You create a whirlwind of spinning blades to strike down $N!", ch, 0, victim, TO_CHAR);
-		act("$n creates a deadly blade barrier that tears into $N!", ch, 0, victim, TO_NOTVICT);
-		act("$n creates a deadly blade barrier that tears into you!", ch, 0, victim, TO_VICT);
+		act("You create a whirlwind of spinning blades to strike down $N!", ch, nullptr, victim, TO_CHAR);
+		act("$n creates a deadly blade barrier that tears into $N!", ch, nullptr, victim, TO_NOTVICT);
+		act("$n creates a deadly blade barrier that tears into you!", ch, nullptr, victim, TO_VICT);
 		damage_old(ch, victim, dam, sn, DAM_SLASH, true);
 
 		for (i = 0; i < spins; i++)
@@ -5444,8 +5444,8 @@ void spell_old_blade_barrier(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [
 
 			dam *= 3;
 			dam /= 4;
-			act("The blades spin and slice away at $n.", victim, 0, 0, TO_ROOM);
-			act("The blades spin and slice away at you.", victim, 0, 0, TO_CHAR);
+			act("The blades spin and slice away at $n.", victim, nullptr, nullptr, TO_ROOM);
+			act("The blades spin and slice away at you.", victim, nullptr, nullptr, TO_CHAR);
 
 			if (victim->ghost > 0)
 				return;
@@ -5454,8 +5454,8 @@ void spell_old_blade_barrier(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [
 		}
 	}
 
-	act("The blade barrier fades away.", ch, 0, 0, TO_ROOM);
-	act("Your blade barrier fades away.", ch, 0, 0, TO_CHAR);
+	act("The blade barrier fades away.", ch, nullptr, nullptr, TO_ROOM);
+	act("Your blade barrier fades away.", ch, nullptr, nullptr, TO_CHAR);
 }
 
 void spell_holy_fire(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
@@ -5491,8 +5491,8 @@ void spell_holy_fire(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_u
 
 	if (number_percent() > chance)
 	{
-		act("$n's heavenly fire turns on $m!", ch, 0, 0, TO_ROOM);
-		act("Your heavenly fire turns on you for your sins!", ch, 0, 0, TO_CHAR);
+		act("$n's heavenly fire turns on $m!", ch, nullptr, nullptr, TO_ROOM);
+		act("Your heavenly fire turns on you for your sins!", ch, nullptr, nullptr, TO_CHAR);
 
 		dam *= dam_mod;
 		dam /= 10;
@@ -5504,8 +5504,8 @@ void spell_holy_fire(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_u
 		return;
 	}
 
-	act("$n calls down fire from the heavens!", ch, 0, 0, TO_ROOM);
-	act("You call down fire from the heavens!", ch, 0, 0, TO_CHAR);
+	act("$n calls down fire from the heavens!", ch, nullptr, nullptr, TO_ROOM);
+	act("You call down fire from the heavens!", ch, nullptr, nullptr, TO_CHAR);
 
 	dam *= dam_mod;
 	dam /= 10;
@@ -5542,16 +5542,16 @@ void spell_talk_to_dead(int /* sn */, int /* level */, CHAR_DATA *ch, SpellTarge
 
 	if (IS_SET(corpse->extra_flags, CORPSE_NO_ANIMATE))
 	{
-		act("$p shudders slightly and a soft moan reaches your ears before it goes silent.", ch, corpse, 0, TO_CHAR);
+		act("$p shudders slightly and a soft moan reaches your ears before it goes silent.", ch, corpse, nullptr, TO_CHAR);
 		return;
 	}
 
-	act("You draw back the spirit of the fallen and $p speaks briefly to you.", ch, corpse, 0, TO_CHAR);
+	act("You draw back the spirit of the fallen and $p speaks briefly to you.", ch, corpse, nullptr, TO_CHAR);
 
 	sprintf(buf, "The spirit tells you 'I was slain by %s, now allow me my peace.'\n\r", corpse->talked);
 	send_to_char(buf, ch);
 
-	act("A faint glow surrounds $p and then fades away.", ch, corpse, 0, TO_ROOM);
+	act("A faint glow surrounds $p and then fades away.", ch, corpse, nullptr, TO_ROOM);
 }
 
 /* New energy drain spell due to anti-paladin's always complaining how
@@ -5572,15 +5572,15 @@ void spell_energy_drain(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[mayb
 	if (saves_spell(level - 3, victim, DAM_NEGATIVE))
 	{
 		send_to_char("You feel a cold chill wash over you, but it passes.\n\r", victim);
-		act("You were unable to drain energy from $N.", ch, 0, victim, TO_CHAR);
+		act("You were unable to drain energy from $N.", ch, nullptr, victim, TO_CHAR);
 		return;
 	}
 
 	amount = dice(level / 3, 2);
 
-	act("You drain $N's life away!", ch, 0, victim, TO_CHAR);
-	act("$n drains $N's life away!", ch, 0, victim, TO_NOTVICT);
-	act("You feel your life slipping away!", ch, 0, victim, TO_VICT);
+	act("You drain $N's life away!", ch, nullptr, victim, TO_CHAR);
+	act("$n drains $N's life away!", ch, nullptr, victim, TO_NOTVICT);
+	act("You feel your life slipping away!", ch, nullptr, victim, TO_VICT);
 
 	damage_old(ch, victim, amount, sn, DAM_NEGATIVE, true);
 
@@ -5607,7 +5607,7 @@ void spell_dark_shield(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe
 
 	if (is_good(victim))
 	{
-		act("$N is too pure for such a spell.", ch, 0, victim, TO_CHAR);
+		act("$N is too pure for such a spell.", ch, nullptr, victim, TO_CHAR);
 		return;
 	}
 
@@ -5621,7 +5621,7 @@ void spell_dark_shield(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe
 	af.location = APPLY_AC;
 	affect_to_char(victim, &af);
 
-	act("$n is surrounded by a darkened shield.", victim, 0, 0, TO_ROOM);
+	act("$n is surrounded by a darkened shield.", victim, nullptr, nullptr, TO_ROOM);
 	send_to_char("You are surrounded by a darkened shield.\n\r", victim);
 }
 
@@ -5658,7 +5658,7 @@ void spell_deathspell(int sn, int level, CHAR_DATA *ch, [[maybe_unused]] SpellTa
 	char buf[MAX_STRING_LENGTH];
 	klevel = level - 7;
 
-	act("$n utters a word of power and the negative energy explodes in the room!", ch, 0, 0, TO_ROOM);
+	act("$n utters a word of power and the negative energy explodes in the room!", ch, nullptr, nullptr, TO_ROOM);
 	send_to_char("You utter a word of power and negative energy explodes into the room!\n\r", ch);
 
 	bonus = 0;
@@ -5689,8 +5689,8 @@ void spell_deathspell(int sn, int level, CHAR_DATA *ch, [[maybe_unused]] SpellTa
 
 		if (vch->level > klevel || IS_SET(vch->act, ACT_UNDEAD) || IS_SET(vch->imm_flags, IMM_NEGATIVE))
 		{
-			act("$n is unaffected by the negative energy field.", vch, 0, 0, TO_ROOM);
-			act("You are unaffected by the negative energy field.", vch, 0, 0, TO_CHAR);
+			act("$n is unaffected by the negative energy field.", vch, nullptr, nullptr, TO_ROOM);
+			act("You are unaffected by the negative energy field.", vch, nullptr, nullptr, TO_CHAR);
 		}
 		else if (vch == ch)
 		{
@@ -5710,7 +5710,7 @@ void spell_deathspell(int sn, int level, CHAR_DATA *ch, [[maybe_unused]] SpellTa
 		}
 		else
 		{
-			act("$n gets a horrible look in $s eye's then keels over dead!", vch, 0, 0, TO_ROOM);
+			act("$n gets a horrible look in $s eye's then keels over dead!", vch, nullptr, nullptr, TO_ROOM);
 			send_to_char("You feel your an intense pain in your head as the energy ruptures your skull!\n\r", vch);
 			raw_kill(ch, vch);
 		}
@@ -5788,8 +5788,8 @@ void spell_heavenly_sceptre_frenzy(int sn, int level, CHAR_DATA *ch, SpellTarget
 	AFFECT_DATA af;
 	if (is_affected(ch, sn) || (!is_good(ch) && !is_evil(ch)))
 	{
-		act("$n's sceptre hums softly but nothing seems to happen.", ch, 0, 0, TO_ROOM);
-		act("Your sceptre hums softly but nothing seems to happen.", ch, 0, 0, TO_CHAR);
+		act("$n's sceptre hums softly but nothing seems to happen.", ch, nullptr, nullptr, TO_ROOM);
+		act("Your sceptre hums softly but nothing seems to happen.", ch, nullptr, nullptr, TO_CHAR);
 		return;
 	}
 
@@ -5822,12 +5822,12 @@ void spell_heavenly_sceptre_frenzy(int sn, int level, CHAR_DATA *ch, SpellTarget
 
 	if (is_good(ch))
 	{
-		act("$n's sceptre glows white and a look of righteous anger in $s eyes.", ch, 0, 0, TO_ROOM);
+		act("$n's sceptre glows white and a look of righteous anger in $s eyes.", ch, nullptr, nullptr, TO_ROOM);
 		send_to_char("Your sceptre glows white and you feel a surge of righteous anger!\n\r", ch);
 	}
 	else if (is_evil(ch))
 	{
-		act("$n's sceptre darkens and a look of righteous anger enters $s eyes.", ch, 0, 0, TO_ROOM);
+		act("$n's sceptre darkens and a look of righteous anger enters $s eyes.", ch, nullptr, nullptr, TO_ROOM);
 		send_to_char("Your sceptre darkens and you feel a surge of righteous anger!\n\r", ch);
 	}
 }
@@ -5844,7 +5844,7 @@ void spell_heavenly_sceptre_fire(int sn, int /* level */, CHAR_DATA *ch, SpellTa
 
 	if (is_affected(ch, sn) || victim == nullptr || ch->level < 30)
 	{
-		act("$n's sceptre hums softly but nothing seems to happen.", ch, 0, 0, TO_ROOM);
+		act("$n's sceptre hums softly but nothing seems to happen.", ch, nullptr, nullptr, TO_ROOM);
 		send_to_char("Your sceptre hums softly but nothing seems to happen.\n\r", ch);
 		WAIT_STATE(ch, 12);
 		return;
@@ -5865,7 +5865,7 @@ void spell_heavenly_sceptre_fire(int sn, int /* level */, CHAR_DATA *ch, SpellTa
 
 	if (number_percent() > ch->level * 2)
 	{
-		act("Your sceptre of heavenly orders crumbles to dust.", ch, 0, 0, TO_ROOM);
+		act("Your sceptre of heavenly orders crumbles to dust.", ch, nullptr, nullptr, TO_ROOM);
 		send_to_char("Your sceptre of heavenly orders crumbles to dust.\n\r", ch);
 
 		// TODO: sceptre is still the nullptr it was declared as, because nothing
@@ -5971,7 +5971,7 @@ void spell_forget(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unus
 	affect_to_char(victim, &af);
 
 	send_to_char("You feel your memories slip away.\n\r", victim);
-	act("$n suddenly looks disoriented.", victim, 0, 0, TO_ROOM);
+	act("$n suddenly looks disoriented.", victim, nullptr, nullptr, TO_ROOM);
 }
 
 void spell_earthbind(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
@@ -6003,7 +6003,7 @@ void spell_earthbind(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_u
 	affect_to_char(victim, &af);
 
 	send_to_char("Your feet suddenly become heavy and earthbound.\n\r", victim);
-	act("$n suddenly drops to the ground.", victim, 0, 0, TO_ROOM);
+	act("$n suddenly drops to the ground.", victim, nullptr, nullptr, TO_ROOM);
 }
 
 void spell_cremate(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
@@ -6013,7 +6013,7 @@ void spell_cremate(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unu
 
 	dam = dice(level, 7);
 
-	act("$n is engulfed in raging fire!", victim, 0, 0, TO_ROOM);
+	act("$n is engulfed in raging fire!", victim, nullptr, nullptr, TO_ROOM);
 	send_to_char("You are engulfed in raging fire!\n\r", victim);
 
 	if (saves_spell(level, victim, DAM_FIRE))
@@ -6040,7 +6040,7 @@ void spell_divine_touch(int sn, int level, CHAR_DATA *ch, SpellTarget /* vo */, 
 	affect_to_char(ch, &af);
 
 	send_to_char("Your hands are surrounded in holy energy.\n\r", ch);
-	act("$n's hands seem to glow with an inner energy.", ch, 0, 0, TO_ROOM);
+	act("$n's hands seem to glow with an inner energy.", ch, nullptr, nullptr, TO_ROOM);
 }
 
 void spell_transfer_object(int /* sn */, int /* level */, CHAR_DATA *ch, SpellTarget /* vo */, CastMode /* mode */)
@@ -6101,8 +6101,8 @@ void spell_transfer_object(int /* sn */, int /* level */, CHAR_DATA *ch, SpellTa
 		|| victim->carry_weight >= can_carry_w(victim)
 		|| isCabalItem(obj))
 	{
-		act("$p glows softly but nothing happens.", ch, obj, 0, TO_CHAR);
-		act("$p glows softly but nothing happens.", ch, obj, 0, TO_ROOM);
+		act("$p glows softly but nothing happens.", ch, obj, nullptr, TO_CHAR);
+		act("$p glows softly but nothing happens.", ch, obj, nullptr, TO_ROOM);
 		return;
 	}
 
@@ -6112,14 +6112,14 @@ void spell_transfer_object(int /* sn */, int /* level */, CHAR_DATA *ch, SpellTa
 		return;
 	}
 
-	act("$p glows softly and vanishes!", ch, obj, 0, TO_CHAR);
-	act("$p glows softly and vanishes!", ch, obj, 0, TO_ROOM);
+	act("$p glows softly and vanishes!", ch, obj, nullptr, TO_CHAR);
+	act("$p glows softly and vanishes!", ch, obj, nullptr, TO_ROOM);
 
 	obj_from_char(obj);
 	obj_to_char(obj, victim);
 
-	act("You suddenly feel heavier as $p pops into your inventory!", victim, obj, 0, TO_CHAR);
-	act("$p suddenly appears from nowhere and pops into $n's possession!", victim, obj, 0, TO_ROOM);
+	act("You suddenly feel heavier as $p pops into your inventory!", victim, obj, nullptr, TO_CHAR);
+	act("$p suddenly appears from nowhere and pops into $n's possession!", victim, obj, nullptr, TO_ROOM);
 }
 
 /* Necros use this to keep body parts longer...for lesser golems */
@@ -6182,13 +6182,13 @@ void spell_power_word_fear(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[m
 		return;
 	}
 
-	act("$n points at $N and utters the word 'Fear!'", ch, 0, victim, TO_NOTVICT);
-	act("$n points at you and utters the word 'Fear!'", ch, 0, victim, TO_VICT);
-	act("You point at $N and utter the word 'Fear!'", ch, 0, victim, TO_CHAR);
+	act("$n points at $N and utters the word 'Fear!'", ch, nullptr, victim, TO_NOTVICT);
+	act("$n points at you and utters the word 'Fear!'", ch, nullptr, victim, TO_VICT);
+	act("You point at $N and utter the word 'Fear!'", ch, nullptr, victim, TO_CHAR);
 
 	if (!is_awake(victim))
 	{
-		act("$n shivers momentarily but it passes.", victim, 0, 0, TO_ROOM);
+		act("$n shivers momentarily but it passes.", victim, nullptr, nullptr, TO_ROOM);
 		send_to_char("You feel a brief terror, but it passes away in your dreams.\n\r", victim);
 		return;
 	}
@@ -6202,7 +6202,7 @@ void spell_power_word_fear(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[m
 
 	if (saves_spell(level, victim, DAM_OTHER))
 	{
-		act("$n shivers momentarily but it passes.", victim, 0, 0, TO_ROOM);
+		act("$n shivers momentarily but it passes.", victim, nullptr, nullptr, TO_ROOM);
 		send_to_char("You feel a brief terror, but it passes.\n\r", victim);
 		return;
 	}
@@ -6217,7 +6217,7 @@ void spell_power_word_fear(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[m
 
 	if (utter_fail)
 	{
-		act("$n's eyes widen and $s heart ruptures from shock!", victim, 0, 0, TO_ROOM);
+		act("$n's eyes widen and $s heart ruptures from shock!", victim, nullptr, nullptr, TO_ROOM);
 		send_to_char("You feel a terror so intense your heart stops dead!\n\r", victim);
 		raw_kill(ch, victim);
 		return;
@@ -6276,7 +6276,7 @@ void spell_imbue_regeneration(int sn, int level, CHAR_DATA *ch, SpellTarget vo, 
 
 	if (is_affected(victim, gsn_atrophy))
 	{
-		act("$n's body stops wasting away.", victim, 0, 0, TO_ROOM);
+		act("$n's body stops wasting away.", victim, nullptr, nullptr, TO_ROOM);
 		send_to_char("Your body stops wasting away.\n\r", victim);
 		affect_strip(victim, gsn_atrophy);
 		return;
@@ -6284,7 +6284,7 @@ void spell_imbue_regeneration(int sn, int level, CHAR_DATA *ch, SpellTarget vo, 
 
 	if (is_affected(victim, skill_lookup("prevent healing")))
 	{
-		act("$n's sickly looking complexion clears up.", victim, 0, 0, TO_ROOM);
+		act("$n's sickly looking complexion clears up.", victim, nullptr, nullptr, TO_ROOM);
 		send_to_char("You no longer feel so sick and weary.\n\r", victim);
 		affect_strip(victim, skill_lookup("prevent healing"));
 		return;
@@ -6294,14 +6294,14 @@ void spell_imbue_regeneration(int sn, int level, CHAR_DATA *ch, SpellTarget vo, 
 	{
 		if (victim != ch)
 		{
-			act("$N's emaciated body heals up with your touch.", ch, 0, victim, TO_CHAR);
-			act("Your emaciated body heals up with $n's touch.", ch, 0, victim, TO_VICT);
-			act("$N's emaciated body heals up with $n's touch.", ch, 0, victim, TO_NOTVICT);
+			act("$N's emaciated body heals up with your touch.", ch, nullptr, victim, TO_CHAR);
+			act("Your emaciated body heals up with $n's touch.", ch, nullptr, victim, TO_VICT);
+			act("$N's emaciated body heals up with $n's touch.", ch, nullptr, victim, TO_NOTVICT);
 		}
 		else
 		{
 			send_to_char("Your emaciated body parts heal up.\n\r", ch);
-			act("$n's emaciated body heals up.", ch, 0, 0, TO_ROOM);
+			act("$n's emaciated body heals up.", ch, nullptr, nullptr, TO_ROOM);
 		}
 
 		affect_strip(victim, skill_lookup("wither"));
@@ -6357,7 +6357,7 @@ void spell_restoration(int /* sn */, int level, CHAR_DATA *ch, SpellTarget vo, C
 	if (is_affected(victim, sn_forget))
 	{
 		send_to_char("You feel your mind becoming clearer.\n\r", victim);
-		act("$n looks less confused.", victim, 0, 0, TO_ROOM);
+		act("$n looks less confused.", victim, nullptr, nullptr, TO_ROOM);
 		affect_strip(victim, sn_forget);
 		success = true;
 	}
@@ -6365,7 +6365,7 @@ void spell_restoration(int /* sn */, int level, CHAR_DATA *ch, SpellTarget vo, C
 	if (is_affected(victim, sn_wither))
 	{
 		send_to_char("Your emaciated body is restored.\n\r", victim);
-		act("$n's emaciated body looks healthier.", victim, 0, 0, TO_ROOM);
+		act("$n's emaciated body looks healthier.", victim, nullptr, nullptr, TO_ROOM);
 		affect_strip(victim, sn_wither);
 		success = true;
 	}
@@ -6380,7 +6380,7 @@ void spell_restoration(int /* sn */, int level, CHAR_DATA *ch, SpellTarget vo, C
 
 	if (is_affected(victim, gsn_atrophy))
 	{
-		act("$n's body stops wasting away.", victim, 0, 0, TO_ROOM);
+		act("$n's body stops wasting away.", victim, nullptr, nullptr, TO_ROOM);
 		send_to_char("Your body stops wasting away.\n\r", victim);
 		affect_strip(victim, gsn_atrophy);
 	}
@@ -6414,7 +6414,7 @@ void spell_prevent_healing(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[m
 	}
 
 	send_to_char("You feel your body losing it's ability to heal.\n\r", victim);
-	act("$n looks very sick.", victim, 0, 0, TO_ROOM);
+	act("$n looks very sick.", victim, nullptr, nullptr, TO_ROOM);
 
 	init_affect(&af);
 	af.where = TO_AFFECTS;
@@ -6487,13 +6487,13 @@ void spell_utter_heal(int /* sn */, int /* level */, CHAR_DATA *ch, SpellTarget 
 	{
 		affect_strip(victim, sn_atrophy);
 		send_to_char("Your body stops wasting away.\n\r", victim);
-		act("$n's body stops wasting away.", victim, 0, 0, TO_ROOM);
+		act("$n's body stops wasting away.", victim, nullptr, nullptr, TO_ROOM);
 		return;
 	}
 
 	if (is_affected(ch, sn_poison) || is_affected(ch, gsn_poison_dust))
 	{
-		act("$n looks better.", victim, 0, 0, TO_ROOM);
+		act("$n looks better.", victim, nullptr, nullptr, TO_ROOM);
 		send_to_char("You feel a warm sensation running through you.\n\r", victim);
 		affect_strip(victim, sn_poison);
 		affect_strip(victim, gsn_poison_dust);
@@ -6501,7 +6501,7 @@ void spell_utter_heal(int /* sn */, int /* level */, CHAR_DATA *ch, SpellTarget 
 
 	if (is_affected(ch, gsn_plague))
 	{
-		act("The sores on $n's body disappear.", victim, 0, 0, TO_ROOM);
+		act("The sores on $n's body disappear.", victim, nullptr, nullptr, TO_ROOM);
 		send_to_char("The sores on your body disappear.\n\r", victim);
 		affect_strip(victim, gsn_plague);
 	}
@@ -6585,15 +6585,15 @@ void spell_crushing_hand(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[may
 	if (saves_spell(level + 1, victim, DAM_OTHER))
 		dam -= 60;
 
-	act("$n creates a huge spectral hand to brutally pummel $N!", ch, 0, victim, TO_NOTVICT);
-	act("$n creates a huge spectral hand to brutally pummel you!", ch, 0, victim, TO_VICT);
-	act("You create a huge spectral hand to brutally pummel $N!", ch, 0, victim, TO_CHAR);
+	act("$n creates a huge spectral hand to brutally pummel $N!", ch, nullptr, victim, TO_NOTVICT);
+	act("$n creates a huge spectral hand to brutally pummel you!", ch, nullptr, victim, TO_VICT);
+	act("You create a huge spectral hand to brutally pummel $N!", ch, nullptr, victim, TO_CHAR);
 
 	if (number_percent() < 60)
 	{
-		act("$N appears to be stunned by the blow.", ch, 0, victim, TO_NOTVICT);
-		act("You feel stunned by the brutal blow.", ch, 0, victim, TO_VICT);
-		act("$N appears to be stunned by the blow.", ch, 0, victim, TO_CHAR);
+		act("$N appears to be stunned by the blow.", ch, nullptr, victim, TO_NOTVICT);
+		act("You feel stunned by the brutal blow.", ch, nullptr, victim, TO_VICT);
+		act("$N appears to be stunned by the blow.", ch, nullptr, victim, TO_CHAR);
 		LAG_CHAR(victim, PULSE_VIOLENCE * 2);
 	}
 
@@ -6619,7 +6619,7 @@ void spell_deafen(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unus
 
 	if (saves_spell(level - 2, victim, DAM_CHARM))
 	{
-		act("You fail to deafen $N.", ch, 0, victim, TO_CHAR);
+		act("You fail to deafen $N.", ch, nullptr, victim, TO_CHAR);
 		return;
 	}
 
@@ -6713,7 +6713,7 @@ void talismanic_end(CHAR_DATA *ch, AFFECT_DATA *af)
 void puddle_evaporate(OBJ_DATA *obj, [[maybe_unused]] OBJ_AFFECT_DATA *af)
 {
 	if (obj->in_room && obj->in_room->people)
-		act("The last traces of the puddle fade, as it seeps into the ground and evaporates.", obj->in_room->people, 0, 0, TO_ALL);
+		act("The last traces of the puddle fade, as it seeps into the ground and evaporates.", obj->in_room->people, nullptr, nullptr, TO_ALL);
 
 	extract_obj(obj);
 }
@@ -6731,13 +6731,13 @@ bool check_somatic(CHAR_DATA *ch)
 
 	if (number_percent() > skill)
 	{
-		act("$n gestures and focuses intently for a moment, but nothing happens.", ch, 0, 0, TO_ROOM);
+		act("$n gestures and focuses intently for a moment, but nothing happens.", ch, nullptr, nullptr, TO_ROOM);
 		send_to_char("You fail to complete the incantation by using somatic gestures.\n\r", ch);
 		return false;
 	}
 
-	act("$n concentrates intently as $e gestures with $s hands.", ch, 0, 0, TO_ROOM);
-	act("You focus intently, using somatic gestures to complete the incantation.", ch, 0, 0, TO_CHAR);
+	act("$n concentrates intently as $e gestures with $s hands.", ch, nullptr, nullptr, TO_ROOM);
+	act("You focus intently, using somatic gestures to complete the incantation.", ch, nullptr, nullptr, TO_CHAR);
 
 	check_improve(ch, gsn_somatic_casting, true, 6);
 

--- a/code/magic.c
+++ b/code/magic.c
@@ -3200,6 +3200,16 @@ void spell_holy_word(int sn, int level, CHAR_DATA *ch, [[maybe_unused]] SpellTar
 	else
 		wrath_num = skill_lookup("dark wrath");
 
+	// TODO: sanc_num is looked up alongside the other three and is the only one
+	// this spell never applies. Allies below receive frenzy and bless, so the
+	// obvious reading is that sanctuary was meant to join them. That is a buff
+	// to an area effect rather than a repair. Sanctuary halves incoming damage
+	// and holy_word applies to every aligned character in the room, so adding
+	// it changes group combat rather than fixing a broken case. Nothing here
+	// records what was intended. There is no comment and no commented out call,
+	// only the unused lookup, which is weaker evidence than the rest of this
+	// file offers elsewhere. This needs a balance decision before the call is
+	// added.
 	sanc_num = skill_lookup("sanctuary");
 	bless_num = skill_lookup("bless");
 	curse_num = skill_lookup("curse");

--- a/code/misc.c
+++ b/code/misc.c
@@ -486,8 +486,8 @@ void spell_summon_nephilim(int /* sn */, int level, CHAR_DATA *ch, SpellTarget /
 	CHAR_DATA *nephilim;
 	int vnum = 2948;
 
-	act("$n calls upon the forces of Hell for a servitor!", ch, 0, 0, TO_ALL);
-	act("You call upon the forces of Hell for a servitor.\n\rA gigantic Nephilim appears at your bidding.", ch, 0, 0, TO_CHAR);
+	act("$n calls upon the forces of Hell for a servitor!", ch, nullptr, nullptr, TO_ALL);
+	act("You call upon the forces of Hell for a servitor.\n\rA gigantic Nephilim appears at your bidding.", ch, nullptr, nullptr, TO_CHAR);
 
 	nephilim = create_mobile(get_mob_index(vnum));
 	nephilim->level = level + 3;
@@ -525,7 +525,7 @@ void do_damdice(CHAR_DATA *ch, char *argument)
 	damdice = (x + x * y) / 2;
 
 	sprintf(buf, "%d", damdice);
-	act(buf, ch, 0, 0, TO_CHAR);
+	act(buf, ch, nullptr, nullptr, TO_CHAR);
 }
 
 void do_devilfavor(CHAR_DATA *ch, char *argument)
@@ -596,8 +596,8 @@ void do_devilfavor(CHAR_DATA *ch, char *argument)
 
 	victim->pcdata->devildata[dev]++;
 
-	act("You grant $N another level of unholy favor.", ch, 0, victim, TO_CHAR);
-	act("You feel a piece of your soul torn away as new power surges through your veins!", ch, 0, victim, TO_VICT);
+	act("You grant $N another level of unholy favor.", ch, nullptr, victim, TO_CHAR);
+	act("You feel a piece of your soul torn away as new power surges through your veins!", ch, nullptr, victim, TO_VICT);
 }
 
 void do_chess(CHAR_DATA *ch, char *argument)
@@ -650,7 +650,7 @@ void do_chess(CHAR_DATA *ch, char *argument)
 	if (!str_cmp(arg1, "reset"))
 	{
 		send_to_char("You sweep the pieces off the board and restore them to their starting positions.\n\r", ch);
-		act("$n clears the pieces off the board and restores them to their original positions.", ch, 0, 0, TO_ROOM);
+		act("$n clears the pieces off the board and restores them to their original positions.", ch, nullptr, nullptr, TO_ROOM);
 
 		reset_chessboard();
 		return;
@@ -664,9 +664,9 @@ void do_chess(CHAR_DATA *ch, char *argument)
 			return;
 		}
 
-		act("You challenge $N to a game of chess!", ch, 0, victim, TO_CHAR);
-		act("$n challenges you to a game of chess!", ch, 0, victim, TO_VICT);
-		act("$n challenges $N to a game of chess!", ch, 0, victim, TO_NOTVICT);
+		act("You challenge $N to a game of chess!", ch, nullptr, victim, TO_CHAR);
+		act("$n challenges you to a game of chess!", ch, nullptr, victim, TO_VICT);
+		act("$n challenges $N to a game of chess!", ch, nullptr, victim, TO_NOTVICT);
 		return;
 	}
 
@@ -931,10 +931,10 @@ void do_chess(CHAR_DATA *ch, char *argument)
 			}
 
 			auto buffer = fmt::format("You place a {} {} on the board at {}.", arg2, arg3, arg4);
-			act(buffer.c_str(), ch, 0, 0, TO_CHAR);
+			act(buffer.c_str(), ch, nullptr, nullptr, TO_CHAR);
 
 			buffer = fmt::format("$n places a {} {} on the board at {}.", arg2, arg3, arg4);
-			act(buffer.c_str(), ch, 0, 0, TO_ROOM);
+			act(buffer.c_str(), ch, nullptr, nullptr, TO_ROOM);
 
 			chessboard[col_to][row_to] = piece;
 			return;
@@ -1143,7 +1143,7 @@ void move_piece(CHAR_DATA *ch, int col_from, int row_from, int col_to, int row_t
 		num_to_letter(col_to),
 		row_to + 1);
 
-	act(buf, ch, 0, 0, TO_ROOM);
+	act(buf, ch, nullptr, nullptr, TO_ROOM);
 
 	if (piece_to == PIECE_NONE)
 		return;
@@ -1152,7 +1152,7 @@ void move_piece(CHAR_DATA *ch, int col_from, int row_from, int col_to, int row_t
 	send_to_char(buf, ch);
 
 	sprintf(buf, "$n captures the %s %s.", (is_white(piece_to)) ? "white" : "black", piece_name(piece_to));
-	act(buf, ch, 0, 0, TO_ROOM);
+	act(buf, ch, nullptr, nullptr, TO_ROOM);
 }
 
 char *piece_name(int piece)

--- a/code/moremagic.c
+++ b/code/moremagic.c
@@ -80,7 +80,7 @@ void spell_enlarge([[maybe_unused]] int sn, int level, CHAR_DATA *ch, SpellTarge
 	if (is_affected(victim, gsn_reduce))
 	{
 		send_to_char("You grow to your normal size.\n\r", ch);
-		act("$n grows to $s normal size!", victim, 0, ch, TO_ROOM);
+		act("$n grows to $s normal size!", victim, nullptr, ch, TO_ROOM);
 		affect_strip(victim, gsn_reduce);
 		return;
 	}
@@ -101,7 +101,7 @@ void spell_enlarge([[maybe_unused]] int sn, int level, CHAR_DATA *ch, SpellTarge
 	affect_to_char(victim, &af);
 
 	send_to_char("Your entire body and gear rapidly grow in size, but you feel somewhat more frail afterward.\n\r", victim);
-	act("$n suddenly swells in all directions, expanding to half again $s normal size!", victim, 0, 0, TO_ROOM);
+	act("$n suddenly swells in all directions, expanding to half again $s normal size!", victim, nullptr, nullptr, TO_ROOM);
 
 	if (!is_npc(victim) && !trusts(ch, victim) && (!Deref(ch->fighting) || !Deref(victim->fighting)))
 	{
@@ -148,14 +148,14 @@ void spell_sunray(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unus
 		dam *= 1;
 
 	// Fuzz it up.
-	act("$n burns $N with the light of the sun!", ch, 0, victim, TO_NOTVICT);
-	act("$n burns you with the light of the sun!", ch, 0, victim, TO_VICT);
-	act("You burn $N with the light of the sun!", ch, 0, victim, TO_CHAR);
+	act("$n burns $N with the light of the sun!", ch, nullptr, victim, TO_NOTVICT);
+	act("$n burns you with the light of the sun!", ch, nullptr, victim, TO_VICT);
+	act("You burn $N with the light of the sun!", ch, nullptr, victim, TO_CHAR);
 
 	if (dam > 120 && number_percent() > 80)
 	{
-		act("$n appears to be blinded by the sun in $s eyes!", victim, 0, 0, TO_ROOM);
-		act("You are blinded by the sun in your eyes!", victim, 0, 0, TO_CHAR);
+		act("$n appears to be blinded by the sun in $s eyes!", victim, nullptr, nullptr, TO_ROOM);
+		act("You are blinded by the sun in your eyes!", victim, nullptr, nullptr, TO_CHAR);
 
 		init_affect(&af);
 		af.where = TO_AFFECTS;
@@ -185,7 +185,7 @@ void spell_cleanse(int sn, [[maybe_unused]] int level, CHAR_DATA *ch, SpellTarge
 	if (is_affected(victim, sn) && cleansed(ch, victim, 1, sn))
 	{
 		if (victim != ch)
-			act("$n is no longer blinded.", victim, 0, ch, TO_ROOM);
+			act("$n is no longer blinded.", victim, nullptr, ch, TO_ROOM);
 
 		send_to_char(skill_table[sn].msg_off, victim);
 		send_to_char("\n\r", victim);
@@ -197,7 +197,7 @@ void spell_cleanse(int sn, [[maybe_unused]] int level, CHAR_DATA *ch, SpellTarge
 	if (is_affected(victim, sn) && cleansed(ch, victim, 2, sn))
 	{
 		if (victim != ch)
-			act("$n looks less ill.", victim, 0, ch, TO_ROOM);
+			act("$n looks less ill.", victim, nullptr, ch, TO_ROOM);
 
 		send_to_char(skill_table[sn].msg_off, victim);
 		send_to_char("\n\r", victim);
@@ -209,7 +209,7 @@ void spell_cleanse(int sn, [[maybe_unused]] int level, CHAR_DATA *ch, SpellTarge
 	if (is_affected(victim, sn) && cleansed(ch, victim, 1, sn))
 	{
 		if (victim != ch)
-			act("$n looks stronger.", victim, 0, ch, TO_ROOM);
+			act("$n looks stronger.", victim, nullptr, ch, TO_ROOM);
 
 		send_to_char(skill_table[sn].msg_off, victim);
 		send_to_char("\n\r", victim);
@@ -221,7 +221,7 @@ void spell_cleanse(int sn, [[maybe_unused]] int level, CHAR_DATA *ch, SpellTarge
 	if (is_affected(victim, sn) && cleansed(ch, victim, 2, sn))
 	{
 		if (victim != ch)
-			act("$n looks less diseased.", victim, 0, ch, TO_ROOM);
+			act("$n looks less diseased.", victim, nullptr, ch, TO_ROOM);
 		send_to_char(skill_table[sn].msg_off, victim);
 		send_to_char("\n\r", victim);
 		affect_strip(victim, sn);
@@ -232,7 +232,7 @@ void spell_cleanse(int sn, [[maybe_unused]] int level, CHAR_DATA *ch, SpellTarge
 	if (is_affected(victim, sn) && cleansed(ch, victim, 2, sn))
 	{
 		if (victim != ch)
-			act("$n starts moving at normal speed again.", victim, 0, ch, TO_ROOM);
+			act("$n starts moving at normal speed again.", victim, nullptr, ch, TO_ROOM);
 
 		send_to_char(skill_table[sn].msg_off, victim);
 		send_to_char("\n\r", victim);
@@ -244,7 +244,7 @@ void spell_cleanse(int sn, [[maybe_unused]] int level, CHAR_DATA *ch, SpellTarge
 	if (is_affected(victim, sn) && cleansed(ch, victim, 4, sn))
 	{
 		if (victim != ch)
-			act("$n looks like $e's just had a rush of memory.", victim, 0, ch, TO_ROOM);
+			act("$n looks like $e's just had a rush of memory.", victim, nullptr, ch, TO_ROOM);
 		send_to_char(skill_table[sn].msg_off, victim);
 		send_to_char("\n\r", victim);
 		affect_strip(victim, sn);
@@ -255,7 +255,7 @@ void spell_cleanse(int sn, [[maybe_unused]] int level, CHAR_DATA *ch, SpellTarge
 	if (is_affected(victim, sn) && cleansed(ch, victim, 3, sn))
 	{
 		if (victim != ch)
-			act("$n's body stops wasting away.", victim, 0, ch, TO_ROOM);
+			act("$n's body stops wasting away.", victim, nullptr, ch, TO_ROOM);
 
 		send_to_char(skill_table[sn].msg_off, victim);
 		send_to_char("\n\r", victim);
@@ -267,7 +267,7 @@ void spell_cleanse(int sn, [[maybe_unused]] int level, CHAR_DATA *ch, SpellTarge
 	if (is_affected(victim, sn) && cleansed(ch, victim, 2, sn))
 	{
 		if (victim != ch)
-			act("$n's curse wears off.", victim, 0, ch, TO_ROOM);
+			act("$n's curse wears off.", victim, nullptr, ch, TO_ROOM);
 
 		send_to_char(skill_table[sn].msg_off, victim);
 		send_to_char("\n\r", victim);
@@ -279,7 +279,7 @@ void spell_cleanse(int sn, [[maybe_unused]] int level, CHAR_DATA *ch, SpellTarge
 	if (is_affected(victim, sn) && cleansed(ch, victim, 4, sn))
 	{
 		if (victim != ch)
-			act("$n stops bleeding.", victim, 0, ch, TO_ROOM);
+			act("$n stops bleeding.", victim, nullptr, ch, TO_ROOM);
 
 		send_to_char(skill_table[sn].msg_off, victim);
 		send_to_char("\n\r", victim);
@@ -669,7 +669,7 @@ void spell_soften(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unus
 	af.duration = 1;
 	affect_to_char(victim, &af);
 
-	act("$n looks frail.", victim, 0, 0, TO_ROOM);
+	act("$n looks frail.", victim, nullptr, nullptr, TO_ROOM);
 	send_to_char("You feel more frail.\n\r", victim);
 }
 
@@ -697,8 +697,8 @@ void spell_fatigue(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unu
 	}
 	else
 	{
-		act("$n looks fatigued.", victim, 0, 0, TO_ROOM);
-		act("You feel very fatigued.", victim, 0, 0, TO_CHAR);
+		act("$n looks fatigued.", victim, nullptr, nullptr, TO_ROOM);
+		act("You feel very fatigued.", victim, nullptr, nullptr, TO_CHAR);
 		victim->move -= dam / 2;
 	}
 
@@ -730,7 +730,7 @@ void spell_strength(int sn, int level, CHAR_DATA *ch, [[maybe_unused]] SpellTarg
 	affect_to_char(ch, &af);
 
 	send_to_char("You fast for a period of time, building up your absolute faith in the strength of your Deity.\n\r", ch);
-	act("$n meditates for a period of time, building up $s faith in $s Deity.", ch, 0, 0, TO_ROOM);
+	act("$n meditates for a period of time, building up $s faith in $s Deity.", ch, nullptr, nullptr, TO_ROOM);
 }
 
 void spell_remove_taint(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_unused]] CastMode mode)
@@ -774,13 +774,13 @@ void spell_worldbind(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe_u
 
 	if (saves_spell(level - 5, victim, DAM_NEGATIVE))
 	{
-		act("You failed to bind $N to this world.", ch, 0, victim, TO_CHAR);
+		act("You failed to bind $N to this world.", ch, nullptr, victim, TO_CHAR);
 		return;
 	}
 
-	act("You sever $N's ties to the spiritual world!", ch, 0, victim, TO_CHAR);
-	act("$n severs $N's ties to the spiritual world!", ch, 0, victim, TO_NOTVICT);
-	act_new("$n severs your ties to the spiritual world!", ch, 0, victim, TO_VICT, POS_DEAD);
+	act("You sever $N's ties to the spiritual world!", ch, nullptr, victim, TO_CHAR);
+	act("$n severs $N's ties to the spiritual world!", ch, nullptr, victim, TO_NOTVICT);
+	act_new("$n severs your ties to the spiritual world!", ch, nullptr, victim, TO_VICT, POS_DEAD);
 
 	init_affect(&af);
 	af.where = TO_AFFECTS;
@@ -811,8 +811,8 @@ void spell_waterbreath(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe
 
 	if (is_affected(victim, gsn_drowning))
 	{
-		act("You feel relieved as you begin breathing water like you would air.", victim, 0, 0, TO_CHAR);
-		act("$n looks relieved as $e begins breathing water like $e would air.", victim, 0, 0, TO_ROOM);
+		act("You feel relieved as you begin breathing water like you would air.", victim, nullptr, nullptr, TO_CHAR);
+		act("$n looks relieved as $e begins breathing water like $e would air.", victim, nullptr, nullptr, TO_ROOM);
 		affect_strip(victim, gsn_drowning);
 	}
 
@@ -833,5 +833,5 @@ void spell_waterbreath(int sn, int level, CHAR_DATA *ch, SpellTarget vo, [[maybe
 	send_to_char("You feel more adept at breathing underwater.\n\r", victim);
 
 	if (ch != victim)
-		act("You give $N the ability to breathe underwater.", ch, 0, victim, TO_CHAR);
+		act("You give $N the ability to breathe underwater.", ch, nullptr, victim, TO_CHAR);
 }

--- a/code/mprog.c
+++ b/code/mprog.c
@@ -1571,7 +1571,7 @@ void attack_prog_lesser_demon(CHAR_DATA *mob, CHAR_DATA *attacker)
 		char_to_room(mob, get_room_index(3));
 
 		RS.Queue.AddToQueue(1, "attack_prog_lesser_demon", "delay_extract", delay_extract, mob);
-		Deref(af->owner)->pcdata->lesserdata[LESSER_BARBAS] = FAVOR_NONE;
+		set_pact_favor(af, false, LESSER_BARBAS, FAVOR_NONE);
 		return;
 	}
 
@@ -1583,19 +1583,19 @@ void attack_prog_lesser_demon(CHAR_DATA *mob, CHAR_DATA *attacker)
 		switch (mob->pIndexData->vnum)
 		{
 			case MOB_VNUM_BARBAS:
-				Deref(af->owner)->pcdata->lesserdata[LESSER_BARBAS] = FAVOR_FAILED;
+				set_pact_favor(af, false, LESSER_BARBAS, FAVOR_FAILED);
 				break;
 			case MOB_VNUM_FURCAS:
-				Deref(af->owner)->pcdata->lesserdata[LESSER_FURCAS] = FAVOR_FAILED;
+				set_pact_favor(af, false, LESSER_FURCAS, FAVOR_FAILED);
 				break;
 			case MOB_VNUM_MALAPHAR:
-				Deref(af->owner)->pcdata->lesserdata[LESSER_MALAPHAR] = FAVOR_FAILED;
+				set_pact_favor(af, false, LESSER_MALAPHAR, FAVOR_FAILED);
 				break;
 			case MOB_VNUM_AAMON:
-				Deref(af->owner)->pcdata->lesserdata[LESSER_AAMON] = FAVOR_FAILED;
+				set_pact_favor(af, false, LESSER_AAMON, FAVOR_FAILED);
 				break;
 			case MOB_VNUM_IPOS:
-				Deref(af->owner)->pcdata->lesserdata[LESSER_IPOS] = FAVOR_FAILED;
+				set_pact_favor(af, false, LESSER_IPOS, FAVOR_FAILED);
 				break;
 			default:
 				return;
@@ -1619,19 +1619,19 @@ void attack_prog_lesser_demon(CHAR_DATA *mob, CHAR_DATA *attacker)
 		switch (mob->pIndexData->vnum)
 		{
 			case MOB_VNUM_BARBAS:
-				Deref(af->owner)->pcdata->lesserdata[LESSER_BARBAS] = FAVOR_NONE;
+				set_pact_favor(af, false, LESSER_BARBAS, FAVOR_NONE);
 				break;
 			case MOB_VNUM_FURCAS:
-				Deref(af->owner)->pcdata->lesserdata[LESSER_FURCAS] = FAVOR_NONE;
+				set_pact_favor(af, false, LESSER_FURCAS, FAVOR_NONE);
 				break;
 			case MOB_VNUM_MALAPHAR:
-				Deref(af->owner)->pcdata->lesserdata[LESSER_MALAPHAR] = FAVOR_NONE;
+				set_pact_favor(af, false, LESSER_MALAPHAR, FAVOR_NONE);
 				break;
 			case MOB_VNUM_AAMON:
-				Deref(af->owner)->pcdata->lesserdata[LESSER_AAMON] = FAVOR_NONE;
+				set_pact_favor(af, false, LESSER_AAMON, FAVOR_NONE);
 				break;
 			case MOB_VNUM_IPOS:
-				Deref(af->owner)->pcdata->lesserdata[LESSER_IPOS] = FAVOR_NONE;
+				set_pact_favor(af, false, LESSER_IPOS, FAVOR_NONE);
 				break;
 			default:
 				return;

--- a/code/mprog.c
+++ b/code/mprog.c
@@ -1304,13 +1304,17 @@ void pulse_prog_tahlu_mist_ward(CHAR_DATA *mob)
 	for (OwningListWalk<DESCRIPTOR_DATA> walk(descriptor_list); !walk.Done(); walk.Step())
 	{
 		DESCRIPTOR_DATA *d = walk.Current();
+		CHAR_DATA *wch = Deref(d->character);
+
+		if (wch == nullptr)
+			continue;
 
 		if (d->connected == CON_PLAYING
-			&& Deref(d->character)->in_room != nullptr
-			&& Deref(d->character)->in_room->area == mob->in_room->area
-			&& is_evil(Deref(d->character)))
+			&& wch->in_room != nullptr
+			&& wch->in_room->area == mob->in_room->area
+			&& is_evil(wch))
 		{
-			ch = Deref(d->character);
+			ch = wch;
 			mist = create_mobile(get_mob_index(1616));
 
 			char_to_room(mist, ch->in_room);
@@ -3226,12 +3230,16 @@ void pulse_prog_area_echo_ward(CHAR_DATA *mob)
 	for (OwningListWalk<DESCRIPTOR_DATA> walk(descriptor_list); !walk.Done(); walk.Step())
 	{
 		DESCRIPTOR_DATA *d = walk.Current();
+		CHAR_DATA *wch = Deref(d->character);
+
+		if (wch == nullptr)
+			continue;
 
 		if (d->connected != CON_PLAYING
-			|| !Deref(d->character)->in_room
-			|| Deref(d->character)->in_room->area != mob->in_room->area
-			|| Deref(d->character)->in_room->vnum < mob->armor[0]
-			|| Deref(d->character)->in_room->vnum > mob->armor[1])
+			|| !wch->in_room
+			|| wch->in_room->area != mob->in_room->area
+			|| wch->in_room->vnum < mob->armor[0]
+			|| wch->in_room->vnum > mob->armor[1])
 		{
 			continue;
 		}

--- a/code/mprog.c
+++ b/code/mprog.c
@@ -611,7 +611,7 @@ void pulse_prog_arangird_patrol(CHAR_DATA *mob)
 	if (mob->in_room->exit[dir_next]->u1.to_room->people)
 	{
 		act("You hear the heavy footsteps of an approaching patrol echo through the caves.",
-			mob->in_room->exit[dir_next]->u1.to_room->people, 0, 0, TO_ALL);
+			mob->in_room->exit[dir_next]->u1.to_room->people, nullptr, nullptr, TO_ALL);
 	}
 }
 
@@ -674,7 +674,7 @@ void speech_prog_ruins_mouth([[maybe_unused]] CHAR_DATA *mob, CHAR_DATA *ch, cha
 		return;
 
 	send_to_char("A magic mouth impossibly beckons for you to follow and strange magicks force you through the shimmering portal.\n\r", ch);
-	act("The magic mouth impossibly beckons for $n to follow and $e vanishes into the portal.", ch, 0, 0, TO_ROOM);
+	act("The magic mouth impossibly beckons for $n to follow and $e vanishes into the portal.", ch, nullptr, nullptr, TO_ROOM);
 
 	char_from_room(ch);
 	char_to_room(ch, to_room);
@@ -912,7 +912,7 @@ void pulse_prog_demon(CHAR_DATA *mob)
 			do_tell(mob, buf);
 		}
 
-		act("$n returns to the Hells.", elemental, 0, 0, TO_ALL);
+		act("$n returns to the Hells.", elemental, nullptr, nullptr, TO_ALL);
 		extract_char(mob, true);
 		return;
 	}
@@ -928,17 +928,17 @@ void pulse_prog_demon(CHAR_DATA *mob)
 
 	if (victim->in_room->vnum != elemental->in_room->vnum)
 	{
-		act("$n steps through a portal, seeking $s prey.", elemental, 0, 0, TO_ALL);
+		act("$n steps through a portal, seeking $s prey.", elemental, nullptr, nullptr, TO_ALL);
 
 		char_from_room(elemental);
 		char_to_room(elemental, victim->in_room);
 
-		act("$n arrives through a portal, seeking $N's blood!", elemental, 0, victim, TO_NOTVICT);
-		act("$n arrives through a portal, seeking your blood!", elemental, 0, victim, TO_VICT);
+		act("$n arrives through a portal, seeking $N's blood!", elemental, nullptr, victim, TO_NOTVICT);
+		act("$n arrives through a portal, seeking your blood!", elemental, nullptr, victim, TO_VICT);
 	}
 
-	act("$n gestures at $N, uttering curses.", elemental, 0, victim, TO_NOTVICT);
-	act("$n gestures at you, uttering curses.", elemental, 0, victim, TO_VICT);
+	act("$n gestures at $N, uttering curses.", elemental, nullptr, victim, TO_NOTVICT);
+	act("$n gestures at you, uttering curses.", elemental, nullptr, victim, TO_VICT);
 
 	multi_hit(elemental, victim, TYPE_UNDEFINED);
 }
@@ -949,8 +949,8 @@ bool aggress_prog_arangird_demon(CHAR_DATA *mob, CHAR_DATA *attacker)
 
 	if ((regthor = get_char_room(mob, "regthor")) != nullptr)
 	{
-		act("An invisible barrier flares around $n, protecting $m from harm.", mob, 0, attacker, TO_VICT);
-		act("An invisible barrier flares around $n as $N approaches.", mob, 0, attacker, TO_NOTVICT);
+		act("An invisible barrier flares around $n, protecting $m from harm.", mob, nullptr, attacker, TO_VICT);
+		act("An invisible barrier flares around $n as $N approaches.", mob, nullptr, attacker, TO_NOTVICT);
 
 		if (Deref(attacker->fighting) == mob)
 			stop_fighting(attacker, mob);
@@ -968,14 +968,14 @@ bool aggress_prog_arangird_regthor(CHAR_DATA *mob, CHAR_DATA *attacker)
 	if ((demon = get_char_room(mob, "ertruza")) == nullptr)
 		return false;
 
-	act("A look of horror crosses $n's face as $s concentration falters.", mob, 0, demon, TO_ALL);
-	act("The barrier surrounding $N flickers and fades, and $n shrieks!", mob, 0, demon, TO_ALL);
-	act("Roaring with anger, $n grabs his former captor and devours $M whole!", demon, 0, mob, TO_ALL);
+	act("A look of horror crosses $n's face as $s concentration falters.", mob, nullptr, demon, TO_ALL);
+	act("The barrier surrounding $N flickers and fades, and $n shrieks!", mob, nullptr, demon, TO_ALL);
+	act("Roaring with anger, $n grabs his former captor and devours $M whole!", demon, nullptr, mob, TO_ALL);
 
 	extract_char(mob, true);
 
-	act("$n then turns you and strikes!", demon, 0, attacker, TO_CHAR);
-	act("$n then turns to $N and strikes!", demon, 0, attacker, TO_ROOM);
+	act("$n then turns you and strikes!", demon, nullptr, attacker, TO_CHAR);
+	act("$n then turns to $N and strikes!", demon, nullptr, attacker, TO_ROOM);
 	do_murder(demon, attacker->name);
 
 	return true;
@@ -990,12 +990,12 @@ void fight_prog_ilopheth_druid(CHAR_DATA *mob, CHAR_DATA *victim)
 	if (rand > 10)
 		return;
 
-	act("With a wave of $s hand, the druid summons a gale that batters the area!", mob, 0, 0, TO_ROOM);
+	act("With a wave of $s hand, the druid summons a gale that batters the area!", mob, nullptr, nullptr, TO_ROOM);
 
 	if (rand == 1)
 	{
-		act("The powerful winds send you tumbling headlong through the bushes!", victim, 0, 0, TO_CHAR);
-		act("The powerful winds send $n tumbling headlong through the bushes!", victim, 0, 0, TO_ROOM);
+		act("The powerful winds send you tumbling headlong through the bushes!", victim, nullptr, nullptr, TO_CHAR);
+		act("The powerful winds send $n tumbling headlong through the bushes!", victim, nullptr, nullptr, TO_ROOM);
 
 		LAG_CHAR(victim, 2 * PULSE_VIOLENCE);
 
@@ -1008,8 +1008,8 @@ void fight_prog_ilopheth_druid(CHAR_DATA *mob, CHAR_DATA *victim)
 	}
 	else
 	{
-		act("The powerful winds send you sprawling in a heap!", victim, 0, 0, TO_CHAR);
-		act("The powerful winds send $n sprawling in a heap!", victim, 0, 0, TO_ROOM);
+		act("The powerful winds send you sprawling in a heap!", victim, nullptr, nullptr, TO_CHAR);
+		act("The powerful winds send $n sprawling in a heap!", victim, nullptr, nullptr, TO_ROOM);
 
 		victim->position = POS_RESTING;
 
@@ -1055,7 +1055,7 @@ void pulse_prog_ilopheth_piranha(CHAR_DATA *mob)
 	char_from_room(mob);
 	char_to_room(mob, surface);
 
-	act("$n leaps from the water, razor teeth flashing!", mob, 0, 0, TO_ROOM);
+	act("$n leaps from the water, razor teeth flashing!", mob, nullptr, nullptr, TO_ROOM);
 
 	damage_new(mob, victim, (20 + dice(5, 6)), TYPE_UNDEFINED, DAM_PIERCE, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "chomp");
 
@@ -1090,7 +1090,7 @@ void pulse_prog_ilopheth_piranha(CHAR_DATA *mob)
 			walk_to_room(adjmob, room);
 
 			if (adjmob->in_room == room)
-				act("The water here ripples, and there appears to be increased movement below the surface.", victim, 0, 0, TO_ALL);
+				act("The water here ripples, and there appears to be increased movement below the surface.", victim, nullptr, nullptr, TO_ALL);
 		}
 	}
 }
@@ -1108,7 +1108,7 @@ void pulse_prog_ilopheth_weatherbeaten(CHAR_DATA *mob)
 
 	if (sun == SolarPosition::Sunset && mob->in_room->vnum == 9121)
 	{
-		act("The old man glances up at the darkening sky, and trudges off into the forest to the south.", mob, 0, 0, TO_ROOM);
+		act("The old man glances up at the darkening sky, and trudges off into the forest to the south.", mob, nullptr, nullptr, TO_ROOM);
 		char_from_room(mob);
 		char_to_room(mob, limbo);
 	}
@@ -1116,7 +1116,7 @@ void pulse_prog_ilopheth_weatherbeaten(CHAR_DATA *mob)
 	{
 		char_from_room(mob);
 		char_to_room(mob, forest);
-		act("An aged man trudges in from the south, and sits down heavily on a large rock.", mob, 0, 0, TO_ROOM);
+		act("An aged man trudges in from the south, and sits down heavily on a large rock.", mob, nullptr, nullptr, TO_ROOM);
 	}
 }
 
@@ -1134,13 +1134,13 @@ void pulse_prog_alstea_ehrlouge(CHAR_DATA *mob)
 
 	if (rnd < 4)
 	{
-		act("Ehrlouge scribbles something down violently, his teeth gritting and chattering.", mob, 0, 0, TO_ROOM);
+		act("Ehrlouge scribbles something down violently, his teeth gritting and chattering.", mob, nullptr, nullptr, TO_ROOM);
 		return;
 	}
 
 	if (rnd > 97)
 	{
-		act("The skeletal figure of Ehrlouge begins to shudder and tremble as he dryly and raspily whimpers.", mob, 0, 0, TO_ROOM);
+		act("The skeletal figure of Ehrlouge begins to shudder and tremble as he dryly and raspily whimpers.", mob, nullptr, nullptr, TO_ROOM);
 		return;
 	}
 }
@@ -1228,7 +1228,7 @@ bool death_prog_outer_guardian(CHAR_DATA *mob, CHAR_DATA *killer)
 					obj_from_char(obj);
 					obj_to_char(obj, othercabalguardian);
 
-					act(buf, mob, 0, 0, TO_ALL);
+					act(buf, mob, nullptr, nullptr, TO_ALL);
 					cabal_shudder(obj->pIndexData->cabal, false);
 				}
 			}
@@ -1272,7 +1272,7 @@ bool death_prog_inner_guardian(CHAR_DATA *mob, CHAR_DATA *killer)
 
 				found = true;
 
-				act(buf, mob, 0, 0, TO_ALL);
+				act(buf, mob, nullptr, nullptr, TO_ALL);
 				cabal_shudder(obj->pIndexData->cabal, false);
 			}
 		}
@@ -1315,8 +1315,8 @@ void pulse_prog_tahlu_mist_ward(CHAR_DATA *mob)
 
 			char_to_room(mist, ch->in_room);
 
-			act("A strange cloud of mist rises from the floor, stretching tendrils towards you!", ch, 0, 0, TO_CHAR);
-			act("A strange cloud of mist rises from the floor, stretching tendrils towards $n.", ch, 0, 0, TO_ROOM);
+			act("A strange cloud of mist rises from the floor, stretching tendrils towards you!", ch, nullptr, nullptr, TO_CHAR);
+			act("A strange cloud of mist rises from the floor, stretching tendrils towards $n.", ch, nullptr, nullptr, TO_ROOM);
 
 			multi_hit(mist, ch, TYPE_UNDEFINED);
 			return;
@@ -1344,7 +1344,7 @@ bool move_prog_horde_shrine_ward(CHAR_DATA *ch, CHAR_DATA * /* mob */, ROOM_INDE
 
 bool aggress_prog_anchor(CHAR_DATA *mob, CHAR_DATA *attacker)
 {
-	act("$n dissipates harmlessly as you turn your attention towards it.", mob, 0, 0, TO_ROOM);
+	act("$n dissipates harmlessly as you turn your attention towards it.", mob, nullptr, nullptr, TO_ROOM);
 
 	stop_fighting(mob, true);
 
@@ -1369,7 +1369,7 @@ bool death_prog_glass(CHAR_DATA *mob, [[maybe_unused]] CHAR_DATA *killer)
 		if (is_safe(ch, vch) || ch == vch)
 			continue;
 
-		act("Some of the exploding glass from $n strikes you!", mob, 0, vch, TO_VICT);
+		act("Some of the exploding glass from $n strikes you!", mob, nullptr, vch, TO_VICT);
 		damage_new(ch, vch, dice(mob->level, 6), TYPE_UNDEFINED, DAM_PIERCE, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "the shattered glass*");
 
 		if ((vch != nullptr) && (number_percent() > 60))
@@ -1417,7 +1417,7 @@ void pulse_prog_shopkeeper(CHAR_DATA *mob)
 		char_from_room(mob);
 		char_to_room(mob, exit->u1.to_room);
 
-		act("$n unlocks the door to the $T and opens for business.", mob, 0, direction_table[reverse_d(pShop->direction)].name, TO_ROOM);
+		act("$n unlocks the door to the $T and opens for business.", mob, nullptr, direction_table[reverse_d(pShop->direction)].name, TO_ROOM);
 
 		if ((exit = exit->u1.to_room->exit[reverse_d(pShop->direction)]))
 		{
@@ -1442,7 +1442,7 @@ void pulse_prog_shopkeeper(CHAR_DATA *mob)
 		char_from_room(mob);
 		char_to_room(mob, exit->u1.to_room);
 
-		act("$n locks the door to the $T as $e closes $s business.", mob, 0, direction_table[reverse_d(pShop->direction)].name, TO_ROOM);
+		act("$n locks the door to the $T as $e closes $s business.", mob, nullptr, direction_table[reverse_d(pShop->direction)].name, TO_ROOM);
 
 		char_from_room(mob);
 		char_to_room(mob, room);
@@ -1473,13 +1473,13 @@ void pulse_prog_shopkeeper(CHAR_DATA *mob)
 		if (is_npc(vch) && IS_SET(vch->act, ACT_SENTINEL))
 			continue;
 
-		act("$n hustles you out the door.", mob, 0, vch, TO_VICT);
-		act("$n hustles $N out the door.", mob, 0, vch, TO_NOTVICT);
+		act("$n hustles you out the door.", mob, nullptr, vch, TO_VICT);
+		act("$n hustles $N out the door.", mob, nullptr, vch, TO_NOTVICT);
 
 		char_from_room(vch);
 		char_to_room(vch, exit->u1.to_room);
 
-		act("$t tosses $n out of $s shop.", vch, mob->short_descr, 0, TO_ROOM);
+		act("$t tosses $n out of $s shop.", vch, mob->short_descr, nullptr, TO_ROOM);
 
 		if (Deref(mob->fighting))
 			stop_fighting(mob, Deref(mob->fighting));
@@ -1497,8 +1497,8 @@ bool move_prog_theatre_guard(CHAR_DATA *ch, CHAR_DATA *mob, [[maybe_unused]] ROO
 
 	if (ch->pause)
 	{
-		act("$n moves to block $N.", mob, 0, ch, TO_ROOM);
-		act("$n moves to block you.", mob, 0, ch, TO_VICT);
+		act("$n moves to block $N.", mob, nullptr, ch, TO_ROOM);
+		act("$n moves to block you.", mob, nullptr, ch, TO_VICT);
 		do_say(mob, "You'd better clean yourself up a little before you go in.");
 		return false;
 	}
@@ -1520,17 +1520,17 @@ void greet_prog_necro_skull(CHAR_DATA *mob, CHAR_DATA *ch)
 	if (is_npc(ch))
 		return;
 
-	act("$n rises into the air and opens its mouth in a silent shriek!", mob, 0, ch, TO_ROOM);
+	act("$n rises into the air and opens its mouth in a silent shriek!", mob, nullptr, ch, TO_ROOM);
 	sprintf(buf, "A skull-sentinel whispers to you '%sMaster, %s has arrived at my location.%s'",
 		get_char_color(ch, "lightred"),
 		palloc_string(ch->name),
 		END_COLOR(ch));
-	act(buf, master, 0, 0, TO_CHAR);
+	act(buf, master, nullptr, nullptr, TO_CHAR);
 }
 
 bool death_prog_necro_skull(CHAR_DATA *mob, [[maybe_unused]] CHAR_DATA *killer)
 {
-	act("$n crumbles into dust.", mob, 0, 0, TO_ROOM);
+	act("$n crumbles into dust.", mob, nullptr, nullptr, TO_ROOM);
 	extract_char(mob, true);
 	return true;
 }
@@ -1539,7 +1539,7 @@ void pulse_prog_necro_skull(CHAR_DATA *mob)
 {
 	if (Deref(mob->leader) == nullptr)
 	{
-		act("$n crumbles into a pile of dust.", mob, 0, 0, TO_ROOM);
+		act("$n crumbles into a pile of dust.", mob, nullptr, nullptr, TO_ROOM);
 		extract_char(mob, true);
 	}
 }
@@ -1559,7 +1559,7 @@ void attack_prog_lesser_demon(CHAR_DATA *mob, CHAR_DATA *attacker)
 		sprintf(buf, "%s I'll be back for ye another time, weakling.", Deref(af->owner)->name);
 		do_tell(mob, buf);
 
-		act("$n vanishes in a crimson flash!", mob, 0, 0, TO_ROOM);
+		act("$n vanishes in a crimson flash!", mob, nullptr, nullptr, TO_ROOM);
 
 		stop_fighting(mob, true);
 
@@ -1600,7 +1600,7 @@ void attack_prog_lesser_demon(CHAR_DATA *mob, CHAR_DATA *attacker)
 		do_emote(mob, "shakes his head angrily.");
 		do_say(mob, "You could have had powers beyond your dreams, fool.  Beyond your dreams....");
 
-		act("$n vanishes in a crimson flash!", mob, 0, 0, TO_ROOM);
+		act("$n vanishes in a crimson flash!", mob, nullptr, nullptr, TO_ROOM);
 		stop_fighting(mob, true);
 
 		char_from_room(mob);
@@ -1639,7 +1639,7 @@ void attack_prog_lesser_demon(CHAR_DATA *mob, CHAR_DATA *attacker)
 		sprintf(buf, "%s I'll be back for ye another time, weakling.", Deref(af->owner)->name);
 		do_tell(mob, buf);
 
-		act("$n vanishes in a crimson flash!", mob, 0, 0, TO_ROOM);
+		act("$n vanishes in a crimson flash!", mob, nullptr, nullptr, TO_ROOM);
 
 		stop_fighting(mob, true);
 
@@ -1692,7 +1692,7 @@ void beat_prog_barbas(CHAR_DATA *mob)
 		{
 			char_from_room(mob);
 			char_to_room(mob, ch->in_room);
-			act("$n has arrived through a gate.", mob, 0, 0, TO_ROOM);
+			act("$n has arrived through a gate.", mob, nullptr, nullptr, TO_ROOM);
 		}
 
 		return;
@@ -1710,7 +1710,7 @@ bool death_prog_barbas(CHAR_DATA *mob, CHAR_DATA *killer)
 	if (!af)
 		return false;
 
-	act("Emitting a ghastly grunt, Barbas falls to the ground in a heap and disappears.", mob, 0, 0, TO_ROOM);
+	act("Emitting a ghastly grunt, Barbas falls to the ground in a heap and disappears.", mob, nullptr, nullptr, TO_ROOM);
 
 	if (killer != Deref(af->owner))
 		return false;
@@ -1797,14 +1797,14 @@ void give_prog_malaphar(CHAR_DATA *mob, CHAR_DATA *ch, OBJ_DATA *obj)
 		do_say(mob, "Surely, friend, you do not believe me to be a pauper?");
 		do_say(mob, "Entirely unacceptable, I'm afraid.");
 
-		act("$n wraps his cloak around him and vanishes into the shadows.", ch, 0, 0, TO_ROOM);
+		act("$n wraps his cloak around him and vanishes into the shadows.", ch, nullptr, nullptr, TO_ROOM);
 
 		extract_char(mob, true);
 		ch->pcdata->lesserdata[LESSER_MALAPHAR] = FAVOR_FAILED;
 		return;
 	}
 
-	act("A thin smile crosses Malaphar's face as he tips his hat to you and vanishes.", mob, 0, 0, TO_ROOM);
+	act("A thin smile crosses Malaphar's face as he tips his hat to you and vanishes.", mob, nullptr, nullptr, TO_ROOM);
 
 	extract_char(mob, true);
 
@@ -1826,12 +1826,12 @@ void bribe_prog_malaphar(CHAR_DATA *mob, CHAR_DATA *ch, int amount)
 		do_say(mob, "Surely, friend, you do not believe me to be a pauper?");
 		do_say(mob, "Entirely unacceptable, I'm afraid.");
 
-		act("$n wraps his cloak around him and vanishes into the shadows.", ch, 0, 0, TO_ROOM);
+		act("$n wraps his cloak around him and vanishes into the shadows.", ch, nullptr, nullptr, TO_ROOM);
 		ch->pcdata->lesserdata[LESSER_MALAPHAR] = FAVOR_FAILED;
 		return;
 	}
 
-	act("A thin smile crosses Malaphar's face as he tips his hat to you and vanishes.", ch, 0, 0, TO_ROOM);
+	act("A thin smile crosses Malaphar's face as he tips his hat to you and vanishes.", ch, nullptr, nullptr, TO_ROOM);
 	send_to_char("A wave of greed flashes over you as your fingers seem somehow more nimble.\n\r", ch);
 
 	ch->pcdata->lesserdata[LESSER_MALAPHAR] = FAVOR_GRANTED;
@@ -1848,8 +1848,8 @@ void greet_prog_furcas(CHAR_DATA *mob, CHAR_DATA *ch)
 	if (ch != Deref(af->owner))
 		return;
 
-	act("Eyes wide with amazement and fear, $n leaps backward away from you!", mob, 0, ch, TO_VICT);
-	act("Eyes wide with amazement and fear, $n leaps backward away from $N!", mob, 0, ch, TO_NOTVICT);
+	act("Eyes wide with amazement and fear, $n leaps backward away from you!", mob, nullptr, ch, TO_VICT);
+	act("Eyes wide with amazement and fear, $n leaps backward away from $N!", mob, nullptr, ch, TO_NOTVICT);
 
 	do_say(mob, "Do not harm us, we hope it will not!  Here!  Here, take it!");
 
@@ -1857,7 +1857,7 @@ void greet_prog_furcas(CHAR_DATA *mob, CHAR_DATA *ch)
 	ch->pcdata->learned[skill_lookup("darksight")] = 1;
 
 	send_to_char("Your eyes burn for a moment, and your vision seems somehow sharper.\n\r", ch);
-	act("$n shrinks back into nearby shadows and is gone.", mob, 0, 0, TO_ROOM);
+	act("$n shrinks back into nearby shadows and is gone.", mob, nullptr, nullptr, TO_ROOM);
 	extract_char(mob, true);
 }
 
@@ -1888,10 +1888,10 @@ void speech_prog_ipos(CHAR_DATA *mob, CHAR_DATA *ch, char *speech)
 	{
 		do_emote(mob, "nearly loses his balance, doubled over with laughter.");
 
-		act("Ipos recites: $t", mob, mob->speechbuf[0], 0, TO_ROOM);
-		act("              $t", mob, mob->speechbuf[1], 0, TO_ROOM);
-		act("              $t", mob, mob->speechbuf[2], 0, TO_ROOM);
-		act("              $t", mob, mob->speechbuf[3], 0, TO_ROOM);
+		act("Ipos recites: $t", mob, mob->speechbuf[0], nullptr, TO_ROOM);
+		act("              $t", mob, mob->speechbuf[1], nullptr, TO_ROOM);
+		act("              $t", mob, mob->speechbuf[2], nullptr, TO_ROOM);
+		act("              $t", mob, mob->speechbuf[3], nullptr, TO_ROOM);
 
 		RS.Queue.AddToQueue(2, "speech_prog_ipos", "do_say_queue", do_say_queue, mob, "Quite the worst bit of garbage I've ever had the joyless task of committing to memory.  Good day,  my rhythmless friend.");
 
@@ -1948,7 +1948,7 @@ void speech_prog_oze(CHAR_DATA *mob, CHAR_DATA *ch, char *speech)
 	{
 		WAIT_STATE(ch, 3 * PULSE_VIOLENCE);
 
-		act("Eyes flickering with nearly extinguished flame, Oze incants a phrase.", mob, 0, 0, TO_ROOM);
+		act("Eyes flickering with nearly extinguished flame, Oze incants a phrase.", mob, nullptr, nullptr, TO_ROOM);
 
 		sprintf(buf, "'siphon' %s", ch->name);
 		do_cast(mob, buf);
@@ -1997,7 +1997,7 @@ void speech_prog_gamygyn(CHAR_DATA *mob, CHAR_DATA *ch, char *speech)
 	{
 		WAIT_STATE(ch, PULSE_VIOLENCE);
 
-		act("Roaring suddenly with a thunder not unlike a thousand horses, $n rises.", mob, 0, 0, TO_ROOM);
+		act("Roaring suddenly with a thunder not unlike a thousand horses, $n rises.", mob, nullptr, nullptr, TO_ROOM);
 
 		RS.Queue.AddToQueue(2, "speech_prog_gamygyn", "act_queue", act_queue, "Plunging suddenly headlong, the demon dissolves into your midsection as you scream involuntarily.", mob, nullptr, ch, TO_VICT);
 		RS.Queue.AddToQueue(2, "speech_prog_gamygyn", "act_queue", act_queue, "Plunging suddenly headlong, the demon dissolves into $N's midsection as $E screams.", mob, nullptr, ch, TO_NOTVICT);
@@ -2024,7 +2024,7 @@ void speech_prog_gamygyn(CHAR_DATA *mob, CHAR_DATA *ch, char *speech)
 	{
 		WAIT_STATE(ch, PULSE_VIOLENCE);
 
-		act("With a flourishing fanfare which seems nonetheless foreboding, $n rises.", mob, 0, 0, TO_ROOM);
+		act("With a flourishing fanfare which seems nonetheless foreboding, $n rises.", mob, nullptr, nullptr, TO_ROOM);
 
 		buffer = fmt::format("{} You may yet live to regret your rash decision.  Doubtless the seeds of realization sprout within you now.", ch->name);
 		RS.Queue.AddToQueue(1, "speech_prog_gamygyn", "do_tell_queue", do_tell_queue, mob, buffer);
@@ -2084,7 +2084,7 @@ void speech_prog_orobas(CHAR_DATA *mob, CHAR_DATA *ch, char *speech)
 	{
 		WAIT_STATE(ch, PULSE_VIOLENCE);
 
-		act("Shrieks of outrage rise up from $n, arms and legs kicking out toward you.", mob, 0, 0, TO_ROOM);
+		act("Shrieks of outrage rise up from $n, arms and legs kicking out toward you.", mob, nullptr, nullptr, TO_ROOM);
 
 		RS.Queue.AddToQueue(1, "speech_prog_orobas", "do_say_queue", do_say_queue, mob, "I expected nothing else.");
 		RS.Queue.AddToQueue(2, "speech_prog_orobas", "act_queue",  act_queue, "With a fierce snarl and many assorted whispers, $n streaks into the darkness.", mob, nullptr, nullptr, TO_ROOM);
@@ -2206,13 +2206,13 @@ void pulse_prog_cornogun(CHAR_DATA *mob)
 	switch (number_range(0, 10))
 	{
 		case 0:
-			act("$n chitters annoyingly at everyone in the room.", mob, 0, 0, TO_ROOM);
+			act("$n chitters annoyingly at everyone in the room.", mob, nullptr, nullptr, TO_ROOM);
 			break;
 		case 1:
-			act("$n pauses momentarily to spit, leaving a disgusting substance all over the floor.", mob, 0, 0, TO_ROOM);
+			act("$n pauses momentarily to spit, leaving a disgusting substance all over the floor.", mob, nullptr, nullptr, TO_ROOM);
 			break;
 		case 2:
-			act("$n ceases flapping its wings incessantly to let out a mournful screech.", mob, 0, 0, TO_ROOM);
+			act("$n ceases flapping its wings incessantly to let out a mournful screech.", mob, nullptr, nullptr, TO_ROOM);
 			break;
 		default:
 			spell_faerie_fog(skill_lookup("faerie fog"), mob->level, mob, SpellTarget(), CastMode::Spell);
@@ -2222,7 +2222,7 @@ void pulse_prog_cornogun(CHAR_DATA *mob)
 
 void entry_prog_cornogun(CHAR_DATA *mob)
 {
-	act("$n flaps in on its tiny wings.", mob, 0, 0, TO_ROOM);
+	act("$n flaps in on its tiny wings.", mob, nullptr, nullptr, TO_ROOM);
 	spell_faerie_fog(skill_lookup("faerie fog"), mob->level, mob, SpellTarget(), CastMode::Spell);
 }
 
@@ -2399,18 +2399,18 @@ void fight_prog_gking(CHAR_DATA *mob, CHAR_DATA *victim)
 		gar1 = create_mobile(get_mob_index(2233));
 		gar2 = create_mobile(get_mob_index(2233));
 
-		act("$n gestures slightly animating the two mithril statues next to the throne!", mob, 0, 0, TO_ROOM);
+		act("$n gestures slightly animating the two mithril statues next to the throne!", mob, nullptr, nullptr, TO_ROOM);
 
 		char_to_room(gar1, mob->in_room);
 		char_to_room(gar2, mob->in_room);
 
-		act("$n screams and attacks you!", gar1, 0, victim, TO_VICT);
-		act("$n screams and attacks $N!", gar1, 0, victim, TO_NOTVICT);
+		act("$n screams and attacks you!", gar1, nullptr, victim, TO_VICT);
+		act("$n screams and attacks $N!", gar1, nullptr, victim, TO_NOTVICT);
 
 		do_murder(gar1, victim->name);
 
-		act("$n screams and attacks you!", gar2, 0, victim, TO_VICT);
-		act("$n screams and attacks $N!", gar2, 0, victim, TO_NOTVICT);
+		act("$n screams and attacks you!", gar2, nullptr, victim, TO_VICT);
+		act("$n screams and attacks $N!", gar2, nullptr, victim, TO_NOTVICT);
 
 		do_murder(gar2, victim->name);
 	}
@@ -2465,8 +2465,8 @@ void greet_prog_tower_shopkeeper(CHAR_DATA *mob, CHAR_DATA *ch)
 
 	affect_to_char(mob, &af);
 
-	act("$N glances over his shoulder at $n and grumbles.", ch, 0, mob, TO_ROOM);
-	act("$n glances over his shoulder at you and grumbles.", mob, 0, ch, TO_VICT);
+	act("$N glances over his shoulder at $n and grumbles.", ch, nullptr, mob, TO_ROOM);
+	act("$n glances over his shoulder at you and grumbles.", mob, nullptr, ch, TO_VICT);
 	RS.Queue.AddToQueue(4, "greet_prog_tower_shopkeeper", "do_say_queue", do_say_queue, mob, "Well,  are ye goin' to buy somethin' or are ye just going t'stand there and stare at me!?");
 	RS.Queue.AddToQueue(24, "greet_prog_tower_shopkeeper", "do_astrip_queue", do_astrip_queue, mob, "");
 }
@@ -2518,8 +2518,8 @@ void pulse_prog_wizard_summon(CHAR_DATA *mob)
 				char_from_room(vch);
 				char_to_room(vch, room2);
 
-				act("$n has summoned you!", mob, 0, vch, TO_VICT);
-				act("$N arrives suddenly.", mob, 0, vch, TO_NOTVICT);
+				act("$n has summoned you!", mob, nullptr, vch, TO_VICT);
+				act("$N arrives suddenly.", mob, nullptr, vch, TO_NOTVICT);
 
 				do_look(vch, "auto");
 
@@ -2800,7 +2800,7 @@ void pulse_prog_fisherman(CHAR_DATA *mob)
 		return;
 	}
 
-	act("$n calmly reels in his catch and deposits it into the basket at his side.", mob, 0, 0, TO_ROOM);
+	act("$n calmly reels in his catch and deposits it into the basket at his side.", mob, nullptr, nullptr, TO_ROOM);
 	obj_to_obj(fish, obj);
 
 	init_affect(&af);
@@ -2817,7 +2817,7 @@ void greet_prog_guild_recruiter(CHAR_DATA *mob, CHAR_DATA *ch)
 	if (ch->level != 1)
 		return;
 
-	act("$N smiles warmly at you.", ch, 0, mob, TO_CHAR);
+	act("$N smiles warmly at you.", ch, nullptr, mob, TO_CHAR);
 	mprog_say(1, "Take the time to read the sign here, friend Shalaran... and if you should decide you would like to join me in the Guild, take heed of its advice.", mob, ch);
 }
 
@@ -2959,14 +2959,14 @@ void fight_prog_law_subdue(CHAR_DATA *mob, CHAR_DATA *ch)
 		mob->tracktimer = 0;
 
 		if (number_range(1, 2) == 1)
-			act("The Hydra trooper dives at your legs, binding you, and you topple to the ground!", mob, 0, ch, TO_VICT);
+			act("The Hydra trooper dives at your legs, binding you, and you topple to the ground!", mob, nullptr, ch, TO_VICT);
 		else
-			act("You crumple as the Dragon trooper lands a hefty blow on the side of your head!", mob, 0, ch, TO_VICT);
+			act("You crumple as the Dragon trooper lands a hefty blow on the side of your head!", mob, nullptr, ch, TO_VICT);
 
-		act("The troopers leap on top of you, and you find yourself quickly immobilized!", mob, 0, ch, TO_VICT);
-		act("The troopers leap on top of $N, and $N finds $Mself quickly immobilized!", mob, 0, ch, TO_NOTVICT);
-		act("You hear the wet sounds of impact against your skull, and everything goes black.", mob, 0, ch, TO_VICT);
-		act("$N's inert form is dragged away toward the gates.", mob, 0, ch, TO_NOTVICT);
+		act("The troopers leap on top of you, and you find yourself quickly immobilized!", mob, nullptr, ch, TO_VICT);
+		act("The troopers leap on top of $N, and $N finds $Mself quickly immobilized!", mob, nullptr, ch, TO_NOTVICT);
+		act("You hear the wet sounds of impact against your skull, and everything goes black.", mob, nullptr, ch, TO_VICT);
+		act("$N's inert form is dragged away toward the gates.", mob, nullptr, ch, TO_NOTVICT);
 
 		ch->position = POS_SLEEPING;
 
@@ -3189,8 +3189,8 @@ void fight_prog_law_subdue(CHAR_DATA *mob, CHAR_DATA *ch)
 	}
 	else
 	{
-		act("The troopers maneuver around you, waiting for an opening.", mob, 0, ch, TO_VICT);
-		act("The troopers maneuver around $N, waiting for an opening.", mob, 0, ch, TO_NOTVICT);
+		act("The troopers maneuver around you, waiting for an opening.", mob, nullptr, ch, TO_VICT);
+		act("The troopers maneuver around $N, waiting for an opening.", mob, nullptr, ch, TO_NOTVICT);
 	}
 }
 
@@ -3200,7 +3200,7 @@ void pulse_prog_troopers(CHAR_DATA *mob)
 
 	if ((gryphon = get_char_room(mob, "gryphon trooper soldier")) == nullptr)
 	{
-		act("$n looks around hurriedly then retreats to call in reinforcements.", mob, 0, 0, TO_ROOM);
+		act("$n looks around hurriedly then retreats to call in reinforcements.", mob, nullptr, nullptr, TO_ROOM);
 		extract_char(mob, true);
 	}
 }
@@ -3257,14 +3257,14 @@ void pulse_prog_shade(CHAR_DATA *mob)
 
 	if (number_percent() > 80)
 	{
-		act("$n plunges an icy hand into the $N's heart!", mob, 0, victim, TO_NOTVICT);
-		act("$n plunges an icy hand into your heart!", mob, 0, victim, TO_VICT);
+		act("$n plunges an icy hand into the $N's heart!", mob, nullptr, victim, TO_NOTVICT);
+		act("$n plunges an icy hand into your heart!", mob, nullptr, victim, TO_VICT);
 		spell = "chill";
 	}
 	else
 	{
-		act("$n creates a conduit into $N's soul and siphons $S life away!", mob, 0, victim, TO_NOTVICT);
-		act("$n creates a conduit into your soul and siphons your life away!!", mob, 0, victim, TO_VICT);
+		act("$n creates a conduit into $N's soul and siphons $S life away!", mob, nullptr, victim, TO_NOTVICT);
+		act("$n creates a conduit into your soul and siphons your life away!!", mob, nullptr, victim, TO_VICT);
 		spell = "vampiric touch";
 	}
 
@@ -3285,8 +3285,8 @@ void pulse_prog_banshee(CHAR_DATA *mob)
 
 	if (number_percent() > 70)
 	{
-		act("$n lets out a terrible wail that forces you to cover your ears in pain!", mob, 0, victim, TO_VICT);
-		act("$n lets out a terrible wail as $e draws near to $N.", mob, 0, victim, TO_NOTVICT);
+		act("$n lets out a terrible wail that forces you to cover your ears in pain!", mob, nullptr, victim, TO_VICT);
+		act("$n lets out a terrible wail as $e draws near to $N.", mob, nullptr, victim, TO_NOTVICT);
 
 		dam = dice(20, 7) + 20;
 
@@ -3294,15 +3294,15 @@ void pulse_prog_banshee(CHAR_DATA *mob)
 	}
 	else if (number_percent() > 40)
 	{
-		act("$n screeches gleefully, mimicking a laugh.", mob, 0, victim, TO_ALL);
-		act("$n's face contorts in terror.", victim, 0, mob, TO_ALL);
-		act("$N's wailing causes your muscles to contort wildly in pain!", mob, 0, victim, TO_CHAR);
+		act("$n screeches gleefully, mimicking a laugh.", mob, nullptr, victim, TO_ALL);
+		act("$n's face contorts in terror.", victim, nullptr, mob, TO_ALL);
+		act("$N's wailing causes your muscles to contort wildly in pain!", mob, nullptr, victim, TO_CHAR);
 
 		spell = "weaken";
 	}
 	else
 	{
-		act("$n begins to howl mournfully, the unnatural notes piercing your mind.", mob, 0, victim, TO_ALL);
+		act("$n begins to howl mournfully, the unnatural notes piercing your mind.", mob, nullptr, victim, TO_ALL);
 		spell = "deafen";
 	}
 
@@ -3324,26 +3324,26 @@ void pulse_prog_phantasm(CHAR_DATA *mob)
 	switch (number_range(0, 5))
 	{
 		case 0:
-			act("$n shows you the face of your worst nightmare, paralyzing you with fear!", mob, 0, victim, TO_VICT);
-			act("$n's ghostly form flickers briefly as $N flinches away in terror.", mob, 0, victim, TO_NOTVICT);
+			act("$n shows you the face of your worst nightmare, paralyzing you with fear!", mob, nullptr, victim, TO_VICT);
+			act("$n's ghostly form flickers briefly as $N flinches away in terror.", mob, nullptr, victim, TO_NOTVICT);
 
 			LAG_CHAR(victim, PULSE_VIOLENCE * 3);
 			break;
 		case 1:
 		case 2:
 		case 3:
-			act("Your death flashes before your eyes.", 0, 0, victim, TO_VICT);
-			act("You feel hope slip away.", 0, 0, victim, TO_VICT);
-			act("$N gets a look of hopelessness on $S face.", mob, 0, victim, TO_NOTVICT);
+			act("Your death flashes before your eyes.", 0, nullptr, victim, TO_VICT);
+			act("You feel hope slip away.", 0, nullptr, victim, TO_VICT);
+			act("$N gets a look of hopelessness on $S face.", mob, nullptr, victim, TO_NOTVICT);
 
 			spell = "curse";
 			break;
 		case 4:
 		case 5:
-			act("$n runs $s fingers down $N's face gently.", mob, 0, victim, TO_NOTVICT);
-			act("$n runs $s fingers down your face gently.", mob, 0, victim, TO_VICT);
-			act("$n plunges $s spectral hand into $N's head, leaving $M looking confused.", mob, 0, victim, TO_NOTVICT);
-			act("$n plunges $s spectral hand into your head, leaving you feeling confused.", mob, 0, victim, TO_VICT);
+			act("$n runs $s fingers down $N's face gently.", mob, nullptr, victim, TO_NOTVICT);
+			act("$n runs $s fingers down your face gently.", mob, nullptr, victim, TO_VICT);
+			act("$n plunges $s spectral hand into $N's head, leaving $M looking confused.", mob, nullptr, victim, TO_NOTVICT);
+			act("$n plunges $s spectral hand into your head, leaving you feeling confused.", mob, nullptr, victim, TO_VICT);
 
 			spell = "forget";
 			break;
@@ -3369,8 +3369,8 @@ void pulse_prog_ravghoul(CHAR_DATA *mob)
 			if (is_affected(victim, gsn_abite))
 				return;
 
-			act("$n grabs $N's arm and takes a bite out of it!", mob, 0, victim, TO_NOTVICT);
-			act("$n grabs your arm and takes a bite out of it!", mob, 0, victim, TO_VICT);
+			act("$n grabs $N's arm and takes a bite out of it!", mob, nullptr, victim, TO_NOTVICT);
+			act("$n grabs your arm and takes a bite out of it!", mob, nullptr, victim, TO_VICT);
 
 			one_hit_new(mob, victim, TYPE_UNDEFINED, HIT_NOSPECIALS, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "bite");
 
@@ -3389,8 +3389,8 @@ void pulse_prog_ravghoul(CHAR_DATA *mob)
 			if (is_affected(victim, gsn_lbite))
 				return;
 
-			act("$n grabs $N's leg and takes a bite out of it!", mob, 0, victim, TO_NOTVICT);
-			act("$n grabs your leg and takes a bite out of it!", mob, 0, victim, TO_VICT);
+			act("$n grabs $N's leg and takes a bite out of it!", mob, nullptr, victim, TO_NOTVICT);
+			act("$n grabs your leg and takes a bite out of it!", mob, nullptr, victim, TO_VICT);
 
 			one_hit_new(mob, victim, TYPE_UNDEFINED, HIT_NOSPECIALS, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "bite");
 
@@ -3406,8 +3406,8 @@ void pulse_prog_ravghoul(CHAR_DATA *mob)
 
 			break;
 		case 2:
-			act("$n moves to $N's flank and takes a bite from the back of $S head!", mob, 0, victim, TO_NOTVICT);
-			act("$n moves to your flank and takes a bite from the back of your head!", mob, 0, victim, TO_VICT);
+			act("$n moves to $N's flank and takes a bite from the back of $S head!", mob, nullptr, victim, TO_NOTVICT);
+			act("$n moves to your flank and takes a bite from the back of your head!", mob, nullptr, victim, TO_VICT);
 
 			one_hit_new(mob, victim, TYPE_UNDEFINED, HIT_NOSPECIALS, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "bite");
 
@@ -3425,10 +3425,10 @@ void pulse_prog_behemoth(CHAR_DATA *mob)
 
 	int dam = dice(14, 14);
 
-	act("Bones clattering in a terrible cacophony, $N charges at $n clumsily!", victim, 0, mob, TO_NOTVICT);
-	act("$N is trampled to the ground!", mob, 0, victim, TO_NOTVICT);
-	act("Bones clattering in a terrible cacophony, $n charges at you!", mob, 0, victim, TO_VICT);
-	act("You are trampled to the ground!", mob, 0, victim, TO_VICT);
+	act("Bones clattering in a terrible cacophony, $N charges at $n clumsily!", victim, nullptr, mob, TO_NOTVICT);
+	act("$N is trampled to the ground!", mob, nullptr, victim, TO_NOTVICT);
+	act("Bones clattering in a terrible cacophony, $n charges at you!", mob, nullptr, victim, TO_VICT);
+	act("You are trampled to the ground!", mob, nullptr, victim, TO_VICT);
 
 	damage_new(mob, victim, dam, TYPE_UNDEFINED, DAM_BASH, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "trampling");
 
@@ -3449,8 +3449,8 @@ void pulse_prog_glass(CHAR_DATA *mob)
 		&& !is_affected(mob, gsn_trophy)
 		&& !is_affected(victim, gsn_impale))
 	{
-		act("$n raises one of its massive arms and impales $N on it!", mob, 0, victim, TO_NOTVICT);
-		act("$n raises one of its massive arms and impales you on it!", mob, 0, victim, TO_VICT);
+		act("$n raises one of its massive arms and impales $N on it!", mob, nullptr, victim, TO_NOTVICT);
+		act("$n raises one of its massive arms and impales you on it!", mob, nullptr, victim, TO_VICT);
 
 		damage_new(mob, victim, dice(16, 15), TYPE_UNDEFINED, DAM_PIERCE, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "impalement");
 
@@ -3498,7 +3498,7 @@ void pulse_prog_night_creeps(CHAR_DATA *mob)
 		if (Deref(mob->fighting))
 			stop_fighting(mob, true);
 
-		act("As the first rays of the sun emerge, $n scuttles away with sickening speed.", mob, 0, 0, TO_ROOM);
+		act("As the first rays of the sun emerge, $n scuttles away with sickening speed.", mob, nullptr, nullptr, TO_ROOM);
 
 		SET_BIT(mob->affected_by, AFF_NOSHOW);
 		return;
@@ -3507,7 +3507,7 @@ void pulse_prog_night_creeps(CHAR_DATA *mob)
 	{
 		REMOVE_BIT(mob->affected_by, AFF_NOSHOW);
 
-		act("Chittering with mindless malice, $n bursts from the cover of shadow and attacks!", mob, 0, 0, TO_ROOM);
+		act("Chittering with mindless malice, $n bursts from the cover of shadow and attacks!", mob, nullptr, nullptr, TO_ROOM);
 
 		for (victim = mob->in_room->people; victim; victim = victim->next_in_room)
 		{
@@ -3530,8 +3530,8 @@ void pulse_prog_night_creeps(CHAR_DATA *mob)
 
 		target = Deref(mob->fighting);
 
-		act("With a vicious clacking noise, $n sinks its razor-sharp pincers into $N!", mob, 0, target, TO_NOTVICT);
-		act("With a vicious clacking noise, $n sinks its razor-sharp pincers into you!", mob, 0, target, TO_VICT);
+		act("With a vicious clacking noise, $n sinks its razor-sharp pincers into $N!", mob, nullptr, target, TO_NOTVICT);
+		act("With a vicious clacking noise, $n sinks its razor-sharp pincers into you!", mob, nullptr, target, TO_VICT);
 		damage_new(mob, target, dice(target->level / 3, 3), TYPE_UNDEFINED, DAM_PIERCE, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "pincering claws$");
 
 		// Re-read rather than reusing the local above: a lethal damage_new
@@ -3577,7 +3577,7 @@ void sucker_pulse(CHAR_DATA *ch, [[maybe_unused]] AFFECT_DATA *af)
 
 	if (!owner)
 	{
-		act("$n sighs in relief as the remains of the flatworm fall away from $s face.", ch, 0, 0, TO_ROOM);
+		act("$n sighs in relief as the remains of the flatworm fall away from $s face.", ch, nullptr, nullptr, TO_ROOM);
 		send_to_char("You sigh in relief as the remains of the flatworm fall away from your face.\n\r", ch);
 		affect_strip(ch, gsn_blindness);
 		return;
@@ -3586,8 +3586,8 @@ void sucker_pulse(CHAR_DATA *ch, [[maybe_unused]] AFFECT_DATA *af)
 	if (number_range(1, 3) != 1)
 		return;
 
-	act("$n swells slightly as it drains the bodily fluids from $N.", owner, 0, ch, TO_NOTVICT);
-	act("$n swells slightly as it drains your bodily fluids!", owner, 0, ch, TO_VICT);
+	act("$n swells slightly as it drains the bodily fluids from $N.", owner, nullptr, ch, TO_NOTVICT);
+	act("$n swells slightly as it drains your bodily fluids!", owner, nullptr, ch, TO_VICT);
 
 	damage_new(owner, ch, dice(8, 5), TYPE_UNDEFINED, DAM_ACID, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "suction");
 	owner->hit += number_range(20, 40);
@@ -3611,10 +3611,10 @@ void greet_prog_face_sucker(CHAR_DATA *mob, CHAR_DATA *ch)
 	mob->hunting = ch->self;
 
 	sprintf(buf, "%sSuddenly, something pale and slimy falls from the ceiling, landing on your face!%s", get_char_color(ch, "red"), END_COLOR(ch));
-	act(buf, mob, 0, ch, TO_VICT);
+	act(buf, mob, nullptr, ch, TO_VICT);
 
 	sprintf(buf, "%sSuddenly, something small and pale falls from the ceiling, landing on $N's face!%s", get_char_color(ch, "red"), END_COLOR(ch));
-	act(buf, mob, 0, ch, TO_NOTVICT);
+	act(buf, mob, nullptr, ch, TO_NOTVICT);
 
 	init_affect(&af);
 	af.where = TO_AFFECTS;
@@ -3628,8 +3628,8 @@ void greet_prog_face_sucker(CHAR_DATA *mob, CHAR_DATA *ch)
 
 	SET_BIT(af.bitvector, AFF_BLIND);
 
-	act("You scream in horror as $n latches itself onto your face!", mob, 0, ch, TO_VICT);
-	act("$N lets out a scream of pure horror as $n latches itself onto $S face!", mob, 0, ch, TO_NOTVICT);
+	act("You scream in horror as $n latches itself onto your face!", mob, nullptr, ch, TO_VICT);
+	act("$N lets out a scream of pure horror as $n latches itself onto $S face!", mob, nullptr, ch, TO_NOTVICT);
 
 	affect_to_char(ch, &af);
 

--- a/code/mspec.c
+++ b/code/mspec.c
@@ -39,8 +39,8 @@ static int fallendesert_spirits_death(CHAR_DATA *ch, CHAR_DATA *mob)
 		REMOVE_BIT(pexit->exit_info, EX_LOCKED);
 		REMOVE_BIT(pexit->exit_info, EX_CLOSED);
 
-		act("With a last wail of anguish, the spirits explode causing a shadow to engulf the cave....", mob, 0, 0, TO_ROOM);
-		act("As the bright light recedes a pinpoint of light coming through a hole to the north.", mob, 0, 0, TO_ROOM);
+		act("With a last wail of anguish, the spirits explode causing a shadow to engulf the cave....", mob, nullptr, nullptr, TO_ROOM);
+		act("As the bright light recedes a pinpoint of light coming through a hole to the north.", mob, nullptr, nullptr, TO_ROOM);
 
 		return 0;
 }
@@ -390,7 +390,7 @@ static int academy_pet_pulse(CHAR_DATA *mob)
 		if (player->level > 22 && !is_immortal(player))
 		{
 			do_say(mob, "You are strong enough to stand on your own now.  Perhaps we shall meet again.");
-			act("$n fades into the shadows.", mob, 0, 0, TO_ROOM);
+			act("$n fades into the shadows.", mob, nullptr, nullptr, TO_ROOM);
 
 			player->pet = nullptr;
 			mob->leader = nullptr;
@@ -404,14 +404,14 @@ static int academy_pet_pulse(CHAR_DATA *mob)
 		{
 			if (Deref(mob->fighting))
 			{
-				act("$n seems to fade into the shadows.", mob, 0, 0, TO_ROOM);
+				act("$n seems to fade into the shadows.", mob, nullptr, nullptr, TO_ROOM);
 				stop_fighting(mob, true);
 			}
 
 			char_from_room(mob);
 			char_to_room(mob, player->in_room);
 
-			act("$n emerges from the shadows behind you.", mob, 0, player, TO_VICT);
+			act("$n emerges from the shadows behind you.", mob, nullptr, player, TO_VICT);
 			return 0;
 		}
 

--- a/code/mud.c
+++ b/code/mud.c
@@ -211,7 +211,6 @@ void CMud::LoadObjLimits()
 	char temp_player_name[MSL];
 	int i;
 	long temp_bounty;
-	long min_bounty = 0;
 	float tempfloat;
 
 	Logger.Info("Loading object counts off players now...");
@@ -248,7 +247,6 @@ void CMud::LoadObjLimits()
 		for (; ;)
 		{
 			int vnum, lastlogin = 0, plevel = 0;
-			bool breakout;
 			char letter;
 			char *word;
 			OBJ_INDEX_DATA *pObjIndex;
@@ -287,7 +285,6 @@ void CMud::LoadObjLimits()
 			if(lastlogin && plevel && plevel < 52 && lastlogin + 3456000 < current_time)
 			{
 				Logger.Info("Autodeleting {}.", temp_player_name);
-				breakout = true;
 				delete_char(temp_player_name, true);
 				break;
 			}
@@ -346,9 +343,7 @@ void CMud::LoadGsn()
 // Sets the time and weather
 void CMud::LoadTime()
 {
-	long lhour;
 
-	lhour = (current_time - 650336715) / (PULSE_TICK / PULSE_PER_SECOND);
 	time_info.hour = ((current_time - RS_EPOCH) % (60 * 24)) / (60);
 	time_info.day = ((current_time - RS_EPOCH) % (60 * 60 * 12)) / (60 * 24);
 	time_info.month = ((current_time - RS_EPOCH) % (60 * 60 * 24 * 6)) / (60 * 60 * 12);

--- a/code/olc.c
+++ b/code/olc.c
@@ -235,9 +235,28 @@ bool run_olc_editor(DESCRIPTOR_DATA *d)
 	return true;
 }
 
+///
+/// What the character is currently editing, or nullptr when there is no
+/// descriptor to be editing through.
+///
+void *olc_edit_target(CHAR_DATA *ch)
+{
+	DESCRIPTOR_DATA *connection = Deref(ch->desc);
+
+	if (connection == nullptr)
+		return nullptr;
+
+	return connection->pEdit;
+}
+
 bool is_editing(CHAR_DATA *ch)
 {
-	switch (Deref(ch->desc)->editor)
+	DESCRIPTOR_DATA *connection = Deref(ch->desc);
+
+	if (connection == nullptr)
+		return false;
+
+	switch (connection->editor)
 	{
 		case ED_AREA:
 		case ED_ROOM:
@@ -257,7 +276,12 @@ char *olc_ed_name(CHAR_DATA *ch)
 
 	buf[0] = '\0';
 
-	switch (Deref(ch->desc)->editor)
+	DESCRIPTOR_DATA *connection = Deref(ch->desc);
+
+	if (connection == nullptr)
+		return buf;
+
+	switch (connection->editor)
 	{
 		case ED_AREA:
 			sprintf(buf, "AEdit");
@@ -290,6 +314,9 @@ char *olc_ed_vnum(CHAR_DATA *ch)
 	buf[0] = '\0';
 
 	DESCRIPTOR_DATA *d = Deref(ch->desc);
+
+	if (d == nullptr)
+		return buf;
 
 	switch (d->editor)
 	{
@@ -352,7 +379,12 @@ void show_olc_cmds(CHAR_DATA *ch, const struct olc_cmd_type *olc_table)
  ****************************************************************************/
 bool show_commands(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 {
-	switch (Deref(ch->desc)->editor)
+	DESCRIPTOR_DATA *connection = Deref(ch->desc);
+
+	if (connection == nullptr)
+		return false;
+
+	switch (connection->editor)
 	{
 		case ED_AREA:
 			show_olc_cmds(ch, aedit_table);
@@ -398,6 +430,9 @@ bool edit_done(CHAR_DATA *ch)
 {
 	DESCRIPTOR_DATA *d = Deref(ch->desc);
 
+	if (d == nullptr)
+		return false;
+
 	d->pEdit = nullptr;
 	d->editor = 0;
 
@@ -419,6 +454,9 @@ void aedit(CHAR_DATA *ch, char *argument)
 	int value;
 
 	EDIT_AREA(ch, pArea);
+
+	if (pArea == nullptr)
+		return;
 
 	smash_tilde(argument);
 	snprintf(arg, sizeof(arg), "%s", argument);
@@ -586,6 +624,10 @@ void oedit(CHAR_DATA *ch, char *argument)
 	argument = one_argument(argument, command);
 
 	EDIT_OBJ(ch, pObj);
+
+	if (pObj == nullptr)
+		return;
+
 	pArea = pObj->area;
 
 	if (!IS_BUILDER(ch, pArea))
@@ -649,6 +691,10 @@ void medit(CHAR_DATA *ch, char *argument)
 	argument = one_argument(argument, command);
 
 	EDIT_MOB(ch, pMob);
+
+	if (pMob == nullptr)
+		return;
+
 	pArea = pMob->area;
 
 	if (!IS_BUILDER(ch, pArea))
@@ -819,6 +865,9 @@ void do_aedit(CHAR_DATA *ch, char *argument)
 
 	DESCRIPTOR_DATA *d = Deref(ch->desc);
 
+	if (d == nullptr)
+		return;
+
 	d->pEdit = (void *)pArea;
 	d->editor = ED_AREA;
 
@@ -863,8 +912,13 @@ void do_redit(CHAR_DATA *ch, char *argument)
 
 		if (redit_create(ch, argument))
 		{
+			DESCRIPTOR_DATA *connection = Deref(ch->desc);
+
+			if (connection == nullptr)
+				return;
+
 			char_from_room(ch);
-			char_to_room(ch, (ROOM_INDEX_DATA *)Deref(ch->desc)->pEdit);
+			char_to_room(ch, (ROOM_INDEX_DATA *)connection->pEdit);
 			SET_BIT(pRoom->area->area_flags, AREA_CHANGED);
 			pRoom = ch->in_room;
 		}
@@ -892,7 +946,12 @@ void do_redit(CHAR_DATA *ch, char *argument)
 		return;
 	}
 
-	Deref(ch->desc)->editor = ED_ROOM;
+	DESCRIPTOR_DATA *connection = Deref(ch->desc);
+
+	if (connection == nullptr)
+		return;
+
+	connection->editor = ED_ROOM;
 	redit_show(ch, "");
 }
 
@@ -934,6 +993,9 @@ void do_oedit(CHAR_DATA *ch, char *argument)
 
 		DESCRIPTOR_DATA *d = Deref(ch->desc);
 
+		if (d == nullptr)
+			return;
+
 		d->pEdit = (void *)pObj;
 		ch->pcdata->editing_item = value;
 		d->editor = ED_OBJECT;
@@ -970,7 +1032,12 @@ void do_oedit(CHAR_DATA *ch, char *argument)
 			if (oedit_create(ch, argument))
 			{
 				SET_BIT(pArea->area_flags, AREA_CHANGED);
-				Deref(ch->desc)->editor = ED_OBJECT;
+				DESCRIPTOR_DATA *connection = Deref(ch->desc);
+
+				if (connection == nullptr)
+					return;
+
+				connection->editor = ED_OBJECT;
 				oedit_show(ch, "");
 			}
 
@@ -1011,6 +1078,9 @@ void do_medit(CHAR_DATA *ch, char *argument)
 
 		DESCRIPTOR_DATA *d = Deref(ch->desc);
 
+		if (d == nullptr)
+			return;
+
 		d->pEdit = (void *)pMob;
 		d->editor = ED_MOBILE;
 
@@ -1046,7 +1116,12 @@ void do_medit(CHAR_DATA *ch, char *argument)
 			if (medit_create(ch, argument))
 			{
 				SET_BIT(pArea->area_flags, AREA_CHANGED);
-				Deref(ch->desc)->editor = ED_MOBILE;
+				DESCRIPTOR_DATA *connection = Deref(ch->desc);
+
+				if (connection == nullptr)
+					return;
+
+				connection->editor = ED_MOBILE;
 			}
 
 			return;

--- a/code/olc.h
+++ b/code/olc.h
@@ -65,10 +65,18 @@ typedef	bool OLC_FUN (CHAR_DATA *ch, char *argument);
 
 
 /* Return pointers to what is being edited. */
-#define EDIT_MOB(ch, mob)		(mob = (MOB_INDEX_DATA *)Deref(ch->desc)->pEdit)
-#define EDIT_OBJ(ch, obj)		(obj = (OBJ_INDEX_DATA *)Deref(ch->desc)->pEdit)
+//
+// These used to arrow straight off Deref(ch->desc), so a character with no
+// descriptor dereferenced null before the editor command had done anything.
+// olc_edit_target yields nullptr in that case instead, and every caller checks
+// it. There is no descriptor to report the failure to, so the callers return
+// without changing anything.
+#define EDIT_MOB(ch, mob)		(mob = (MOB_INDEX_DATA *)olc_edit_target(ch))
+#define EDIT_OBJ(ch, obj)		(obj = (OBJ_INDEX_DATA *)olc_edit_target(ch))
 #define EDIT_ROOM(ch, room)		(room = ch->in_room)
-#define EDIT_AREA(ch, area)		(area = (AREA_DATA *)Deref(ch->desc)->pEdit)
+#define EDIT_AREA(ch, area)		(area = (AREA_DATA *)olc_edit_target(ch))
+
+void *olc_edit_target(CHAR_DATA *ch);
 
 
 /*

--- a/code/olc_act.c
+++ b/code/olc_act.c
@@ -3201,13 +3201,36 @@ bool redit_mana(CHAR_DATA *ch, char *argument)
 	return false;
 }
 
-bool redit_clan(CHAR_DATA *ch, [[maybe_unused]] char *argument)
+bool redit_clan(CHAR_DATA *ch, char *argument)
 {
 	ROOM_INDEX_DATA *pRoom;
+	char buf[MAX_STRING_LENGTH];
 
 	EDIT_ROOM(ch, pRoom);
 
-	send_to_char("Clan set.\n\r", ch);
+	if (argument[0] == '\0')
+	{
+		send_to_char("Syntax:  clan (name)\n\r", ch);
+		send_to_char("         clan none\n\r", ch);
+		return false;
+	}
+
+	// cabal_lookup returns 0 for anything it does not recognize, and 0 is also
+	// the "none" cabal, so an unknown name would otherwise clear the room
+	// silently instead of reporting a typo.
+	int cabal = cabal_lookup(argument);
+
+	if (cabal == 0 && str_cmp(argument, cabal_table[0].name))
+	{
+		sprintf(buf, "There is no '%s' cabal.\n\r", argument);
+		send_to_char(buf, ch);
+		return false;
+	}
+
+	pRoom->cabal = cabal;
+
+	sprintf(buf, "Clan set to %s.\n\r", cabal_table[cabal].name);
+	send_to_char(buf, ch);
 	return true;
 }
 

--- a/code/olc_act.c
+++ b/code/olc_act.c
@@ -648,8 +648,6 @@ bool medit_vnum(CHAR_DATA *ch, char *argument)
 	if (pMob == nullptr)
 		return false;
 
-	return false;
-
 	if (!*argument || !is_number(argument))
 	{
 		send_to_char("Syntax: vnum <vnum>\n\r", ch);
@@ -658,19 +656,59 @@ bool medit_vnum(CHAR_DATA *ch, char *argument)
 
 	vnum = atoi(argument);
 
-	if (vnum >= ch->in_room->area->min_vnum && vnum <= ch->in_room->area->max_vnum)
-	{
-		pMob->vnum = vnum;
-		send_to_char("Vnum set.\n\r", ch);
-		return true;
-	}
-	else
+	if (vnum < ch->in_room->area->min_vnum || vnum > ch->in_room->area->max_vnum)
 	{
 		send_to_char("That vnum is not within the area range.\n\r", ch);
 		return false;
 	}
 
-	return false;
+	if (vnum == pMob->vnum)
+	{
+		send_to_char("That is already this mobile's vnum.\n\r", ch);
+		return false;
+	}
+
+	if (get_mob_index(vnum) != nullptr)
+	{
+		send_to_char("That vnum is already in use.\n\r", ch);
+		return false;
+	}
+
+	// The hash bucket is chosen by vnum, so assigning the new number in place
+	// would strand the prototype in the old bucket where get_mob_index cannot
+	// find it under either number. Unlink from the old bucket, renumber, then
+	// link into the new one.
+	int iHash = pMob->vnum % MAX_KEY_HASH;
+
+	if (mob_index_hash[iHash] == pMob)
+	{
+		mob_index_hash[iHash] = pMob->next;
+	}
+	else
+	{
+		MOB_INDEX_DATA *prev = mob_index_hash[iHash];
+
+		while (prev != nullptr && prev->next != pMob)
+			prev = prev->next;
+
+		if (prev == nullptr)
+		{
+			send_to_char("That mobile is not in the index. Vnum unchanged.\n\r", ch);
+			return false;
+		}
+
+		prev->next = pMob->next;
+	}
+
+	pMob->vnum = vnum;
+
+	iHash = vnum % MAX_KEY_HASH;
+	pMob->next = mob_index_hash[iHash];
+	mob_index_hash[iHash] = pMob;
+
+	send_to_char("Vnum set.\n\r", ch);
+	send_to_char("Resets referring to the old vnum are NOT updated. Check them before saving.\n\r", ch);
+	return true;
 }
 
 bool medit_group(CHAR_DATA *ch, char *argument)

--- a/code/olc_act.c
+++ b/code/olc_act.c
@@ -524,6 +524,11 @@ bool redit_olist(CHAR_DATA *ch, char *argument)
 
 bool redit_mshow(CHAR_DATA *ch, char *argument)
 {
+	DESCRIPTOR_DATA *connection = Deref(ch->desc);
+
+	if (connection == nullptr)
+		return false;
+
 	MOB_INDEX_DATA *pMob;
 	int value;
 
@@ -549,16 +554,21 @@ bool redit_mshow(CHAR_DATA *ch, char *argument)
 			return false;
 		}
 
-		Deref(ch->desc)->pEdit = (void *)pMob;
+		connection->pEdit = (void *)pMob;
 	}
 
 	medit_show(ch, argument);
-	Deref(ch->desc)->pEdit = (void *)ch->in_room;
+	connection->pEdit = (void *)ch->in_room;
 	return false;
 }
 
 bool redit_oshow(CHAR_DATA *ch, char *argument)
 {
+	DESCRIPTOR_DATA *connection = Deref(ch->desc);
+
+	if (connection == nullptr)
+		return false;
+
 	OBJ_INDEX_DATA *pObj;
 	int value;
 
@@ -584,11 +594,11 @@ bool redit_oshow(CHAR_DATA *ch, char *argument)
 			return false;
 		}
 
-		Deref(ch->desc)->pEdit = (void *)pObj;
+		connection->pEdit = (void *)pObj;
 	}
 
 	oedit_show(ch, argument);
-	Deref(ch->desc)->pEdit = (void *)ch->in_room;
+	connection->pEdit = (void *)ch->in_room;
 	return false;
 }
 
@@ -635,6 +645,9 @@ bool medit_vnum(CHAR_DATA *ch, char *argument)
 
 	EDIT_MOB(ch, pMob);
 
+	if (pMob == nullptr)
+		return false;
+
 	return false;
 
 	if (!*argument || !is_number(argument))
@@ -666,6 +679,9 @@ bool medit_group(CHAR_DATA *ch, char *argument)
 
 	EDIT_MOB(ch, pMob);
 
+	if (pMob == nullptr)
+		return false;
+
 	if (!*argument || !is_number(argument))
 	{
 		send_to_char("Syntax:  group <xxyy>  - First vnum in your area\n\r", ch);
@@ -685,6 +701,9 @@ bool medit_speech(CHAR_DATA *ch, char *argument)
 	int type;
 
 	EDIT_MOB(ch, pMobIndex);
+
+	if (pMobIndex == nullptr)
+		return false;
 
 	if (!*argument)
 	{
@@ -913,6 +932,9 @@ bool medit_prog(CHAR_DATA *ch, char *argument)
 
 	EDIT_MOB(ch, pMobIndex);
 
+	if (pMobIndex == nullptr)
+		return false;
+
 	if (!*argument)
 	{
 		send_to_char("The following mob progs are available:\n\r", ch);
@@ -1010,6 +1032,9 @@ bool oedit_prog(CHAR_DATA *ch, char *argument)
 
 	EDIT_OBJ(ch, pObjIndex);
 
+	if (pObjIndex == nullptr)
+		return false;
+
 	if (!*argument)
 	{
 		send_to_char("The following object programs are available:\n\r", ch);
@@ -1105,6 +1130,9 @@ bool oedit_spec(CHAR_DATA *ch, char *argument)
 	OBJ_INDEX_DATA *pObjIndex;
 
 	EDIT_OBJ(ch, pObjIndex);
+
+	if (pObjIndex == nullptr)
+		return false;
 
 	argument = one_argument(argument, add);
 	argument = one_argument(argument, prog);
@@ -1508,6 +1536,9 @@ bool aedit_type(CHAR_DATA *ch, char *argument)
 
 	EDIT_AREA(ch, pArea);
 
+	if (pArea == nullptr)
+		return false;
+
 	if (!*argument)
 	{
 		send_to_char("Syntax:  type <type>\n\r", ch);
@@ -1536,6 +1567,9 @@ bool aedit_prog(CHAR_DATA *ch, char *argument)
 	bool found = false;
 
 	EDIT_AREA(ch, pArea);
+
+	if (pArea == nullptr)
+		return false;
 
 	if (!*argument)
 	{
@@ -1637,6 +1671,9 @@ bool aedit_security(CHAR_DATA *ch, char *argument)
 
 	EDIT_AREA(ch, pArea);
 
+	if (pArea == nullptr)
+		return false;
+
 	one_argument(argument, sec);
 
 	if (!is_number(sec) || sec[0] == '\0')
@@ -1673,6 +1710,9 @@ bool aedit_show(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 	char buf[MAX_STRING_LENGTH];
 
 	EDIT_AREA(ch, pArea);
+
+	if (pArea == nullptr)
+		return false;
 
 	sprintf(buf, "Name:     [%5d] %s\n\r", pArea->vnum, pArea->name);
 	send_to_char(buf, ch);
@@ -1758,6 +1798,9 @@ bool aedit_reset(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 
 	EDIT_AREA(ch, pArea);
 
+	if (pArea == nullptr)
+		return false;
+
 	reset_area(pArea);
 	send_to_char("Area reset.\n\r", ch);
 
@@ -1777,7 +1820,12 @@ bool aedit_create(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 	pArea = new_area();
 	area_last->next = pArea;
 	area_last = pArea; /* Thanks, Walker. */
-	Deref(ch->desc)->pEdit = (void *)pArea;
+	DESCRIPTOR_DATA *connection = Deref(ch->desc);
+
+	if (connection == nullptr)
+		return false;
+
+	connection->pEdit = (void *)pArea;
 
 	SET_BIT(pArea->area_flags, AREA_ADDED);
 	send_to_char("Area Created.\n\r", ch);
@@ -1789,6 +1837,9 @@ bool aedit_name(CHAR_DATA *ch, char *argument)
 	AREA_DATA *pArea;
 
 	EDIT_AREA(ch, pArea);
+
+	if (pArea == nullptr)
+		return false;
 
 	if (argument[0] == '\0')
 	{
@@ -1808,6 +1859,9 @@ bool aedit_credits(CHAR_DATA *ch, char *argument)
 	AREA_DATA *pArea;
 
 	EDIT_AREA(ch, pArea);
+
+	if (pArea == nullptr)
+		return false;
 
 	if (argument[0] == '\0')
 	{
@@ -1829,6 +1883,9 @@ bool aedit_file(CHAR_DATA *ch, char *argument)
 	int i, length;
 
 	EDIT_AREA(ch, pArea);
+
+	if (pArea == nullptr)
+		return false;
 
 	one_argument(argument, file); /* Forces Lowercase */
 
@@ -1876,6 +1933,9 @@ bool aedit_level(CHAR_DATA *ch, char *argument)
 
 	EDIT_AREA(ch, pArea);
 
+	if (pArea == nullptr)
+		return false;
+
 	argument = one_argument(argument, lowc);
 	argument = one_argument(argument, highc);
 
@@ -1907,6 +1967,9 @@ bool aedit_age(CHAR_DATA *ch, char *argument)
 
 	EDIT_AREA(ch, pArea);
 
+	if (pArea == nullptr)
+		return false;
+
 	one_argument(argument, age);
 
 	if (!is_number(age) || age[0] == '\0')
@@ -1927,6 +1990,9 @@ bool aedit_builder(CHAR_DATA *ch, char *argument)
 	char buf[MAX_STRING_LENGTH];
 
 	EDIT_AREA(ch, pArea);
+
+	if (pArea == nullptr)
+		return false;
 
 	if (argument[0] == '\0')
 	{
@@ -1988,6 +2054,9 @@ bool aedit_vnum(CHAR_DATA *ch, char *argument)
 
 	EDIT_AREA(ch, pArea);
 
+	if (pArea == nullptr)
+		return false;
+
 	argument = one_argument(argument, lower);
 	one_argument(argument, upper);
 
@@ -2039,6 +2108,9 @@ bool aedit_lvnum(CHAR_DATA *ch, char *argument)
 
 	EDIT_AREA(ch, pArea);
 
+	if (pArea == nullptr)
+		return false;
+
 	one_argument(argument, lower);
 
 	if (!is_number(lower) || lower[0] == '\0')
@@ -2078,6 +2150,9 @@ bool aedit_uvnum(CHAR_DATA *ch, char *argument)
 	int iupper;
 
 	EDIT_AREA(ch, pArea);
+
+	if (pArea == nullptr)
+		return false;
 
 	one_argument(argument, upper);
 
@@ -2136,6 +2211,9 @@ bool aedit_climate(CHAR_DATA *ch, char *argument)
 	int icli = 0, climate;
 
 	EDIT_AREA(ch, pArea);
+
+	if (pArea == nullptr)
+		return false;
 
 	one_argument(argument, wcli);
 
@@ -2951,6 +3029,11 @@ bool redit_ed(CHAR_DATA *ch, char *argument)
 
 bool redit_create(CHAR_DATA *ch, char *argument)
 {
+	DESCRIPTOR_DATA *connection = Deref(ch->desc);
+
+	if (connection == nullptr)
+		return false;
+
 	AREA_DATA *pArea;
 	ROOM_INDEX_DATA *pRoom;
 	int value;
@@ -2997,7 +3080,7 @@ bool redit_create(CHAR_DATA *ch, char *argument)
 	iHash = value % MAX_KEY_HASH;
 	pRoom->next = room_index_hash[iHash];
 	room_index_hash[iHash] = pRoom;
-	Deref(ch->desc)->pEdit = (void *)pRoom;
+	connection->pEdit = (void *)pRoom;
 
 	sprintf(buf, "Room #%d created.\n\r", value);
 	send_to_char(buf, ch);
@@ -3931,6 +4014,9 @@ bool oedit_show(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 
 	EDIT_OBJ(ch, pObj);
 
+	if (pObj == nullptr)
+		return false;
+
 	sprintf(buf, "Name:             [%s]\n\r", pObj->name);
 	send_to_char(buf, ch);
 
@@ -4237,6 +4323,9 @@ bool oedit_addapply(CHAR_DATA *ch, char *argument)
 
 	EDIT_OBJ(ch, pObj);
 
+	if (pObj == nullptr)
+		return false;
+
 	argument = one_argument(argument, loc);
 	one_argument(argument, mod);
 
@@ -4274,6 +4363,9 @@ bool oedit_addaffect(CHAR_DATA *ch, char *argument)
 	char value2[MAX_STRING_LENGTH];
 
 	EDIT_OBJ(ch, pObj);
+
+	if (pObj == nullptr)
+		return false;
 
 	argument = one_argument( argument, loc );
 	argument = one_argument( argument, mod );
@@ -4321,6 +4413,9 @@ bool oedit_delapply(CHAR_DATA *ch, char *argument)
 
 	EDIT_OBJ(ch, pObj);
 
+	if (pObj == nullptr)
+		return false;
+
 	one_argument(argument, apply);
 
 	if (!is_number(apply) || apply[0] == '\0')
@@ -4366,6 +4461,9 @@ bool oedit_msg(CHAR_DATA *ch, char *argument)
 	char target[MSL];
 
 	EDIT_OBJ(ch, pObj);
+
+	if (pObj == nullptr)
+		return false;
 
 	argument = one_argument(argument, type);
 	argument = one_argument(argument, target);
@@ -4447,6 +4545,9 @@ bool oedit_limit(CHAR_DATA *ch, char *argument)
 
 	EDIT_OBJ(ch, pObj);
 
+	if (pObj == nullptr)
+		return false;
+
 	if (argument[0] == '\0')
 	{
 		send_to_char("Syntax:  limit (number)\n\r"\
@@ -4474,6 +4575,9 @@ bool oedit_verb(CHAR_DATA *ch, char *argument)
 
 	EDIT_OBJ(ch, pObj);
 
+	if (pObj == nullptr)
+		return false;
+
 	if (argument[0] == '\0')
 	{
 		send_to_char("Syntax:  verb (verb name)\n\r", ch);
@@ -4491,6 +4595,9 @@ bool oedit_cabal(CHAR_DATA *ch, char *argument)
 	int cabal;
 
 	EDIT_OBJ(ch, pObj);
+
+	if (pObj == nullptr)
+		return false;
 
 	if (argument[0] == '\0')
 	{
@@ -4518,6 +4625,9 @@ bool oedit_timer(CHAR_DATA *ch, char *argument)
 
 	EDIT_OBJ(ch, pObj);
 
+	if (pObj == nullptr)
+		return false;
+
 	if (argument[0] == '\0')
 	{
 		send_to_char("Syntax:  timer (number)\n\r"\
@@ -4544,6 +4654,9 @@ bool oedit_restrict(CHAR_DATA *ch, char *argument)
 	int bit, count;
 
 	EDIT_OBJ(ch, pObj);
+
+	if (pObj == nullptr)
+		return false;
 
 	if (argument[0] == '\0')
 	{
@@ -4583,6 +4696,9 @@ bool oedit_notes(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 
 	EDIT_OBJ(ch, pObj);
 
+	if (pObj == nullptr)
+		return false;
+
 	string_append(ch, &pObj->notes);
 	return true;
 }
@@ -4591,6 +4707,9 @@ bool oedit_wear_name(CHAR_DATA *ch, char *argument)
 {
 	OBJ_INDEX_DATA *pObj;
 	EDIT_OBJ(ch, pObj);
+
+	if (pObj == nullptr)
+		return false;
 
 	if (argument[0] == '\0')
 	{
@@ -4611,6 +4730,9 @@ bool oedit_flag(CHAR_DATA *ch, char *argument)
 	AFFECT_DATA pAf, *af;
 
 	EDIT_OBJ(ch, pObj);
+
+	if (pObj == nullptr)
+		return false;
 
 	argument = one_argument(argument, arg1);
 	argument = one_argument(argument, arg2);
@@ -4718,6 +4840,9 @@ bool oedit_name(CHAR_DATA *ch, char *argument)
 
 	EDIT_OBJ(ch, pObj);
 
+	if (pObj == nullptr)
+		return false;
+
 	if (argument[0] == '\0')
 	{
 		send_to_char("Syntax:  name [string]\n\r", ch);
@@ -4736,6 +4861,9 @@ bool oedit_short(CHAR_DATA *ch, char *argument)
 	OBJ_INDEX_DATA *pObj;
 
 	EDIT_OBJ(ch, pObj);
+
+	if (pObj == nullptr)
+		return false;
 
 	if (argument[0] == '\0')
 	{
@@ -4756,6 +4884,9 @@ bool oedit_long(CHAR_DATA *ch, char *argument)
 	OBJ_INDEX_DATA *pObj;
 
 	EDIT_OBJ(ch, pObj);
+
+	if (pObj == nullptr)
+		return false;
 
 	if (argument[0] == '\0')
 	{
@@ -4790,6 +4921,9 @@ bool oedit_values(CHAR_DATA *ch, char *argument, int value)
 	OBJ_INDEX_DATA *pObj;
 
 	EDIT_OBJ(ch, pObj);
+
+	if (pObj == nullptr)
+		return false;
 
 	if (set_value(ch, pObj, argument, value))
 		return true;
@@ -4843,6 +4977,9 @@ bool oedit_weight(CHAR_DATA *ch, char *argument)
 
 	EDIT_OBJ(ch, pObj);
 
+	if (pObj == nullptr)
+		return false;
+
 	if (argument[0] == '\0' || !is_number(argument))
 	{
 		send_to_char("Syntax:  weight [number]\n\r", ch);
@@ -4861,6 +4998,9 @@ bool oedit_cost(CHAR_DATA *ch, char *argument)
 
 	EDIT_OBJ(ch, pObj);
 
+	if (pObj == nullptr)
+		return false;
+
 	if (argument[0] == '\0' || !is_number(argument))
 	{
 		send_to_char("Syntax:  cost [number]\n\r", ch);
@@ -4875,6 +5015,11 @@ bool oedit_cost(CHAR_DATA *ch, char *argument)
 
 bool oedit_create(CHAR_DATA *ch, char *argument)
 {
+	DESCRIPTOR_DATA *connection = Deref(ch->desc);
+
+	if (connection == nullptr)
+		return false;
+
 	OBJ_INDEX_DATA *pObj;
 	AREA_DATA *pArea;
 	int value;
@@ -4918,7 +5063,7 @@ bool oedit_create(CHAR_DATA *ch, char *argument)
 	iHash = value % MAX_KEY_HASH;
 	pObj->next = obj_index_hash[iHash];
 	obj_index_hash[iHash] = pObj;
-	Deref(ch->desc)->pEdit = (void *)pObj;
+	connection->pEdit = (void *)pObj;
 
 	send_to_char("Object Created.\n\r", ch);
 	return true;
@@ -4930,6 +5075,9 @@ bool oedit_ed(CHAR_DATA *ch, char *argument)
 	char command[MAX_INPUT_LENGTH];
 
 	EDIT_OBJ(ch, pObj);
+
+	if (pObj == nullptr)
+		return false;
 
 	argument = one_argument(argument, command);
 
@@ -5060,6 +5208,9 @@ bool oedit_extra(CHAR_DATA *ch, char *argument) /* Moved out of oedit() due to n
 	{
 		EDIT_OBJ(ch, pObj);
 
+		if (pObj == nullptr)
+			return false;
+
 		value = flag_value(extra_flags, argument);
 		if ((value) != NO_FLAG)
 		{
@@ -5085,6 +5236,9 @@ bool oedit_wear(CHAR_DATA *ch, char *argument) /* Moved out of oedit() due to na
 	{
 		EDIT_OBJ(ch, pObj);
 
+		if (pObj == nullptr)
+			return false;
+
 		value = flag_value(wear_flags, argument);
 		if ((value) != NO_FLAG)
 		{
@@ -5108,6 +5262,9 @@ bool oedit_type(CHAR_DATA *ch, char *argument) /* Moved out of oedit() due to na
 	if (argument[0] != '\0')
 	{
 		EDIT_OBJ(ch, pObj);
+
+		if (pObj == nullptr)
+			return false;
 
 		value = flag_value(type_flags, argument);
 		if ((value) != NO_FLAG)
@@ -5141,6 +5298,9 @@ bool oedit_material(CHAR_DATA *ch, char *argument)
 
 	EDIT_OBJ(ch, pObj);
 
+	if (pObj == nullptr)
+		return false;
+
 	if (argument[0] == '\0')
 	{
 		send_to_char("Syntax:  material [string]\n\r", ch);
@@ -5161,6 +5321,9 @@ bool oedit_material(CHAR_DATA *ch, char *argument)
 	int value;
 
 	EDIT_OBJ(ch, pObj);
+
+	if (pObj == nullptr)
+		return false;
 
 	if ( argument[0] != '\0' )
 	{
@@ -5185,6 +5348,9 @@ bool oedit_level(CHAR_DATA *ch, char *argument)
 
 	EDIT_OBJ(ch, pObj);
 
+	if (pObj == nullptr)
+		return false;
+
 	if (argument[0] == '\0' || !is_number(argument))
 	{
 		send_to_char("Syntax:  level [number]\n\r", ch);
@@ -5205,6 +5371,9 @@ bool oedit_condition(CHAR_DATA *ch, char *argument)
 	if (argument[0] != '\0' && (value = atoi(argument)) >= 0 && (value <= 100))
 	{
 		EDIT_OBJ(ch, pObj);
+
+		if (pObj == nullptr)
+			return false;
 
 		pObj->condition = value;
 		send_to_char("Condition set.\n\r", ch);
@@ -5227,6 +5396,10 @@ bool medit_limit(CHAR_DATA *ch, char *argument)
 	int low, high;
 
 	EDIT_MOB(ch, pMob);
+
+	if (pMob == nullptr)
+		return false;
+
 	argument = one_argument(argument, arg1);
 	argument = one_argument(argument, arg2);
 
@@ -5259,6 +5432,9 @@ bool medit_optional(CHAR_DATA *ch, char *argument)
 	BARRED_DATA *bar = nullptr;
 
 	EDIT_MOB(ch, pMob);
+
+	if (pMob == nullptr)
+		return false;
 
 	argument = one_argument(argument, arg1);
 	argument = one_argument(argument, arg2);
@@ -5482,6 +5658,9 @@ bool medit_yell(CHAR_DATA *ch, char *argument)
 
 	EDIT_MOB(ch, pMob);
 
+	if (pMob == nullptr)
+		return false;
+
 	pMob->attack_yell = palloc_string(argument);
 	return true;
 }
@@ -5491,6 +5670,9 @@ bool medit_notes(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 	MOB_INDEX_DATA *pMob;
 
 	EDIT_MOB(ch, pMob);
+
+	if (pMob == nullptr)
+		return false;
 
 	string_append(ch, &pMob->notes);
 	return true;
@@ -5519,6 +5701,9 @@ bool medit_class(CHAR_DATA *ch, char *argument)
 	char arg1[MSL], arg2[MSL], arg3[MSL];
 
 	EDIT_MOB(ch, pMob);
+
+	if (pMob == nullptr)
+		return false;
 
 	argument = one_argument(argument, arg1);
 	argument = one_argument(argument, arg2);
@@ -5609,6 +5794,9 @@ bool medit_show(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 	int i;
 
 	EDIT_MOB(ch, pMob);
+
+	if (pMob == nullptr)
+		return false;
 
 	sprintf(buf, "Name:        [%s]\n\rArea:        [%5d] %s\n\r",
 		pMob->player_name,
@@ -5932,6 +6120,11 @@ bool medit_show(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 
 bool medit_create(CHAR_DATA *ch, char *argument)
 {
+	DESCRIPTOR_DATA *connection = Deref(ch->desc);
+
+	if (connection == nullptr)
+		return false;
+
 	MOB_INDEX_DATA *pMob;
 	AREA_DATA *pArea;
 	int value;
@@ -5978,7 +6171,7 @@ bool medit_create(CHAR_DATA *ch, char *argument)
 
 	pMob->next = mob_index_hash[iHash];
 	mob_index_hash[iHash] = pMob;
-	Deref(ch->desc)->pEdit = (void *)pMob;
+	connection->pEdit = (void *)pMob;
 
 	send_to_char("Mobile Created.\n\r", ch);
 	return true;
@@ -5990,6 +6183,9 @@ bool medit_spec(CHAR_DATA *ch, char *argument)
 	MOB_INDEX_DATA *pMob;
 
 	EDIT_MOB(ch, pMob);
+
+	if (pMob == nullptr)
+		return false;
 
 	if ( argument[0] == '\0' )
 	{
@@ -6023,6 +6219,9 @@ bool medit_damtype(CHAR_DATA *ch, char *argument)
 
 	EDIT_MOB(ch, pMob);
 
+	if (pMob == nullptr)
+		return false;
+
 	if (argument[0] == '\0')
 	{
 		send_to_char("Syntax:  damtype [damage message]\n\r", ch);
@@ -6049,6 +6248,9 @@ bool medit_align(CHAR_DATA *ch, char *argument)
 
 	EDIT_MOB(ch, pMob);
 
+	if (pMob == nullptr)
+		return false;
+
 	if (argument[0] == '\0' || !is_number(argument))
 	{
 		send_to_char("Syntax:  alignment [number]\n\r", ch);
@@ -6066,6 +6268,9 @@ bool medit_level(CHAR_DATA *ch, char *argument)
 	MOB_INDEX_DATA *pMob;
 
 	EDIT_MOB(ch, pMob);
+
+	if (pMob == nullptr)
+		return false;
 
 	if (argument[0] == '\0' || !is_number(argument))
 	{
@@ -6096,6 +6301,9 @@ bool medit_desc(CHAR_DATA *ch, char *argument)
 
 	EDIT_MOB(ch, pMob);
 
+	if (pMob == nullptr)
+		return false;
+
 	if (argument[0] == '\0')
 	{
 		string_append(ch, &pMob->description);
@@ -6111,6 +6319,9 @@ bool medit_long(CHAR_DATA *ch, char *argument)
 	MOB_INDEX_DATA *pMob;
 
 	EDIT_MOB(ch, pMob);
+
+	if (pMob == nullptr)
+		return false;
 
 	if (argument[0] == '\0')
 	{
@@ -6133,6 +6344,9 @@ bool medit_short(CHAR_DATA *ch, char *argument)
 
 	EDIT_MOB(ch, pMob);
 
+	if (pMob == nullptr)
+		return false;
+
 	if (argument[0] == '\0')
 	{
 		send_to_char("Syntax:  short [string]\n\r", ch);
@@ -6151,6 +6365,9 @@ bool medit_name(CHAR_DATA *ch, char *argument)
 	MOB_INDEX_DATA *pMob;
 
 	EDIT_MOB(ch, pMob);
+
+	if (pMob == nullptr)
+		return false;
 
 	if (argument[0] == '\0')
 	{
@@ -6171,6 +6388,9 @@ bool medit_cabal(CHAR_DATA *ch, char *argument)
 	int cabal;
 
 	EDIT_MOB(ch, pMob);
+
+	if (pMob == nullptr)
+		return false;
 
 	if (argument[0] == '\0')
 	{
@@ -6202,6 +6422,9 @@ bool medit_shop(CHAR_DATA *ch, char *argument)
 	argument = one_argument(argument, arg2);
 
 	EDIT_MOB(ch, pMob);
+
+	if (pMob == nullptr)
+		return false;
 
 	if (arg1[0] == '\0')
 	{
@@ -6259,6 +6482,9 @@ bool medit_sex(CHAR_DATA *ch, char *argument) /* Moved out of medit() due to nam
 	{
 		EDIT_MOB(ch, pMob);
 
+		if (pMob == nullptr)
+			return false;
+
 		value = flag_value(sex_flags, argument);
 
 		if (value != NO_FLAG)
@@ -6283,6 +6509,9 @@ bool medit_act(CHAR_DATA *ch, char *argument) /* Moved out of medit() due to nam
 	if (argument[0] != '\0')
 	{
 		EDIT_MOB(ch, pMob);
+
+		if (pMob == nullptr)
+			return false;
 
 		value = flag_value(act_flags, argument);
 
@@ -6309,6 +6538,9 @@ bool medit_affect(CHAR_DATA *ch, char *argument) /* Moved out of medit() due to 
 	if (argument[0] != '\0')
 	{
 		EDIT_MOB(ch, pMob);
+
+		if (pMob == nullptr)
+			return false;
 
 		value = flag_value(affect_flags, argument);
 		if ((value) != NO_FLAG)
@@ -6337,6 +6569,10 @@ bool medit_ac(CHAR_DATA *ch, char *argument)
 			break;
 
 		EDIT_MOB(ch, pMob);
+
+		if (pMob == nullptr)
+			return false;
+
 		argument = one_argument(argument, arg);
 
 		if (!is_number(arg))
@@ -6406,6 +6642,9 @@ bool medit_form(CHAR_DATA *ch, char *argument)
 	{
 		EDIT_MOB(ch, pMob);
 
+		if (pMob == nullptr)
+			return false;
+
 		value = flag_value(form_flags, argument);
 
 		if (value != NO_FLAG)
@@ -6430,6 +6669,9 @@ bool medit_part(CHAR_DATA *ch, char *argument)
 	if (argument[0] != '\0')
 	{
 		EDIT_MOB(ch, pMob);
+
+		if (pMob == nullptr)
+			return false;
 
 		value = flag_value(part_flags, argument);
 
@@ -6456,6 +6698,9 @@ bool medit_imm(CHAR_DATA *ch, char *argument)
 	{
 		EDIT_MOB(ch, pMob);
 
+		if (pMob == nullptr)
+			return false;
+
 		value = flag_value(imm_flags, argument);
 
 		if (value != NO_FLAG)
@@ -6481,6 +6726,9 @@ bool medit_res(CHAR_DATA *ch, char *argument)
 	{
 		EDIT_MOB(ch, pMob);
 
+		if (pMob == nullptr)
+			return false;
+
 		value = flag_value(res_flags, argument);
 
 		if (value != NO_FLAG)
@@ -6505,6 +6753,9 @@ bool medit_vuln(CHAR_DATA *ch, char *argument)
 	if (argument[0] != '\0')
 	{
 		EDIT_MOB(ch, pMob);
+
+		if (pMob == nullptr)
+			return false;
 
 		value = flag_value(vuln_flags, argument);
 
@@ -6535,6 +6786,9 @@ bool medit_material(CHAR_DATA *ch, char *argument)
 
 	EDIT_MOB(ch, pMob);
 
+	if (pMob == nullptr)
+		return false;
+
 	if ((value = flag_value( material_type, argument)) != NO_FLAG)
 	{
 		pMob->material = material_name(value);
@@ -6556,6 +6810,9 @@ bool medit_off(CHAR_DATA *ch, char *argument)
 	if (argument[0] != '\0')
 	{
 		EDIT_MOB(ch, pMob);
+
+		if (pMob == nullptr)
+			return false;
 
 		value = flag_value(off_flags, argument);
 
@@ -6582,6 +6839,9 @@ bool medit_size(CHAR_DATA *ch, char *argument)
 	{
 		EDIT_MOB(ch, pMob);
 
+		if (pMob == nullptr)
+			return false;
+
 		value = flag_value(size_flags, argument);
 
 		if (value != NO_FLAG)
@@ -6605,6 +6865,9 @@ bool medit_hitdice(CHAR_DATA *ch, char *argument)
 	MOB_INDEX_DATA *pMob;
 
 	EDIT_MOB(ch, pMob);
+
+	if (pMob == nullptr)
+		return false;
 
 	if (argument[0] == '\0')
 	{
@@ -6669,6 +6932,9 @@ bool medit_manadice(CHAR_DATA *ch, char *argument)
 	MOB_INDEX_DATA *pMob;
 
 	EDIT_MOB(ch, pMob);
+
+	if (pMob == nullptr)
+		return false;
 
 	if (argument[0] == '\0')
 	{
@@ -6739,6 +7005,9 @@ bool medit_damdice(CHAR_DATA *ch, char *argument)
 	MOB_INDEX_DATA *pMob;
 
 	EDIT_MOB(ch, pMob);
+
+	if (pMob == nullptr)
+		return false;
 
 	if (argument[0] == '\0')
 	{
@@ -6811,6 +7080,9 @@ bool medit_race(CHAR_DATA *ch, char *argument)
 	{
 		EDIT_MOB(ch, pMob);
 
+		if (pMob == nullptr)
+			return false;
+
 		pMob->race = race;
 		BITWISE_OR(pMob->off_flags, race_data_lookup(race)->off);
 		BITWISE_OR(pMob->imm_flags, race_data_lookup(race)->imm);
@@ -6861,6 +7133,9 @@ bool medit_position(CHAR_DATA *ch, char *argument)
 
 	EDIT_MOB(ch, pMob);
 
+	if (pMob == nullptr)
+		return false;
+
 	pMob->start_pos = value;
 	send_to_char("Start position set.\n\r", ch);
 	return true;
@@ -6872,6 +7147,9 @@ bool medit_gold(CHAR_DATA *ch, char *argument)
 	int index;
 
 	EDIT_MOB(ch, pMob);
+
+	if (pMob == nullptr)
+		return false;
 
 	if (argument[0] == '\0')
 	{
@@ -6897,6 +7175,9 @@ bool medit_hitroll(CHAR_DATA *ch, char *argument)
 	MOB_INDEX_DATA *pMob;
 
 	EDIT_MOB(ch, pMob);
+
+	if (pMob == nullptr)
+		return false;
 
 	if (argument[0] == '\0' || !is_number(argument))
 	{

--- a/code/olc_save.c
+++ b/code/olc_save.c
@@ -1124,6 +1124,9 @@ void do_asave(CHAR_DATA *ch, char *argument)
 		{
 			DESCRIPTOR_DATA *d = Deref(ch->desc);
 
+			if (d == nullptr)
+				return;
+
 			/* Is character currently editing. */
 			if (d->editor == 0)
 			{

--- a/code/olc_save.c
+++ b/code/olc_save.c
@@ -897,7 +897,6 @@ void save_shops([[maybe_unused]] FILE *fp, [[maybe_unused]] AREA_DATA *pArea)
 
 void save_area(AREA_DATA *pArea)
 {
-	long long temp_bit;
 	FILE *fp = nullptr;
 
 	std::string backupPath = std::string(RIFT_AREA_DIR) + "/backup/" + pArea->file_name + ".bak";
@@ -922,7 +921,6 @@ void save_area(AREA_DATA *pArea)
 	fprintf(fp, "%d\n", pArea->security);
 	fprintf(fp, "%s~\n\n", pArea->builders);
 
-	temp_bit = pArea->area_flags[0] + pArea->area_flags[1];
 
 	save_mobiles(fp, pArea);
 	save_objects(fp, pArea);

--- a/code/prof.c
+++ b/code/prof.c
@@ -794,7 +794,7 @@ bool CProficiencies::InterpCommand(char *command, char *argument)
 		if (foundPos == std::string::npos)
 			continue;
 		
-		auto pindex = ProfIndexLookup(cmd.prerequisite);
+		auto pindex = ProfIndexLookup(cmd.prerequisite.data());
 		if (cmd.prerequisite == "none" || pindex == -1 || ch->Profs()->HasProf(pindex))
 		{
 			(cmd.cmd) (ch, argument);

--- a/code/prof.c
+++ b/code/prof.c
@@ -301,7 +301,7 @@ void CProficiencies::GetProfsTaughtByTrainer(char_data* ch, char_data* trainer)
 		return;
 	}
 
-	act("You may learn the following proficiencies from $N:", ch, 0, trainer, TO_CHAR);
+	act("You may learn the following proficiencies from $N:", ch, nullptr, trainer, TO_CHAR);
 
 	const int prof_table_size = std::size(prof_table);
 	const int profs_taught_size = std::size(trainer->pIndexData->profs_taught);
@@ -923,7 +923,7 @@ void prof_tracking(CHAR_DATA *ch, char *argument)
 		return;
 	}
 
-	act("$n begins to poke and prod at the ground, clearly searching for something.", ch, 0, 0, TO_ROOM);
+	act("$n begins to poke and prod at the ground, clearly searching for something.", ch, nullptr, nullptr, TO_ROOM);
 	auto buffer = std::string("You were unable to find any sign of $N here.");
 
 	char *direction = nullptr;
@@ -965,8 +965,8 @@ void build_fire(CHAR_DATA *ch, int dur)
 {
 	if (number_percent() > 60 + ch->Profs()->GetProf("firestarting") * 3)
 	{
-		act("$n's fire dies out despite $s best attempts to kindle it.", ch, 0, 0, TO_ROOM);
-		act("Your fire dies out despite your best attempts to kindle it.", ch, 0, 0, TO_CHAR);
+		act("$n's fire dies out despite $s best attempts to kindle it.", ch, nullptr, nullptr, TO_ROOM);
+		act("Your fire dies out despite your best attempts to kindle it.", ch, nullptr, nullptr, TO_CHAR);
 		ch->Profs()->CheckImprove("firestarting", 300);
 		return;
 	}
@@ -974,7 +974,7 @@ void build_fire(CHAR_DATA *ch, int dur)
 	auto buffer = fmt::format("{}The spark is caught by some dried brush, and it quickly erupts into a blazing campfire!{}",
 		get_char_color(ch, "lightred"),
 		END_COLOR(ch));
-	act(buffer.c_str(), ch, 0, 0, TO_ALL);
+	act(buffer.c_str(), ch, nullptr, nullptr, TO_ALL);
 
 	auto fire = create_object(get_obj_index(OBJ_VNUM_CAMPFIRE), ch->level);
 	fire->value[0] = ch->Profs()->GetProf("firestarting") + 1;
@@ -1018,8 +1018,8 @@ void prof_firestart(CHAR_DATA *ch, [[maybe_unused]] char *argument)
 	}
 
 	auto dur = 12;
-	act("You begin to build a campfire, gathering sticks and twigs from your surroundings.", ch, 0, 0, TO_CHAR);
-	act("$n begins to build a campfire, gathering sticks and twigs from $s surroundings.", ch, 0, 0, TO_ROOM);
+	act("You begin to build a campfire, gathering sticks and twigs from your surroundings.", ch, nullptr, nullptr, TO_CHAR);
+	act("$n begins to build a campfire, gathering sticks and twigs from $s surroundings.", ch, nullptr, nullptr, TO_ROOM);
 	ch->move -= ch->level;
 
 	RS.Queue.AddToQueue(1, "prof_firestart", "send_to_char_queue", send_to_char_queue, "You rub two sticks together, trying to produce a flame.\n\r", ch);
@@ -1062,7 +1062,7 @@ void prof_appraise(CHAR_DATA *ch, char *argument)
 		: std::max((float)0, obj->cost - (mcost * obj->cost));
 
 	auto buffer = fmt::format("You estimate the value of $p to be approximately {} gold.", (int)tcost);
-	act(buffer.c_str(), ch, obj, 0, TO_CHAR);
+	act(buffer.c_str(), ch, obj, nullptr, TO_CHAR);
 	ch->Profs()->CheckImprove("appraising", 80);
 
 	WAIT_STATE(ch, PULSE_VIOLENCE);
@@ -1093,13 +1093,13 @@ void prof_butcher(CHAR_DATA *ch, char *argument)
 		return;
 	}
 
-	act("$n butchers $p, carefully gutting it, extracting the edible portions and slicing them into rough chunks.", ch, obj, 0, TO_ROOM);
-	act("You butcher $p, carefully gutting it, extracting the edible portions and slicing them into rough chunks.", ch, obj, 0, TO_CHAR);
+	act("$n butchers $p, carefully gutting it, extracting the edible portions and slicing them into rough chunks.", ch, obj, nullptr, TO_ROOM);
+	act("You butcher $p, carefully gutting it, extracting the edible portions and slicing them into rough chunks.", ch, obj, nullptr, TO_CHAR);
 
 	extract_obj(obj);
 
 	int nummeat = std::max(1, (ch->Profs()->GetProf("butchery") + 2) / 3);
-	act("After the butchering process, you are left with $i pieces of meat.", ch, &nummeat, 0, TO_CHAR);
+	act("After the butchering process, you are left with $i pieces of meat.", ch, &nummeat, nullptr, TO_CHAR);
 
 	for (auto i = 0; i < nummeat; i++)
 	{
@@ -1157,13 +1157,13 @@ void prof_bandage(CHAR_DATA *ch, char *argument)
 	if (victim == ch)
 	{
 		send_to_char("You bandage your wounds, staunching the worst of the bleeding.\n\r", ch);
-		act("$n bandages $s wounds, staunching the worst of $s bleeding.", ch, 0, 0, TO_ROOM);
+		act("$n bandages $s wounds, staunching the worst of $s bleeding.", ch, nullptr, nullptr, TO_ROOM);
 	}
 	else
 	{
-		act("You bandage $N's wounds, staunching the worst of $S bleeding.", ch, 0, victim, TO_CHAR);
-		act("$n bandages your wounds, staunching the worst of the bleeding.", ch, 0, victim, TO_VICT);
-		act("$n bandages $N's wounds, staunching the worst of $S bleeding.", ch, 0, victim, TO_NOTVICT);
+		act("You bandage $N's wounds, staunching the worst of $S bleeding.", ch, nullptr, victim, TO_CHAR);
+		act("$n bandages your wounds, staunching the worst of the bleeding.", ch, nullptr, victim, TO_VICT);
+		act("$n bandages $N's wounds, staunching the worst of $S bleeding.", ch, nullptr, victim, TO_NOTVICT);
 	}
 
 	float hadd = (std::max(ch->Profs()->GetProf("bandaging") * 0.4, (double)1) * victim->level) + victim->hit;

--- a/code/prof.h
+++ b/code/prof.h
@@ -2,6 +2,7 @@
 #define PROF_H
 
 #include <time.h>
+#include <string_view>
 #include <vector>
 #include <algorithm>
 
@@ -42,9 +43,9 @@ struct proficiency_msg
 
 struct prof_cmd_type
 {
-	char *name;
+	std::string_view name;
 	DO_FUN *cmd;
-	char *prerequisite;
+	std::string_view prerequisite;
 };
 
 

--- a/code/quest.c
+++ b/code/quest.c
@@ -815,12 +815,16 @@ void pulse_prog_ilopheth_hermit(CHAR_DATA *mob)
 	for (OwningListWalk<DESCRIPTOR_DATA> walk(descriptor_list); !walk.Done(); walk.Step())
 	{
 		DESCRIPTOR_DATA *d = walk.Current();
+		CHAR_DATA *wch = Deref(d->character);
 
-		if (d->connected == CON_PLAYING && !is_npc(Deref(d->character)) && Deref(d->character)->in_room != nullptr &&
-			Deref(d->character)->in_room->area != nullptr && Deref(d->character)->in_room->area == mob->in_room->area &&
-			Deref(d->character)->pcdata->quests[TALISMANIC_QUEST] == 5 && number_percent() < 5)
+		if (wch == nullptr)
+			continue;
+
+		if (d->connected == CON_PLAYING && !is_npc(wch) && wch->in_room != nullptr &&
+			wch->in_room->area != nullptr && wch->in_room->area == mob->in_room->area &&
+			wch->pcdata->quests[TALISMANIC_QUEST] == 5 && number_percent() < 5)
 		{
-			sprintf(buf, "%s You!  Coming again to grub, eh?  You'll pay, oh yes yes, you will!", Deref(d->character)->name);
+			sprintf(buf, "%s You!  Coming again to grub, eh?  You'll pay, oh yes yes, you will!", wch->name);
 			do_tell(mob, buf);
 
 			act("A bolt of lightning streaks down from the clouds above!", Deref(d->character), nullptr, nullptr, TO_ALL);

--- a/code/quest.c
+++ b/code/quest.c
@@ -243,14 +243,14 @@ void greet_prog_cimar_dollgirl(CHAR_DATA *mob, CHAR_DATA *ch)
 	switch (ch->pcdata->quests[DOLL_QUEST])
 	{
 		case 0:
-			act("$n approaches $N and asks $M something.", mob, 0, ch, TO_NOTVICT);
+			act("$n approaches $N and asks $M something.", mob, nullptr, ch, TO_NOTVICT);
 			sprintf(buf, "A red eyed girl asks '%sPlease... will you help me find my doll?%s'\n\r",
 				get_char_color(ch, "speech"),
 				END_COLOR(ch));
 			send_to_char(buf, ch);
 			break;
 		case 1:
-			act("$n approaches $N and asks $M something.", mob, 0, ch, TO_NOTVICT);
+			act("$n approaches $N and asks $M something.", mob, nullptr, ch, TO_NOTVICT);
 			sprintf(buf, "A red-eyed girl asks '%sD-did you find my d-doll?%s'\n\r",
 				get_char_color(ch, "speech"),
 				END_COLOR(ch));
@@ -258,11 +258,11 @@ void greet_prog_cimar_dollgirl(CHAR_DATA *mob, CHAR_DATA *ch)
 			break;
 		case 2:
 		case 3:
-			act("$n catches sight of you and her sobs intensify.", mob, 0, ch, TO_VICT);
-			act("$n catches sight of $N and her sobs intensify.", mob, 0, ch, TO_NOTVICT);
+			act("$n catches sight of you and her sobs intensify.", mob, nullptr, ch, TO_VICT);
+			act("$n catches sight of $N and her sobs intensify.", mob, nullptr, ch, TO_NOTVICT);
 			break;
 		case 4:
-			act("$n catches sight of you and gives you a smile and a wink.", mob, 0, ch, TO_VICT);
+			act("$n catches sight of you and gives you a smile and a wink.", mob, nullptr, ch, TO_VICT);
 			break;
 	}
 }
@@ -286,7 +286,7 @@ void speech_prog_cimar_dollgirl(CHAR_DATA *mob, CHAR_DATA *ch, char *speech)
 			if (!str_prefix("yes", speech))
 			{
 				do_emote(mob, "'s eyes light up and gleam with hope.");
-				act("$n approaches $N and murmurs something to $M.", mob, 0, ch, TO_NOTVICT);
+				act("$n approaches $N and murmurs something to $M.", mob, nullptr, ch, TO_NOTVICT);
 
 				sprintf(buf,
 					"A red-eyed girl says '%sI lost it somewhere on Wormwood Avenue... I saw a rat, and it tried to bite "\
@@ -302,7 +302,7 @@ void speech_prog_cimar_dollgirl(CHAR_DATA *mob, CHAR_DATA *ch, char *speech)
 
 			if (!str_prefix("no", speech))
 			{
-				act("A brief look of shock crosses $n's face and she turns away, sobbing.", mob, 0, 0, TO_ROOM);
+				act("A brief look of shock crosses $n's face and she turns away, sobbing.", mob, nullptr, nullptr, TO_ROOM);
 
 				ch->pcdata->quests[DOLL_QUEST] = 2;
 				ch->pcdata->reputation -= 10;
@@ -320,12 +320,12 @@ void speech_prog_cimar_dollgirl(CHAR_DATA *mob, CHAR_DATA *ch, char *speech)
 				}
 				else
 				{
-					act("$n stops crying suddenly and studies your face for a moment.", mob, 0, ch, TO_VICT);
-					act("$n stops crying suddenly and studies $N's face for a moment.", mob, 0, ch, TO_NOTVICT);
+					act("$n stops crying suddenly and studies your face for a moment.", mob, nullptr, ch, TO_VICT);
+					act("$n stops crying suddenly and studies $N's face for a moment.", mob, nullptr, ch, TO_NOTVICT);
 					do_say(mob, "Why... would you l-lie to me?  W-why?");
 
-					act("$n turns away from you and wails pitifully.", mob, 0, ch, TO_VICT);
-					act("$n turns away from $N and wails pitifully.", mob, 0, ch, TO_NOTVICT);
+					act("$n turns away from you and wails pitifully.", mob, nullptr, ch, TO_VICT);
+					act("$n turns away from $N and wails pitifully.", mob, nullptr, ch, TO_NOTVICT);
 
 					ch->pcdata->quests[DOLL_QUEST] = 3;
 					ch->pcdata->reputation -= 15;
@@ -353,9 +353,9 @@ void give_prog_cimar_dollgirl(CHAR_DATA *mob, CHAR_DATA *ch, OBJ_DATA *obj)
 	if (!can_do_quest(ch, DOLL_QUEST))
 		return;
 
-	act("$N snatches the doll from your hands and examines it intently.", ch, 0, mob, TO_CHAR);
-	act("$N snatches the doll from $n's hands and examines it intently.", ch, 0, mob, TO_ROOM);
-	act("$N lets out a squeal of gleeful laughter and skips away, dangling the doll loosely by its leg.", ch, 0, mob, TO_ALL);
+	act("$N snatches the doll from your hands and examines it intently.", ch, nullptr, mob, TO_CHAR);
+	act("$N snatches the doll from $n's hands and examines it intently.", ch, nullptr, mob, TO_ROOM);
+	act("$N lets out a squeal of gleeful laughter and skips away, dangling the doll loosely by its leg.", ch, nullptr, mob, TO_ALL);
 
 	extract_char(mob, true);
 
@@ -393,7 +393,7 @@ void greet_prog_cimar_sorcgm(CHAR_DATA *mob, CHAR_DATA *ch)
 				"hiding, however, for there are many who would seek to learn his secrets.  Pelamon is his name.  Speak "\
 				"it that he may know you are a friend.  Do not shame me by proving unworthy in his eyes.%s'",
 				get_char_color(ch, "red"), ch->name, END_COLOR(ch));
-		act(buf, mob, 0, ch, TO_VICT);
+		act(buf, mob, nullptr, ch, TO_VICT);
 
 		ch->pcdata->quests[TALISMANIC_QUEST] = 1;
 	}
@@ -402,7 +402,7 @@ void greet_prog_cimar_sorcgm(CHAR_DATA *mob, CHAR_DATA *ch)
 		sprintf(buf, "$n whispers '%sRemember.  A hermit north and to the west.  His name is Pelamon.%s'",
 			get_char_color(ch, "red"),
 			END_COLOR(ch));
-		act(buf, mob, 0, ch, TO_VICT);
+		act(buf, mob, nullptr, ch, TO_VICT);
 	}
 }
 
@@ -456,9 +456,9 @@ void speech_prog_ilopheth_shack(ROOM_INDEX_DATA *room, CHAR_DATA *ch, char *spee
 				char_from_room(mob);
 				char_to_room(mob, room);
 
-				act("A previously-unnoticed door on the shack to the west creaks loudly open.", ch, 0, 0, TO_ALL);
-				act("A hermit clad in tattered robes grabs $n by the hand and drags $m in!", ch, 0, 0, TO_ROOM);
-				act("A hermit clad in tattered robes grabs you by the hand and drags you in!", ch, 0, 0, TO_CHAR);
+				act("A previously-unnoticed door on the shack to the west creaks loudly open.", ch, nullptr, nullptr, TO_ALL);
+				act("A hermit clad in tattered robes grabs $n by the hand and drags $m in!", ch, nullptr, nullptr, TO_ROOM);
+				act("A hermit clad in tattered robes grabs you by the hand and drags you in!", ch, nullptr, nullptr, TO_CHAR);
 
 				char_from_room(mob);
 				char_from_room(ch);
@@ -500,9 +500,9 @@ void speech_prog_ilopheth_shack(ROOM_INDEX_DATA *room, CHAR_DATA *ch, char *spee
 					char_from_room(mob);
 					char_to_room(mob, room);
 
-					act("A previously-unnoticed door on the shack to the west creaks loudly open.", ch, 0, 0, TO_ALL);
-					act("A hermit clad in tattered robes grabs $n by the hand and drags $m in!", ch, 0, 0, TO_ROOM);
-					act("A hermit clad in tattered robes grabs you by the hand and drags you in!", ch, 0, 0, TO_CHAR);
+					act("A previously-unnoticed door on the shack to the west creaks loudly open.", ch, nullptr, nullptr, TO_ALL);
+					act("A hermit clad in tattered robes grabs $n by the hand and drags $m in!", ch, nullptr, nullptr, TO_ROOM);
+					act("A hermit clad in tattered robes grabs you by the hand and drags you in!", ch, nullptr, nullptr, TO_CHAR);
 
 					char_from_room(mob);
 					char_from_room(ch);
@@ -536,9 +536,9 @@ void speech_prog_ilopheth_shack(ROOM_INDEX_DATA *room, CHAR_DATA *ch, char *spee
 					char_from_room(mob);
 					char_to_room(mob, room);
 
-					act("A previously-unnoticed door on the shack to the west creaks loudly open.", ch, 0, 0, TO_ALL);
-					act("A hermit clad in tattered robes grabs $n by the hand and drags $m in!", ch, 0, 0, TO_ROOM);
-					act("A hermit clad in tattered robes grabs you by the hand and drags you in!", ch, 0, 0, TO_CHAR);
+					act("A previously-unnoticed door on the shack to the west creaks loudly open.", ch, nullptr, nullptr, TO_ALL);
+					act("A hermit clad in tattered robes grabs $n by the hand and drags $m in!", ch, nullptr, nullptr, TO_ROOM);
+					act("A hermit clad in tattered robes grabs you by the hand and drags you in!", ch, nullptr, nullptr, TO_CHAR);
 
 					char_from_room(mob);
 					char_from_room(ch);
@@ -553,7 +553,7 @@ void speech_prog_ilopheth_shack(ROOM_INDEX_DATA *room, CHAR_DATA *ch, char *spee
 
 			break;
 		case 5:
-			act("A bolt of lightning streaks down from the clouds above!", ch, 0, 0, TO_ALL);
+			act("A bolt of lightning streaks down from the clouds above!", ch, nullptr, nullptr, TO_ALL);
 			do_myell(ch, "Argh!  I've been struck by lightning!", nullptr);
 
 			damage_new(mob, ch, dice(ch->level, 8), gsn_call_lightning, DAM_LIGHTNING, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "The lightning strike*");
@@ -823,7 +823,7 @@ void pulse_prog_ilopheth_hermit(CHAR_DATA *mob)
 			sprintf(buf, "%s You!  Coming again to grub, eh?  You'll pay, oh yes yes, you will!", Deref(d->character)->name);
 			do_tell(mob, buf);
 
-			act("A bolt of lightning streaks down from the clouds above!", Deref(d->character), 0, 0, TO_ALL);
+			act("A bolt of lightning streaks down from the clouds above!", Deref(d->character), nullptr, nullptr, TO_ALL);
 			do_myell(Deref(d->character), "Argh!  I've been struck by lightning!", nullptr);
 
 			damage_new(mob, Deref(d->character), dice(Deref(d->character)->level, 8), gsn_call_lightning, DAM_LIGHTNING, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "The lightning strike*");
@@ -847,21 +847,21 @@ void greet_prog_drow_scribe(CHAR_DATA *mob, CHAR_DATA *ch)
 
 	if (ch->pcdata->quests[SCRIBE_QUEST] == 0)
 	{
-		act("The drow scribe looks up at you with a look of contemplation on his face.", ch, 0, 0, TO_CHAR);
-		act("The drow scribe looks up at $n with a look of contemplation on his face.", ch, 0, 0, TO_ROOM);
+		act("The drow scribe looks up at you with a look of contemplation on his face.", ch, nullptr, nullptr, TO_CHAR);
+		act("The drow scribe looks up at $n with a look of contemplation on his face.", ch, nullptr, nullptr, TO_ROOM);
 		do_say(mob, "You there... You look like you could use a bit of extra gold.  Am I right?");
 		ch->pcdata->quests[SCRIBE_QUEST] = 1;
 	}
 	else if (ch->pcdata->quests[SCRIBE_QUEST] == 1)
 	{
-		act("The drow scribe snorts at you as you enter.", ch, 0, 0, TO_CHAR);
-		act("The drow scribe snorts at $n as $e enters.", ch, 0, 0, TO_ROOM);
+		act("The drow scribe snorts at you as you enter.", ch, nullptr, nullptr, TO_CHAR);
+		act("The drow scribe snorts at $n as $e enters.", ch, nullptr, nullptr, TO_ROOM);
 		sprintf(buf, "Well, %s?  Do you want the job or not?", ch->name);
 		do_say(mob, buf);
 	}
 	else if (ch->pcdata->quests[SCRIBE_QUEST] == 2)
 	{
-		act("The drow scribe looks up from his work quickly.", ch, 0, 0, TO_ROOM);
+		act("The drow scribe looks up from his work quickly.", ch, nullptr, nullptr, TO_ROOM);
 		sprintf(buf, "Hand me the fruit, %s.", ch->name);
 		do_say(mob, buf);
 	}
@@ -903,7 +903,7 @@ void give_prog_drow_scribe(CHAR_DATA *mob, CHAR_DATA *ch, OBJ_DATA *obj)
 	if (obj->pIndexData->vnum != 14222)
 	{
 		do_say(mob, "Bah!  This is not what I want!");
-		act("$n roughly throws $p to the ground.", mob, obj, 0, TO_ROOM);
+		act("$n roughly throws $p to the ground.", mob, obj, nullptr, TO_ROOM);
 		obj_from_char(obj);
 		obj_to_room(obj, mob->in_room);
 		return;
@@ -953,7 +953,7 @@ void greet_prog_headmaster(CHAR_DATA *mob, CHAR_DATA *ch)
 	if (ch->pcdata->quests[MUD_SCHOOL] > 1)
 		return;
 
-	act("$N nods solemnly to you.", ch, 0, mob, TO_CHAR);
+	act("$N nods solemnly to you.", ch, nullptr, mob, TO_CHAR);
 	mprog_tell(1,
 		"Welcome to the guildhall of the Shalaran Academy.  Here, my guildmasters and I will train you in the "\
 		"fine arts of combat.  Type 'practice' and 'train' here to prepare yourself before moving on.", mob, ch);
@@ -972,7 +972,7 @@ void greet_prog_pay_char(CHAR_DATA *mob, CHAR_DATA *ch)
 	mprog_tell(0,
 			"I highly recommend you visit Cimar's shops and stock up on items you might need.  The kiosk and the "\
 			"general store are very important.", mob, ch);
-	act("$N gives you 500 gold.", ch, 0, mob, TO_CHAR);
+	act("$N gives you 500 gold.", ch, nullptr, mob, TO_CHAR);
 
 	ch->gold += 500;
 
@@ -1002,8 +1002,8 @@ void greet_prog_starvin_pete(CHAR_DATA *mob, CHAR_DATA *ch)
 			mprog_say(0, "Bag!  Must have bag!", mob, ch);
 			break;
 		case 3:
-			act("$N winks at you.", ch, 0, mob, TO_CHAR);
-			act("$N winks at $n.", ch, 0, mob, TO_ROOM);
+			act("$N winks at you.", ch, nullptr, mob, TO_CHAR);
+			act("$N winks at $n.", ch, nullptr, mob, TO_ROOM);
 			break;
 	}
 }
@@ -1031,9 +1031,9 @@ void give_prog_starvin_pete(CHAR_DATA *mob, CHAR_DATA *ch, OBJ_DATA *obj)
 					extract_obj(obj);
 				}
 
-				act("$n sings joyfully at the sight of meat!", mob, 0, ch, TO_ALL);
-				act("$N gratefully hands you 10 gold coins.", ch, 0, mob, TO_CHAR);
-				act("$N hands $n some coins.", ch, 0, mob, TO_ROOM);
+				act("$n sings joyfully at the sight of meat!", mob, nullptr, ch, TO_ALL);
+				act("$N gratefully hands you 10 gold coins.", ch, nullptr, mob, TO_CHAR);
+				act("$N hands $n some coins.", ch, nullptr, mob, TO_ROOM);
 
 				ch->gold += 10;
 				gain_exp(ch, 50);
@@ -1060,12 +1060,12 @@ void give_prog_starvin_pete(CHAR_DATA *mob, CHAR_DATA *ch, OBJ_DATA *obj)
 		case 2:
 			if (obj->pIndexData->vnum == 2416)
 			{
-				act("$N dances wildly before you!", ch, 0, mob, TO_ALL);
+				act("$N dances wildly before you!", ch, nullptr, mob, TO_ALL);
 				sprintf(buf,
 					"$N whispers '%sVery near here... plate in the ground, treasure under the plate... Pete's strange "\
 					"friend tell Pete... but dangerous down there, bring safety!  Oh... also, need rope.%s'",
 					get_char_color(ch, "red"), END_COLOR(ch));
-				act(buf, ch, 0, mob, TO_CHAR);
+				act(buf, ch, nullptr, mob, TO_CHAR);
 				ch->pcdata->quests[PETE_QUEST] = 3;
 			}
 			else
@@ -1080,9 +1080,9 @@ void give_prog_starvin_pete(CHAR_DATA *mob, CHAR_DATA *ch, OBJ_DATA *obj)
 		case 3:
 			if (!str_cmp(material_table[obj->pIndexData->material_index].mat_name, "meat"))
 			{
-				act("$n sings joyfully at the sight of meat!", mob, 0, ch, TO_ALL);
-				act("$N gratefully hands you 10 gold coins.", ch, 0, mob, TO_CHAR);
-				act("$N hands $n some coins.", ch, 0, mob, TO_ROOM);
+				act("$n sings joyfully at the sight of meat!", mob, nullptr, ch, TO_ALL);
+				act("$N gratefully hands you 10 gold coins.", ch, nullptr, mob, TO_CHAR);
+				act("$N hands $n some coins.", ch, nullptr, mob, TO_ROOM);
 				ch->gold += 10;
 				act("$N gobbles down $p noisily.", ch, obj, mob, TO_ALL);
 				obj_from_char(obj);
@@ -1115,11 +1115,11 @@ int academy_smith_greet(CHAR_DATA *ch, CHAR_DATA *mob)
 
 		if (!can_do_quest(ch, SMITH_QUEST) || STAGE(ch) != 0)
 			return 0;
-		act("$N looks up from his forge, sweat dripping down his brow.", ch, 0, mob, TO_CHAR);
+		act("$N looks up from his forge, sweat dripping down his brow.", ch, nullptr, mob, TO_CHAR);
 		if (is_good(ch))
-			act("$N smiles at you broadly.", ch, 0, mob, TO_CHAR);
+			act("$N smiles at you broadly.", ch, nullptr, mob, TO_CHAR);
 		else
-			act("$N regards you carefully, sizing you up.", ch, 0, mob, TO_CHAR);
+			act("$N regards you carefully, sizing you up.", ch, nullptr, mob, TO_CHAR);
 		mprog_say(2, "You there.  Yer look like yer in the market for something more powerful, eh?", mob, ch);
 		SET_STAGE(ch, 1);
 

--- a/code/rprog.c
+++ b/code/rprog.c
@@ -180,7 +180,7 @@ void pulse_prog_cimar_sewergrate(ROOM_INDEX_DATA *room)
 	if (!room->people)
 		return;
 
-	act("The sewer grate emits a soft burbling sound, and a stench fills the air.", room->people, 0, 0, TO_ALL);
+	act("The sewer grate emits a soft burbling sound, and a stench fills the air.", room->people, nullptr, nullptr, TO_ALL);
 }
 
 void pulse_prog_cim_conv(ROOM_INDEX_DATA *room)
@@ -191,7 +191,7 @@ void pulse_prog_cim_conv(ROOM_INDEX_DATA *room)
 	if (!room->people)
 		return;
 
-	act("Conversations buffet you, and your eyes are drawn to a sign on the wall.", room->people, 0, 0, TO_ALL);
+	act("Conversations buffet you, and your eyes are drawn to a sign on the wall.", room->people, nullptr, nullptr, TO_ALL);
 }
 
 void entry_prog_ilopheth_flute(ROOM_INDEX_DATA *room, CHAR_DATA *ch)
@@ -222,14 +222,14 @@ void entry_prog_ilopheth_flute(ROOM_INDEX_DATA *room, CHAR_DATA *ch)
 		sprintf(buf, "%sThe weathered old man ceases his flute-playing and regards you intently.%s",
 			get_char_color(ch, "magenta"),
 			END_COLOR(ch));
-		act(buf, man, 0, ch, TO_VICT);
+		act(buf, man, nullptr, ch, TO_VICT);
 	}
 	else if (room == adj)
 	{
 		sprintf(buf, "%sA haunting melody echoes from the north, its rich tones exuding melancholy and grief.%s",
 			get_char_color(ch, "magenta"),
 			END_COLOR(ch));
-		act(buf, ch, 0, 0, TO_CHAR);
+		act(buf, ch, nullptr, nullptr, TO_CHAR);
 	}
 }
 
@@ -247,7 +247,7 @@ void entry_prog_sidhe_ankle([[maybe_unused]] ROOM_INDEX_DATA *room, CHAR_DATA *c
 		return;
 
 	send_to_char("You feel a sharp pain in your ankle as your foot slips on a loose rock.\n\r", ch);
-	act("$n winces in pain as $e twists his ankle on a loose rock.", ch, 0, 0, TO_ROOM);
+	act("$n winces in pain as $e twists his ankle on a loose rock.", ch, nullptr, nullptr, TO_ROOM);
 
 	damage_new(ch, ch, dice(ch->level, 2), TYPE_UNDEFINED, DAM_BASH, true, HIT_UNBLOCKABLE, HIT_NOADD, HIT_NOMULT, "twisted ankle");
 
@@ -295,8 +295,8 @@ bool open_prog_mudschool_key([[maybe_unused]] ROOM_INDEX_DATA *room, CHAR_DATA *
 	obj = create_object(get_obj_index(24596), 1);
 	send_to_char("It's locked...\n\r", ch);
 	obj_to_char(obj, ch);
-	act("With a sudden flash of lavender light, a pudgy hand pops into existence and gives you a key!", ch, 0, 0, TO_CHAR);
-	act("With a sudden flash of lavender light, a pudgy hand pops into existence gives $n a key!", ch, 0, 0, TO_ROOM);
+	act("With a sudden flash of lavender light, a pudgy hand pops into existence and gives you a key!", ch, nullptr, nullptr, TO_CHAR);
+	act("With a sudden flash of lavender light, a pudgy hand pops into existence gives $n a key!", ch, nullptr, nullptr, TO_ROOM);
 
 	return false;
 }
@@ -324,13 +324,13 @@ bool move_prog_mudschool_key(ROOM_INDEX_DATA *room, CHAR_DATA *ch, int dir)
 
 	if (found)
 	{
-		act("As you pass through the door, $p crumbles to dust.", ch, obj, 0, TO_CHAR);
+		act("As you pass through the door, $p crumbles to dust.", ch, obj, nullptr, TO_CHAR);
 		obj_from_char(obj);
 		extract_obj(obj);
 	}
 
 	if (room->people)
-		act("The eastern door slams shut.", room->people, 0, 0, TO_ROOM);
+		act("The eastern door slams shut.", room->people, nullptr, nullptr, TO_ROOM);
 
 	return true;
 }
@@ -342,8 +342,8 @@ bool move_prog_door_close(ROOM_INDEX_DATA *room, CHAR_DATA *ch, int dir)
 	if (IS_SET(exit->exit_info, EX_CLOSED))
 		return true;
 
-	act("The door to the north closes up behind you, locking with a tiny click.", ch, 0, 0, TO_CHAR);
-	act("The door to the south closes up behind $n, locking with a tiny click.", ch, 0, 0, TO_ROOM);
+	act("The door to the north closes up behind you, locking with a tiny click.", ch, nullptr, nullptr, TO_CHAR);
+	act("The door to the south closes up behind $n, locking with a tiny click.", ch, nullptr, nullptr, TO_ROOM);
 	SET_BIT(exit->exit_info, EX_CLOSED);
 	SET_BIT(exit->exit_info, EX_LOCKED);
 	SET_BIT(exit->exit_info, EX_NONOBVIOUS);
@@ -377,8 +377,8 @@ void pulse_prog_mudschool_snake(ROOM_INDEX_DATA *room)
 
 	snake = create_mobile(get_mob_index(24546));
 	char_to_room(snake, room);
-	act("Sensing warmth and moisture, a rootsnake bursts from a nearby root and attacks you!", ch, 0, 0, TO_CHAR);
-	act("Sensing warmth and moisture, a rootsnake bursts from a nearby root and attacks $n!", ch, 0, 0, TO_ROOM);
+	act("Sensing warmth and moisture, a rootsnake bursts from a nearby root and attacks you!", ch, nullptr, nullptr, TO_CHAR);
+	act("Sensing warmth and moisture, a rootsnake bursts from a nearby root and attacks $n!", ch, nullptr, nullptr, TO_ROOM);
 
 	do_murder(snake, ch->name);
 
@@ -435,7 +435,7 @@ bool move_prog_stone_roll(ROOM_INDEX_DATA *room, CHAR_DATA *ch, [[maybe_unused]]
 	SET_BIT(exit->exit_info, EX_LOCKED);
 	SET_BIT(exit->exit_info, EX_NONOBVIOUS);
 
-	act("As you pass through, the stone rolls violently back into place!", ch, 0, 0, TO_CHAR);
+	act("As you pass through, the stone rolls violently back into place!", ch, nullptr, nullptr, TO_CHAR);
 
 	for (corpse = room->contents; corpse != nullptr; corpse = corpse->next_content)
 	{
@@ -480,7 +480,7 @@ bool move_prog_horde_shrine([[maybe_unused]] ROOM_INDEX_DATA *room, CHAR_DATA *c
 void entry_prog_iseldheim_lift([[maybe_unused]] ROOM_INDEX_DATA *room, CHAR_DATA *ch)
 {
 	send_to_char("You step onto the swaying lift.\n\r", ch);
-	act("$n steps onto the lift, causing it to sway momentarily.", ch, 0, 0, TO_ROOM);
+	act("$n steps onto the lift, causing it to sway momentarily.", ch, nullptr, nullptr, TO_ROOM);
 }
 
 void drop_prog_elven_star([[maybe_unused]] ROOM_INDEX_DATA *room, CHAR_DATA *ch, OBJ_DATA *obj)
@@ -492,7 +492,7 @@ void drop_prog_elven_star([[maybe_unused]] ROOM_INDEX_DATA *room, CHAR_DATA *ch,
 	if (vnum != 4637 && vnum != 4638 && vnum != 4639 && vnum != 4640 && vnum != 4641)
 		return;
 
-	act("As $p falls to the ground, it is immediately drawn to it's place in the star of the Chilliad.", ch, obj, 0, TO_ROOM);
+	act("As $p falls to the ground, it is immediately drawn to it's place in the star of the Chilliad.", ch, obj, nullptr, TO_ROOM);
 }
 
 void speech_prog_elven_down([[maybe_unused]] ROOM_INDEX_DATA *room, CHAR_DATA *ch, char *speech)
@@ -516,8 +516,8 @@ void speech_prog_elven_down([[maybe_unused]] ROOM_INDEX_DATA *room, CHAR_DATA *c
 		raf.duration = 0;
 		affect_to_room(ch->in_room, &raf);
 
-		act("A chill wind blows through the room, extinguishing the candle.", ch, 0, 0, TO_CHAR);
-		act("A chill wind blows through the room, extinguishing the candle.", ch, 0, 0, TO_ROOM);
+		act("A chill wind blows through the room, extinguishing the candle.", ch, nullptr, nullptr, TO_CHAR);
+		act("A chill wind blows through the room, extinguishing the candle.", ch, nullptr, nullptr, TO_ROOM);
 
 		for (ich = ch->in_room->people; ich != nullptr; ich = ich->next_in_room)
 		{
@@ -544,8 +544,8 @@ void rprog_elven_down_end(CHAR_DATA *ch, [[maybe_unused]] AFFECT_DATA *af)
 	char_from_room(ch);
 	char_to_room(ch, to_room);
 
-	act("You feel the floor drop beneath you, and you feel yourself fall and then impact as you hit the ground.", ch, 0, 0, TO_CHAR);
-	act("$n appears out of thin air, crumpling in to the ground with a thud.", ch, 0, 0, TO_ROOM);
+	act("You feel the floor drop beneath you, and you feel yourself fall and then impact as you hit the ground.", ch, nullptr, nullptr, TO_CHAR);
+	act("$n appears out of thin air, crumpling in to the ground with a thud.", ch, nullptr, nullptr, TO_ROOM);
 }
 
 void pulse_prog_elven_star([[maybe_unused]] ROOM_INDEX_DATA *room)
@@ -566,8 +566,8 @@ void pulse_prog_elven_star([[maybe_unused]] ROOM_INDEX_DATA *room)
 		{
 			if(ch != nullptr)
 			{
-				act("As the star is completed, you hear a noise nearby.",ch,0,0,TO_ROOM);
-				act("Their purpose fulfilled, the gems disintegrate.",ch,0,0,TO_ROOM);
+				act("As the star is completed, you hear a noise nearby.",ch,nullptr,nullptr,TO_ROOM);
+				act("Their purpose fulfilled, the gems disintegrate.",ch,nullptr,nullptr,TO_ROOM);
 			}
 
 			extract_obj(obj);

--- a/code/save.c
+++ b/code/save.c
@@ -794,7 +794,7 @@ void fwrite_obj(CHAR_DATA *ch, OBJ_DATA *obj, FILE *fp, int iNest)
 	if (str_cmp(obj->description, obj->pIndexData->description))
 		fprintf(fp, "Desc %s~\n", obj->description);
 
-	if (obj->owner != "")
+	if (obj->owner != nullptr)
 		fprintf(fp, "Owner %s~\n", obj->owner);
 
 	if (!vector_equal(obj->extra_flags, obj->pIndexData->extra_flags))
@@ -2091,6 +2091,12 @@ void fread_obj(CHAR_DATA *ch, FILE *fp)
 		obj->name = palloc_string("");
 		obj->short_descr = palloc_string("");
 		obj->description = palloc_string("");
+		// create_object gives every object this sentinel, but this fallback runs
+		// when the prototype is gone or the entry is old-style, and it used to
+		// leave owner null. Readers spell the no-owner case "none" (act_obj.c
+		// is_restricted), and str_cmp reports null as differing, so a null owner
+		// reads as owned by someone else.
+		obj->owner = palloc_string("none");
 	}
 
 	fNest = false;

--- a/code/save.c
+++ b/code/save.c
@@ -1894,7 +1894,6 @@ void fread_pet(CHAR_DATA *ch, FILE *fp)
 
 				if (!str_cmp(word, "Affc"))
 				{
-					CHAR_DATA *wch = nullptr;
 					char *owner;
 					char *afname;
 					AFFECT_DATA paf;

--- a/code/scan.c
+++ b/code/scan.c
@@ -133,7 +133,7 @@ void do_scan(CHAR_DATA *ch, char *argument)
 
 			if (af)
 			{
-				act("Your vision sharpens as you peer through your multifaceted crystal.", ch, 0, 0, TO_CHAR);
+				act("Your vision sharpens as you peer through your multifaceted crystal.", ch, nullptr, nullptr, TO_CHAR);
 				depth += af->modifier / 100;
 			}
 		}

--- a/code/skills.c
+++ b/code/skills.c
@@ -667,10 +667,10 @@ void check_style_improve(CHAR_DATA *ch, int style, int multiplier)
 							get_char_color(ch, "lightyellow"),
 							style_table[style].name,
 							END_COLOR(ch));
-						act(test, ch, 0, 0, TO_CHAR);
+						act(test, ch, nullptr, nullptr, TO_CHAR);
 
 						sprintf(test, "You feel ready to learn the %s skill.", style_percent[i].name);
-						act(test, ch, 0, 0, TO_CHAR);
+						act(test, ch, nullptr, nullptr, TO_CHAR);
 					}
 				}
 			}

--- a/code/skills.c
+++ b/code/skills.c
@@ -202,6 +202,7 @@ void do_spells(CHAR_DATA *ch, char *argument)
 			break;
 
 		if ((level = skill_table[sn].skill_level[ch->Class()->GetIndex()]) < LEVEL_HERO + 1
+			&& (fAll || level <= ch->level)
 			&& level >= min_lev
 			&& level <= max_lev
 			&& skill_table[sn].spell_fun != spell_null
@@ -367,6 +368,7 @@ void do_skills(CHAR_DATA *ch, char *argument)
 			&&  ch->pcdata->learned[sn] > 0)
 		*/
 		if ((level = skill_table[sn].skill_level[ch->Class()->GetIndex()]) < LEVEL_HERO + 1
+			&& (fAll || level <= ch->level)
 			&& level >= min_lev
 			&& level <= max_lev
 			&& skill_table[sn].spell_fun == spell_null

--- a/code/string.c
+++ b/code/string.c
@@ -47,7 +47,12 @@ void string_edit(CHAR_DATA *ch, char **pString)
 	else
 		**pString = '\0';
 
-	Deref(ch->desc)->pString = pString;
+	DESCRIPTOR_DATA *connection = Deref(ch->desc);
+
+	if (connection == nullptr)
+		return;
+
+	connection->pString = pString;
 }
 
 /*****************************************************************************
@@ -70,7 +75,12 @@ void string_append(CHAR_DATA *ch, char **pString)
 	if (*(*pString + strlen(*pString) - 1) != '\r')
 		send_to_char("\n\r", ch);
 
-	Deref(ch->desc)->pString = pString;
+	DESCRIPTOR_DATA *connection = Deref(ch->desc);
+
+	if (connection == nullptr)
+		return;
+
+	connection->pString = pString;
 }
 
 /*****************************************************************************

--- a/code/tattoo.c
+++ b/code/tattoo.c
@@ -198,8 +198,8 @@ void do_invoke_jackass(CHAR_DATA *ch)
 
 	obj = get_eq_char(ch, WEAR_BRAND);
 
-	act("$n's $p doesn't glow much due to $s stupidity.", ch, obj, 0, TO_ROOM);
-	act("Your $p doesn't glow much, probably because you're a jackass.", ch, obj, 0, TO_CHAR);
+	act("$n's $p doesn't glow much due to $s stupidity.", ch, obj, nullptr, TO_ROOM);
+	act("Your $p doesn't glow much, probably because you're a jackass.", ch, obj, nullptr, TO_CHAR);
 
 	send_to_char("You smite yourself! What a jackass!\n\r", ch);
 
@@ -221,8 +221,8 @@ void do_invoke_detlef(CHAR_DATA *ch)
 
 	obj = get_eq_char(ch, WEAR_BRAND);
 
-	act("$n's $p glows green.",ch,obj,0,TO_ROOM);
-	act("Your $p glows green.",ch,obj,0,TO_CHAR);
+	act("$n's $p glows green.",ch,obj,nullptr,TO_ROOM);
+	act("Your $p glows green.",ch,obj,nullptr,TO_CHAR);
 
 	ch->hit += (ch->level*2) * 10;
 	ch->hit = std::min(ch->hit,ch->max_hit);
@@ -265,12 +265,12 @@ void do_invoke_gabe(CHAR_DATA *ch)
 
 	if (ch->position == POS_FIGHTING)
 	{
-		act("You can not invoke your lords power during a fight!", ch, 0, 0, TO_CHAR);
+		act("You can not invoke your lords power during a fight!", ch, nullptr, nullptr, TO_CHAR);
 		return;
 	}
 
 	obj = get_eq_char(ch, WEAR_BRAND);
 
-	act("$n's $p glows a bright gold.", ch, obj, 0, TO_ROOM);
-	act("Your $p glows a bright gold.", ch, obj, 0, TO_CHAR);
+	act("$n's $p glows a bright gold.", ch, obj, nullptr, TO_ROOM);
+	act("Your $p glows a bright gold.", ch, obj, nullptr, TO_CHAR);
 }

--- a/code/update.c
+++ b/code/update.c
@@ -1160,11 +1160,9 @@ void calabren_update(void)
  */
 void char_update(void)
 {
-	CHAR_DATA *ch_quit;
 	int hgain;
 	bool ghost= false;
 
-	ch_quit = nullptr;
 
 	/* update save counter */
 	save_number++;
@@ -1523,7 +1521,6 @@ void char_update(void)
 void obj_update(void)
 {
 	OBJ_DATA *obj;
-	OBJ_DATA *obj_next;
 	CHAR_DATA *cguard;
 
 	for (OwningListWalk<OBJ_DATA> walk(object_list); !walk.Done(); walk.Step())
@@ -2380,7 +2377,7 @@ void do_forcetick([[maybe_unused]] CHAR_DATA *ch, [[maybe_unused]] char *argumen
 
 void affect_update(void)
 {
-	OBJ_DATA *obj, *obj_next;
+	OBJ_DATA *obj;
 	ROOM_INDEX_DATA *room;
 	AREA_DATA *area;
 
@@ -2529,7 +2526,6 @@ void room_affect_update(void)
 			if (well == nullptr)
 				continue;
 
-			auto room_exit_size = std::size(room->exit);
 			auto well_grav_distance = get_grav_distance(well);
 
 			direction = 0;
@@ -2960,7 +2956,7 @@ void ayell_update(void)
 void iprog_pulse_update(bool isTick)
 {
 	char *direction;
-	OBJ_DATA *obj, *obj_next;
+	OBJ_DATA *obj;
 	ROOM_INDEX_DATA *to_room;
 	EXIT_DATA *pexit;
 	int door;

--- a/code/update.c
+++ b/code/update.c
@@ -1829,9 +1829,11 @@ void track_update(void)
 		// has already gone back on the free list -- the exact failure this
 		// field stopped being a raw pointer to avoid. Re-reading costs an
 		// array index and an integer compare, and yields null instead.
-		if (tch->in_room == Deref(tch->last_fought)->in_room)
+		CHAR_DATA *quarry = Deref(tch->last_fought);
+
+		if (quarry != nullptr && tch->in_room == quarry->in_room)
 		{
-			track_attack(tch, Deref(tch->last_fought));
+			track_attack(tch, quarry);
 			continue;
 		}
 
@@ -2706,9 +2708,11 @@ void room_affect_update(void)
 
 					if (!is_npc(vch))
 					{
-						if (vch->in_room == Deref(af->owner)->in_room)
+						CHAR_DATA *owner = Deref(af->owner);
+
+						if (owner != nullptr && vch->in_room == owner->in_room)
 						{
-							sprintf(buf, "Help! I'm being drowned by %s's tidal wave!", pers(Deref(af->owner), vch));
+							sprintf(buf, "Help! I'm being drowned by %s's tidal wave!", pers(owner, vch));
 							do_myell(vch, buf, nullptr);
 						}
 						else

--- a/code/update.c
+++ b/code/update.c
@@ -1431,7 +1431,7 @@ void char_update(void)
 
 							if (!owner || ch == owner)
 							{
-								act("You feel invigorated as your $t supplication is renewed by your deity.", ch, skill_table[paf->type].name, 0, TO_CHAR);
+								act("You feel invigorated as your $t supplication is renewed by your deity.", ch, skill_table[paf->type].name, nullptr, TO_CHAR);
 							}
 							else
 							{
@@ -1454,7 +1454,7 @@ void char_update(void)
 						}
 
 						if (paf->type && str_cmp(skill_table[paf->type].room_msg_off, "") && is_awake(ch))
-							act(skill_table[paf->type].room_msg_off, ch, 0, 0, TO_ROOM);
+							act(skill_table[paf->type].room_msg_off, ch, nullptr, nullptr, TO_ROOM);
 					}
 
 					// A charm running out has to release the following as well
@@ -1550,7 +1550,7 @@ void obj_update(void)
 			|| (obj->in_room
 				&& (obj->in_room->sector_type == SECT_WATER || obj->in_room->sector_type == SECT_UNDERWATER)))
 		{
-			act("The water extinguishes $p.", carrier, obj, 0, TO_CHAR);
+			act("The water extinguishes $p.", carrier, obj, nullptr, TO_CHAR);
 
 			if (is_affected_obj(obj, gsn_immolate))
 				affect_strip_obj(obj, gsn_immolate);
@@ -1730,7 +1730,7 @@ void obj_update(void)
 							for (t_obj = obj->contains; t_obj != nullptr; t_obj = next_obj)
 							{
 								next_obj = t_obj->next_content;
-								act_new("$p returns to you.", owner, t_obj, 0, TO_CHAR, POS_DEAD);
+								act_new("$p returns to you.", owner, t_obj, nullptr, TO_CHAR, POS_DEAD);
 
 								if (t_obj->item_type == ITEM_MONEY)
 								{
@@ -2212,7 +2212,7 @@ void age_update(void)
 			}
 			else
 			{
-				act("$n slowly fades away as $s souls departs the mortal planes.", ch, 0, 0, TO_ROOM);
+				act("$n slowly fades away as $s souls departs the mortal planes.", ch, nullptr, nullptr, TO_ROOM);
 				send_to_char("Your soul finally departs the mortal planes.\n\r", ch);
 				wiznet("$N has finally died of old age.", ch, nullptr, 0, 0, 0);
 
@@ -2241,7 +2241,7 @@ void age_update(void)
 		if (get_hours(ch) < ch->pcdata->death_time && !timedied)
 			continue;
 
-		act("$n closes $s eyes for the final time as age catches up with $m at last.", ch, 0, 0, TO_ROOM);
+		act("$n closes $s eyes for the final time as age catches up with $m at last.", ch, nullptr, nullptr, TO_ROOM);
 		send_to_char("You close your eyes for the final time as age catches up with you at last.\n\r", ch);
 		age_death(ch);
 
@@ -2566,9 +2566,9 @@ void room_affect_update(void)
 							char_to_room(victim, prevroom);
 							dirname = flag_name_lookup(reverse_d(direction), direction_table);
 
-							act("A powerful force drags you inexorably $T.", victim, 0, dirname, TO_CHAR);
+							act("A powerful force drags you inexorably $T.", victim, nullptr, dirname, TO_CHAR);
 							do_look(victim, "auto");
-							act("An invisible force drags $n into the room from the $T.", victim, 0, flag_name_lookup(direction, direction_table), TO_ROOM);
+							act("An invisible force drags $n into the room from the $T.", victim, nullptr, flag_name_lookup(direction, direction_table), TO_ROOM);
 						}
 					}
 
@@ -2875,7 +2875,7 @@ void room_affect_update(void)
 					break;
 
 				if (room->people)
-					act("The violent winds blow $p away!", room->people, obj, 0, TO_ALL);
+					act("The violent winds blow $p away!", room->people, obj, nullptr, TO_ALL);
 
 				obj_from_room(obj);
 				obj_to_room(obj, to_room);
@@ -2884,7 +2884,7 @@ void room_affect_update(void)
 				if (!to_room->people)
 					continue;
 
-				act("The violent winds blow $p in!", to_room->people, obj, 0, TO_ALL);
+				act("The violent winds blow $p in!", to_room->people, obj, nullptr, TO_ALL);
 
 				if (caster == nullptr)
 					continue;
@@ -2919,11 +2919,11 @@ void room_affect_update(void)
 					to_room->area->area_type == ARE_UNOPENED)
 					break;
 				send_to_char("The violent winds buffet you out of the room!\n\r", victim);
-				act("The violent winds buffet $n out of the room!", victim, 0, 0, TO_ROOM);
+				act("The violent winds buffet $n out of the room!", victim, nullptr, nullptr, TO_ROOM);
 				char_from_room(victim);
 				char_to_room(victim, to_room);
 				do_look(victim, "auto");
-				act("The violent winds buffet $n into the room!", victim, 0, 0, TO_ROOM);
+				act("The violent winds buffet $n into the room!", victim, nullptr, nullptr, TO_ROOM);
 			}
 		}
 	}
@@ -2989,7 +2989,7 @@ void iprog_pulse_update(bool isTick)
 
 						if (to_room->people)
 						{
-							act("$p drifts in.", to_room->people, obj, 0, TO_ALL);
+							act("$p drifts in.", to_room->people, obj, nullptr, TO_ALL);
 						}
 
 						obj_from_room(obj);
@@ -3032,15 +3032,15 @@ void iprog_pulse_update(bool isTick)
 						}
 
 						if (to_room->sector_type == SECT_WATER && to_room->people)
-							act("$p suddenly bobs up and surfaces.", to_room->people, obj, 0, TO_ALL);
+							act("$p suddenly bobs up and surfaces.", to_room->people, obj, nullptr, TO_ALL);
 						else if (to_room->people)
-							act("$p floats in from below.", to_room->people, obj, 0, TO_ALL);
+							act("$p floats in from below.", to_room->people, obj, nullptr, TO_ALL);
 					}
 					else
 					{
 						if (obj->in_room->people && obj->in_room->sector_type == SECT_WATER)
 						{
-							act("$p sinks beneath the surface.", obj->in_room->people, obj, 0, TO_ALL);
+							act("$p sinks beneath the surface.", obj->in_room->people, obj, nullptr, TO_ALL);
 						}
 						else if (obj->in_room->people && obj->in_room->sector_type == SECT_UNDERWATER)
 						{
@@ -3049,7 +3049,7 @@ void iprog_pulse_update(bool isTick)
 						}
 
 						if (to_room->people)
-							act("$p sinks in from above.", to_room->people, obj, 0, TO_ALL);
+							act("$p sinks in from above.", to_room->people, obj, nullptr, TO_ALL);
 					}
 
 					obj_from_room(obj);
@@ -3125,13 +3125,13 @@ bool do_mob_cast(CHAR_DATA *ch)
 	{
 		if (skill_table[sn].target == TAR_CHAR_DEFENSIVE)
 		{
-			act("$n closes $s eyes with a look of concentration for a moment.", ch, 0, 0, TO_ROOM);
+			act("$n closes $s eyes with a look of concentration for a moment.", ch, nullptr, nullptr, TO_ROOM);
 		}
 		else
 		{
-			act("You narrow your eyes and glare in $N's direction.", ch, 0, victim, TO_CHAR);
-			act("$n narrows $s eyes and glares in $N's direction.", ch, 0, victim, TO_NOTVICT);
-			act("$n narrows $s eyes and glares in your direction.", ch, 0, victim, TO_VICT);
+			act("You narrow your eyes and glare in $N's direction.", ch, nullptr, victim, TO_CHAR);
+			act("$n narrows $s eyes and glares in $N's direction.", ch, nullptr, victim, TO_NOTVICT);
+			act("$n narrows $s eyes and glares in your direction.", ch, nullptr, victim, TO_VICT);
 		}
 	}
 	else if (!IS_SET(ch->form, FORM_NOSPEECH))

--- a/code/update.c
+++ b/code/update.c
@@ -2648,18 +2648,32 @@ void room_affect_update(void)
 			}
 		}
 
-		if (is_affected_room(room, gsn_tidalwave))
+		// The wave is stored as a pair: one affect at APPLY_ROOM_NONE carrying the
+		// countdown, and one at APPLY_ROOM_NOPE carrying the damage dice. Asking
+		// is_affected_room for the wave is satisfied by either half on its own, so
+		// finding both is the condition, and the searches below are that test.
+		af = nullptr;
+		for (auto &r : room->affected)
 		{
-			af = nullptr;
-			for (auto &r : room->affected)
+			if (r.type == gsn_tidalwave && r.location == APPLY_ROOM_NONE)
 			{
-				if (r.type == gsn_tidalwave && r.location == APPLY_ROOM_NONE)
-				{
-					af = &r;
-					break;
-				}
+				af = &r;
+				break;
 			}
+		}
 
+		af2 = nullptr;
+		for (auto &r : room->affected)
+		{
+			if (r.type == gsn_tidalwave && r.location == APPLY_ROOM_NOPE)
+			{
+				af2 = &r;
+				break;
+			}
+		}
+
+		if (af != nullptr && af2 != nullptr)
+		{
 			if (af->modifier == 1)
 			{
 				for (vch = room->people; vch != nullptr; vch = vch->next_in_room)
@@ -2674,16 +2688,6 @@ void room_affect_update(void)
 			}
 			else if (af->modifier == 0)
 			{
-				af2 = nullptr;
-				for (auto &r : room->affected)
-				{
-					if (r.type == gsn_tidalwave && r.location == APPLY_ROOM_NOPE)
-					{
-						af2 = &r;
-						break;
-					}
-				}
-
 				for (vch = room->people; vch != nullptr; vch = vch->next_in_room)
 				{
 					sprintf(buf, "%sA massive tidal wave rolls in, engulfing the area!%s\n\r",
@@ -2783,18 +2787,13 @@ void room_affect_update(void)
 							new_affect_to_char(vch, &cvaf);
 						}
 
-						paf = nullptr;
-						for (auto &paf_elem : vch->affected)
-						{
-							if (paf_elem.type == gsn_noxious_fumes)
-							{
-								paf = &paf_elem;
-								break;
-							}
-						}
+						paf = affect_find(vch->affected, gsn_noxious_fumes);
 
-						paf->modifier = URANGE(0, paf->modifier, 5);
-						paf->modifier++;
+						if (paf != nullptr)
+						{
+							paf->modifier = URANGE(0, paf->modifier, 5);
+							paf->modifier++;
+						}
 
 						init_affect(&cvaf2);
 						cvaf2.where = TO_AFFECTS;

--- a/code/vote.c
+++ b/code/vote.c
@@ -259,7 +259,12 @@ void do_vote(CHAR_DATA *ch, char *argument)
 		vote.vote_for = arg1;
 		vote.cabal = ch->cabal;
 		vote.time = current_time;
-		vote.host = ch->pcdata->host ? ch->pcdata->host : Deref(ch->desc)->host;
+		DESCRIPTOR_DATA *connection = Deref(ch->desc);
+
+		if (ch->pcdata->host)
+			vote.host = ch->pcdata->host;
+		else if (connection != nullptr)
+			vote.host = connection->host;
 
 		votes.Add(vote);
 

--- a/tests/fight_tests.c
+++ b/tests/fight_tests.c
@@ -291,9 +291,9 @@ SCENARIO("a reference to a freed opponent reads as nothing", "[stop_fighting]")
 }
 static bool CommandExists(const char *name)
 {
-	for (auto cmd = 0; cmd_table[cmd].name[0] != '\0'; cmd++)
+	for (auto cmd = 0; !cmd_table[cmd].name.empty(); cmd++)
 	{
-		if (!str_cmp(cmd_table[cmd].name, name))
+		if (cmd_table[cmd].name == name)
 			return true;
 	}
 

--- a/tests/smoke/mkchar.py
+++ b/tests/smoke/mkchar.py
@@ -221,9 +221,53 @@ def main():
     print(">>> who lists a class tag (%s)" % tag.group(1))
 
     cast_a_spell(s)
+    outfit_a_character(s)
 
     s.sock.close()
     return 0
+
+
+def outfit_a_character(s):
+    """Check the starting kit do_outfit produced during creation.
+
+    nanny calls do_outfit once, and do_outfit then affects the character for 80
+    ticks, so this cannot run the command itself -- it asserts the result of the
+    call creation already made. That is still the only coverage do_outfit has.
+
+    It walks the equipment list because that is the only way to tell a piece
+    that was created from one that was skipped: do_outfit prints nothing per
+    slot, and a vnum that resolved to nothing would take the server down on the
+    next create_object rather than report anything.
+
+    The shield is listed deliberately. It does not come from the per-slot vnums
+    the other five use -- it comes from the OBJ_VNUM_SCHOOL_SHIELD block, which
+    is gated on not wielding a two-hander and on having no light, so it is the
+    one piece here whose absence would look like a normal outcome.
+    """
+    s.send("equipment")
+    reply = s.recv(2.0)
+
+    if "You are using:" not in reply:
+        s.fail("'equipment' produced no equipment list")
+
+    # do_equipment skips empty slots entirely, so a slot label is present only
+    # when something is worn there. These are the labels, not the slot names:
+    # WEAR_BODY renders as "torso", and "<worn on body>" is a different slot
+    # (WEAR_ABOUT) that outfit does not fill.
+    labels = {
+        "body": "<worn on torso>",
+        "legs": "<worn on legs>",
+        "feet": "<worn on feet>",
+        "hands": "<worn on hands>",
+        "arms": "<worn on arms>",
+        "shield": "<worn as shield>",
+    }
+    missing = [slot for slot, label in labels.items() if label not in reply]
+
+    if missing:
+        s.fail("outfit did not fill: %s" % ", ".join(sorted(missing)))
+
+    print(">>> outfit: all six slots worn, shield included")
 
 
 def cast_a_spell(s):


### PR DESCRIPTION
This PR contains fixes for more game crash bugs, refining affect logic, fix for a few game commands, and more C-style string -> C++ std::string / std::string_view work.

Also updated the smoke test to flesh it out a bit more by outfittign a test character.

### Crash fixes
- `pull` and `uncoil` walked an entwine affect with zero checks. A warrior whose victim had been extracted crashed the server. Fixed.
- `rune <room>` passed `pexit->keyword` from a branch that never sets `pexit` which would be a NRE. Fixed.
- A `tripwire` search tested `raf->type` instead of `r.type` which would be a NRE. Fixed.
- The tidal wave is stored as two affects but only one was checked. Fixed.
- `burning_touch` read the owner's level after the owner was gone which would be a NRE. Fixed.
- Demon-pact favor writes went through `pcdata`, which is null for every NPC. Fixed.
- `prompt %o` dereferenced null on every login. Fixed.


### Command fixes
- `medit_vnum` removed the early return and fixed the rehash logic.
- `finger` printed race under Sex. Fixed.
- `spells` and `skills` parsed `all` and ignored it. The default now hides entries above your level; `all` shows them.
- `delete` archived every character's pfile, permanently retiring the name. It now honors the 15-hour rule the code already computed.
- `redit_clan` reported "Clan set." while setting nothing. Fixed.
